### PR TITLE
All Manuals - Typo, grammar, and weird word choice fixes, etc.

### DIFF
--- a/docs/en/manuals/3dgraphics.md
+++ b/docs/en/manuals/3dgraphics.md
@@ -36,13 +36,13 @@ Animation clips in Collada are not supported. To use multiple animations per mod
 
 ## Materials, shaders and textures
 
-3D software commonly allows you to set properties to your object vertices, like coloring and texturing. This information goes into the Collada *.dae* file that you export from your 3D software. Depending on the requirements of your game you will have to select and/or create appropriate and _performant_ materials for your objects. A material combines _shader programs_ with a set of parameters for rendering of the object.
+3D software commonly allows you to set properties on your object vertices, like coloring and texturing. This information goes into the Collada *.dae* file that you export from your 3D software. Depending on the requirements of your game you will have to select and/or create appropriate and _performant_ materials for your objects. A material combines _shader programs_ with a set of parameters for rendering of the object.
 
 You will also need to design and implement a game camera that works with your intended gameplay.
 
 Your Defold project has some built-in materials that are used to render sprites, tiles, particles and GUI nodes. For 3D models, there is no suitable built-in material so we have to create one. For the example book model there is a "textured.material" resource ready-made.
 
-Read the [Material documentation](/manuals/material) for information how materials work and how you can create materials that work with textured 3D models.
+Read the [Material documentation](/manuals/material) for information on how materials work and how you can create materials that work with textured 3D models.
 
 The [Shader manual](/manuals/shader) contains information on how shader programs work.
 

--- a/docs/en/manuals/android.md
+++ b/docs/en/manuals/android.md
@@ -5,7 +5,7 @@ brief: This manual describes how to build and run Defold applications on Android
 
 # Android development
 
-Android development differs from iOS development in that the devices give free access to upload content. It is very easy to build a version of your game and copy it onto an Android device. You can as easily put the development engine on a device for iterative development on the device over wifi.
+Android development differs from iOS development in that the devices give free access to upload content. It is very easy to build a version of your game and copy it onto an Android device. You can just as easily put the development engine on a device for iterative development on the device over wifi.
 
 ## Android and Google Play signing process
 

--- a/docs/en/manuals/animation.md
+++ b/docs/en/manuals/animation.md
@@ -40,9 +40,9 @@ Property animation
 Sprites and GUI box nodes can play flip-book animations and you have great control over them at runtime.
 
 Sprites
-: To run an animation during runtime you post [`play_animation`](/ref/sprite#play_animation)messages to the Sprite component you want to animate the texture on. 
+: To run an animation during runtime you post [`play_animation`](/ref/sprite#play_animation) messages to the Sprite component you want to animate the texture on.
 
-  As soon as an animation is finished playing, the engine sends back a [`animation_done`](/ref/sprite#animation_done) message to the script that sent the `play_animation` message.
+  As soon as an animation is finished playing, the engine sends back an [`animation_done`](/ref/sprite#animation_done) message to the script that sent the `play_animation` message.
 
 GUI box nodes
 : To run an animation during runtime you use the [`gui.play_flipbook()`](/ref/gui#play_flipbook) function. See below for an example.
@@ -83,7 +83,7 @@ end
 
 function on_message(self, message_id, message, sender)
     if message_id == hash("animation_done") then
-        -- one of the transition animations are finished, let's start looping
+        -- one of the transition animations is finished, let's start looping
         if self.dodge then
             msg.post("#sprite", "play_animation", {id = hash("dodge_idle")})
         else
@@ -168,7 +168,7 @@ msg.post("pistol", "set_parent", { parent_id = hand })
 
 ## Timeline events
 
-Spine animations can trigger timed events by sending messages at precise moments. They are very useful for events that should take place in sync with your animation, like playing footstep sounds, spawning particle effects, attach or detach objects to the bone hierarchy or anything else you would like happen.
+Spine animations can trigger timed events by sending messages at precise moments. They are very useful for events that should take place in sync with your animation, like playing footstep sounds, spawning particle effects, attaching or detaching objects to the bone hierarchy or anything else you would like to happen.
 
 Events are added in the Spine software and are visualized on the playback timeline:
 
@@ -257,7 +257,7 @@ local bone_go = model.get_go("#wiggler", "Bone_002")
 
 ## Cursor animation
 
-Just as Spine models, 3D models can be animated by manipulating the `cursor` property:
+Just like Spine models, 3D models can be animated by manipulating the `cursor` property:
 
 ```lua
 -- Set the animation on #model but don't start it
@@ -307,7 +307,7 @@ gui.animate(node, hash("position.x"), 100, gui.EASING_INOUTQUAD, 0.5)
 
 ## Playback Modes
 
-Animations can be played either once or looping. How the animation plays is determined by the playback mode:
+Animations can be played either once or in a loop. How the animation plays is determined by the playback mode:
 
 * go.PLAYBACK_NONE
 * go.PLAYBACK_ONCE_FORWARD
@@ -317,7 +317,7 @@ Animations can be played either once or looping. How the animation plays is dete
 * go.PLAYBACK_LOOP_BACKWARD
 * go.PLAYBACK_LOOP_PINGPONG
 
-The pingpong modes run the animation first forwards, then backward. A set of corresponding modes exist for GUI property animations:
+The pingpong modes run the animation first forward, then backward. A set of corresponding modes exist for GUI property animations:
 
 * gui.PLAYBACK_NONE
 * gui.PLAYBACK_ONCE_FORWARD
@@ -404,14 +404,14 @@ local values = { 0, 0, 0, 0, 0, 0, 0, 0,
                  0, 0, 0, 0, 0, 0, 0, 0,
                  1, 1, 1, 1, 1, 1, 1, 1 }
 local square_easing = vmath.vector(values)
-go.animate("go", "position.y", go.PLAYBACK_LOOP_PINGPONG, 100, square_easing, 2.0)
+go.animate("go", "position.y", go.PLAYBACK_LOOP_PINGPONG, 200, square_easing, 2.0)
 ```
 
 ![Square curve](images/animation/square_curve.png)
 
 ## Completion callbacks
 
-All animation functions (`go.animate()`, `gui.animate()`, `gui.play_flipbook()`, `gui.play_spine_anim()`, `spine.play_anim()` and `model.play_anim()`) supports an optional Lua callback function as the last argument. This function will be called when the animation has played to the end. The function is never called for looping animations, nor when an animation is manually canceled via `go.cancel_animations()`. The callback can be used to trigger events on animation completion or to chain multiple animations together.
+All animation functions (`go.animate()`, `gui.animate()`, `gui.play_flipbook()`, `gui.play_spine_anim()`, `spine.play_anim()` and `model.play_anim()`) support an optional Lua callback function as the last argument. This function will be called when the animation has played to the end. The function is never called for looping animations, nor when an animation is manually canceled via `go.cancel_animations()`. The callback can be used to trigger events on animation completion or to chain multiple animations together.
 
 The exact function signature of the callback differs slightly betweeen the animation functions. See the API documentation for the function you are using.
 

--- a/docs/en/manuals/application-lifecycle.md
+++ b/docs/en/manuals/application-lifecycle.md
@@ -11,29 +11,29 @@ The lifecycle of a Defold application or game is on the large scale simple. The 
 
 In many cases only a rudimentary understanding of Defold's inner workings is necessary. However, you might run into edge cases where the exact order Defold carries out its tasks becomes vital. This document describes how the engine runs an application from start to finish.
 
-The application starts by initializing everything that is needed to run the engine. It loads the main collection and calls [`init()`](/ref/go#init) on all loaded components that has an `init()` Lua function (script components and GUI components with GUI scripts). This allows you to do custom initialization.
+The application starts by initializing everything that is needed to run the engine. It loads the main collection and calls [`init()`](/ref/go#init) on all loaded components that have an `init()` Lua function (script components and GUI components with GUI scripts). This allows you to do custom initialization.
 
-The application then enters the update loop where the application will spend a majority of its lifetime. Each frame, game objects and the components they contain are updated. Any script and GUI script [`update()`](/ref/go#update) functions are called. During the update loop messages are dispatched to their recipients, sounds are played and all graphics are rendered.
+The application then enters the update loop where the application will spend the majority of its lifetime. Each frame, game objects and the components they contain are updated. Any script and GUI script [`update()`](/ref/go#update) functions are called. During the update loop messages are dispatched to their recipients, sounds are played and all graphics are rendered.
 
-At some point the applications lifecycle will come to an end. Before the application quits the engine steps out of the update loop and enters a finalization stage. It prepares all loaded game objects for deletion. All object components’ [`final()`](/ref/go#final) functions are called, which allows for custom cleanup. Then the objects are deleted and the main collection is unloaded.
+At some point the application's lifecycle will come to an end. Before the application quits the engine steps out of the update loop and enters a finalization stage. It prepares all loaded game objects for deletion. All object components’ [`final()`](/ref/go#final) functions are called, which allows for custom cleanup. Then the objects are deleted and the main collection is unloaded.
 
 ## Initialization
 
+This diagram contains a more detailed breakdown of the initialization steps. The steps involved in the "dispatch messages" pass (right before "spawn dynamic objects") have been put in a separate block to the right for clarity.
+
 ![Lifecycle overview](images/application_lifecycle/application_lifecycle_init.png)
 
-This diagram contains a more detailed breakdown of the initialization steps. The steps involved in the "dispatch messages" pass (right before "spawn dynamic objects") has been put in a separate block to the right for clarity. application lifecycle init.png
-
-The actual steps the engine takes during initialization, before the main collection is loaded is, in fact, much longer. The memory profiler, sockets, graphics, HID (input devices), sound, physics and much more is set up. The application configuration is also loaded ("game.project") and set up.
+The engine actually takes many more steps during initialization, before the main collection is loaded. The memory profiler, sockets, graphics, HID (input devices), sound, physics and much more are set up. The application configuration ("game.project") is also loaded and set up.
 
 The first user-controllable entry point, at the end of engine initialization, is the call to the current render script’s `init()` function.
 
-The main collection is then loaded and initialized. All game objects in the collection apply their transforms to their children (translation/change of position, movement, rotation and scaling) onto their children. All component `init()` functions that exists are then called.
+The main collection is then loaded and initialized. All game objects in the collection apply their transforms (translation (change of position), rotation and scaling) to their children. All component `init()` functions that exist are then called.
 
 ::: sidenote
-The order game object component `init()` functions are called is unspecified. You should not assume that the engines initialize objects belonging to the same collection in a certain order.
+The order in which game object component `init()` functions are called is unspecified. You should not assume that the engine initializes objects belonging to the same collection in a certain order.
 :::
 
-Since your `init()` code can post new messages, tell factories to spawn new objects, mark objects for deletion and do all sorts of things the engine performs a full "post-update" pass next. This pass carries out message delivery, the actual factory game object spawning and object deletion. Note that the post-update pass includes a  "dispatch messages" sequence that not only sends any queued messages but also handles messages sent to collection proxies. Any subsequent updates on the proxies (enable and disable, loading and mark for unloading) is performed during those steps.
+Since your `init()` code can post new messages, tell factories to spawn new objects, mark objects for deletion and do all sorts of things, the engine performs a full "post-update" pass next. This pass carries out message delivery, the actual factory game object spawning and object deletion. Note that the post-update pass includes a "dispatch messages" sequence that not only sends any queued messages but also handles messages sent to collection proxies. Any subsequent updates on the proxies (enable and disable, loading and mark for unloading) are performed during those steps.
 
 Studying the diagram above reveals that it is fully possible to load a [collection proxy](/manuals/collection-proxy) during `init()`, ensure all its contained objects are initialized, and then unload the collection through the proxy---all this before the first component `update()` is called, i.e. before the engine has left the initialization stage and entered the update loop:
 
@@ -62,25 +62,25 @@ end
 
 ## The update loop
 
-The update loop runs through a long sequence once every frame. The update sequence in the diagram below are divided into logical sequence blocks for clarity. "Dispatch messages" is also broken out separately for the same reason:
+The update loop runs through a long sequence once every frame. The update sequence in the diagram below is divided into logical sequence blocks for clarity. "Dispatch messages" is also broken out separately for the same reason:
 
 ![Update loop](images/application_lifecycle/application_lifecycle_update.png)
 
 ## Input
 
-Input is is read from available devices, mapped against [input bindings](/manuals/input) and then dispatched. Any game object that has acquired input focus gets input sent to all its component `on_input()` functions. A game object with a script component and a GUI component with a GUI script will get input to both components’ `on_input()` functions---given that they are defined and that they have acquired input focus.
+Input is is read from available devices, mapped against [input bindings](/manuals/input) and then dispatched. Any game object that has acquired input focus gets input sent to all its components' `on_input()` functions. A game object with a script component and a GUI component with a GUI script will get input to both components’ `on_input()` functions---given that they are defined and that they have acquired input focus.
 
-Any game object that has acquired input focus and that contain collection proxy components dispatches input further to components in the proxy collection belonging to game objects that has acquired input focus. This process continues recursively down enabled collection proxies within enabled collection proxies.
+Any game object that has acquired input focus and contains collection proxy components dispatches input to components inside the proxy collection. This process continues recursively down enabled collection proxies within enabled collection proxies.
 
 ## Update
 
-Each game object component in the main collection is traversed. If any of these component has a script `update(),` then it will be called. If the component is a collection proxy, each component in the proxy collection is recursively updated with all the steps in the "update" sequence in the diagram above.
+Each game object component in the main collection is traversed. If any of these components has a script `update()` function, then that will be called. If the component is a collection proxy, each component in the proxy collection is recursively updated with all the steps in the "update" sequence in the diagram above.
 
 ::: sidenote
-The order game object component `update()` functions are called is unspecified. You should not assume that the engines updates objects belonging to the same collection in a certain order.
+The order in which game object component `update()` functions are called is unspecified. You should not assume that the engine updates objects belonging to the same collection in a certain order.
 :::
 
-In the next step all posted messages are dispatched. Since any receiver component’s `on_message()` code can post additional messages the message dispatcher will continue to dispatch posted messaged until the message queue is empty. There is, however, a limit to how many runs through the message queue the message dispatcher performs. See [Message passing](/manuals/message-passing) and the section "Advanced topics" for details.
+In the next step all posted messages are dispatched. Since any receiver components’ `on_message()` code can post additional messages the message dispatcher will continue to dispatch posted messaged until the message queue is empty. There is, however, a limit to how many runs through the message queue the message dispatcher performs. See [Message passing](/manuals/message-passing) and the section "Advanced topics" for details.
 
 For collision object components, physics messages (collisions, triggers, ray_cast responses etc) are dispatched throughout the encompassing game object to all components that contain a script with an `on_message()` function.
 
@@ -92,29 +92,29 @@ The render update block dispatches messages to the `@render` socket (camera comp
 
 ## Post update
 
-After the updates, a post update sequence is run. It unloads from memory collection proxies that are marked for unloading (this happens during the "dispatch messages" sequence). Any game object that is marked for deletion will call all of its components’ `final()` functions called—if there are any. The code in `final()` functions often posts new messages to the queue so a "dispatch messages" pass is run afterwards.
+After the updates, a post update sequence is run. It unloads from memory collection proxies that are marked for unloading (this happens during the "dispatch messages" sequence). Any game object that is marked for deletion will call all of its components’ `final()` functions, if there are any. The code in `final()` functions often posts new messages to the queue so a "dispatch messages" pass is run afterwards.
 
-Any factory components that has been told to spawn a game object will do that next. Finally, game objects that are marked for deletion are actually deleted.
+Any factory component that has been told to spawn a game object will do that next. Finally, game objects that are marked for deletion are actually deleted.
 
-The last steps in the update loop involves dispatching `@system` messages (`exit`, `reboot` messages, toggling the profiler, starting and stopping video capture etc). Then graphics is rendered. During the graphics rendering, video capture is done, as is any rendering of the visual profiler (see the [Debugging documentation](/manuals/debugging).)
+The last step in the update loop involves dispatching `@system` messages (`exit`, `reboot` messages, toggling the profiler, starting and stopping video capture etc). Then graphics are rendered. During the graphics rendering, video capture is done, as is any rendering of the visual profiler (see the [Debugging documentation](/manuals/debugging).)
 
 ## Frame rate and collection time step
 
-The number of frame updates per seconds (which equals the number of update-loop runs per second) can be set in the project settings, or programmatically by sending an `set_update_frequency` message to the `@system` socket. In addition, it is possible to set the _time step_ for collection proxies individually by sending a `set_time_step` message to the proxy. Changing a collection's time step does not affect the frame rate. It has an effect on the physics update time step as well as the `dt` variable passed to `update().` Also note that altering the time step does not alter the number of times `update()` will be called each frame---it is always exactly once.
+The number of frame updates per second (which equals the number of update-loop runs per second) can be set in the project settings, or programmatically by sending a `set_update_frequency` message to the `@system` socket. In addition, it is possible to set the _time step_ for collection proxies individually by sending a `set_time_step` message to the proxy. Changing a collection's time step does not affect the frame rate. It does affect the physics update time step as well as the `dt` variable passed to `update().` Also note that altering the time step does not alter the number of times `update()` will be called each frame---it is always exactly once.
 
 (See the [Collection proxy manual](/manuals/collection-proxy) and [`set_time_step`](/ref/collection-proxy#set_time_step) for details)
 
 ## Finalization
 
-At the point when the application exits, it finishes the last update loop sequence, which will unload any collection proxies: finalizing and deleting all game objects in the proxy collection.
+When the application exits, first it finishes the last update loop sequence, which will unload any collection proxies: finalizing and deleting all game objects in each proxy collection.
 
-The engine lastly enters a finalization sequence that handles the main collection and its objects:
+When that is done the engine enters a finalization sequence that handles the main collection and its objects:
 
 ![Finalization](images/application_lifecycle/application_lifecycle_final.png)
 
 Component `final()` functions are called first. A subsequent dispatching of messages follows. Finally, all game objects are deleted and the main collection is unloaded.
 
-The engine follows up with behind the scenes shutting down of subsystems, project configuration is deleted, memory profiler is shut down, and so forth.
+The engine follows up with behind the scenes shutting down of subsystems: project configuration is deleted, the memory profiler is shut down, and so forth.
 
 The application is now completely shut down.
 

--- a/docs/en/manuals/bob.md
+++ b/docs/en/manuals/bob.md
@@ -8,7 +8,7 @@ brief: Bob is a command line tool for building Defold projects. This manual expl
 
 Bob is a command line tool for building Defold projects outside of the normal editor workflow.
 
-Bob is able to build data (corresponding to the build step of selecting the editor menu item <kbd>Project ▸ Build And Launch</kbd>), create data archives and standalone, distributable application bundles (corresponding to the editor menu item <kbd>Project ▸ Bundle ▸ ...</kbd> options)
+Bob is able to build data (corresponding to the build step of selecting the editor menu item <kbd>Project ▸ Build And Launch</kbd>), create data archives and create standalone, distributable application bundles (corresponding to the editor menu item <kbd>Project ▸ Bundle ▸ ...</kbd> options)
 
 Bob is distributed as a Java _JAR_ archive containing everything needed to build. You find the latest *bob.jar* distribution at http://d.defold.com. Select a release, then download *bob/bob.jar*. To run the Bob tool, you need Java 8 installed on your computer. You can download a version of Java from https://www.java.com.
 

--- a/docs/en/manuals/building-blocks.md
+++ b/docs/en/manuals/building-blocks.md
@@ -78,7 +78,7 @@ msg.post("my_object", "set_parent", { parent_id = go.get_id("my_parent") })
 
 ## Components
 
-Components are used to give specific expression and/or functionality to game objects. They don't live a life on their own but have to be contained inside game objects. There are two different ways in which you can create new components in the editor:
+Components are used to give specific expression and/or functionality to game objects. They don't live a life of their own but have to be contained inside game objects. There are two different ways in which you can create new components in the editor:
 
 1. Create a component-type _file_, then create an instance of that component inside a game object.
 2. Create an _in-place_ instance of a component in a game object.
@@ -97,7 +97,7 @@ embedded_instances {
 
 The component specific data are stored in the component file referenced via the *component* property.
 
-The most common component type is probably the _script component_ that you use to create behaviors. It is easy to forget that there is a clear boundary between the script component and the containing game object. For instance, the following style of message passing is common:
+The most common component type is probably the _script component_, which you use to create behaviors. It is easy to forget that there is a clear boundary between the script component and the containing game object. For instance, the following style of message passing is common:
 
 ```lua
 msg.post("my_object", "my_message", { my_data = 1 }})
@@ -168,7 +168,7 @@ data: "components {\n"
 
 ## Collections
 
-Collections are Defold's mechanism for creating templates, or what in other engines are called "prefabs". Collections are tree structures that holds game objects and other collections. A collection is _always_ stored on file and brought into the game in one of two ways:
+Collections are Defold's mechanism for creating templates, or what in other engines are called "prefabs". Collections are tree structures that hold game objects and other collections. A collection is _always_ stored on file and brought into the game in one of two ways:
 
 1. Either at build time by placing the collection in another collection in the editor.
 2. At runtime by dynamically loading all resources gathered in the collection through a _collection proxy_ (See [Collection proxy documentation](/manuals/collection-proxy) for details).

--- a/docs/en/manuals/camera.md
+++ b/docs/en/manuals/camera.md
@@ -17,7 +17,7 @@ Cameras in OpenGL are expressed as coordinate systems with a viewer, or eye, pos
 
 ![Camera planes](images/cameras/cameras_planes.png)
 
-A 3D camera usually have a viewing volume, a _frustum_, that is shaped like a cut off pyramid. The effect of this is that objects further away from the camera will be rendered smaller--the perspective will be realistic. The wider the _field of view_, the more the camera sees of the scenery, and the more dramatic will the difference between near and far object be.
+A 3D camera usually has a viewing volume, a _frustum_, that is shaped like a cut off pyramid. The effect of this is that objects further away from the camera will be rendered smaller--the perspective will be realistic. The wider the _field of view_, the more the camera sees of the scenery, and the more dramatic the difference between near and far objects will be.
 
 ![Camera field of view](images/cameras/cameras_fov.png)
 
@@ -53,13 +53,13 @@ auto_aspect_ratio
 
 ## Camera focus
 
-To activate the camera and have it feed its view and projection matrices, you send the component a `acquire_camera_focus` message:
+To activate the camera and have it feed its view and projection matrices, you send the component an `acquire_camera_focus` message:
 
 ```lua
 msg.post("#camera", "acquire_camera_focus")
 ```
 
-As soon as the camera component has camera focus, it will each frame send a `set_view_projection` message to the `@render` socket, i.e. to your render script:
+As soon as the camera component has camera focus, each frame it will send a `set_view_projection` message to the `@render` socket, i.e. to your render script:
 
 ```lua
 -- example.render_script
@@ -81,7 +81,7 @@ function on_message(self, message_id, message)
 end
 ```
 
-If you use both camera view and projection in your render script you will get a camera view into your game world with 3D perspective, even though your game content is strictly 2D. This is sometimes useful. You can, for instance, move the camera back to reveal more of the level. A simple camera script that measures the current camera move speed and pulls it back relative that speed could look like this:
+If you use both camera view and projection in your render script you will get a camera view into your game world with 3D perspective, even if your game content is strictly 2D. This is sometimes useful. You can, for instance, move the camera back to reveal more of the level. A simple camera script that measures the current camera move speed and pulls it back relative that speed could look like this:
 
 ```lua
 -- camera.script

--- a/docs/en/manuals/collection-factory.md
+++ b/docs/en/manuals/collection-factory.md
@@ -7,15 +7,15 @@ brief: This manual explains how to use collection factory components to spawn hi
 
 The collection factory component is used to spawn ready made blueprint hierarchies of game objects (collections) into a running game.
 
-Collections provide a powerful mechanism to create reusable templates, or "prefabs" in Defold. For an overview on Collections, see the [Building blocks documentation](/manuals/building-blocks#_collections). Collections can be placed in the editor and be cloned into the game at compile-time, and they can be dynamically inserted into your game in two ways:
+Collections provide a powerful mechanism to create reusable templates, or "prefabs" in Defold. For an overview on Collections, see the [Building blocks documentation](/manuals/building-blocks#_collections). Collections can be placed in the editor and be cloned into the game at compile-time, or they can be dynamically inserted into your game in two ways:
 
 1. Loaded through collection proxies. This method essentially loads a new isolated world (including how physics interact) into a running game. The loaded collection is accessed through a new socket. All assets contained in the collection are loaded through the proxy when you message the proxy to start loading. This makes them very useful to, for instance, change levels in a game. For more information, see the [Collection proxy documentation](/manuals/collection-proxy).
 
-2. Collection factory components allow spawning of the content of a collection proxy into the current main collection. This is analogous to performing factory spawning of all game objects inside the collection and then building the parent-child hierarchy between the objects. Typical use cases is to spawn enemies consisting of multiple game objects (enemy + weapon, for instance).
+2. Spawned into the current main collection with a collection factory component. This is analogous to performing factory spawning of all game objects inside the collection and then building the parent-child hierarchy between the objects. A typical use case is to spawn enemies consisting of multiple game objects (enemy + weapon, for instance).
 
 ## Spawning a collection
 
-For the simple case, spawning a collection is performed exactly as when spawning a game object. Suppose we creating a planet sprite and want to spawn complex astronaut figures on the planet surface. We can then simply add a *Collection factory* to the "planet" gameobject and set *astronaut.collection* (supposing it exists) as the component's *prototype*:
+For simple cases, you can spawn a collection just as you would spawn a game object. Suppose we are creating a planet sprite and want to spawn complex astronaut figures on the planet surface. We can simply add a *Collection factory* to the "planet" gameobject and set *astronaut.collection* (supposing it exists) as the component's *prototype*:
 
 ![Collection factory](images/collection_factory/collection_factory_factory.png)
 
@@ -29,7 +29,7 @@ The astronaut that is spawned is a tree of game objects, and we need to be able 
 
 ![Collection to spawn](images/collection_factory/collection_factory_collection.png)
 
-The regular factory component returns an id to the spawned object. The collection factory returns a table that maps a hash of the collection-local id of each object to the runtime id of each object. A prefix `/collection[N]/`, where `[N]` is a counter, is added to the id to uniquely identify each instance:
+The regular factory component returns the id of the spawned object. The collection factory returns a table that maps a hash of the collection-local id of each object to the runtime id of each object. A prefix `/collection[N]/`, where `[N]` is a counter, is added to the id to uniquely identify each instance:
 
 ```lua
 pprint(astro)
@@ -41,7 +41,7 @@ pprint(astro)
 -- }
 ```
 
-Observe that the parent-child relations between "astronaut" and "probe" is not reflected in the id/path of the objects but only in the runtime scene-graph, i.e. how objects are transformed together. Re-parenting an object never changes its id.
+Observe that the parent-child relationships between "astronaut" and "probe" are not reflected in the id/path of the objects but only in the runtime scene-graph, i.e. how objects are transformed together. Re-parenting an object never changes its id.
 
 ## Properties
 

--- a/docs/en/manuals/collection-proxy.md
+++ b/docs/en/manuals/collection-proxy.md
@@ -19,23 +19,23 @@ Loading/unloading ("streaming") of regions in a seamless large world is possible
 * Loading/unloading of mini-games.
 * Loading/unloading of user selected content (music, background images etc)
 
-Collection proxies allow you to keep your content separated in collections and then dynamically manage the collections through scripting. A collection proxy component act as an outlet that serves on behalf of a collection file---you can communicate with a collection file that is not yet loaded, through the proxy. You can tell a collection proxy to load, initialize, enable, disable, finalize and unload the collection it is an outlet for.
+Collection proxies allow you to keep your content separated in collections and then dynamically manage the collections through scripting. A collection proxy component acts as an outlet that serves on behalf of a collection file---you can communicate with a collection file that is not yet loaded through the proxy. You can tell a collection proxy to load, initialize, enable, disable, finalize and unload the collection it is an outlet for.
 
-All communication with collection proxies regarding loading and unloading is done asynchronously: however, the actual loading and unloading is not implemented as a background process, so the engine will briefly pause when the actual loading and unloading happens.
+All communication with collection proxies regarding loading and unloading is done asynchronously: however, the actual loading and unloading is not implemented as a background process, so the engine will briefly pause when the loading and unloading happens.
 
 ## Worlds
 
-Through collection proxies is it thus possible to switch the top level collection, or to load more than one top level collection into the engine. When doing so it is important to know that each top level collection is a separate physical world. Physics interactions (collisions, triggers, ray-casts) happen between objects belonging to the same collection. There is no physics interaction happening between objects belonging to different top level collections.
+Through collection proxies is it possible to switch the top level collection, or to load more than one top level collection into the engine. When doing so it is important to know that each top level collection is a separate physical world. Physics interactions (collisions, triggers, ray-casts) only happen between objects belonging to the same collection. There is no physics interaction between objects belonging to different top level collections.
 
-In the following example we have split the game world into two collections that we dynamically load through collection proxies. The loading and unloading of the two collections is controlled by a game object called "loader" that we put in our main collection "worlds". We configure the game to automatically load the "worlds.collection" file at startup (see [Project settings documentation](/manuals/project-settings) for details). The collection "worlds" will hold the "loader" object as well as the GUI elements that allow us to move our character around.
+In the following example we have split the game world into two collections that we dynamically load through collection proxies. The loading and unloading of the two collections is controlled by a game object called "loader" that we put in our main collection, "worlds". We configure the game to automatically load the "worlds.collection" file at startup (see [Project settings documentation](/manuals/project-settings) for details). The "worlds" collection will hold the "loader" object as well as the GUI elements that allow us to move our character around.
 
 ![Worlds 1](images/collection_proxies/collection_proxy_worlds_loader.png)
 
-The first collection, "world1", is on the left with purple ground tiles. To the right of the "exit" sign is  the "world2" collection with green ground tiles.
+The first collection, "world1", is on the left with purple ground tiles. To the right of the "exit" sign is the "world2" collection with green ground tiles.
 
 ![Worlds 1](images/collection_proxies/collection_proxy_worlds_1.png)
 
-Our player character is set up with physics collision against all ground tiles in the level and that allows the player to roll the character on the ground. But let’s see what happens when the player reaches the end of the "world1" collection:
+Our player character is set up with physics collision against all ground tiles in the level, which allows the player to roll the character on the ground. But let’s see what happens when the player reaches the end of the "world1" collection:
 
 ![Worlds 2](images/collection_proxies/collection_proxy_worlds_2.png)
 
@@ -94,7 +94,7 @@ function on_message(self, message_id, message, sender)
 end
 ```
 
-Alternatively your logic can check the origin of the message an act accordingly. The collection proxy that sent the "proxy_loaded" is indicated in the fragment part of the sender URL:
+Alternatively your logic can check the origin of the message an act accordingly. The collection proxy that sent the "proxy_loaded" message is indicated in the fragment part of the sender URL:
 
 ```lua
 function on_message(self, message_id, message, sender)
@@ -143,7 +143,7 @@ Here’s the setup in the "world2" collection:
 
 ![Trigger world 2](images/collection_proxies/collection_proxy_trigger_2.png)
 
-The "exit" sign is placed in the exact same coordinates in both collections giving one tile of overlap between them. Also notice that there is a "player" object in "world2" as well as in "world1". Because each collection is its own physics world we need a separate player in each and we just make sure to transfer the position and input control from one player object to the other when we move between the worlds.
+The "exit" sign is placed at the exact same coordinates in both collections, giving one tile of overlap between them. Also notice that there is a "player" object in "world2" as well as in "world1". Because each collection is its own physics world we need a separate player in each and we just make sure to transfer the position and input control from one player object to the other when we move between the worlds.
 
 ```lua
 function on_message(self, message_id, message, sender)
@@ -185,7 +185,7 @@ end
 3. Then it’s time to switch the player object. We start by sending the current player a message requesting the data we need, which is the current position of the player object:
 4. We get a response back and pass the player data to the player in the newly loaded collection:
 
-The message `inherit_player` just inherits the position sent so the new player is repositioned to the same spot where the old player was (in the trigger, which is fine. It won’t detect the new player since they are parts of two different collections, and physical worlds)
+The message `inherit_player` just inherits the position sent so the new player is repositioned to the same spot where the old player was. (It's inside the trigger, but that is fine. It won’t detect the new player since they are parts of two different collections and therefore separate physical worlds.)
 
 If we run the game we can move from "world1" to "world2", but the player object in "world1" is still present, and will fall through the world of "world2".
 
@@ -211,12 +211,12 @@ msg.post("loader#world1", "unload")
 : This message disables the collection through the proxy. It recursively disables all the objects in the collection loaded through the proxy.
 
 `final`
-: Finalizes the collection through the proxy. It recursively finalizes all the objects in the collection.
+: This message finalizes the collection through the proxy. It recursively finalizes all the objects in the collection.
 
 `unload`
 : This message removes the collection from memory. If you don’t need the finer grained control, you can send the `unload` message without first disabling and finalizing the collection. The proxy will then automatically disable and finalize the collection before it’s unloaded.
 
-When the proxy has unloaded the collection it will send back a `proxy_unloaded` to the script that sent the `unload` message:
+When the proxy has unloaded the collection it will send back a `proxy_unloaded` message to the script that sent the `unload` message:
 
 ```lua
 if message_id == hash("unload_level") then
@@ -252,7 +252,7 @@ In a real game you wouldn’t want to unload a collection that is still visible 
 
 ## Input
 
-If you have objects in your loaded collection that require input actions, you need to make sure that the game object that contain the collection proxy acquires input. When the game object receives input messages these are propagated to the components of that object, i.e. the collection proxies. The input actions are sent via the proxy into the loaded collection.
+If you have objects in your loaded collection that require input actions, you need to make sure that the game object that contains the collection proxy acquires input. When the game object receives input messages these are propagated to the components of that object, i.e. the collection proxies. The input actions are sent via the proxy into the loaded collection.
 
 ![Input](images/collection_proxies/collection_proxy_input.png)
 
@@ -266,11 +266,11 @@ function init(self)
 end
 ```
 
-Any object in either "world1" or "world2" (that is loaded) can now send `acquire_input_focus` and start receiving input actions. (For more information on input, see [Input](/manuals/input))
+Any object in either "world1" or "world2" (that is loaded) can now `acquire_input_focus` and start receiving input actions. (For more information on input, see [Input](/manuals/input).)
 
 ## Time step
 
-Each collection proxy can individually control the update time step in relation to the application update frequency. You can set the global update frequency in the application project settings (it defaults to 60 frame updates per seconds), or it can be set by sending a message to the `@system` socket:
+Each collection proxy can individually control the update time step in relation to the application update frequency. You can set the global update frequency in the application project settings (it defaults to 60 frame updates per second), or it can be set by sending a message to the `@system` socket:
 
 ```lua
 msg.post("@system:", "set_update_frequency", { frequency = 60 } )

--- a/docs/en/manuals/debugging.md
+++ b/docs/en/manuals/debugging.md
@@ -81,10 +81,10 @@ Mapped remote request for '/' to '/Users/my_user/Documents/Projects/Defold_proje
 Debugging session started in '/Users/my_user/Documents/Projects/Defold_project'.
 ```
 
-Now it it possible to use the debugging features available in ZeroBrane; you can step, inspect, add and remove breakpoints etc.
+Now it is possible to use the debugging features available in ZeroBrane; you can step, inspect, add and remove breakpoints etc.
 
 ::: sidenote
-The debugging will only be enabled for the lua context from where debugging is initiated. Enabling "shared_state" in game.project means you can debug all your application no matter where you started.
+The debugging will only be enabled for the lua context from where debugging is initiated. Enabling "shared_state" in game.project means you can debug your whole application no matter where you started.
 :::
 
 ![Auto completion](images/debugging/code.png)
@@ -108,7 +108,7 @@ This also means it is important to make sure to have network connectivity from t
 
 It is possible to make ZeroBrane automatically open Lua script files during debugging. This makes it possible to step into functions in other source files without having to open them manually.
 
-First step is to access the editor configuration file. Recommended is to change the user version of the file.
+The first step is to access the editor configuration file. It is recommended that you change the user version of the file.
 
 - Select menu:Edit[Preferences > Settings: User]
 - Add the following to the configuration file:
@@ -124,7 +124,7 @@ First step is to access the editor configuration file. Recommended is to change 
 
 ## Hot reloading
 
-Defold allows you to perform hot reloading of resources. When developing a game this feature helps speed up certain task enormously. It allows you to change scripts in a game while it is running live. Common use-cases is to tweak gameplay parameters or to perform debugging on a running game.
+Defold allows you to perform hot reloading of resources. When developing a game this feature helps speed up certain task enormously. It allows you to change scripts in a game while it is running live. Common use-cases are to tweak gameplay parameters or to perform debugging on a running game.
 
 To reload a changed resource, simply select the menu item <kbd>Edit ▸ Reload Resource</kbd> or press the corresponding shortcut on the keyboard:
 
@@ -181,7 +181,7 @@ Below the frames overview is a detailed frame data view. You can click on any fr
 
 ## Frame data
 
-The frame data view is a table where all data for the currently selected frame is broken down into detail. You can view how many milliseconds is spent in each engine scope (to the left) and also see sample points within the scopes (middle column). On the right hand side is a table of counters. The numbers presented are counters so it is easy to, for instance, track the number of draw calls required for each frame in the sample data.
+The frame data view is a table where all data for the currently selected frame is broken down into detail. You can view how many milliseconds are spent in each engine scope (to the left) and also see sample points within the scopes (middle column). On the right hand side is a table of counters. The numbers presented are counters so it is easy to, for instance, track the number of draw calls required for each frame in the sample data.
 
 ![Frame data](images/debugging/webprofiler_frame_data.png)
 

--- a/docs/en/manuals/extensions.md
+++ b/docs/en/manuals/extensions.md
@@ -1,6 +1,6 @@
 ---
 title: Writing native extensions for Defold
-brief: This manual explains how to write a native extensions for the Defold game engine and how to compile it through the zero setup cloud builders.
+brief: This manual explains how to write a native extension for the Defold game engine and how to compile it through the zero setup cloud builders.
 ---
 
 # Native extensions
@@ -8,18 +8,18 @@ brief: This manual explains how to write a native extensions for the Defold game
 If you need custom interaction with external software or hardware on a low level where Lua won't suffice, the Defold SDK allows you to write extensions to the engine in the C++ language. Typical use cases for native extensions are:
 
 - Interaction with specific hardware, for instance the camera on mobile phones.
-- Interaction with external low level API:s, for instance advertising network API:s that does not allow interaction through network API:s where Luasocket could be used.
+- Interaction with external low level APIs, for instance advertising network APIs that do not allow interaction through network APIs where Luasocket could be used.
 - High performance calculations.
 
 ## The build platform
 
-Defold provides a zero setup entry point to native extensions with a cloud based build solution. Any native extension that is developed and added to a game project becomes part of the ordinary project content. There is no need to build special versions of the engine and distribute to team members, that is handled automatically---any team member that builds and runs the project will get a project specific engine executable with all native extensions baked in.
+Defold provides a zero setup entry point to native extensions with a cloud based build solution. Any native extension that is developed and added to a game project becomes part of the ordinary project content. There is no need to build special versions of the engine and distribute them to team members, that is handled automatically---any team member that builds and runs the project will get a project specific engine executable with all native extensions baked in.
 
 ![Cloud build](images/extensions/cloud_build.png)
 
 ## Project layout
 
-To create a new extension, create a folder in the project root. This folder will contain all settings, source code, libraries and resources associated with the extension. The extension builder recognizes the folder structure and collects any source files and libraries .
+To create a new extension, create a folder in the project root. This folder will contain all settings, source code, libraries and resources associated with the extension. The extension builder recognizes the folder structure and collects any source files and libraries.
 
 ![Project layout](images/extensions/layout.png)
 
@@ -195,7 +195,7 @@ platforms:
 
 ## Known issues
 
-The native extension feature is in an alpha state, meaning that that the API:s can still change. Furthermore, not all features are in place yet.
+The native extension feature is in an alpha state, meaning that that the APIs can still change. Furthermore, not all features are in place yet.
 
 Platforms
 : We currently only support building extensions for: macOS, iOS and Android. Android lacks support for *.java* and *.jar* archives

--- a/docs/en/manuals/facebook.md
+++ b/docs/en/manuals/facebook.md
@@ -5,17 +5,17 @@ brief: This manual explains how to setup and integrate Facebook functionality in
 
 # Facebook
 
-The Facebook APIs allows you to interact with Facebook's game connectivity features in a uniform way for games on iOS, Android and HTML5.
+The Facebook API allows you to interact with Facebook's game connectivity features in a uniform way for games on iOS, Android and HTML5.
 
-The Defold Facebook APIs brings the various platform specific Facebook APIs under a unified set of functions that work the same on iOS, Android and HTML5 (through Facebook Canvas). To get started with Facebook connectivity in your games, you need a Facebook account.
+The Defold Facebook API brings the various platform specific Facebook APIs under a unified set of functions that work the same on iOS, Android and HTML5 (through Facebook Canvas). To get started with Facebook connectivity in your games, you need a Facebook account.
 
 ::: important
-As of Defold 1.2.92, the Facebook API is redesigned with a new way of interacting with Facebook. The previous API:s still work so no breaking changes are introduced. However, the old API:s should be considered deprecated and not used in new applications.
+As of Defold 1.2.92, the Facebook API is redesigned with a new way of interacting with Facebook. The previous API still works, no breaking changes were introduced. However, the old API should be considered deprecated and not used in new applications.
 :::
 
 ## Registering as a Facebook developer
 
-To develop for Facebook requires that you sign up as a Facebook developer. This allows you to create Facebook applications that your Defold game can communicate with.
+To develop for Facebook you must sign up as a Facebook developer. This allows you to create Facebook applications that your Defold game can communicate with.
 
 * Head over to [Facebook for developers](https://developers.facebook.com)
 * Log in with your Facebook account.
@@ -26,14 +26,14 @@ To develop for Facebook requires that you sign up as a Facebook developer. This 
 
 ## Creating a Facebook app
 
-The next step is to create a Facebook application. The <kbd>My Apps</kbd> menu in the corner lists your apps, and there is a choice <kbd>Add a New App</kbd>.
+The next step is to create a Facebook application. The <kbd>My Apps</kbd> menu in the corner lists your apps, and there is an option to <kbd>Add a New App</kbd>.
 
 ![Add new app](images/facebook/add_new_app_menu.png)
 
 You are presented with a selection of target platforms. Click *basic setup* to skip the wizards.
 
 ::: sidenote
-Most information provided through the wizards are irrelevant when developing on Defold. In particular, you usually don't need to edit *Info.plist* or *AndroidManifest.xml* yourself. Defold does that work for you.
+Most information provided through the wizards is irrelevant when developing on Defold. In particular, you usually don't need to edit *Info.plist* or *AndroidManifest.xml* yourself. Defold does that work for you.
 :::
 
 ![Add new app platform](images/facebook/add_new_app_platform.png)
@@ -44,7 +44,7 @@ You can easily add, remove and change platform settings in the app dashboard. Yo
 
 ![App dashboard settings](images/facebook/add_platform.png)
 
-Click the *Settings* tab. Notice the numerical *App ID*. That identifier needs to go into the [project settings](/manuals/project-settings) of your Defold game. Unfortunately this setting is hidden in the editor (this will change soon), but you easily add it. Right-click the *game.project* file in the *Project Explorer* and select <kbd>Open With ▸ Text Editor</kbd>.
+Click the *Settings* tab. Notice the numerical *App ID*. That identifier needs to go into the [project settings](/manuals/project-settings) of your Defold game. Unfortunately this setting is hidden in the editor (this will change soon), but you can easily add it. Right-click the *game.project* file in the *Project Explorer* and select <kbd>Open With ▸ Text Editor</kbd>.
 
 ![Open project settings with](images/facebook/project_open_with.png)
 
@@ -64,13 +64,13 @@ For iOS you need to specify the game's `bundle_identifier` as specified in *game
 
 ## Android
 
-For Android you need to specify *Google Play Package Name*, which is the game's *package* identifier specified in *game.project*. You should also generate hashes of the certificate(s) you use and enter them into the *Key Hashes* field. You can generate a hash from a *certificate.pem* with openssl:
+For Android you need to specify a *Google Play Package Name*, which is the game's *package* identifier specified in *game.project*. You should also generate hashes of the certificate(s) you use and enter them into the *Key Hashes* field. You can generate a hash from a *certificate.pem* with openssl:
 
 ```sh
 $ cat certificate.pem | openssl x509 -outform der | openssl sha1 -binary | openssl base64
 ```
 
-(See [Creating certificates and keys](/manuals/android/#_creating_certificates_and_keys) in the Android manual for details how to create your own signing files)
+(See [Creating certificates and keys](/manuals/android/#_creating_certificates_and_keys) in the Android manual for details on how to create your own signing files.)
 
 ![Android settings](images/facebook/settings_android.png)
 
@@ -156,7 +156,7 @@ DEBUG:SCRIPT:
 }
 ```
 
-* The full Defold Facebook APIs are documented in the [Facebook reference documentation](/ref/facebook).
+* The full Defold Facebook API is documented in the [Facebook reference documentation](/ref/facebook).
 * The Facebook Graph API is documented here: https://developers.facebook.com/docs/graph-api
 
 ## Development caveats

--- a/docs/en/manuals/factory.md
+++ b/docs/en/manuals/factory.md
@@ -40,7 +40,7 @@ factory.create(component, p)
 : (optional) A Lua table with any script property values to initiate the game object with. See the [Script property manual](/manuals/script-properties) for information on script properties.
 
 `[scale]`
-: (optional) The scale of the spawned game object. The scale can be expressed as a `number` (greater than 0) which specifies uniform scaling along all axis. You can also provide a `vector3` where each component specifies scaling along the corresponding axis.
+: (optional) The scale of the spawned game object. The scale can be expressed as a `number` (greater than 0) which specifies uniform scaling along all axes. You can also provide a `vector3` where each component specifies scaling along the corresponding axis.
 
 For example:
 
@@ -82,7 +82,7 @@ end
 ![Spawned game object with property and scaling](images/factory/factory_spawned2.png)
 
 ::: sidenote
-Defold does not currently support non uniform scaling of collision shapes. If you provide a non uniform scale value, for instance `vmath.vector3(1.0, 2.0, 1.0)` the sprite will scale correctly but the collision shapes won't
+Defold does not currently support non uniform scaling of collision shapes. If you provide a non uniform scale value, for instance `vmath.vector3(1.0, 2.0, 1.0)` the sprite will scale correctly but the collision shapes won't.
 :::
 
 ## Tracking spawned and parent objects
@@ -113,7 +113,7 @@ end
 go.delete_all(self.spawned_coins)
 ```
 
-It is also common that you want the spawned object to be aware of the game object that spawned it. One case would be a some type of autonomous object that can be spawned only one at a time. The spawned object then needs to inform the spawner when it is deleted or inactivated so another one can be spawned:
+It is also common that you want the spawned object to be aware of the game object that spawned it. One case would be some type of autonomous object that can be spawned only one at a time. The spawned object then needs to inform the spawner when it is deleted or inactivated so another one can be spawned:
 
 ```lua
 -- spawner.script
@@ -145,11 +145,11 @@ end
 
 ## Instance limits
 
-The project setting *max_instances* in *Collection related settings* limits the total number of game object instances that can exist in a world (the main.collection loaded at startup or any world loaded via a collection proxy). All game objects that exist in the world is counted agaist that limit and it does not matter if they are placed by hand in the editor or spawned in runtime through a script.
+The project setting *max_instances* in *Collection related settings* limits the total number of game object instances that can exist in a world (the main.collection loaded at startup or any world loaded via a collection proxy). All game objects that exist in the world are counted agaist that limit and it does not matter if they are placed by hand in the editor or spawned in runtime through a script.
 
 ![Max instances](images/factory/factory_max_instances.png)
 
-So if you set *max_instances* to 1024 and have 24 manually placed game objects in your main collection, you can spawn an additional 1000 game objects. And as soon as you delete a game object, you are free to spawn another instance.
+So if you set *max_instances* to 1024 and have 24 manually placed game objects in your main collection, you can spawn an additional 1000 game objects. As soon as you delete a game object, you are free to spawn another instance.
 
 ## Pooling of game objects
 

--- a/docs/en/manuals/font.md
+++ b/docs/en/manuals/font.md
@@ -5,7 +5,7 @@ brief: This manual describes how Defold handles fonts and how to bring fonts ont
 
 # Font files
 
-Fonts are used to render label components and text nodes in GUI scenes. Defold supports font files in TrueType, OpenType or BMFont format that can be added to your project and automatically converted into a graphical format that Defold can render. Two font rendering techniques are available, bitmap and distance field, each with its specific benefits and drawbacks.
+Fonts are used to render label components and text nodes in GUI scenes. Defold supports font files in TrueType, OpenType or BMFont format, which can be added to your project and automatically converted into a graphical format that Defold can render. Two font rendering techniques are available, bitmap and distance field, each with its own specific benefits and drawbacks.
 
 ## Creating a font
 
@@ -59,16 +59,16 @@ Shadow rendering of fonts is currently disabled by default because of performanc
 : This property controls the type of font that is generated.
 
   - `TYPE_BITMAP`. For OTF and TTF files, the imported font is converted into a font sheet texture where the bitmap data is used to render text nodes. The color channels are used to encode different aspects of the font, such as the face shape, outline and drop shadow. The preview shows the raw font texture with the font face in the red channel, the outline in the green channel and shadow in the blue channel. The pixel density of the font is fixed so it will look good in its generated size or scaled down. Bitmap fonts are very fast to render but size limited---scaling up a bitmap font quickly creates artifacts.
-  - `TYPE_DISTANCE_FIELD` The imported font is converted into a font sheet texture where the pixel data represent not screen pixels but distances to the font edge. See below for details.
+  - `TYPE_DISTANCE_FIELD` The imported font is converted into a font sheet texture where the pixel data represents not screen pixels but distances to the font edge. See below for details.
 
 *all_chars*
-: If you set this property to `true` all glyphs available in the source file are included in the output.
+: If you set this property to `true` all glyphs available in the source file will be included in the output.
 
 *cache_width*
-: Set this to constrain the width of the glyph cache bitmap. When the engine renders text, it looks on the cache bitmap for a glyph. If it does not exist there it will be added to the cache before rendering. If the cache bitmap is too small to contain the glyphs the engine is asked to render, an error (`ERROR:RENDER: Out of available cache cells! Consider increasing cache_width or cache_height for the font.`) is signalled. If this value is 0 then the cache size is automatically.
+: Set this to constrain the width of the glyph cache bitmap. When the engine renders text, it looks on the cache bitmap for a glyph. If it does not exist there, it will be added to the cache before rendering. If the cache bitmap is too small to contain all the glyphs the engine is asked to render, an error (`ERROR:RENDER: Out of available cache cells! Consider increasing cache_width or cache_height for the font.`) is signalled. If this value is 0 then the cache size is set automatically.
 
 *cache_height*
-: Set this to constrain the height of the glyph cache bitmap. If this value is 0 then the cache size is automatically.
+: Set this to constrain the height of the glyph cache bitmap. If this value is 0 then the cache size is set automatically.
 
 ::: sidenote
 The ASCII printable characters are:
@@ -99,7 +99,7 @@ For the font to render correctly, don't forget to set the material property to *
 
 ## Distance field fonts
 
-To create a distance field font, simply select `TYPE_DISTANCE_FIELD` as *output_format*. This creates a distance field map for the font. When the engine renders the font, a special shader is required to interprets the distance data and use that to create a sharp font edge. Distance field fonts are more resource intensive than bitmap fonts, but allow for much greater sizing flexibility.
+To create a distance field font, simply select `TYPE_DISTANCE_FIELD` as *output_format*. This creates a distance field map for the font. When the engine renders the font, a special shader is required to interpret the distance data and use that to create a sharp font edge. Distance field fonts are more resource intensive than bitmap fonts, but allow for much greater sizing flexibility.
 
 ![Distance field font](images/font/fonts_distance_field.png)
 

--- a/docs/en/manuals/gui-clipping.md
+++ b/docs/en/manuals/gui-clipping.md
@@ -28,7 +28,7 @@ Clipping can be applied to box nodes and pie nodes. Text nodes can not clip othe
 
 ![Clipping properties](images/clipping/clipping_properties.png)
 
-Stencil clipping can be applied to box nodes and pie nodes. Stencils has some limitations:
+Stencil clipping can be applied to box nodes and pie nodes. Stencils have some limitations:
 
 - The total number of stencil clippers can not exceed 256.
 - The maximum nesting depth of child _stencil_ nodes is 8 levels deep. (Only nodes with stencil clipping count.)
@@ -38,11 +38,11 @@ Stencil clipping can be applied to box nodes and pie nodes. Stencils has some li
 
 ## Stencil mask
 
-To understand how stencil clipping works, it is useful to imagine how a hierarchy of stencils apply their individual clipping shapes, in turn down the hierarchy, to the total mask. The mask set of a clipping node is inherited to the children of that node and the children can never _extend_ the mask, only clip it. Let's look at a concrete example:
+To understand how stencil clipping works, it is useful to imagine how a hierarchy of stencils apply their individual clipping shapes, in turn down the hierarchy, to the total mask. The mask set of a clipping node is inherited by the children of that node and the children can never _extend_ the mask, only clip it. Let's look at a concrete example:
 
 ![Clipping hierarchy](images/clipping/clipping_hierarchy.png)
 
-The hexagon and square shapes are both set to stencil clippers. Setting the *Inverted clipper* property inverts the mask as inherited to that node. For the hierarchy above, four combinations of normal and inverted clippers are possible:
+The hexagon and square shapes are both set to stencil clippers. Setting the *Inverted clipper* property inverts the mask as inherited by that node. For the hierarchy above, four combinations of normal and inverted clippers are possible:
 
 ![Stencil masks](images/clipping/clipping_stencil_masks.png)
 
@@ -52,9 +52,9 @@ If a node below an inverted node is also set to *Inverted clipper*, the part of 
 
 ## Layers
 
-Layers can be used to control rendering order (and batching) of nodes. When using layers and clipping nodes the usual layering order is overridden. Clipping order take precedence over layer order, meaning that regardless of what layer a node belongs to, it will be clipped according to the node hierarchy. Layers only affects the draw order of graphics--and furthermore, the layer set on a clipping node does only affect the draw order _in that clipper's hierarchy_.
+Layers can be used to control rendering order (and batching) of nodes. When using layers and clipping nodes the usual layering order is overridden. Clipping order take precedence over layer order, meaning that regardless of what layer a node belongs to, it will be clipped according to the node hierarchy. Layers only affect the draw order of graphics--and furthermore, the layer set on a clipping node only affects the draw order _in that clipper's hierarchy_.
 
-To illustrate, consider this clipper node "window_and_shadow" that has an inner shadow texture applied to it. By setting the node's *Visible clipper* property and then layering it ("layer2") in relation to the clipped "map" node ("layer0"), the clipper's texture is rendered on top of the child "map". Note that the layer set on "map", nor the one on "window_and_shadow", has any effect on its render order in relation to "blue_box" ("layer2") and "orange_box" ("layer1"). If you want to change the render order of "window_and_shadow" in relation to "blue_box" and "orange_box", simply change their order in the node tree.
+To illustrate, consider this clipper node "window_and_shadow" that has an inner shadow texture applied to it. By setting the node's *Visible clipper* property and then layering it ("layer2") in relation to the clipped "map" node ("layer0"), the clipper's texture is rendered on top of the child "map". Note that neither the layer set on "map", nor the one on "window_and_shadow", has any effect on its render order in relation to "blue_box" ("layer2") and "orange_box" ("layer1"). If you want to change the render order of "window_and_shadow" in relation to "blue_box" and "orange_box", simply change their order in the node tree.
 
 ![Layers and clipping](images/clipping/clipping_layers.png)
 

--- a/docs/en/manuals/gui-layouts.md
+++ b/docs/en/manuals/gui-layouts.md
@@ -7,7 +7,7 @@ brief: Defold supports GUIs that automatically adapt to screen orientation chang
 
 Defold supports GUIs that automatically adapt to screen orientation changes on mobile devices. Using this feature allows you to design GUIs that adapt to the orientation and aspect ratio of the screen.
 
-The dynamic layout of GUI:s works by matching display profiles to the current width and height of the display that the game is running on.
+The dynamic layout of GUIs works by matching display profiles to the current width and height of the display that the game is running on.
 
 ## Display profiles
 
@@ -21,7 +21,7 @@ Landscape
 Portrait
 : 720 pixels wide and 1280 pixels high
 
-For devices with an aspect ratio of 16:9 these profiles are probably enough. Even if the actual physical dimensions of the screen is higher or lower, the engine will automatically select the a profile that is closest. If you need to alter the default profiles, simply copy the built in file to a new place within your project or create a new file, then change the setting in `project.settings` so the engine knows which profiles-file to use:
+For devices with an aspect ratio of 16:9 these profiles are probably enough. Even if the actual physical dimensions of the screen are higher or lower, the engine will automatically select the a profile that is closest. If you need to alter the default profiles, simply copy the built in file to a new place within your project or create a new file, then change the setting in `project.settings` so the engine knows which profiles-file to use:
 
 ![Project settings](images/layouts/layouts_project_settings.png)
 
@@ -49,11 +49,11 @@ You also get visual feedback on whether a node overrides a property on the curre
 
 ![Editing with layouts](images/layouts/layouts_modified.png)
 
-Note that layers only override properties. A layer cannot delete or create new nodes. If you need to remove a node from a layer you can either move the node off-screen or delete it with script logic. You should also pay attention to the currently selected layout. If you add a layout to your project, the new layout will be set up according to the currently selected layout. Also, copying and pasting nodes considers the currently selected layout, when copying and when pasting.
+Note that layers only override properties. A layer cannot delete or create new nodes. If you need to remove a node from a layer you can either move the node off-screen or delete it with script logic. You should also pay attention to the currently selected layout. If you add a layout to your project, the new layout will be set up according to the currently selected layout. Also, copying and pasting nodes considers the currently selected layout, when copying *and* when pasting.
 
 ## Layout change messages
 
-When the engine switches layout as a result of device rotation, a message `layout_changed` is posted to the GUI components' scripts that are affected by the change. The message contains the hashed id of the layout so script can perform logic depending on which layout is selected:
+When the engine switches layout as a result of device rotation, a `layout_changed` message is posted to the GUI components' scripts that are affected by the change. The message contains the hashed id of the layout so the script can perform logic depending on which layout is selected:
 
 ```lua
 function on_message(self, message_id, message, sender)
@@ -72,7 +72,7 @@ In addition, the current render script receives a message whenever the window (g
 ```lua
 function on_message(self, message_id, message)
     if message_id == hash("window_resized") then
-      -- The window was resized. message.width and message.height contains the
+      -- The window was resized. message.width and message.height contain the
       -- new dimensions of the window.
     end
 end

--- a/docs/en/manuals/gui-pie.md
+++ b/docs/en/manuals/gui-pie.md
@@ -5,11 +5,11 @@ brief: This manual explains how to use pie nodes in Defold GUI scenes.
 
 # GUI pie nodes
 
-Pie nodes can be used to create circular or ellipsoid objects. In its simplest form, a pie node is simply a circle or ellipse inscribed in the node bounding box. If the width and height is identical, the circle's diameter will be that value. If the width and height differ, the node is instead an ellipse with the node width being the horizontal extent of the ellipse and the height being the vertical extent. The texture set for the node is applied straight, with the corners of the texture correlating to the corners of the node bounding box.
+Pie nodes can be used to create circular or ellipsoid objects. In its simplest form, a pie node is simply a circle or ellipse inscribed in the node bounding box. If the width and height are identical, the circle's diameter will be that value. If the width and height differ, the node will instead be an ellipse with the node width being the horizontal extent of the ellipse and the height being the vertical extent. The texture set for the node is applied straight, with the corners of the texture correlating to the corners of the node bounding box.
 
 ![Pie node](images/gui/gui_pie_create.png)
 
-Pie nodes have a set of properties that makes it possible to use them to create a wide range of shapes. All of these properties can be changed programmatically (see [GUI API documentation](/ref/gui) for details) and some can be animated.
+Pie nodes have a set of properties that make it possible to use them to create a wide range of shapes. All of these properties can be changed programmatically (see [GUI API documentation](/ref/gui) for details) and some can be animated.
 
 ![Pie properties](images/gui/gui_pie_properties.png)
 
@@ -23,11 +23,11 @@ Perimeter vertices
 : The number of segments that will be used to build the shape, expressed as the number of vertices required to fully circumscribe the 360 degree perimeter of the node.
 
 Pie fill angle
-: How much of the pie should be filled. Expressed as an counter-clockwise angle starting from the right.
+: How much of the pie should be filled. Expressed as a counter-clockwise angle starting from the right.
 
 ![Radius and angle](images/gui/gui_pie_radius_angle.png)
 
-The *Outer bounds* extend the shape to the node bounding box. Together with an *Inner radius* and/or a *Pie fill angle*, some pretty complex shapes can be created.
+The *Outer bounds ▸ Rectangle* option extends the shape to the node bounding box. Together with an *Inner radius* and/or a *Pie fill angle*, some pretty complex shapes can be created.
 
 ![Rectangle bounds](images/gui/gui_pie_rectangular.png)
 

--- a/docs/en/manuals/gui-spine.md
+++ b/docs/en/manuals/gui-spine.md
@@ -50,7 +50,7 @@ The individual bones in the Spine skeleton exist as GUI nodes. The nodes are nam
 
 ![Spine bone names](images/gui/gui_spine_bones.png)
 
-To, for instance, attach another node to an existing bone node, fetch the bone node by name with the [`gui.get_spine_bone()`](/ref/gui#gui.get_spine_bone) and attach the child:
+For instance, to attach another node to an existing bone node, fetch the bone node by name with [`gui.get_spine_bone()`](/ref/gui#gui.get_spine_bone) and attach the child to it:
 
 ```lua
 -- Attach a text node to the tail of the cat
@@ -60,7 +60,7 @@ local tail = gui.get_spine_bone(cat, "tail")
 gui.set_parent(textnode, tail)
 ```
 
-All bones are also accessible through [`go.get_node()`](/ref/gui#gui.get_node), by the bone name prefixed by the name of the name of the Spine node and a slash (`/`):
+All bones are also accessible through [`gui.get_node()`](/ref/gui#gui.get_node), by the bone name prefixed by the name of the name of the Spine node and a slash (`/`):
 
 ```lua
 -- Attach a text node to the tail of the cat

--- a/docs/en/manuals/gui-templates.md
+++ b/docs/en/manuals/gui-templates.md
@@ -7,7 +7,7 @@ brief: This manual explains the Defold GUI template system that is used to creat
 
 GUI templates provide a simple but powerful mechanism to create reusable visual GUI components based on shared templates or "prefabs". This manual explains the feature and how to use it.
 
-GUI templates are GUI scenes that are inserted into another GUI scene as a compound node, much like sub-collections can be placed inside other collections. But while a placed sub-collection can override the position of the sub-collection's root and any defined script-properties, a GUI template node can override any property values. Also, like sub-collections, GUI template nodes does not exist as a runtime concept, only as an editing tool.
+GUI templates are GUI scenes that are inserted into another GUI scene as a compound node, much like sub-collections can be placed inside other collections. But while a placed sub-collection can override the position of the sub-collection's root and any defined script-properties, a GUI template node can override any property values. Also, like sub-collections, GUI template nodes do not exist as a runtime concept, only as an editing tool.
 
 ## Creating and using a template
 
@@ -15,11 +15,11 @@ Since a GUI template is a plain GUI scene, there's nothing special about how the
 
 ![Button template](images/gui-templates/gui-templates-button.png)
 
-Now we can add any number of instances of the button to another GUI scene. Create or open a new scene and select <kbd>Gui ▸ Add Template Node</kbd>, alternatively right-click *Nodes* in the *Outline* and select <kbd>Add Template</kbd> from the drop-down.
+Now we can add any number of instances of the button to another GUI scene. Create or open a new scene, then select <kbd>Gui ▸ Add Template Node</kbd> or right-click *Nodes* in the *Outline* and select <kbd>Add Template</kbd> from the drop-down.
 
 ![Add template](images/gui-templates/gui-templates-add-template.png)
 
-Select the GUI scene file to use as template, in this case *button.gui*. You can add any number of nodes, each an instance based on the same template. If we change the template, each instance updates immediately in the editor, reflecting the changes. Notice that all nodes present in the template node are accessible in the *Outline* view. Nodes under a template node are automatically named with a prefix "[template node id]/".
+Select the GUI scene file to use as a template, in this case *button.gui*. You can add any number of nodes, each an instance based on the same template. If we change the template, each instance updates immediately in the editor, reflecting the changes. Notice that all nodes present in the template node are accessible in the *Outline* view. Nodes under a template node are automatically named with a prefix "[template node id]/".
 
 ![Node instances](images/gui-templates/gui-templates-instances.png)
 
@@ -33,7 +33,7 @@ Each instance node can overload any of the properties set in the template. Simpl
 
 ## Layers
 
-Layers behave as expected. Any property settings done to a particular layout in the template file is reflected in the layout of the instance nodes, given that the layer exists. Conversely, overloads to the template node instances affects the layer that is currently selected.
+Layers behave as expected. Any property settings done to a particular layout in the template file are reflected in the layout of the instance nodes, given that the layer exists. Conversely, overloads to the template node instances affect the layer that is currently selected.
 
 ![Overloading in layers](images/gui-templates/gui-templates-layers.png)
 
@@ -47,4 +47,4 @@ if gui.pick_node(gui.get_node("button_ok/frame"), x, y) then
 end
 ```
 
-Note though that there is no template node present during runtime. All nodes under a template node are added to the game but the template node itself exists only in the editor. Also, if you add a script to the template GUI scene, the script will be ignored, only one script is tied to each GUI scene and is set on the scene root node in the *Outline* view as usual.
+Note that there is no template node present during runtime. All nodes under a template node are added to the game but the template node itself exists only in the editor. Also, if you add a script to the template GUI scene, the script will be ignored, only one script is tied to each GUI scene and is set on the scene root node in the *Outline* view as usual.

--- a/docs/en/manuals/gui-text.md
+++ b/docs/en/manuals/gui-text.md
@@ -22,11 +22,11 @@ Text nodes have a set of special properties:
 : This property contains the text displayed.
 
 *Line Break*
-: Text alignment follows the pivot setting and setting the this property allows the text to flow over several lines. The width of the node determines where the text will wrap.
+: Text alignment follows the pivot setting and setting this property allows the text to flow over several lines. The width of the node determines where the text will wrap.
 
 ## Alignment
 
-By setting the node pivot you can change the adjust mode for the text.
+By setting the node pivot you can change the alignment mode for the text.
 
 *Center*
 : If the pivot is set to `Center`, `North` or `South`, the text is center-aligned.

--- a/docs/en/manuals/gui.md
+++ b/docs/en/manuals/gui.md
@@ -17,7 +17,7 @@ A graphical user interface in Defold is a game object component that you build a
 The GUI is not part of the collection’s coordinate system but is rendered independently of the game view. Because of this it is not placed in a particular location in the collection editor, nor does it have a visual representation in the collection editor. However, GUI components have to reside in a game object that has a location in a collection. Changing that location has no effect on the GUI.
 
 ::: important
-The rendering behavior can be changed in the render script but it is usually desirable to use this arrangement since the user interface is a separate visual "layer" on top of the game view and you usually want HUD items and menus on certain spots on screen.
+The rendering behavior can be changed in the render script but it is usually desirable to use the default arrangement since the user interface is a separate visual "layer" on top of the game view and you usually want HUD items and menus on certain spots on screen.
 :::
 
 ## Nodes
@@ -61,7 +61,7 @@ Each of these properties can also be animated in script (see [Property animation
 
 You can use images and animations from texture atlases or tile sources as part of your GUI interface component. To do so, an image resource (atlas or tile source) must first be added, then all images and animations included in the resource can be applied to GUI nodes. You add textures either by right clicking the *Textures* folder, through the <kbd>GUI</kbd> top menu, or with keyboard shortcuts.
 
-Textures that has been added to the GUI can be applied to box and pie nodes.
+Textures that have been added to the GUI can be applied to box and pie nodes.
 
 ![Textures](images/gui/gui_texture.png)
 
@@ -77,7 +77,7 @@ Box nodes are always rendered, even if they do not have a texture assigned to th
 
 ## Slice-9 texturing
 
-Many GUIs and HUDs feature elements that are context sensitive in regards to their size. Panels and dialogs often need to be resized to fit the containing content and that will cause problems as soon as you apply texturing to the scaled node. Let's say that you want to use a large set of buttons where the width is determined by the amount of text you write on the button. Making a box node, applying a texture and then scale it will result in deformation:
+Many GUIs and HUDs feature elements that are context sensitive in regard to their size. Panels and dialogs often need to be resized to fit the containing content and that will cause problems as soon as you apply texturing to the scaled node. Let's say that you want to use a large set of buttons where the width is determined by the amount of text you write on the button. Making a box node, applying a texture and then scaling it will result in deformation:
 
 ![GUI bad scaling](images/gui/gui_scaling.png)
 
@@ -105,7 +105,7 @@ It might also be tempting to use a 1 pixel wide bottom or top edge segment to sa
 
 ## Index: rendering order
 
-All nodes are rendered in the order they are listed under the "Nodes" folder. The node on top of the list is drawn first and will appear behind any other node. The last node in the list is drawn last, meaning it will appear in front of all other nodes. Drag nodes in the list to change their index order. You can also change and group the ordering of nodes with layers (see below).
+All nodes are rendered in the order they are listed under the "Nodes" folder. The node on top of the list is drawn first and will appear behind every other node. The last node in the list is drawn last, meaning it will appear in front of all other nodes. Drag nodes in the list to change their index order. You can also change and group the ordering of nodes with layers (see below).
 
 If you set the Z-value on a node the draw order will not change. The Z-values on nodes are ignored.
 
@@ -177,7 +177,7 @@ You create a GUI Script File in your project and attach it to the GUI component 
 
 ![Script](images/gui/gui_script.png)
 
-The script file is by default equipped with functions just as game object scripts:
+The script file is by default equipped with functions just like game object scripts:
 
 ```lua
 function init(self)
@@ -212,7 +212,7 @@ end
 
 ```
 
-GUI components can thus receive input and messages just as game objects. You send messages to a GUI component by addressing the component in the fragment part of the URL:
+GUI components can thus receive input and messages just like game objects. You send messages to a GUI component by addressing the component in the fragment part of the URL:
 
 ```lua
 local msgdata = { score = 4711, stars = 3, health = 6 }
@@ -223,9 +223,9 @@ msg.post("hud#gui", "set_stats", msgdata)
 
 GUI components are rendered separately and on top of other game content and there are some mechanisms in place to make life easier for game developers that target device that have screens of different resolutions and aspect ratios.
 
-Your Defold game project specifies a target resolution in the *game project* settings, however one or more of your target devices might have a different screen resolution and aspect ratio. In this case this means that your game will be up- or downscaled to fit the target screen.
+Your Defold game project specifies a target resolution in the *game project* settings; however, one or more of your target devices might have a different screen resolution and aspect ratio. In this case this means that your game will be up- or downscaled to fit the target screen.
 
-Defold deals with the scaling of any GUI components differently to other game content. It also provides you with a set of simple, but powerful tools to lay out your user interface independently of resolution and/or aspect ratio.
+Defold deals with the scaling of any GUI components differently to other game content. It also provides you with a set of simple but powerful tools to lay out your user interface independently of resolution and/or aspect ratio.
 
 Let’s illustrate with a little experiment and create a game app with a GUI. The display size is set to a square with dimensions 1024x1024. The game contains a GUI component with a level menu on top of some imagery. This is how it looks when run on a computer:
 
@@ -235,7 +235,7 @@ Now, if we run the same app on the iPad (with a very different screen size and a
 
 ![iPad square](images/gui/gui_ipad.png)
 
-We see that on the iPad the game is stretched out to fill the screen. The octopus in the background is deformed, but the GUI elements are not. The text nodes are rendered with the correct aspect ratio and keeps their location in the center of the screen.
+We see that on the iPad the game is stretched out to fill the screen. The octopus in the background is deformed, but the GUI elements are not. The text nodes are rendered with the correct aspect ratio and keep their location in the center of the screen.
 
 You can easily simulate changes to the screen resolution and aspect ratio by changing the window size of your running Defold game. Running the game on a device with a different resolution and aspect ratio is equivalent to changing the window. When the window changes size it triggers redrawing and re-positioning of GUI components, according to a set of adjustment and anchoring rules that give you good control over your user interface layout.
 
@@ -265,7 +265,7 @@ Now let’s see what happens to the box nodes when the window is resized:
 
 The `Stretch` node is just deformed to the new shape whereas the `Fit` and `Zoom` nodes keep their aspect ratio. The `Fit` node is fit inside the would-be reshaped bounding box (the grid square that it's in) and the `Zoom` node covers the would-be reshaped bounding box.
 
-Text nodes behave in exactly the same way. The adjust mode applies to the invisible text bounding box that controls the shape of the text.
+Text nodes behave in exactly the same way. The adjust mode applies to the invisible bounding box that controls the shape of the text.
 
 ## Anchors
 
@@ -299,17 +299,17 @@ In practice this means that if you set the Xanchor property to `Right` and the Y
 
 ![Anchor top right](images/gui/gui_anchor_topright.png)
 
-This example shows a node that has `Top` and `Right` anchoring. It is `Fit` adjusted and has *Pivot* set to `North East`. When the window stretch, the node is fit inside the "would-be" reshaped box (the blue dotted rectangle) and also anchored.
+This example shows a node that has `Top` and `Right` anchoring. It is `Fit` adjusted and has *Pivot* set to `North East`. When the window stretches, the node is fit inside the "would-be" reshaped box (the blue dotted rectangle) and also anchored.
 
 ## Pivot
 
-Each node has a position, scale and rotation inside the GUI coordinate system. A node is placed on that position so that its pivot is at the set coordinate and any rotation is done around that same pivot. For text nodes the text will be aligned according to the pivot setting.
+Each node has a position, rotation and scale inside the GUI coordinate system. A node is placed so that its pivot is at the set coordinate and any rotation is done around that same pivot. For text nodes the text will be aligned according to the pivot setting.
 
-The default positioning and rotation of nodes happen against the center of the node—it has the *Pivot* property set to `Center`. You can change the pivot of a node to any of one of the following settings:
+The default positioning and rotation of nodes happens against the center of the node---it has the *Pivot* property set to `Center`. You can change the pivot of a node to any of one of the following settings:
 
 * `Center`
 * `North`, `South`, `East`, `West`
-* `North` West, `North East`, `South West`, `South East`
+* `North West`, `North East`, `South West`, `South East`
 
 The following image illustrates the position of each pivot setting:
 
@@ -393,9 +393,9 @@ See [`go.animate()`](/ref/go#go.animate) for details on the parameters.
 
 The `property` parameter is usually given as a constant (`gui.PROP_POSITION` etc), but can also be supplied as described in the Properties guide (see [Properties](/manuals/properties)). This is handy if you want to animate just a specific component of a compound property value.
 
-For instance, the `color` property describes a, RGBA value, encoded in a vector4 value with one component for each color component red, green and blue, and the last one for alpha. The vector components are named respectively `x`, `y`, `z` and `w` and the alpha is thus in the `w` component.
+For instance, the `color` property describes an RGBA value, encoded in a vector4 value with one component for each color component---red, green, blue and the last one for alpha. The vector components are named respectively `x`, `y`, `z` and `w` and the alpha is thus in the `w` component.
 
-To fade up and down the alpha value of a node we can do that with the following piece of code:
+To fade up and down the alpha value of a node we can use the following piece of code:
 
 ```lua
 function fadeup(self, node)
@@ -407,7 +407,7 @@ function fadedown(self, node)
 end
 ```
 
-Now we can call either `fadeup()` or `fadedown()` and supply the node we want the alpha animated on. Note that we set the `complete_function` parameter to supply the function to call when the animation is done, effectively chaining an endless loop of fade up and fade downs.
+Now we can call either `fadeup()` or `fadedown()` and supply the node we want the alpha animated on. Note that we set the `complete_function` parameter to supply the function to call when the animation is done, effectively chaining an endless loop of fade ups and fade downs.
 
 ## Render script
 
@@ -446,4 +446,3 @@ render.draw(self.text_pred)
 This now affects all GUI components that are rendered. Here’s a version of our previous level menu with the modified render-script:
 
 ![Render script](images/gui/gui_renderscript.png)
-

--- a/docs/en/manuals/html5.md
+++ b/docs/en/manuals/html5.md
@@ -118,7 +118,7 @@ onSetProgress(current, max)
 
 
 onDismissSplash()
-: This callback is invoked by the application when the application is loaded and it is about to begin execution and render to the canvas (i.e. the splash screen should be dismisses).
+: This callback is invoked by the application when the application is loaded and it is about to begin execution and render to the canvas (i.e. the splash screen should be dismissed).
 
 
 The default implementation also contains logic to deal with window resizing events. If you wish to change or replace the implementation, the main module provides two helper functions:

--- a/docs/en/manuals/iap.md
+++ b/docs/en/manuals/iap.md
@@ -5,13 +5,13 @@ brief: In-app purchases (or in-app billing) allows you to charge your players or
 
 # In-app purchases
 
-Defold provides a unified, simple to use interface to Apple's iOS Appstore "in-app purchases" and Google Play's or Amazon's "in-app billing" on Android devices. Facebook Canvas "game payments" is supported for Facebook Canvas. These services gives you the opportunity to sell products as:
+Defold provides a unified, simple to use interface to Apple's iOS Appstore "in-app purchases" and Google Play's or Amazon's "in-app billing" on Android devices. Facebook Canvas "game payments" are supported for Facebook Canvas. These services gives you the opportunity to sell products as:
 
 * Standard in-app products (one time billing) of consumables or non-consumables and
 * Subscriptions (recurring, automated billing)
 
 ::: important
-The current Defold interface allows full interaction with Apple's Storekit functionality. For Google Play and Facebook Canvas, the interface is identical, meaning that you can run the same code on either platform. However, some process flow might differ from platform to platform. Also note that there is currently no support for OS X purchases through Mac Appstore.
+The current Defold interface allows full interaction with Apple's Storekit functionality. For Google Play and Facebook Canvas, the interface is identical, meaning that you can run the same code on either platform. However, some process flow might differ from platform to platform. Also note that there is currently no support for OS X purchases through the Mac Appstore.
 :::
 
 Detailed documentation from Apple, Google, Amazon and Facebook can be found here:
@@ -50,7 +50,7 @@ The procedure on iOS and Android is similar:
 
     ![iTunes Connect and Google Play Dev Console](images/iap/itunes_connect_google_play.png)
 
-4. For Google Play, you need to _upload and publish_ an alpha *.apk* file. For iTunes Connect, you should _not upload_ the development binary to iTunes Connect until the application is ready for App Review approval. If you upload a not binary to iTunes Connect and it is not fully functional, Apple will likely reject it.
+4. For Google Play, you need to _upload and publish_ an alpha *.apk* file. For iTunes Connect, you should _not upload_ the development binary to iTunes Connect until the application is ready for App Review approval. If you upload a binary to iTunes Connect and it is not fully functional, Apple will likely reject it.
 
 5. Create products for your app.
 
@@ -60,7 +60,7 @@ The procedure on iOS and Android is similar:
 
 6. Add test users.
     - The iTunes Connect page *Users and Roles* allow you to add users that can do test purchases in the _sandbox environment_. You should sign your app with a Developer certificate and use the sandbox account in Appstore on the test device.
-    - On Google Play Developer Console, choose *Settings > Account Details* where you can add user emails to the License Testing section. Separate the emails by commas. This allows your testers to use test purchases that don’t actually cost real money.
+    - From the Google Play Developer Console, choose *Settings > Account Details* where you can add user emails to the License Testing section. Separate the emails by commas. This allows your testers to use test purchases that don’t actually cost real money.
     - On Google Play, you also need to set up a Google Group for your testers. Google uses Groups to manage testers that can download your app from the Alpha and Beta stores. Click on the *Alpha Testing* tab and then *Manage list of testers* to add your Google Group as Alpha testers. The app must have passed through alpha publishing before you can see the opt-in link.
 
 ![Alpha testers](images/iap/alpha_testers.png)
@@ -151,13 +151,13 @@ Most payment providers only supports synchronous payments. This means that the c
 
 ## Asynchronous payments
 
-Some payment providers requires supporting asynchronous payments. This means that the client (your application) will only receive a notification when the payment is initiated. In order to verify completion of payment, further communication have to be done from developer server (or client) with the payment provider in order to verify.
-In the case of an initiated asynchronous payment the iap listener will receive the state TRANS_STATE_UNVERIFIED to indicate this (as opposed to TRANS_STATE_PURCHASED). This is the final state of the payment, meaning no more callbacks will be done on this transaction.
+Some payment providers require supporting asynchronous payments. This means that the client (your application) will only receive a notification when the payment is initiated. In order to verify completion of payment, further communication needs to be done between the developer server (or client) and the payment provider in order to verify.
+In the case of an initiated asynchronous payment the IAP listener will receive the state TRANS_STATE_UNVERIFIED to indicate this (as opposed to TRANS_STATE_PURCHASED). This is the final state of the payment, meaning no more callbacks will be done on this transaction.
 
 ## Purchase fulfillment
 
 In order to complete a purchase from a payment provider, the application needs to signal a purchase fulfillment to the provider telling the provider the purchase has gone through (for example by developer server-side verification).
-Iap support both auto-completion where fulfillment is automatically signaled to the provider when a purchase is complete (this is the default behavior). You can also disable the auto completion in the game project settings. You are then required to call iap.finish() when the transaction is complete, which will signal purchase fulfillment to the provider.
+IAP supports auto-completion, where fulfillment is automatically signaled to the provider when a purchase is complete (this is the default behavior). You can also disable auto-completion in the game project settings. You are then required to call iap.finish() when the transaction is complete, which will signal purchase fulfillment to the provider.
 
 ## Transaction receipt
 
@@ -166,19 +166,19 @@ The receipt is a signed chunk of data that can be sent to the App Store to verif
 ## Troubleshooting
 
 Android `iap.list()` returns "failed to fetch product"
-: You need to upload and publish an *.apk* on the alpha or beta channels on Google Play Developer Console. Also make sure that the _time and date_ on your device is correct.
+: You need to upload and publish an *.apk* on the alpha or beta channels on the Google Play Developer Console. Also make sure that the _time and date_ on your device is correct.
 
 iOS `iap.list()` returns nothing
 : Make sure that you’ve requested an iOS Paid Applications account, and all proper documentation has been filed. Without proper authorization, your iOS app purchasing (even test purchases) will not work.
 
   Check that the AppId you have on the "Member Center" has in-app purchases activated and that you are signing your app (or the dev-app) with a provisioning profile that is up to date with the AppId (check the "Enabled Services:" field in the provisioning profile details in the "Certificates, Identifiers & Profiles" area of "Member Center")
 
-  Wait. It can take a few hours for the In-App product IDs are propagated to the Sandbox environment.
+  Wait. It can take a few hours for the In-App product IDs to propagate to the Sandbox environment.
 
 iOS `iap.list()` fails logging error "Unexpected callback set"
-: iap.list does not support nested calls. Calling iap.list from an iap.list callback function will be ignored with the engine logging this error.
+: iap.list does not support nested calls. Calling iap.list from an iap.list callback function will be ignored, with the engine logging this error.
 
 On iOS, the "price_string" field contains '~' characters
-: The '~' characters are placeholders where no matching character could be found in the font file. The "price_string" field returned in the product list when using `iap.list()` is formatted with _non breaking space_ (`\u00a0`) between the value and the currency denominator. If you render this string in the GUI, you need to add the character to the font's *extra_characters* field. On Mac OS X you can type non breaking spaces by pressing <kbd>Option + SPACE</kbd>. See http://en.wikipedia.org/wiki/Non-breaking_space for more information.
+: The '~' characters are placeholders where no matching character could be found in the font file. The "price_string" field returned in the product list when using `iap.list()` is formatted with a _non breaking space_ (`\u00a0`) between the value and the currency denominator. If you render this string in the GUI, you need to add the character to the font's *extra_characters* field. On Mac OS X you can type non breaking spaces by pressing <kbd>Option + SPACE</kbd>. See http://en.wikipedia.org/wiki/Non-breaking_space for more information.
 
 

--- a/docs/en/manuals/input.md
+++ b/docs/en/manuals/input.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Device input in Defold
 brief: This manual explains how you capture input actions and create interactive script reactions.
 ---
@@ -20,11 +20,11 @@ On Windows, only XBox 360 controllers are currently supported. To hook up your 3
 
 All user input is captured by the engine and dispatched as actions to script- and GUI script components in game objects that have acquired input focus and that implement the `on_input()` function.
 
-Before the input reaches your script it is translated through input bindings into meaningful actions:
+Before the input reaches your scripts it is translated through input bindings into meaningful actions:
 
 ![Input bindings](images/input/input_bindings.png)
 
-Depending on the components that have acquired input focus, and whether they consume this input or pass it on, the input may or may not reach a specific component's `on_input()`. We will look at how this works in detail below.
+Depending on which components have acquired input focus and whether they consume this input or pass it on, the input may or may not reach a specific component's `on_input()`. We will look at how this works in detail below.
 
 ## Input bindings
 
@@ -43,7 +43,7 @@ There are five types of triggers that you can create. They are device specific:
 Right click on a trigger type and select <kbd>Add [TYPE]\_trigger...</kbd> to add a new trigger. Each trigger has two fields:
 
 *input*
-: A scroll list with the available inputs to listen to.
+: The raw input to listen for, selected from a scroll list of available inputs.
 
 *action*
 : The action name given to input actions when they are created and dispatched to your scripts. It is fine to have the same action names assigned to multiple actions. For instance, it is convenient to be able to bind the <kbd>Space</kbd> key to the action `jump` and the gamepad "A" button to the same action name.
@@ -56,7 +56,7 @@ For instance, to set up key bindings for movement left and right for a game, you
 
 ![Input key bindings](images/input/input_key_bindings.png)
 
-Here, the inputs `KEY_LEFT` (the left arrow key on the keyboard) and `KEY_RIGHT` (the right arrow key) are bound to the action names `move_left` and `move_right` respectively. The benefit of separating the hardware input from the logical actions is that if you decide later on that you want to change which hardware inputs trigger what actions, there is only one place to modify.
+Here, the inputs `KEY_LEFT` (the left arrow key on the keyboard) and `KEY_RIGHT` (the right arrow key) are bound to the action names `move_left` and `move_right` respectively. The benefit of separating the hardware input from the logical actions is that if you decide later on that you want to change which hardware inputs trigger what actions, you only have to modify it in one place.
 
 ## Acquiring and releasing input focus
 
@@ -115,7 +115,7 @@ When working with collection proxies it is imperative to understand how input is
 
 ## Action fields
 
-The `action` parameter sent to `on_input()` for each input message is a Lua table containing useful data like the value of the input, the position of the input, whether button input was `pressed`, `repeated` or `released`.
+The `action` parameter sent to `on_input()` for each input message is a Lua table containing useful data like the value of the input, the position of the input and whether button input was `pressed`, `repeated` or `released`.
 
 `action.pressed`
 : `true` the first frame the input was detected, otherwise `false`.
@@ -133,7 +133,7 @@ See [on_input()](/ref/go#on_input) for details on the available action fields.
 
 ## Screen positions
 
-Mouse and touch input set fields in the `action` table for location (`x` and `y`) as well as movement (`dx` and `dy`). These inputs also set specific fields that are calculated against the real screen space. These fields are called:
+Mouse and touch inputs set fields in the `action` table for location (`x` and `y`) as well as movement (`dx` and `dy`). These inputs also set specific fields that are calculated against the real screen space. These fields are called:
 
 `screen_x` and `screen_y`
 : The real screen position
@@ -145,14 +145,14 @@ These fields are useful on devices where the screen pixel position differs from 
 
 ## Key triggers
 
-Key triggers are simple one-key inputs that acts as button input. They are useful for games that needs to tie specific buttons to specific functions, like the `move_left` and `move_right` button setup above. If you need to read arbitrary key input, use text triggers (see below).
+Key triggers are simple one-key inputs that act as button inputs. They are useful for games that need to tie specific buttons to specific functions, like the `move_left` and `move_right` button setup above. If you need to read arbitrary key input, use text triggers (see below).
 
 ## Mouse triggers
 
-Mouse triggers come in two forms. The first one is mouse button and wheel input that you set up in your input bindings.
+Mouse input comes in two forms. First there are mouse button and wheel inputs, which are set up in your input bindings just like key triggers; then there is mouse movement input, which is handled differently (see below).
 
 Mouse button inputs
-: Use these to detect mouse presses.
+: Use these to detect mouse button presses.
 
   Note that the inputs `MOUSE_BUTTON_LEFT`, `MOUSE_BUTTON_RIGHT` and `MOUSE_BUTTON_MIDDLE` are equivalent to `MOUSE_BUTTON_1`, `MOUSE_BUTTON_2` and `MOUSE_BUTTON_3`.
 
@@ -161,14 +161,14 @@ Currently, `MOUSE_BUTTON_LEFT` (or `MOUSE_BUTTON_1`) input actions are sent for 
 :::
 
 Mouse wheel inputs
-: Use these to detect scroll actions. The field `action.value` is `1` if the wheel is scrolled and `0` otherwise. (Scroll actions are dealt with as they were button presses. Defold do not currently support fine grained scroll input on touch pads.)
+: Use these to detect scroll actions. The field `action.value` is `1` if the wheel is scrolled and `0` otherwise. (Scroll actions are dealt with as they were button presses. Defold does not currently support fine grained scroll input on touch pads.)
 
 Mouse movement
-: Mouse movement cannot be bound in the input bindings, and does not set the `action_id` to a name. Instead, the `action_id` is set to `nil` and the `action` table is populated with the location and delta movement of the mouse position. Note that mouse movement events are not received unless at least one mouse trigger is set up in your input bindings. 
+: Mouse movement cannot be bound in the input bindings, and does not set the `action_id` to a name. Instead, the `action_id` is set to `nil` and the `action` table is populated with the location and delta movement of the mouse position. Note that mouse movement events are not received unless at least one mouse trigger is set up in your input bindings.
 
 ## Gamepad triggers
 
-The gamepad triggers allows you to bind standard gamepad input to game functions. Defold supports multiple gamepads through the host operating system and offers bindings for:
+Gamepad triggers allow you to bind standard gamepad input to game functions. Defold supports multiple gamepads through the host operating system and offers bindings for:
 
 1. Left and right sticks (direction and clicks)
 2. Left and right digital pads
@@ -224,10 +224,10 @@ Here, a component "factory" is used to spawn a simple particle effect with `fact
 
 ## Text triggers
 
-Text triggers allows you to read arbitrary text input. There are two types of text triggers:
+Text triggers allow you to read arbitrary text input. There are two types of text triggers:
 
 `TEXT`
-: This input triggers captures normal text input.
+: This input trigger captures normal text input.
 
   A text trigger sets the `text` field of the action table to a string containing the typed character. The action is only fired at the press of the button, no `release` or `repeated` action is sent.
 
@@ -266,11 +266,11 @@ Text triggers allows you to read arbitrary text input. There are two types of te
 
 ## The input stack
 
-Any game object that acquires input focus is put first in the list of objects that listens to input. This list is called the *input stack*. Input actions are dispatched to the top object's components first and actions then trickles further down the stack to other components that listens to input:
+Any game object that acquires input focus is put first in the list of objects that listen to input. This list is called the *input stack*. Input actions are dispatched to the top object's components first and actions then trickle further down the stack to other components that listen to input:
 
 ![Input stack](images/input/input_stack.png)
 
-Dispatch of actions happen within the same frame so unless you deliberately control the dispatch of actions down the stack (see "Consuming input" below) it will appear as if all listening components' `on_input()` functions will receive actions simultaneously.
+All actions are dispatched within the same frame so unless you deliberately control the dispatch of actions down the stack (see "Consuming input" below) it will appear as if all listening components' `on_input()` functions will receive actions simultaneously.
 
 ## Stack order
 
@@ -317,7 +317,7 @@ Running this code will result in an input stack ordered like this:
 
 A component's `on_input()` code can actively control whether actions should be passed on down the stack or not:
 
-1. If the component `on_input()` code returns `false`, or if there is no return statement in the code (an omitted return statement implies a `nil` return which is a false value in Lua) input actions will be passed on to the next game object on the input stack.
+1. If the component's `on_input()` code returns `false`, or if there is no return statement in the code (an omitted return statement implies a `nil` return which is a false value in Lua) input actions will be passed on to the next game object on the input stack.
 2. If any of a game object components' scripts return `true` in its `on_input()` then the input is consumed and not passed on to other objects further down the input stack.
 
 ::: sidenote
@@ -365,7 +365,7 @@ The pause menu GUI runs the following code:
 
 ```lua
 function init(self)
-    -- Fetch background node and disable.
+    -- Fetch background node and disable it.
     -- Everything is childed under it.
     local node = gui.get_node("background")
     gui.set_enabled(node, false)
@@ -416,9 +416,9 @@ The `on_input()` function of the pause menu GUI script returns `true` as long as
 
 ## Input and Collection Proxies
 
-The input stack is actually not global--there exist a separate local input stack for each collection. If you use collection proxies to structure your game it is imperative to understand how input is dispatched through collections.
+The input stack is actually not global---there exists a separate local input stack for each collection. If you use collection proxies to structure your game it is imperative to understand how input is dispatched through collections.
 
-When input actions are passed on down the current collection's input stack and reaches a game object that contain a collection proxy component that is enabled, those actions will continue down the input stack of the dynamically loaded collection before they continue down the main collection's stack. The following diagram clarifies the process:
+When input actions are passed on down the current collection's input stack and reach a game object that contains a collection proxy component that is enabled, those actions will continue down the input stack of the dynamically loaded collection before they continue down the main collection's stack. The following diagram clarifies the process:
 
 ![Input stack proxy](images/input/input_stack_proxy.png)
 

--- a/docs/en/manuals/introduction.md
+++ b/docs/en/manuals/introduction.md
@@ -5,15 +5,15 @@ brief: A brief introduction that covers the core concepts of Defold and is inten
 
 # Welcome to Defold
 
-Welcome to Defold. This introduction covers the core concepts of Defold and is intended to give an overview to the editor and the most important features. All descriptions are quite brief but there are links to more thorough documentation.
+Welcome to Defold. This introduction covers the core concepts of Defold and is intended to give an overview of the editor and the most important features. All descriptions are quite brief but there are links to more thorough documentation.
 
 ## Philosophy
 
-Defold is designed with a clear philosophy of simplicity. It is a turn-key production platform, but Defold does not try to provide all-encompassing solutions for everything. Instead, we believe the job of Defold is to empower you, the game creator, with simple, strong tools that allows you to realize your unique vision.
+Defold is designed with a clear philosophy of simplicity. It is a turn-key production platform, but Defold does not try to provide all-encompassing solutions for everything. Instead, we believe the job of Defold is to empower you, the game creator, with simple, strong tools that allow you to realize your unique vision.
 
 Sometimes that means that you have to do a bit more work yourself, but it also means that the path to the goal is clear. Ready made solutions seldom fit perfectly and when they don't it can be hard, or even impossible, to get them to work exactly the way you need them to.
 
-If you are an experienced developer, Defold's core concepts may be pretty straightforward to understand, but please take the time to read this overview carefully--some of our concepts are, even though simple, different from what you might initially expect.
+If you are an experienced developer, Defold's core concepts may be pretty straightforward to understand, but please take the time to read this overview carefully---some of our concepts are, even though simple, different from what you might initially expect.
 
 ## Scripts
 
@@ -33,13 +33,13 @@ Here, "explosion" is the name of the object's sound component where the script r
 
 Components communicate with each other and other systems through message passing. Components also respond to a set of predefined messages that alter them or trigger specific actions. You send messages to hide graphics, play sounds or nudge physics objects. The engine also uses messages to notify components of events, for instance when physics shapes collide.
 
-The message passing mechanism needs a recipient for each sent message. Therefore, everything in the game has an address, or an URL. Every game object and component has a unique URL which allows any two components in your app or game to send messages to each other.
+The message passing mechanism needs a recipient for each sent message. Therefore, everything in the game has an address, or URL. Every game object and component has a unique URL which allows any two components in your app or game to send messages to each other.
 
 See the [Message passing documentation](/manuals/message-passing) for an in depth explanation of how message passing works.
 
 ## Factories
 
-In some situations you cannot manually place all needed game objects in a collection, but you have to create the game objects dynamically, on the fly. For instance, a player might fire bullets and each shot should be dynamically spawned and sent off whenever the player presses the trigger. To create game objects dynamically (from a pre-allocated pool of objects), you use a factory component.
+In some situations you cannot manually place all needed game objects in a collection, you have to create the game objects dynamically, on the fly. For instance, a player might fire bullets and each shot should be dynamically spawned and sent off whenever the player presses the trigger. To create game objects dynamically (from a pre-allocated pool of objects), you use a factory component.
 
 ![Factory](images/introduction/introduction_factory.png)
 
@@ -54,7 +54,7 @@ Most games are created as a collaborative effort between two or more people. We 
 
 ![Collaboration](images/introduction/introduction_collaboration.png)
 
-When you create a new project, a central repository is automatically created on our servers. During development, the files you create and modify are your personal view of this repository. When you have done some work and is ready to share your changes, just synchronize your personal view with the central repository. The editor uploads your changes, downloads any new changes (from other team members) and helps resolve conflicts if you and someone else has edited the same piece of project data. All changes are recorded and logged so there is a clear history of what has happened in your project. You don't have to worry about backups and you will never need to email files back and forth with your team. Read more about project collaboration in the [Workflow documentation](/manuals/workflow/).
+When you create a new project, a central repository is automatically created on our servers. During development, the files you create and modify are your personal view of this repository. When you have done some work and are ready to share your changes, just synchronize your personal view with the central repository. The editor uploads your changes, downloads any new changes (from other team members) and helps resolve conflicts if you and someone else have edited the same piece of project data. All changes are recorded and logged so there is a clear history of what has happened in your project. You don't have to worry about backups and you will never need to email files back and forth with your team. Read more about project collaboration in the [Workflow documentation](/manuals/workflow/).
 
 Defold's collaboration tools are built on the popular and extremely powerful distributed version control system "Git". (If you're interested in Git, you can read more on http://git-scm.com).
 
@@ -76,7 +76,7 @@ Script
 : ![Script](images/icons/cog.png){.left} See above for a description of scripts.
 
 Sound
-: ![Sound](images/icons/sound.png){.left} The sound component is responsible for playing a specific sound. Currently, Defold supports soundfiles of the type WAV.
+: ![Sound](images/icons/sound.png){.left} The sound component is responsible for playing a specific sound. Currently, Defold supports sound files in the WAV and Ogg Vorbis formats.
 
 Collision object
 : ![Collision object](images/icons/weight.png){.left} Collision objects are components that extend game objects with physical properties (like spatial shape, weight, friction and restitution). These properties govern how the collision object should collide with other collision objects. The most common types of collision objects are kinematic objects, dynamic objects and triggers. A kinematic object gives detailed collision information that you have to manually respond to, a dynamic object is automatically simulated by the physics engine to obey Newtonian laws of physics. Triggers are simple shapes that detect if other shapes have entered or exited the trigger.
@@ -88,12 +88,12 @@ Sprite
 : ![Sprite](images/icons/pictures.png){.left} A sprite is a component that extends game objects with graphics. It displays an image either from a Tile source or from an Atlas. Sprites have built-in support for flip-book and bone animation. Sprites are usually used for characters and items. See the [2D graphics documentation](/manuals/2dgraphics) for more information.
 
 Atlas
-: ![Atlas](images/icons/pictures_atlas.png){.left} An atlas is a set of separate images that are compiled into a larger sheet for performance and memory reasons. You can store still images or flip-book animated series of images. Atlases are used by Sprite and ParticleFX components to share graphics resources. See the [2D graphics documentation](/manuals/2dgraphics) for more information.
+: ![Atlas](images/icons/pictures_atlas.png){.left} An atlas is a set of separate images that are compiled into a larger sheet for performance and memory reasons. They can contain still images or flip-book animated series of images. Atlases are used by Sprite and ParticleFX components to share graphics resources. See the [2D graphics documentation](/manuals/2dgraphics) for more information.
 
   ![Atlas](images/introduction/introduction_atlas.png)
 
 Tile source
-: ![Tile source](images/icons/small_tiles.png){.left} A tile source describes a texture that is composed of multiple smaller images, everyone with the same size. The component support flip-book animation. You can define animations over a sequence of images in the tile source. Tile sources can also automatically calculate collision shapes from image data. This is very useful for creating tiled levels that object can collide and interact with. Tile sources are used by Tile map (and Sprite and ParticleFX although Atlases are usually to prefer) components to share graphics resources. See the [2D graphics documentation](/manuals/2dgraphics) for more information.
+: ![Tile source](images/icons/small_tiles.png){.left} A tile source describes a texture that is composed of multiple smaller images, each with the same size. You can define flip-book animations from a sequence of images in a tile source. Tile sources can also automatically calculate collision shapes from image data. This is very useful for creating tiled levels that object can collide and interact with. Tile sources are used by Tile map (and Sprite and ParticleFX although Atlases are usually preferred) components to share graphics resources. See the [2D graphics documentation](/manuals/2dgraphics) for more information.
 
   ![Tile source](images/introduction/introduction_tilesource.png)
 
@@ -102,7 +102,7 @@ Tile source
   ![Tile source shape](images/introduction/introduction_tilesource_hull.png)
 
 Tile map
-: ![Tile map](images/icons/layer_grid.png){.left} Tile map components display images from a tile source in one or more overlaid grids. They are most commonly used to build game environments: ground, walls, buildings and obstacles. A tile map can display several layers aligned on top of each other with specified blend mode. This is useful to, for example, put foilage on top of grass background tiles. It is also possible to dynamically change the displayed image in a tile. That allows you to, for instance, destroy a bridge and make it impassable by simply replacing the tiles with ones depicting the broken down bridge and containing the corresponding physics shape.
+: ![Tile map](images/icons/layer_grid.png){.left} Tile map components display images from a tile source in one or more overlaid grids. They are most commonly used to build game environments: ground, walls, buildings and obstacles. A tile map can display several layers aligned on top of each other with a specified blend mode. This is useful to, for example, put foliage on top of grass background tiles. It is also possible to dynamically change the displayed image in a tile. That allows you to, for instance, destroy a bridge and make it impassable by simply replacing the tiles with ones depicting the broken down bridge and containing the corresponding physics shape.
 
   ![Tile map](images/introduction/introduction_tilemap.png)
 
@@ -114,7 +114,7 @@ ParticleFX
   ![ParticleFX](images/introduction/introduction_particlefx.png)
 
 GUI
-: ![GUI component](images/icons/text_allcaps.png){.left} A GUI component contains elements used to construct user interfaces: text and colored and/or textured blocks. Elements can be organized into hierarchial structures, scripted and animated. GUI components are typically used to create heads-up displays, menu systems and on-screen notifications. GUI components are controlled with GUI scripts that defines the behavior of the GUI and controls the user interaction with it. Read more in the [GUI documentation](/manuals/gui).
+: ![GUI component](images/icons/text_allcaps.png){.left} A GUI component contains elements used to construct user interfaces: text and colored and/or textured blocks. Elements can be organized into hierarchical structures, scripted and animated. GUI components are typically used to create heads-up displays, menu systems and on-screen notifications. GUI components are controlled with GUI scripts that define the behavior of the GUI and control the user interaction with it. Read more in the [GUI documentation](/manuals/gui).
 
   ![GUI](images/introduction/introduction_gui.png)
 
@@ -122,27 +122,27 @@ GUI script
 : ![GUI script](images/icons/cog.png){.left} GUI scripts are used to define the behaviour of GUI components. They control GUI animations and how the user interacts with the GUI.
 
 Font
-: ![Font file](images/icons/font.png){.left} A Font is built from a TrueType or OpenType font file. The Font specifies which size to render the font in and what type of decoration (outline and shadow) the rendered font should have. Fonts are used by GUI components.
+: ![Font file](images/icons/font.png){.left} A Font is built from a TrueType or OpenType font file. The Font specifies which size to render the font in and what type of decoration (outline and shadow) the rendered font should have. Fonts are used by GUI and Label components.
 
   ![Font](images/introduction/introduction_font.png)
 
 Input binding
-: ![Input binding](images/icons/keyboard.png){.left} Input binding files define how the game should interpret hardware input (mouse, keyboard, touchscreen and game pads). The file bind hardware input to high level input _actions_ like "jump" and "move_forward". In script components that listens to input you are then able to script the actions the game or app should take given certain input. See the [Input documentation](/manuals/input) for details.
+: ![Input binding](images/icons/keyboard.png){.left} Input binding files define how the game should interpret hardware input (mouse, keyboard, touchscreen and gamepad). The file binds hardware input to high level input _actions_ like "jump" and "move_forward". In script components that listen to input you are able to script the actions the game or app should take given certain input. See the [Input documentation](/manuals/input) for details.
 
   ![Input binding](images/introduction/introduction_input_binding.png)
 
 Camera
-: ![Camera](images/icons/camera.png){.left} Camera components helps to decide what part of the game world should be visible and how it should be projected. A common use case is to attach a camera to the player game object, or having a separate game object with a camera that follows the player around with some smoothing algorithm.
+: ![Camera](images/icons/camera.png){.left} Camera components help to decide what part of the game world should be visible and how it should be projected. A common use case is to attach a camera to the player game object, or to have a separate game object with a camera that follows the player around with some smoothing algorithm.
 
 Material
 : ![Material](images/icons/large_tiles.png){.left} Materials define how different objects should be rendered by specifying shaders and their properties.
 
 Render
-: ![Render](images/icons/paintcan.png){.left} Render files contains settings used when rendering the game to the screen. Render files define which Render script to use for rendering and which materials to use.
+: ![Render](images/icons/paintcan.png){.left} Render files contain settings used when rendering the game to the screen. Render files define which Render script to use for rendering and which materials to use.
 
 Render script
 : ![Render script](images/icons/cog.png){.left} A Render script is a Lua script that controls how the game or app should be rendered to the screen. There is a default Render script that covers most common cases, but you can write your own if you need custom lighting models and other effects.
 
 Collection proxy
-: ![Collection proxy](images/icons/bricks_proxy.png){.left} A Collection proxy is used to load and enable collections on the fly while an app or game is running. The most common use case for Collection proxies are to load levels as they are to be played. See the [Collection proxy documentation](/manuals/collection-proxy) for details.
+: ![Collection proxy](images/icons/bricks_proxy.png){.left} A Collection proxy is used to load and enable collections on the fly while an app or game is running. The most common use case for Collection proxies is to load levels as they are to be played. See the [Collection proxy documentation](/manuals/collection-proxy) for details.
 

--- a/docs/en/manuals/ios.md
+++ b/docs/en/manuals/ios.md
@@ -13,19 +13,19 @@ The security associated with iOS apps consists of several components. To get acc
 
 ![Apple Member Center](images/ios/apple_member_center.png)
 
-The section *Certificates, Identifiers & Profiles* contains all the tools you need. From here, you can create, delete and edit:
+The section *Certificates, Identifiers & Profiles* contains all the tools you need. From here you can create, delete and edit:
 
 Certificates
-: Apple issued cryptographic certificates that identifies you as a developer. You can create development or production certificates. Developer certificates allow you to test certain features such as the in-app purchase mechanism in a sandbox test environment. Production certificates are used to sign the final app for upload to the App Store. You need a certificate to sign apps before you can put them on your device for testing.
+: Apple-issued cryptographic certificates that identify you as a developer. You can create development or production certificates. Developer certificates allow you to test certain features such as the in-app purchase mechanism in a sandbox test environment. Production certificates are used to sign the final app for upload to the App Store. You need a certificate to sign apps before you can put them on your device for testing.
 
 Identifiers
-: Identifiers for various use. It is possible to register wildcard identifiers (i.e. `some.prefix.*`) which can be used with several apps. App IDs can contain Application Service information, like if the app enables Passbook integration, the Game Center etc. Such App IDs cannot be wildcard identifiers. For Application Services to function, your application's *bundle identifier* must match the App ID identifier.
+: Identifiers for various uses. It is possible to register wildcard identifiers (i.e. `some.prefix.*`) which can be used with several apps. App IDs can contain Application Service information, like if the app enables Passbook integration, the Game Center, etc. Such App IDs cannot be wildcard identifiers. For Application Services to function, your application's *bundle identifier* must match the App ID identifier.
 
 Devices
 : Each development device needs to be registered with their UDID (Unique Device IDentifier). See below for details on how to find the UDID of your device.
 
 Provisioning Profiles
-: Provisioning profiles associate certificates with App IDs and specific devices. It basically tells which app by what developer is allowed to be on what devices.
+: Provisioning profiles associate certificates with App IDs and specific devices. They basically tell which app by what developer is allowed to be on what devices.
 
 When signing your games and apps in Defold, you need a valid certificate and a valid provisioning profile.
 
@@ -55,18 +55,18 @@ Currently, at least one team member needs to run OS X and be a registered Apple 
 
 * The signer needs a certificate installed on his/her computer.
 * The signer needs a mobile provisioning profile on his/her computer.
-* The signer needs to collect all the UDIDs from other members and add these to his/hers mobile provisioning file.
+* The signer needs to collect all the UDIDs from other members and add these to his/her mobile provisioning file.
 
 To upload a signed development app to the Defold Dashboard, the following steps are required:
 
-- In the editor, select to <kbd>Project ▸ Sign iOS App...</kbd>
+- In the editor, select <kbd>Project ▸ Sign iOS App...</kbd>
 - Select your code signing identity.
 - Browse for your mobile provisioning file.
 - Press the *Sign and upload* button.
 
 ![Signing the app](images/ios/sign.png)
 
-The Defold dev app is uploaded to the project page in the Dashboard.
+The Defold dev app is uploaded to the project page on the Dashboard.
 Each project member can now:
 
 - Browse to the Dashboard from their iOS device.
@@ -108,5 +108,5 @@ Your device does not appear in the Targets menu
 : Make sure that your device is connected to the same wifi network as your computer.
 
 The game does not start with a message about mis-matching versions
-: This happens when you have upgraded the editor to the latest version. You need to sign the app again (<kbd>Project ▸ Sign iOS App...</kbd>) which creates a new dev app from the current engine version. Then download the new app from the dashboard on your device.
+: This happens when you have upgraded the editor to the latest version. You need to sign the app again (<kbd>Project ▸ Sign iOS App...</kbd>) which creates a new dev app from the current engine version. Then download the new app from the dashboard onto your device.
 

--- a/docs/en/manuals/label.md
+++ b/docs/en/manuals/label.md
@@ -5,7 +5,7 @@ brief: This manual explains how to use label components to use text with game ob
 
 # Label
 
-The *Label* component exists to allow you to attach text content to any game object. While Defold's GUI support is advanced, using it to glue information to in game objects can be tricky since GUI:s does not live in the game world.
+The *Label* component exists to allow you to attach text content to any game object. While Defold's GUI support is advanced, using it to glue information to in game objects can be tricky since GUIs do not live in the game world.
 
 ## Creating a label
 
@@ -13,11 +13,11 @@ A label component renders a piece of text on screen, in game space. By default i
 
 To create a Label component, either:
 
-1. Add a new component in-place in an existing game object by right clicking the game object and select *Add Component*. Select *Label* and press *OK*.
+1. Add a new component in-place in an existing game object by right clicking the game object and selecting *Add Component*. Select *Label* and press *OK*.
 
   ![Add label](images/label/add_label.png)
 
-2. If you want to instanciate several labels from the same template you can alternatively make a new *Label File* (right click a folder in the *Project Explorer* and select <kbd>New ▸ Label File</kbd>) and then add that to one or more game objects by right clicking the game objects and select <kbd>Add Component From File</kbd> and select your new label file.
+2. If you want to instantiate several labels from the same template you can alternatively make a new *Label File* (right click a folder in the *Project Explorer* and select <kbd>New ▸ Label File</kbd>) and then add that to one or more game objects by right clicking the game objects, selecting <kbd>Add Component From File</kbd> and selecting your new label file.
 
 The new label component has a set of special properties exposed that you can change in the editor or in runtime.
 
@@ -68,7 +68,7 @@ Note that the default material has shadow rendering disabled for performance rea
 
 ## Alignment
 
-By setting the pivot you can change the adjust mode for the text.
+By setting the pivot you can change the alignment mode for the text.
 
 *Center*
 : If the pivot is set to `Center`, `North` or `South`, the text is center-aligned.
@@ -83,7 +83,7 @@ By setting the pivot you can change the adjust mode for the text.
 
 ## Runtime manipulation
 
-You can manipulate labels in runtime by reading and setting the label text as well as the various properties.
+You can manipulate labels in runtime by getting and setting the label text as well as the various other properties.
 
 `color`
 : The label color (`vector4`)

--- a/docs/en/manuals/libraries.md
+++ b/docs/en/manuals/libraries.md
@@ -7,7 +7,7 @@ brief: The Libraries feature allows you to share assets between projects. This m
 
 The Libraries feature allows you to share assets between projects. It is a simple but very powerful mechanism that you can use in your workflow in a number of ways.
 
-Libraries is useful for the following uses:
+Libraries are useful for the following purposes:
 
 * To copy assets from a finished project to a new one. If you are making a sequel to an earlier game, this is an easy way to get going.
 * To build a library of templates that you can copy into you projects and then customize or specialize.
@@ -29,23 +29,23 @@ Libraries are referred to via a standard URL. Each project has a Library URL tha
 
 ## Setting up library dependencies
 
-Open the project you would like to have access to the library. In the project settings, add the URL to the *dependencies* property. You can specify multiple dependent projects if you want. Just list them separated by spaces:
+Open the project that you would like to access the library from. In the project settings, add the Library URL to the *dependencies* property. You can specify multiple dependent projects if you want. Just list them separated by spaces:
 
 ![Dependencies](images/libraries/libraries_dependencies.png)
 
-Now, select <kbd>Project ▸ Fetch Libraries</kbd> to update library dependencies. This happens automatically whenever you open a project so you will only need to do this if the dependencies change without re-opening the project. This happens if you add or remove dependency libraries or if one of the dependency library projects are changed and synchronized by someone.
+Now, select <kbd>Project ▸ Fetch Libraries</kbd> to update library dependencies. This happens automatically whenever you open a project so you will only need to do this if the dependencies change without re-opening the project. This happens if you add or remove dependency libraries or if one of the dependency library projects is changed and synchronized by someone.
 
 ![Fetch Libraries](images/libraries/libraries_fetch_libraries.png)
 
-Now the folders that you shared appears in the Project Explorer and you can use everything you shared. Any synchronized changes done to the library project will be available in your project.
+Now the folders that you shared appear in the Project Explorer and you can use everything you shared. Any synchronized changes done to the library project will be available in your project.
 
 ![Library setup done](images/libraries/libraries_done.png)
 
 ## Broken references
 
-Library sharing only include files that are located under the shared folder. If you create something that reference assets that are located outside of the shared hierarchy, the referece paths will be broken.
+Library sharing only includes files that are located under the shared folder. If you create something that references assets that are located outside of the shared hierarchy, the reference paths will be broken.
 
-In the example, the library folder *shared_sprites* contain an atlas. The PNG images that are gathered in that atlas, however, live in a folder in the library project that is not shared.
+In the example, the library folder *shared_sprites* contains an atlas. The PNG images that are gathered in that atlas, however, live in a folder in the library project that is not shared.
 
 ![Bad references](images/libraries/libraries_bad_references.png)
 
@@ -69,10 +69,10 @@ images {
 }
 ```
 
-It should now be clear what the problem is. The atlas file references these PNG images to a path that does not exist in the local project. You can fix the problem by adding the */cards_example/images* folder to the list of shared folders in the library project. Another option is to create a local folder */cards_example/images* and drop PNG files with the right names there.
+It should now be clear what the problem is. The atlas file references these PNG images from a path that does not exist in the local project. You can fix the problem by adding the */cards_example/images* folder to the list of shared folders in the library project. Another option is to create a local folder */cards_example/images* and drop PNG files with the right names there.
 
 ## Name collisions
 
-Since you can list several project URL:s in the *dependencies* project setting you might encounter a name collision. This happens if two or more of the dependent projects share a folder with the same name in the *include_dirs* project setting.
+Since you can list several project URLs in the *dependencies* project setting you might encounter a name collision. This happens if two or more of the dependent projects share a folder with the same name in the *include_dirs* project setting.
 
-Defold resolves name collisions by simply ignoring all but the last reference to folders of the same name in the order the project URL:s are specified in the *dependencies* list. For instance. If you list 3 library project URL:s in the dependencies and all of them share a folder named *items*, only one *items* folder will show up---the one belonging to the project that is last in the URL list.
+Defold resolves name collisions by simply ignoring all but the last reference to folders of the same name in the order the project URLs are specified in the *dependencies* list. For instance. If you list 3 library project URLs in the dependencies and all of them share a folder named *items*, only one *items* folder will show up---the one belonging to the project that is last in the URL list.

--- a/docs/en/manuals/live-update.md
+++ b/docs/en/manuals/live-update.md
@@ -1,6 +1,6 @@
 ---
 title: Live update content in Defold
-brief: The Live update functionality provides a mechanism allowing the runtime to fetch and store resources to the application bundle that was intentionally left out of the bundle at build time. This manual explains how it works.
+brief: The Live update functionality provides a mechanism allowing the runtime to fetch and store resources to the application bundle that were intentionally left out of the bundle at build time. This manual explains how it works.
 ---
 
 # Live update
@@ -9,9 +9,9 @@ When bundling a game, Defold packs all the game resources into the resulting pla
 
 - Your game features a series of episodes and you wish to include only the first one for players to try out before they decide if they want to continue with the rest of the game.
 - Your game is targeted for HTML5. On the browser, loading an application from storage means that the entire application package has to be downloaded before startup. On such a platform you may wish to send a minimal start package and get the app up and running quickly before you download the rest of the game resources.
-- Your game contains very large resources (images, videos etc) that you wish to postpone downloading of until they are about to show in the game. This to keep the install size down.
+- Your game contains very large resources (images, videos etc) that you wish to postpone the downloading of until they are about to show in the game. This is to keep the install size down.
 
-The Live update functionality expands the concept of the collection proxy with a mechanism allowing the runtime to fetch and store resources to the application bundle that was intentionally left out of the bundle at build time.
+The Live update functionality expands the concept of the collection proxy with a mechanism allowing the runtime to fetch and store resources to the application bundle that were intentionally left out of the bundle at build time.
 
 ## Preparing content for Live update
 
@@ -27,7 +27,7 @@ This is done by simply checking the *Exclude* checkbox in the collection proxy p
 
 ## Live update settings
 
-When the bundler creates an applicatin bundle, it needs to store any excluded resources somewhere. The project settings for Live update governs the location for those resources. The settings is found under <kbd>Project ▸ Live update Settings...</kbd>.
+When the bundler creates an application bundle, it needs to store any excluded resources somewhere. The project settings for Live update govern the location for those resources. The settings are found under <kbd>Project ▸ Live update Settings...</kbd>.
 
 ![Live update settings](images/live-update/aws-settings.png)
 
@@ -37,7 +37,7 @@ There are two ways Defold can store the settings. Choose the method in the *Mode
 : This option tells Defold to automatically upload excluded resources to an Amazon Web Service (AWS) S3 bucket. Fill in your AWS *Credential profile* name, select the appropriate *Bucket* and provide a *Prefix* name. [See below for details how to set up an AWS account](#_setting_up_amazon_web_service).
 
 `Zip`
-: This option tells Defold to create a Zip archive file with any excluded resources. The archive is saved at location of the *Export path* setting.
+: This option tells Defold to create a Zip archive file with any excluded resources. The archive is saved at the location specified in the *Export path* setting.
 
 
 ## Scripting with excluded collection proxies
@@ -182,7 +182,7 @@ This section will explain how to create a new user with limited access on Amazon
 
     Open up the *Services* menu and select *IAM* which is located under the _Security, Identity & Compliance_ category ([Amazon IAM Console](https://console.aws.amazon.com/iam)). Select *Policies* in the menu to the left and you will see all your existing policies together with the option to create a new policy.
 
-    Click the button *Create Policy*, and the choose to _Create Your Own Policy_. The policy in this example will allow a user to list all buckets, which is only required when configuring a Defold project for Live update. It will also allow the user to get the Access Control List (ACL) and upload resources to the specific bucket used for Live update resources. For additional information about Amazon Identity and Access Management (IAM), please see [the Amazon documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/access.html).
+    Click the button *Create Policy*, and then choose to _Create Your Own Policy_. The policy in this example will allow a user to list all buckets, which is only required when configuring a Defold project for Live update. It will also allow the user to get the Access Control List (ACL) and upload resources to the specific bucket used for Live update resources. For additional information about Amazon Identity and Access Management (IAM), please see [the Amazon documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/access.html).
 
     ```json
     {
@@ -238,7 +238,7 @@ This section will explain how to create a new user with limited access on Amazon
     $ touch ~/.aws/credentials
     ```
 
-    The file *~/.aws/credentials* will contain your credentials to access Amazon Web Services through programmatic access and is a standardised way to manage AWS credentials. Open the file in a text editor and enter your *Access key ID* and *Secret access key* in the below format.
+    The file *~/.aws/credentials* will contain your credentials to access Amazon Web Services through programmatic access and is a standardised way to manage AWS credentials. Open the file in a text editor and enter your *Access key ID* and *Secret access key* in the format shown below.
 
     ```ini
     [defold-liveupdate-example]
@@ -246,7 +246,7 @@ This section will explain how to create a new user with limited access on Amazon
     aws_secret_access_key = <Secret access key>
     ```
 
-    The identifier specified within the brackets, in this example _defold-liveupdate-example_, is the same identifier that you should provide when configuring your projects Live update settings in the Defold editor.
+    The identifier specified within the brackets, in this example _defold-liveupdate-example_, is the same identifier that you should provide when configuring your project's Live update settings in the Defold editor.
 
     ![Live update settings](images/live-update/05-liveupdate-settings.png)
 
@@ -257,13 +257,13 @@ The manifest is an internal data structure that holds a list of all resources in
 From the user's perspective, the manifest is a numeric handle, leaving the details of how it's managed to the engine.
 
 ::: important
-Currently, only the initial build manifest is available. The ability to store new manifests is a planned update to the system. This will allow you to modify or add resources to a published game that was not known at build time.
+Currently, only the initial build manifest is available. The ability to store new manifests is a planned update to the system. This will allow you to modify or add resources to a published game that were not known at build time.
 :::
 
 ## Development caveats
 
 Debugging
-: When running a bundled version of your game, you don't have direct access to a console. This causes problems for debugging. However, you can run the application from command line or by double clicking the executable in the bundle directly:
+: When running a bundled version of your game, you don't have direct access to a console. This causes problems for debugging. However, you can run the application from the command line or by double clicking the executable in the bundle directly:
 
   ![Running a bundle application](images/live-update/run-bundle.png)
 
@@ -279,5 +279,5 @@ Forcing re-download of resources
 ## Known issues
 
 - At the moment you have access only to the manifest that is created at build-time. In the near future you will be able to store new manifests. This will allow you to modify existing resources, or add new resources to the game through Live update.
-- [`resource.store_resource()`](/ref/resource/#resource.store_resource) is currently blocking the main thread, meaning that if you store large resources you will experience hitches.
+- [`resource.store_resource()`](/ref/resource/#resource.store_resource) currently blocks the main thread, meaning that if you store large resources you will experience hitches.
 

--- a/docs/en/manuals/lua.md
+++ b/docs/en/manuals/lua.md
@@ -7,7 +7,7 @@ brief: This manual will give a quick introduction to the basics of Lua programmi
 
 The Defold engine has the Lua language embedded for scripting. Lua is a lightweight dynamic language that is powerful, fast, and easy to embed. It is widely used as a videogame scripting language. Lua programs are written in a simple procedural syntax. The language is dynamically typed and is run by a bytecode interpreter. It features automatic memory management with incremental garbage collection.
 
-This manual will give a quick introduction to the basics of Lua programming in general and what you need to consider when working with Lua in Defold. If you have some experience with Python, Perl, Ruby, Javascript or a similar dynamic language you will get going pretty quick. If you are totally new to programming you might want to start with a Lua book aimed at beginners. There are plenty to choose from.
+This manual will give a quick introduction to the basics of Lua programming in general and what you need to consider when working with Lua in Defold. If you have some experience with Python, Perl, Ruby, Javascript or a similar dynamic language you will get going pretty quickly. If you are totally new to programming you might want to start with a Lua book aimed at beginners. There are plenty to choose from.
 
 ## Lua versions
 We aim to keep Defold the same across all platforms, but we currently have a small discrepancy between Lua versions. For HTML5 and iOS 64 bit platforms we use Lua 5.1 but for other platforms we use LuaJIT. LuaJIT is based on 5.1 but contains a few additional features.
@@ -129,7 +129,7 @@ string
   ```
 
 function
-: Functions are first class values in Lua, meaning that you can pass them as parameters to functions and return them as values. Variables assigned to a function contains a reference to the function. You can assign variables to anonymous functions, but Lua provides syntactic sugar (`function name(param1, param2) ... end`) for convenience.
+: Functions are first class values in Lua, meaning that you can pass them as parameters to functions and return them as values. Variables assigned to a function contain a reference to the function. You can assign variables to anonymous functions, but Lua provides syntactic sugar (`function name(param1, param2) ... end`) for convenience.
 
   ```lua
   -- Assign 'my_plus' to function
@@ -167,7 +167,7 @@ function
   ```
 
 table
-: Tables are the only data-structuring type in Lua. It is an associative array _object_ that is used to represent lists, arrays, sequences, symbol tables, sets, records, graphs, trees etc. Tables are always anonymous and variables you assign a table does not contain the table itself, but a reference to it. When initializing a table as a sequence, the first index is `1`, not `0`.
+: Tables are the only data-structuring type in Lua. They are associative array _objects_ that are used to represent lists, arrays, sequences, symbol tables, sets, records, graphs, trees etc. Tables are always anonymous and variables you assign a table to do not contain the table itself, but a reference to it. When initializing a table as a sequence, the first index is `1`, not `0`.
 
   ```lua
   -- Initialize a table as a sequence
@@ -211,7 +211,7 @@ userdata
 : Userdata is provided to allow arbitrary C data to be stored in Lua variables. Defold uses Lua userdata objects to store Hash values (hash), URL objects (url), Math objects (vector3, vector4, matrix4, quaternion), Game objects, GUI nodes (node), Render predicates (predicate), Render targets (render_target) and Render constant buffers (constant_buffer)
 
 thread
-: Threads represents independent threads of execution and it is used to implement coroutines. See below for details.
+: Threads represent independent threads of execution and are used to implement coroutines. See below for details.
 
 ## Operators
 
@@ -463,7 +463,7 @@ end
 
 ## Coroutines
 
-Functions execute from beginning to end and there is no way to stop it midway through. Coroutines allow you to do that, which can be very convenient in some cases. Suppose we want to create a very specific frame-by-frame animation where we move a game object from y position `0` to some very specific y positions frame 1 to frame 5. We could solve that with a counter in the `update()` function (see below) and a list of the positions. However, with a coroutine we get a very clean implementation that is easy to extend and work with. All state is contained within the coroutine itself.
+Functions execute from beginning to end and there is no way to stop them midway through. Coroutines allow you to do that, which can be very convenient in some cases. Suppose we want to create a very specific frame-by-frame animation where we move a game object from y position `0` to some very specific y positions from frame 1 to frame 5. We could solve that with a counter in the `update()` function (see below) and a list of the positions. However, with a coroutine we get a very clean implementation that is easy to extend and work with. All state is contained within the coroutine itself.
 
 When a coroutine yields it returns control back to the caller but remembers its execution point so it can continue from there later on.
 
@@ -500,15 +500,15 @@ The Defold editor supports Lua script editing with syntax coloring and auto-comp
 There are three types of Lua script in Defold, each has different Defold libraries available.
 
 Logic scripts
-: Extension _.script_. Run by script components in game objects. Logic scripts are usually used to control game objects and the logic that binds the game together with level loading, game rules and so forth. Logic scripts has access to all Defold library functions except [GUI](/ref/gui) and [Render](/ref/render) functions.
+: Extension _.script_. Run by script components in game objects. Logic scripts are usually used to control game objects and the logic that binds the game together with level loading, game rules and so forth. Logic scripts have access to all Defold library functions except [GUI](/ref/gui) and [Render](/ref/render) functions.
 
 
 GUI scripts
-: Extension _.guiscript_. Run by GUI components and usually contains the logic required to display GUI elements like heads up displays, menus etc. GUI scripts has access to the [GUI](/ref/gui) library functions.
+: Extension _.gui_script_. Run by GUI components and usually containing the logic required to display GUI elements like heads up displays, menus etc. GUI scripts have access to the [GUI](/ref/gui) library functions.
 
 
 Render scripts
-: Extension _.renderscript_. Run by the rendering pipeline and contains the logic required to render all app/game graphics each frame. Render scripts has access to the [Render](/ref/render) library functions.
+: Extension _.renderscript_. Run by the rendering pipeline and containing the logic required to render all app/game graphics each frame. Render scripts have access to the [Render](/ref/render) library functions.
 
 
 ## Script execution and callbacks
@@ -565,9 +565,9 @@ Defold executes Lua scripts as part of the engine lifecycle and exposes the life
 
 A game object with a script component implements some logic. Often, that logic is dependent on some external factor. An enemy AI might react to the player being within a certain radius from the AI; a door might unlock and open as a result of player interaction, etc, etc.
 
-The `update()` function allows you to implement complex behaviors defined as a state machine running each frame--sometimes that is the adequate approach. But there is a cost associated with each call to `update()`. Unless you really need the function you should delete it and instead try to build your logic _reactively_. It is cheaper to passively wait for some message to trigger a response than it is to actively probe the game world for data to respond to. Furthermore, solving a design problem reactively also often leads to cleaner and more stable design and implementation.
+The `update()` function allows you to implement complex behaviors defined as a state machine running each frame---sometimes that is the adequate approach. But there is a cost associated with each call to `update()`. Unless you really need the function you should delete it and instead try to build your logic _reactively_. It is cheaper to passively wait for some message to trigger a response than it is to actively probe the game world for data to respond to. Furthermore, solving a design problem reactively also often leads to cleaner and more stable design and implementation.
 
-Let's look at a concrete example. Suppose that you want a script component to send a message 2 seconds after it has been initiated. It should then wait for a certain response message and after received the response, it should send another message 5 seconds later. The non reactive code for that would look something like this:
+Let's look at a concrete example. Suppose that you want a script component to send a message 2 seconds after it has been initiated. It should then wait for a certain response message and after receiving the response, it should send another message 5 seconds later. The non reactive code for that would look something like this:
 
 ```lua
 function init(self)
@@ -629,7 +629,7 @@ function on_message(self, message_id, message, sender)
 end
 ```
 
-This is cleaner and easier to follow. We get rid of internal state variables that are often hard to follow through the logic--and which might lead to subtle bugs. We also dispose of the `update()` function completely. That relieves the engine from calling our script 60 times a second, even if it's just idling.
+This is cleaner and easier to follow. We get rid of internal state variables that are often hard to follow through the logic---and which might lead to subtle bugs. We also dispose of the `update()` function completely. That relieves the engine from calling our script 60 times a second, even if it's just idling.
 
 ## Lua contexts in Defold
 
@@ -643,7 +643,7 @@ Defold allows you to use the same script file in several separate game object co
 -- 'my_global_value' will be available from all scripts, gui_scripts, render script and modules (Lua files)
 my_global_value = "global scope"
 
--- this value will be shared through all component instances that uses this particular script file
+-- this value will be shared through all component instances that use this particular script file
 local script_value = "script scope"
 
 function init(self, dt)
@@ -739,14 +739,14 @@ print(collectgarbage("count") * 1024)
 A common implementation design consideration is how to structure code for shared behaviors. Several approaches are possible.
 
 Behaviors in a module
-: Encapsulating a behavior in a module allows you to easily share code between different game objects’ script components (and GUI scripts). When writing module functions it is generally best to write strictly functional code. There are cases where stored state or side effects is a necessity (or leads to cleaner design). If you have to store internal state in the module, be aware that components share Lua contexts. See the [Modules documentation](/manuals/modules) for details.
+: Encapsulating a behavior in a module allows you to easily share code between different game objects’ script components (and GUI scripts). When writing module functions it is generally best to write strictly functional code. There are cases where stored state or side effects are a necessity (or lead to cleaner design). If you have to store internal state in the module, be aware that components share Lua contexts. See the [Modules documentation](/manuals/modules) for details.
 
   ![Module](images/lua/lua_module.png)
 
-  Also, even if it is possible to have module code directly modify the internals of a game object (by passing `self` to a module function) it is strongly disencouraged to do so since you create very tight coupling.
+  Also, even if it is possible to have module code directly modify the internals of a game object (by passing `self` to a module function) we strongly discourage you from doing so since you will create very tight coupling.
 
 A helper game object with encapsulated behavior
-: Just like you can contain script code in a Lua module, you can contained it in a game object with a script component. The difference is that if you contain it in a game object and you communicate with it strictly through message passing.
+: Just like you can contain script code in a Lua module, you can contain it in a game object with a script component. The difference is that if you contain it in a game object you can communicate with it strictly through message passing.
 
   ![Helper](images/lua/lua_helper.png)
 

--- a/docs/en/manuals/material.md
+++ b/docs/en/manuals/material.md
@@ -10,7 +10,7 @@ Materials are the Defold way of expressing how a graphical component (a sprite, 
 A material holds _Tags_, information that is used in the rendering pipeline to select objects to be rendered. It also holds references to _shader programs_ that are compiled through the available graphics driver and uploaded to the graphics hardware and run when the component is rendered each frame.
 
 * For more information on the render pipeline, see the [Rendering documentation](/manuals/rendering).
-* For an in depth explanation on shader programs, see the [Shader documentation](/manuals/shader).
+* For an in depth explanation of shader programs, see the [Shader documentation](/manuals/shader).
 
 ## Creating a material
 
@@ -54,7 +54,7 @@ The vertex shader will need matrices so each vertex can be translated to the cli
 
 ## Shader programs
 
-For the material to work, we have to first edit the vertex shader programs:
+For the material to work, we have to first edit the vertex shader program:
 
 ```glsl
 // flat.vp
@@ -108,7 +108,7 @@ void main()
 
 ## Setting the material
 
-Each of the graphical object types have a *Material* property that allows you to set a specific material for each component you create. If you don't set the material, a default one is automatically selected. To make a model render with your newly created material, set the *Material* property to reference the material file. You find a guide on how to import 3D models into Defold in the [Models documentation](/manuals/models).
+Each of the graphical object types has a *Material* property that allows you to set a specific material for each component you create. If you don't set the material, a default one is automatically selected. To make a model render with your newly created material, set the *Material* property to reference the material file. You can find a guide on how to import 3D models into Defold in the [Models documentation](/manuals/models).
 
 ![Set material](images/materials/materials_set_material.png)
 
@@ -118,7 +118,7 @@ You should now be able to see the resulting rendering of your model. Even though
 
 ## Constant buffers
 
-When the rendering pipeline draws it pulls constant values from a default system constants buffer. Custom constant buffers are used to override the default constants and instead set shader program variables programmatically in the render script. These are then passed to the `render.draw()` function.
+When the rendering pipeline draws, it pulls constant values from a default system constants buffer. Custom constant buffers are used to override the default constants and instead set shader program variables programmatically in the render script. These are then passed to the `render.draw()` function.
 
 ```lua
 self.constants = render.constant_buffer() -- <1>
@@ -155,13 +155,13 @@ Defold currently supports a single texture per material.
 
 ## Sampler settings
 
-You can optionally configure specific samplers in the materials file. Att a sampler, name it according to the name used in the shader program and set the wrap and filter settings to your liking.
+You can optionally configure specific samplers in the materials file. Add a sampler, name it according to the name used in the shader program and set the wrap and filter settings to your liking.
 
 ![Sampler settings](images/materials/materials_sampler_settings.png)
 
 ## Wrap modes
 
-The wrap mode can be set on the U and V axis independently:
+The wrap mode can be set on the U and V axes independently:
 
 WRAP_MODE_REPEAT
 : Texture data outside the range [0,1] will repeat
@@ -221,7 +221,7 @@ CONSTANT_TYPE_USER
 
 ## Vertex shader attributes
 
-_Attributes_ are values associated with individual vertices. Different component types has a different set of attributes. To access them, simply declare them in your shader program:
+_Attributes_ are values associated with individual vertices. Different component types have different sets of attributes. To access them, simply declare them in your shader program:
 
 ```glsl
 // position and texture coordinates for this vertex.

--- a/docs/en/manuals/message-passing.md
+++ b/docs/en/manuals/message-passing.md
@@ -7,7 +7,7 @@ brief: Message passing is the mechanism used by Defold to permit loosely coupled
 
 Message passing is the mechanism used by Defold to permit objects to communicate without creating dependencies between them. This manual assumes that you have a basic understanding of *Game Objects*, *Components* and *Collections*.
 
-When programming it is generally best to couple all objects, code modules or components [as loosely as possible](http://en.wikipedia.org/wiki/Loose_coupling). Any object that has a dependency to the inner workings of another object is considered to be _tightly coupled_ and such coupling often lead to code that is harder to maintain and is a common source of bugs---some of which can be very hard to track down.
+When programming it is generally best to couple all objects, code modules or components [as loosely as possible](http://en.wikipedia.org/wiki/Loose_coupling). Any object that has a dependency to the inner workings of another object is considered to be _tightly coupled_ and such coupling often leads to code that is harder to maintain and it is a common source of bugs---some of which can be very hard to track down.
 
 Defold's Lua integration does not provide object orientation in the sense that you define your application by setting up class hierarchies with inheritance (like Java, C++ or C#). Instead, Defold extends Lua with a simple and powerful object oriented design with the following characteristics:
 
@@ -17,7 +17,7 @@ Defold's Lua integration does not provide object orientation in the sense that y
 
 ## Addressing and URLs
 
-Every object in Defold is uniquely addressed through a URL (Uniform Resource Locator). The address is set at compile time and stays fixed throughout  the object’s lifetime. This means that if you save the address to an object it will stay valid for as long as the object exists; you never have to worry about updating object references that you store.
+Every object in Defold is uniquely addressed through a URL (Uniform Resource Locator). The address is set at compile time and stays fixed throughout the object’s lifetime. This means that if you save the address to an object it will stay valid for as long as the object exists; you never have to worry about updating object references that you store.
 
 When you organize your project, you add game objects into a hierarchy of collections. In its simplest form it’s a set of game objects directly under the top level collection, but often you would want to group things a bit more. For instance, suppose you have a simple game consisting of:
 
@@ -44,7 +44,7 @@ Some of this game content will live in separate files in the project. For instan
 1. The id you assign something
 2. In what collection you put it
 
-The Defold editor will automatically assign unique id:s within the current collection when you place a collection or game object. You can change these names to whatever you like--the editor will keep track of the id:s and make sure that names don't collide. If you force a name collision, the Defold editor will signal an error.
+The Defold editor will automatically assign unique id:s within the current collection when you place a collection or game object. You can change these names to whatever you like---the editor will keep track of the id:s and make sure that names don't collide. If you force a name collision, the Defold editor will signal an error.
 
 All addresses are expressed by a *URL* that uniquely identify each message sender and receiver in the running game. The URL consists of three components and is written in the following generic format:
 
@@ -56,7 +56,7 @@ socket
 : Identifies which "world" the sender or receiver lives in. This is important when working with [Collection Proxies](/manuals/collection-proxy) and is then used to identify the _dynamically loaded collection_.
 
 path
-: This part of the URL usually contain the full id of the target _game object_.
+: This part of the URL usually contains the full id of the target _game object_.
 
 fragment
 : The id of the target _component_ within the specified game object.
@@ -79,7 +79,7 @@ If you send a message to an unknown recipient, Defold will signal an error in th
 ERROR:GAMEOBJECT: Instance '/level/enemy' could not be found when dispatching message 'hello' sent from default:/level/hero#brain
 ```
 
-In most cases, the above way of writing full URL:s is unnecessary and way too specific. Let's instead look at 3 more common examples of how to write messages in our example game:
+In most cases, the above way of writing full URLs is unnecessary and way too specific. Let's instead look at 3 more common examples of how to write messages in our example game:
 
 ![Message passing](images/message_passing/message_passing.png)
 
@@ -132,11 +132,11 @@ Message 3
   msg.post("/interface#gui", "update_minimap")
   ```
 
-  Here is another case where we cannot specify a relative URL. Instead we have to write the full id of the "interface" object and direct the message to the "gui" component. Script and GUI components are the only game object components that have Lua script associated with them. They can react to arbitrary messages. It is important to remember that GUI scripts must be added to the GUI scene that you add as a component to the game object. Messages between GUI scripts and other scripts works exactly the same way.
+  Here is another case where we cannot specify a relative URL. Instead we have to write the full id of the "interface" object and direct the message to the "gui" component. Script and GUI components are the only game object components that have Lua scripts associated with them. They can react to arbitrary messages. It is important to remember that a GUI script must be added to the GUI scene that you add as a component to the game object. Messages between GUI scripts and other scripts work exactly the same way.
 
 ## Shorthands
 
-We have seen how it is possible to leave out redundant information from the URL:s when constructing messages. In addition, Defold provides two handy shorthands that you can use:
+We have seen how it is possible to leave out redundant information from the URLs when constructing messages. In addition, Defold provides two handy shorthands that you can use:
 
 `.`
 : A URL shorthand for the current game object.
@@ -195,7 +195,7 @@ For convenience we add a message that sets all information on the HUD in one go.
 msg.post("hud#script", "set_stats", { score = 100, stars = 2, health = 4 })
 ```
 
-The call adds a `message` parameter with additional data to the message. The argument is optional and should be a Lua table, with key-value pairs inside curly braces. Almost any type of data can be included in the message Lua table. You can pass numbers, strings, booleans, URL:s, hashes and nested tables. You can not, however, pass functions.
+The call adds a `message` parameter with additional data to the message. The argument is optional and should be a Lua table, with key-value pairs inside curly braces. Almost any type of data can be included in the message Lua table. You can pass numbers, strings, booleans, URLs, hashes and nested tables. You can not, however, pass functions.
 
 ```lua
 -- Send table data containing a nested table
@@ -239,7 +239,7 @@ The console output shows the message, data and sender:
 
 ```txt
 DEBUG:SCRIPT: hash: [set_stats]
-DEBUG:SCRIPT: 
+DEBUG:SCRIPT:
 {
   health = 4,
   stars = 2,
@@ -310,7 +310,7 @@ local parent = go.get_id("tree")
 msg.post(".", "set_parent", { parent_id = parent })
 ```
 
-Parent-child hierarchies can also be set up the editor, and will still be dynamic. Let’s, for example, build a tree with hearts in it. It will consist of a “tree” object and a number of “heart” objects. We also have a “pot” in where the tree lives. First we have to place these objects in a collection in order to make them parent and child. We're calling this collection “hearttree”. Then we can simply drag the heart objects onto the tree object to child them:
+Parent-child hierarchies can also be set up the editor, and will still be dynamic. Let’s, for example, build a tree with hearts in it. It will consist of a “tree” object and a number of “heart” objects. We also have a “pot” in which the tree lives. First we have to place these objects in a collection in order to make them parent and child. We're calling this collection “hearttree”. Then we can simply drag the heart objects onto the tree object to child them:
 
 ![Heart tree](images/message_passing/editor_heart_tree.png)
 
@@ -356,7 +356,7 @@ Defold uses sockets for communicating with certain engine subsystems. Those are:
 - `@render:`
 - `@system:`
 
-Note that all are sockets with no path nor fragment.
+Note that all are sockets with no path or fragment.
 
 For instance, you can toggle the system profiler by sending a message `msg.post("@system:", "toggle_profile")`
 
@@ -443,7 +443,7 @@ DEBUG:SCRIPT: UPDATE 4
 DEBUG:SCRIPT: 75 dispatch passes before this update.
 DEBUG:SCRIPT: UPDATE 5
 DEBUG:SCRIPT: 75 dispatch passes before this update.
-``
+```
 
 We see that this particular Defold engine version performs 10 dispatch passes on the message queue between `init()` and the first call to `update()`. It then performs 75 passes during each subsequent update loop.
 

--- a/docs/en/manuals/model.md
+++ b/docs/en/manuals/model.md
@@ -48,7 +48,7 @@ With the model in place you need to specify a number of properties
 : This property should point to the texture image file that you want applied to the object.
 
 *Skeleton*
-: This property should refer to the Collada *.dae* file that contaist the skeleton to use for animation.
+: This property should refer to the Collada *.dae* file that contains the skeleton to use for animation.
 
 *Animations*
 : Set this to the *Animation Set File* that contains the animations you want to use on the model.

--- a/docs/en/manuals/modules.md
+++ b/docs/en/manuals/modules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Lua modules in Defold
 brief: Lua modules allow you to structure your project and create reusable library code. This manual explains how to do that in Defold.
 ---
@@ -84,7 +84,7 @@ This code works pretty well and it makes the butterfly animate between random po
 
 ![Blue and yellow butterflies](images/modules/modules_blue_and_yellow.png)
 
-The code for flying randomly already exist, so creating the script for the yellow butterfly is straightforward:
+The code for flying randomly already exists, so creating the script for the yellow butterfly is straightforward:
 
 ```lua
 require "modules_example.flying"
@@ -186,7 +186,7 @@ end
 return M
 ```
 
-The difference is that we create a table flying that we populate with our data (`flying.origins`) and functions (`flying.fly_randomly()`). We end the module by returning the table. To use the module we change the butterfly scripts to:
+The difference is that we create a table, "flying", that we populate with our data (`flying.origins`) and functions (`flying.fly_randomly()`). We end the module by returning the table. To use the module we change the butterfly scripts to:
 
 ```lua
 flying = require "modules_example.flying"
@@ -276,7 +276,7 @@ return M
 
 ## Allowing monkey patching
 
->   "A monkey patch is a way to extend or modify the run-time code of dynamic languages 
+>   "A monkey patch is a way to extend or modify the run-time code of dynamic languages
 >   without altering the original source code." [Wikipedia]
 
 Lua is a dynamic language and as such it is possible to modify all of the builtin modules. This is extremely powerful and very useful, primarily for testing and debugging purposes. Monkey patching easily leads to strong coupling, which is usually a bad idea. However, if you write a module, you should make it possible to monkey patch your custom modules as well. Lua allows you to do things like:
@@ -298,7 +298,7 @@ setmetatable(M, {
 return M
 ```
 
-Tricks like the above is usually not a good idea. You should leave the decision on what to do to your module to the user.
+Tricks like the above are usually not a good idea. You should leave the decision on what to do to your module to the user.
 
 ## Beware of locals
 
@@ -510,7 +510,7 @@ print(foobar.public_function(fb, “bar”))
 ## Stateless modules using metatables
 
 ::: sidenote
-_Metatables_ is a powerful feature in Lua. A good tutorial on how they work can be found here: http://nova-fusion.com/2011/06/30/lua-metatables-tutorial/
+_Metatables_ are a powerful feature in Lua. A good tutorial on how they work can be found here: http://nova-fusion.com/2011/06/30/lua-metatables-tutorial/
 :::
 
 Another approach is to use a constructor function that returns a new table with state _and_ the public functions of the module each time it’s called:
@@ -600,6 +600,6 @@ If a function in the module account is named `login(username, password)` the exp
 Details on the LDoc documentation standard can be found here: https://github.com/stevedonovan/LDoc
 :::
 
-When documenting a module or function, remember to write documentation only when it adds information that can’t be inferred from function and argument names. In many cases short, well named functions and well named function arguments are enough to infer how the modules works, what to use and what to expect from a function call. Document return values, preconditions and examples of usage. Write documentation using the LDoc standard.
+When documenting a module or function, remember to write documentation only when it adds information that can’t be inferred from function and argument names. In many cases short, well named functions and well named function arguments are enough to infer how the module works, what to use and what to expect from a function call. Document return values, preconditions and examples of usage. Write documentation using the LDoc standard.
 
 

--- a/docs/en/manuals/particlefx.md
+++ b/docs/en/manuals/particlefx.md
@@ -20,7 +20,7 @@ Emitter
 : A positioned shape that emits particles uniformly distributed over the shape.
 
 Modifier
-: Affects the velocity of spawned particles (field in Maya). Acceleration, drag, radial and vortex.
+: Affects the velocity of spawned particles (field in Maya). There are four types of modifiers: Acceleration, Drag, Radial and Vortex.
 
 Image (Tile source or Atlas)
 : Used for adding textures and flip-book animations, see the [2D graphics documentation](/manuals/2dgraphics)
@@ -44,7 +44,7 @@ All number properties can be tweaked using the mouse-wheel (or scroll gesture on
 
 ![ParticleFX Curve Editor](images/particlefx/curve_editor.png)
 
-Different properties can be keyed over different time lines, which means that their value can change over time. It is possible to see which properties have this ability in the reference below.
+Different properties can be keyed over different timelines, which means that their value can change over time. It is possible to see which properties have this ability in the reference below.
 
 To key a value:
 
@@ -56,7 +56,7 @@ To reset a keyed property, select Curve again from the context menu in its text 
 To auto-zoom the Curve Editor to display all curves, press <kbd>F</kbd>.
 
 Spread
-: When a property has two fields, the first is the value and the second is the spread. The value is what you key. The spread is a variation which is applied randomly for each spawned particle. E.g. if the value is 50 and the spread is 10, each spawned particle will get 50 +/- 10 as value.
+: When a property has two fields, the first is the value and the second is the spread. The value is what you key. The spread is a variation which is applied randomly for each spawned particle. E.g. if the value is 50 and the spread is 10, each spawned particle will get a value of 50 +/- 10.
 
 ## Emitter properties
 
@@ -72,7 +72,7 @@ Duration
 Space
 : In which geometrical space the spawned particles will exist.
   - `World` means the particles are left in the world and move independently of the emitter;
-  - `Emitter` means they will move relative the emitter.
+  - `Emitter` means they will move relative to the emitter.
 
 Position/rotation
 : Transform of the emitter relative the ParticleFX component.
@@ -107,7 +107,7 @@ Type
   - `Cone` - A 3D cone which emits particles from its bottom corner directed out through the top disc of the cone. *Emitter Size X* defines the diameter of the top disc and *Y* defines the height.
 
 Start Delay
-: How long time to wait after the ParticleFX has been started before this emitter will start emitting particles.
+: How long to wait after the ParticleFX has been started before this emitter will start emitting particles.
 
 ## Keyable emitter properties
 

--- a/docs/en/manuals/physics.md
+++ b/docs/en/manuals/physics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Physics in Defold
 brief: Defold includes physics engines for 2D and 3D. They allow you to simulate Newtonian physics interactions between different types of collision objects. This manual explains how this works.
 ---
@@ -9,7 +9,7 @@ Defold includes a modified version of the [Box2D](http://www.box2d.org) physics 
 
 ## Collision objects
 
-A collision object is a component you use to extends a game object with physical behaviour. A collision object has different physical properties (like weight, restitution and friction) and its spatial extension is defined by one or more _shapes_ that you attach to the component. Defold supports the following types of collision object:
+A collision object is a component you use to extend a game object with physical behaviour. A collision object has different physical properties (like weight, restitution and friction) and its spatial extension is defined by one or more _shapes_ that you attach to the component. Defold supports the following types of collision objects:
 
 Static objects
 : These do not react in themselves, but any other object that collides with static objects will react. These are very useful (and cheap performance-wise) for building level geometry (i.e. ground and walls) that does not move. You cannot move or otherwise change static objects.
@@ -33,7 +33,7 @@ A collision object is constructed out of one or more physics shapes:
 
 * Box shapes
 * Sphere shapes
-* Capsule shapes (does only work with 3D physics!)
+* Capsule shapes (these only work with 3D physics!)
 
 You add these shapes and can use the ordinary editor transform tools to scale, rotate and position them. Each collision object has a number of properties:
 
@@ -49,7 +49,7 @@ If you set the type to `Dynamic` and forget to set the mass to non zero you will
 
 ## Friction
 
-Friction makes it possible to make object slide realistically against each other. The friction value is usually set between `0` (no friction at all---a very slippery object) and `1` (strong friction---an abrasive object). However, any positive value is valid.
+Friction makes it possible for objects to slide realistically against each other. The friction value is usually set between `0` (no friction at all---a very slippery object) and `1` (strong friction---an abrasive object). However, any positive value is valid.
 
 The friction strength is proportional to the normal force (this is called Coulomb friction). When the friction force is computed between two shapes (`A` and `B`), the friction values of both objects are combined by the geometric mean:
 
@@ -61,7 +61,7 @@ This means that if one of the objects has zero friction then the contact between
 
 ## Restitution
 
-The restitution value sets the bounciness of the object. The value is usually between 0 (inelastic collision—the object does not bounce at all) and 1 (perfectly elastic collision—the object's velocity will be exactly reflected in the bounce)
+The restitution value sets the bounciness of the object. The value is usually between 0 (inelastic collision—the object does not bounce at all) and 1 (perfectly elastic collision---the object's velocity will be exactly reflected in the bounce)
 
 Restitution values between two shapes (`A` and `B`) are combined using the following formula:
 
@@ -75,7 +75,7 @@ When a shape develops multiple contacts, restitution is simulated approximately 
 
 ## Linear and angular damping
 
-Damping reduces the linear and angular velocities of the body. It is different from friction that only occurs with contact and can be used to give objects a floaty appearance, like they are moving through something thicker than air. Valid values for both linear and angular damping is between 0 and 1.
+Damping reduces the linear and angular velocities of the body. It is different from friction, which only occurs during contact, and can be used to give objects a floaty appearance, like they are moving through something thicker than air. Valid values for both linear and angular damping are between 0 and 1.
 
 Box2D approximates damping for stability and performance. At small values, the damping effect is independent of the time step while at larger damping values, the damping effect varies with the time step. If you run your game with a fixed time step, this never becomes an issue.
 
@@ -146,7 +146,7 @@ To use the collision shapes from the Tile Source, create a collisionobject in th
 
 - Set the Group and Mask properties.
 
-- Make sure that the Group and Mask properties of the Collision Objects you want colliding with the tiles.
+- Make sure that the Group and Mask properties of the Collision Objects you want colliding with the tiles are set accordingly.
 
 ## Collision messages
 
@@ -204,7 +204,7 @@ This message is sent when one of the colliding objects is Dynamic or Kinematic. 
 `group`
 : the collision group of the other collision object (`hash`).
 
-For a game or application where you need to separate objects perfectly, the `contact_point_response` message gives you all information you need. However, note that for any given collision pair, a number of `contact_point_response` message can be received each frame.
+For a game or application where you need to separate objects perfectly, the `contact_point_response` message gives you all information you need. However, note that for any given collision pair, a number of `contact_point_response` messages can be received each frame.
 
 ## Triggers
 
@@ -255,11 +255,11 @@ The distance covered can be found if we project the penetration vector of Object
 function on_message(self, message_id, message, sender)
     -- Handle collision
     if message_id == hash("contact_point_response") then
-        -- Get the info needed to move out of collision. We might 
+        -- Get the info needed to move out of collision. We might
         -- get several contact points back and have to calculate
         -- how to move out of all accumulatively:
         if message.distance > 0 then
-            -- First, project the penetration vector on 
+            -- First, project the penetration vector on
             -- accumulated correction
             local proj = vmath.project(self.correction, message.normal * message.distance)
             if proj < 1 then
@@ -278,7 +278,7 @@ end
 ## Best practices
 
 Triggers
-: Trigger collision objects are sometimes too limited. Suppose you want a trigger that controls the intensity of a sound--the further the player moves into the trigger, the more intense the sound. This scenario requires a trigger that provides the penetration distance in the trigger. For this, a plain trigger collision object won’t do. Instead, you can set up a Kinematic object and never performing any separation of collisions but instead only registering them and use the collision data.
+: Trigger collision objects are sometimes too limited. Suppose you want a trigger that controls the intensity of a sound---the further the player moves into the trigger, the more intense the sound. This scenario requires a trigger that provides the penetration distance in the trigger. For this, a plain trigger collision object won’t do. Instead, you can set up a Kinematic object and never perform any separation of collisions but instead only register them and use the collision data.
 
 ::: sidenote
 Kinematic objects are more expensive than triggers, so use them wisely.
@@ -287,14 +287,14 @@ Kinematic objects are more expensive than triggers, so use them wisely.
 Choosing between Dynamic or Kinematic objects
 : If you are making a game with a player character (of some sort) that you maneuver through a level, it might seem like a good idea to create the player character as a Dynamic physics object and the world as a Static physics object. Player input is then handled by applying various forces on the player object.
 
-  Going down that path is possible, but it is extremely hard to achieve great results. Your game controls will likely feel generic—like thousands of other games, since it is implemented the same way on the same physics engine. The problem boils down to the fact that the Box2D physics simulation is a realistic Newtonian simulation whereas a platformer is usually fundamentally different. You will therefore have to fight hard to make a Newtonian simulation behave in non-Newtonian fashion.
+  Going down that path is possible, but it is extremely hard to achieve great results. Your game controls will likely feel generic---like thousands of other games, since it is implemented the same way on the same physics engine. The problem boils down to the fact that the Box2D physics simulation is a realistic Newtonian simulation whereas a platformer is usually fundamentally different. You will therefore have to fight hard to make a Newtonian simulation behave in a non-Newtonian fashion.
 
   One immediate problem is what should happen at edges. With a dynamic simulation running, the player physics object (here set up as a box) behaves like a realistic box and will tip over any edges.
 
   ![Dynamic physics](images/physics/physics_dynamic.png)
 
-  This particular problem can be solved by setting the "Locked Rotation" property in the character's collision object. However, the example illustrates the core of the problem which is that the behavior of the character should be under the control of _you_, the designer/programmer and not being directly controlled by a physics simulation over which you have very limited control.
+  This particular problem can be solved by setting the "Locked Rotation" property in the character's collision object. However, the example illustrates the core of the problem which is that the behavior of the character should be under the control of _you_, the designer/programmer and not be directly controlled by a physics simulation over which you have very limited control.
 
-  So it is highly recommended that you implement your player character as a Kinematic physics object. Use the physics engine to detect collisions and deal with collisions and object separations as you need. Such an approach will initially require more work, but allows you to really design and fine-tune the player experience into something really good and unique.
+  So it is highly recommended that you implement your player character as a Kinematic physics object. Use the physics engine to detect collisions and deal with collisions and object separations as you need. Such an approach will initially require more work, but will allow you to design and fine-tune the player experience into something really good and unique.
 
 (Some of the graphic assets used are made by Kenney: http://kenney.nl/assets)

--- a/docs/en/manuals/project-settings.md
+++ b/docs/en/manuals/project-settings.md
@@ -5,7 +5,7 @@ brief: This manual describes how project specific settings work in Defold.
 
 # Project settings
 
-The file *game.project* contains all project wide settings. It must stay in the root of the project and must be named *game.project*. The first thing the engine does when starting up and launching your game is looking for this file.
+The file *game.project* contains all project wide settings. It must stay in the root folder of the project and must be named *game.project*. The first thing the engine does when starting up and launching your game is look for this file.
 
 Every setting in the file belongs to a category. The format of the file is simple text and can be edited by any standard text editor. The format looks like this:
 
@@ -42,7 +42,7 @@ $ dmengine --config=bootstrap.main_collection=/my.collectionc
 $ dmengine --config=test.my_value=4711
 ```
 
-Custom values can---just as any other config value---be read with [`sys.get_config()`](/ref/sys/#sys.get_config).
+Custom values can---just like any other config value---be read with [`sys.get_config()`](/ref/sys/#sys.get_config).
 
 ## Project
 
@@ -53,7 +53,7 @@ version
 : The version of the application.
 
 write_log
-: When checked the engine will write a log file *log.txt* in the project root. When running on iOS, the log file can be accessed through iTunes and the *Apps* tab and the *File Sharing* section. On Android, the file is stored in the apps external storage. When running the *dmengine* development app, you can view the log with:
+: When checked, the engine will write a log file *log.txt* in the project root. When running on iOS, the log file can be accessed through iTunes and the *Apps* tab and the *File Sharing* section. On Android, the file is stored in the app's external storage. When running the *dmengine* development app, you can view the log with:
 
 ```bash
 $ adb shell cat /mnt/sdcard/Android/data/com.defold.dmengine/files/log.txt
@@ -63,7 +63,7 @@ compress_archive
 : Enables compression of archives when bundling. Note that this currently applies to all platforms except Android where the apk already contains all data compressed.
 
 dependencies
-: A comma-separated list of URL:s to the project *Library URL*:s (can be found in the [Defold dashboard](//dashboard.defold.com)) that this project uses. Note that you need to be a member of the dependent projects.
+: A comma-separated list of URLs to the project *Library URL*s (can be found in the [Defold dashboard](//dashboard.defold.com)) that this project uses. Note that you need to be a member of the dependent projects.
 
 custom_resources (hidden setting)
 : A comma separated list of resources that will be included in the project. If directories are specified, all files and directories in that directory are recursively included.
@@ -378,7 +378,7 @@ appid (hidden setting)
 ## IAP
 
 auto_finish_transactions
-: Check to automatically finish iap transactions. If unchecked, you need to explicitly call `iap.finish()` after a successful transaction, checked by default.
+: Check to automatically finish IAP transactions. If unchecked, you need to explicitly call `iap.finish()` after a successful transaction, checked by default.
 
 
 

--- a/docs/en/manuals/properties.md
+++ b/docs/en/manuals/properties.md
@@ -21,7 +21,7 @@ Composite properties of type `vector3`, `vector4` or `quaternion` also expose th
 go.set("game_object", "position.x", 10)
 ```
 
-The functions `go.get()`, `go.set()` and `go.animate()` take a reference as their first parameter and a property identifier as their second. The reference identifies the game object or component and can be a string, a hash or an URL. URLs are explained in detail in the [Message passing documentation](/manuals/message-passing). The property identifier is a string or hash that names the property:
+The functions `go.get()`, `go.set()` and `go.animate()` take a reference as their first parameter and a property identifier as their second. The reference identifies the game object or component and can be a string, a hash or a URL. URLs are explained in detail in the [Message passing documentation](/manuals/message-passing). The property identifier is a string or hash that names the property:
 
 ```lua
 -- Set the x-scale of the sprite component
@@ -30,7 +30,7 @@ local prop = hash("scale.x")
 go.set(url, prop, 2.0)
 ```
 
-For GUI nodes, the node identifier is provided as first parameter to the property specific function:
+For GUI nodes, the node identifier is provided as the first parameter to the property specific function:
 
 ```lua
 -- Get the color of the button
@@ -57,7 +57,7 @@ Legacy functions for reading and writing game object properties also exist. They
 | property   | description                            | type            |                  |
 | ---------- | -------------------------------------- | --------------- | ---------------- |
 | *position* | The local position of the game object. | `vector3`.      | `get+set`{.mark} |
-| *rotation* | Local rotation of game object, expressed as quaternion.  | `quaternion` | `get+set`{.mark} |
+| *rotation* | Local rotation of game object, expressed as a quaternion.  | `quaternion` | `get+set`{.mark} |
 | *euler*    | Local rotation of game object, Euler angles. | `vector3` | `get+set`{.mark} |
 | *scale*    | Local non uniform scale of the game object, expressed as a vector where each component contains a multiplier along each axis. To double the size in x and y, provide vmath.vector3(2.0, 2.0, 0) | `vector3` | `get+set`{.mark} |
 
@@ -73,10 +73,10 @@ Legacy functions for reading and writing game object properties also exist. They
 | property   | description                            | type            |                  |
 | ---------- | -------------------------------------- | --------------- | ---------------- |
 | *mass*     | The mass of the collision object. | `number` | `get`{.mark} |
-| *linear_velocity* | The current linear velocity for the collision object. | `vector3` | `get`{.mark} |
-| *angular_velocity* | The current angular velocity for the collision object. | `vector3` | `get`{.mark} |
-| *linear_damping* | Linear damping for the collision object. | `vector3` | `get+set`{.mark} |
-| *angular_damping* | Angular damping for the collision object. | `vector3` | `get+set`{.mark} |
+| *linear_velocity* | The current linear velocity of the collision object. | `vector3` | `get`{.mark} |
+| *angular_velocity* | The current angular velocity of the collision object. | `vector3` | `get`{.mark} |
+| *linear_damping* | Linear damping of the collision object. | `vector3` | `get+set`{.mark} |
+| *angular_damping* | Angular damping of the collision object. | `vector3` | `get+set`{.mark} |
 
 *SPINE MODEL COMPONENT PROPERTIES*
 
@@ -97,7 +97,7 @@ Legacy functions for reading and writing game object properties also exist. They
 
 ## GUI node properties
 
-GUI nodes also contain properties, but they are read and written through special getter and setter functions. For each property there exist one get- and one set- function. There is also a set of constants defined to use as reference to the properties when animating them. If you need to refer to separate property components you have to use the string name of the property, or a hash of the string name.
+GUI nodes also contain properties, but they are read and written through special getter and setter functions. For each property there exists one get- and one set- function. There is also a set of constants defined to use as reference to the properties when animating them. If you need to refer to separate property components you have to use the string name of the property, or a hash of the string name.
 
 * `position` (or `gui.PROP_POSITION`)
 * `rotation` (or `gui.PROP_ROTATION`)

--- a/docs/en/manuals/push.md
+++ b/docs/en/manuals/push.md
@@ -7,19 +7,19 @@ brief: This document describes how to set up and implement remote and local iOS 
 
 Push notifications are available on iOS and Android devices and allow your game to inform the player about changes and updates. The core functionality is similar between iOS and Android but there are some platform specific differences that you need to consider.
 
-For a push notifications to find its way from server to the target device, certain bits of information is required for your app. The most complex parts consists of security information that you set in the application so the notification system can verify the legitimity of the client receiving notifications. But you will also need a piece of security information for your notification server so the Apple or Google servers can verify that your server is a legitimate notification sender. Finally, when you send notifications, you need to be able to uniquely direct notifications to specific user's device. For that you retreive and use a token that is unique to the particular device (i.e. user).
+For a push notification to find its way from the server to the target device, certain bits of information are required for your app. The most complex part consists of security information that you set in the application so the notification system can verify the legitimacy of the client receiving notifications. But you will also need a piece of security information for your notification server so the Apple or Google servers can verify that your server is a legitimate notification sender. Finally, when you send notifications, you need to be able to uniquely direct notifications to a specific user's device. For that you retreive and use a token that is unique to the particular device (i.e. user).
 
 ## iOS setup
 
 ::: sidenote
-To get acquainted with the Apple Push Notification Servide, a good idea is to start by reading Apple's own documentation on how the service works. You find it on https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
+To get acquainted with the Apple Push Notification Service, a good idea is to start by reading Apple's own documentation on how the service works. You can find it at https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
 :::
 
 On iOS, you need the following information to send notifications:
 
 * Push Notifications must be enabled in the App ID.
 * A provisioning profile containing this valid App ID is also required.
-* You also need an Apple Push Notification service SSL Certificate to be allowed to send notification data to the Apple Push Notification server from your messaging server application.
+* You also need an Apple Push Notification Service SSL Certificate to be allowed to send notification data to the Apple Push Notification server from your messaging server application.
 
 To get everything in place, head over to the [Apple Developer Member center](https://developer.apple.com/membercenter). Edit your AppID to enable Push Notifications.
 
@@ -29,9 +29,9 @@ You also need to create an Apple Push Notification service SSL certificate:
 
 ![APN SSL certificate](images/push/push_ios_certificate.png)
 
-The certificate will be needed on your server that will send out push notifications. While developing, you can download and install the certificate on your machine and run a push test apps such as [APNS-Pusher](https://github.com/KnuffApp/APNS-Pusher) or [NWPusher](https://github.com/noodlewerk/NWPusher).
+The certificate will be needed on your server that will send out push notifications. While developing, you can download and install the certificate on your machine and run a push test app such as [APNS-Pusher](https://github.com/KnuffApp/APNS-Pusher) or [NWPusher](https://github.com/noodlewerk/NWPusher).
 
-Make sure that you create a new provisioning profile, from the AppID and that you get that onto your device. You can do that manually from the "Member Center" page or through Xcode.
+Make sure that you create a new provisioning profile from the AppID, and that you get it onto your device. You can do that manually from the "Member Center" page or through Xcode.
 
 ![Provisioning profile](images/push/push_ios_provisioning_profile.png)
 
@@ -97,10 +97,10 @@ If you're running a push test app, you can now try to send notifications to your
 
 ![Pusher test](images/push/push_ios_pusher.png)
 
-The notification should arrive to the client soon after you send it, from within your test application, arriving to the function `push_listener()`:
+The notification should arrive at the client soon after you send it, from within your test application, arriving to the function `push_listener()`:
 
 ```txt
-DEBUG:SCRIPT: 
+DEBUG:SCRIPT:
 {
   aps = {
     badge = 42,
@@ -167,7 +167,7 @@ local payload = '{"data" : {"field" : "Some value", "field2" : "Other value"}}'
 id, err = push.schedule(3, "A notification!", "Hello there", payload, { action = "get going" })
 ```
 
-The id is uniquely identifying this scheduled notification and can be stored for later The final parameter to `push.schedule()` takes a table with platform specific settings:
+The id is uniquely identifying this scheduled notification and can be stored for later. The final parameter to `push.schedule()` takes a table with platform specific settings:
 
 action
 : (iOS only). The alert action string to be used as the title of the right button of the alert or the value of the unlock slider, where the value replaces "unlock" in "slide to unlock" text.
@@ -183,12 +183,12 @@ priority
   - push.PRIORITY_DEFAULT
   - push.PRIORITY_HIGH
   - push.PRIORITY_MAX
-  
+
   Unless specified, the max priority level is used.
 
 ## Inspecting scheduled notifications
 
-The API provides two functions to inspect what is currently scheduled. 
+The API provides two functions to inspect what is currently scheduled.
 
 ```lua
 n = push.get_scheduled(id)
@@ -198,7 +198,7 @@ pprint(n)
 Which results in a table containing all details on the scheduled notification:
 
 ```txt
-DEBUG:SCRIPT: 
+DEBUG:SCRIPT:
 {
   payload = {"data":{"field":"Some value","field2":"Other value"}},
   title = A notification!,
@@ -208,7 +208,7 @@ DEBUG:SCRIPT:
 }
 ```
 
-Note that `seconds` indicate the number of seconds left for the notification to fire. It is also possible to retreive a table with _all_ scheduled notifications:
+Note that `seconds` indicates the number of seconds left for the notification to fire. It is also possible to retreive a table with _all_ scheduled notifications:
 
 ```lua
 all_n = push.get_all_scheduled()
@@ -218,7 +218,7 @@ pprint(all_n)
 Which results in a table pairing notification id:s with their respective data:
 
 ```txt
-DEBUG:SCRIPT: 
+DEBUG:SCRIPT:
 {
   0 = {
     payload = {"data":{"field":"Some value","field2":"Other value"}},

--- a/docs/en/manuals/rendering.md
+++ b/docs/en/manuals/rendering.md
@@ -5,7 +5,7 @@ brief: This manual explains how Defold's render pipeline works and how you can p
 
 # Rendering
 
-Every object that is shown on screen by the engine: sprites, models, tiles, particles or GUI nodes are drawn by a renderer. At the heart of the renderer is a render script that controls the render pipeline. By default, every 2D object is drawn with the correct bitmap with the specified blending and at the correct Z depth--so you might not have to ever think about rendering beyond ordering and simple blending. For most 2D games, the default pipeline functions well, but your game might have special requirements. If that is the case, Defold allows you to write a tailor-made rendering pipeline.
+Every object that is shown on screen by the engine: sprites, models, tiles, particles or GUI nodes, are drawn by a renderer. At the heart of the renderer is a render script that controls the render pipeline. By default, every 2D object is drawn with the correct bitmap with the specified blending and at the correct Z depth---so you might not have to ever think about rendering beyond ordering and simple blending. For most 2D games, the default pipeline functions well, but your game might have special requirements. If that is the case, Defold allows you to write a tailor-made rendering pipeline.
 
 ## The default renderer
 
@@ -29,12 +29,12 @@ To set up a custom renderer, you can do as follows:
 You can, of course, create a render script from scratch but it is a good idea to start with a copy of the default script if you are new to Defold and/or OpenGL ES rendering.
 
 ::: sidenote
-The render script has a special place in the lifecycle of your game. Detailed can be found in the [Application lifecycle documentation](/manuals/application-lifecycle).
+The render script has a special place in the lifecycle of your game. Details can be found in the [Application lifecycle documentation](/manuals/application-lifecycle).
 :::
 
 ## Render predicates
 
-To be able to control the draw order of objects, you create render _predicates_. A predicate declares what should be drawn based on a selection of material _tags_. Each object that is drawn onto the screen has a material attached to it and it controls exactly how the object should be drawn, down to which shader program to run. In the material, you specify one or more _tags_ associated with the material. This is compiled into a bit field when building the game, but is expressed as plain text tags in the editor. In your render script, create one or more render predicates and specify which tags should belong to the predicate. When you finally draw the predicate, each object with a material containing a tag matching the list specified to the predicate will be drawn. A more detailed description on materials can be found in the [Material documentation](/manuals/material).
+To be able to control the draw order of objects, you create render _predicates_. A predicate declares what should be drawn based on a selection of material _tags_. Each object that is drawn onto the screen has a material attached to it and it controls exactly how the object should be drawn, down to which shader program to run. In the material, you specify one or more _tags_ associated with the material. This is compiled into a bit field when building the game, but is expressed as plain text tags in the editor. In your render script, create one or more render predicates and specify which tags should belong to the predicate. When you finally draw the predicate, each object with a material containing a tag matching the list specified for the predicate will be drawn. A more detailed description on materials can be found in the [Material documentation](/manuals/material).
 
 ![Render predicate](images/rendering/rendering_predicate.png)
 
@@ -75,7 +75,7 @@ Information on how to define and use custom project settings can be found in the
 
 The `update()` function is called each frame. Its function is to perform the actual drawing by calling the underlying OpenGL ES APIs (OpenGL Embedded Systems API). To properly understand what's going on in the `update()` function, you need to understand how OpenGL works. There are many great resources on OpenGL ES available. The official site is a good starting place. You find it at https://www.khronos.org/opengles/
 
-The following example contains one major addition to the built in script which is the setup necessary to properly draw 3D models. As you saw above, a `self.model_pred` predicate is constructed. Elsewhere a material corresponding to this predicate has been defined and been applied to a 3D model component. The code for `update()` requires some specific handling of that predicate:
+The following example contains one major addition to the built in script which is the setup necessary to properly draw 3D models. As you saw above, a `self.model_pred` predicate is constructed. Elsewhere a material corresponding to this predicate has been defined and applied to a 3D model component. The code for `update()` requires some specific handling of that predicate:
 
 ```lua
 function update(self)
@@ -165,7 +165,7 @@ The `@render` socket has some built-in messages. The engine will send you a `win
 ```
 function on_message(self, message_id, message)
   if message_id == hash("window_resized") then
-    -- The window was resized. message.width and message.height contains new dimensions.
+    -- The window was resized. message.width and message.height contain the new dimensions.
     ...
   end
 end
@@ -184,7 +184,7 @@ msg.post("@render:", "draw_text", { text = "Hello world!", position = vmath.vect
 These messages are intended to be used to draw debug information. You can easily visualize ray_casts and vectors and print debug or development statistics in a programmatic manner. This data relates to your render script as follows:
 
 * Any lines added to the scene through the `draw_line` message are drawn with the `render.draw_debug3d()` call.
-* Any text added to the scene through the `draw_text` message are drawn in the built in "system_font" font. The system font has a material with tag "text" and is thus drawn in the "self.text_pred" predicate in the above render script.
+* Any text added to the scene through the `draw_text` message is drawn in the built in "system_font" font. The system font has a material with tag "text" and is thus drawn in the "self.text_pred" predicate in the above render script.
 
 ::: sidenote
 The visual profiler accessible through the `toggle_profile` message sent to the `@system` socket is not part of the scriptable renderer. It is drawn separate from your render script.

--- a/docs/en/manuals/scene-editing.md
+++ b/docs/en/manuals/scene-editing.md
@@ -5,7 +5,9 @@ brief: Defold contains a number of editors, but the Scene Editor is the one used
 
 # Scene editing
 
-Defold contains a number of editors, but the Scene Editor is the one used the most. All Game Objects and Collections, as well as some component types are created and edited in this editor.
+Defold contains a number of editors, but the Scene Editor is the one used the most. All Game Objects and Collections, as well as some component types, are created and edited in this editor.
+
+## Viewport Navigation
 
 Pan
 : <kbd>Alt</kbd> + <kbd>Middle button</kbd> (three button mouse) or <kbd>Option + Ctrl</kbd> + <kbd>Mouse button</kbd> (one button mouse)
@@ -13,7 +15,7 @@ Pan
 Zoom
 : <kbd>Alt</kbd> + <kbd>Right button</kbd> (three button mouse) or <kbd>Ctrl</kbd> + <kbd>Mouse button</kbd> (one button). If your mouse has a scroll wheel, it can be used to zoom.
 
-If you have a mouse wheel, it can be used to zoom the view. In OS X, two finger swipes up and down on the trackpad is equivalent to rolling the mouse wheel so you can use that gesture to zoom.
+If you have a mouse wheel, it can be used to zoom the view. In OS X, two finger swipes up and down on the trackpad are equivalent to rolling the mouse wheel, so you can use those gestures to zoom.
 
 To reset the view to where the whole scene is visible in the window, select <kbd>Scene ▸ Frame Objects</kbd>{.menu} from the menu or press <kbd>F</kbd>.
 
@@ -54,7 +56,7 @@ The *Rotate Tool* is accessible through the menu <kbd>Scene ▸ Rotate Tool</kbd
 
 ![Rotate object](images/scene_editing/scene_editing_rotate.png)
 
-The tool consists of three handles that you can manipulate. If you are working on 2D objects, you would probably only want to use the handle that rotates around the *Z* axis, which is the blue circle around the object. Click and drag on the circle to rotate the object.
+This tool consists of three handles that you can manipulate. If you are working on 2D objects, you would probably only want to use the handle that rotates around the *Z* axis, which is the blue circle around the object. Click and drag on the circle to rotate the object.
 
 If you want to rotate around the *X* or *Y* axis, click and drag on the green and red circles. Since the view is peripendicular to those axis, the circles only appear as two lines crossing the object: a green horizontal one and a red vertical.
 
@@ -76,5 +78,5 @@ It is often convenient to be able to disable the visual rendering of certain typ
 
 ![Showing information](images/scene_editing/scene_editing_show.png)
 
-The choices you make are stored in the editor and applies to all Scene Editor instances. Your choices are rememberered between sessions too so if you close the Defold editor down and start it up the next day, your Show settings will be intact.
+The choices you make are stored in the editor and apply to all Scene Editor instances. Your choices are rememberered between sessions too so if you close the Defold editor down and start it up the next day, your Show settings will be intact.
 

--- a/docs/en/manuals/script-properties.md
+++ b/docs/en/manuals/script-properties.md
@@ -83,7 +83,7 @@ Any script component instance that uses the script can set the value specificall
 In the case where the game object holding the script lives inside a sub-collection, expand the game object node in the collection to select the script.
 :::
 
-The editor property inspector will automatically show a widget that is feasible for the type of property that you have declared. Numbers are entered in text boxes, vectors and quartenions as a set of numbers in boxes, hashes allow you to enter the string that will be hashed and URLs give you a drop down with all _relative_, local (that is, within the same collection) objects and components. You are still able to enter URL values manually, too.
+The editor property inspector will automatically show a widget that is appropriate for the type of property that you have declared. Numbers are entered in text boxes, vectors and quaternions as a set of numbers in boxes, hashes allow you to enter the string that will be hashed and URLs give you a drop down with all _relative_, local (that is, within the same collection) objects and components. You are still able to enter URL values manually, too.
 
 ![Property example](images/script_properties/script_properties_example.png)
 
@@ -96,12 +96,12 @@ Through `self`
 
   ```lua
   go.property("my_property", 1)
-  
+
   ...
   function init(self)
       self.other_property = 2
   end
-  
+
   function update(self, dt)
       -- Read and write the property
       if self.my_property == 1 and self.other_property == 3 then
@@ -117,16 +117,16 @@ As a script component property
   -- myobject.script
   -- This script is attached to the object "myobject". The script component is called "script".
   go.property("my_property", 1)
-  
+
   ...
   ```
-  
+
   ```lua
   -- another.script
   -- increase "my_property" in "myobject#script" by 1
   local val = go.get("myobject#script", "my_property")
   go.set("myobject#script", "my_property", val + 1)
-  
+
   -- animate "my_property" in "myobject#script"
   go.animate("myobject#script", "my_property", go.PLAYBACK_LOOP_PINGPONG, 100, go.EASING_LINEAR, 2.0)
   ```
@@ -154,10 +154,10 @@ props[hash("/object3")] = { another_property = 4 }
 local ids = collectionfactory.create("#collectionfactory", nil, nil, props)
 ```
 
-The property values provided via `factory.create()` and `collectionfactory.create()` override any value set in the game object file as well as the default value in the script.
+The property values provided via `factory.create()` and `collectionfactory.create()` override any values set in the game object file as well as the default values in the script.
 
 ::: important
-If you have several script components attached to a game object, it is possible to put script properties in any of the script files. Suppose that the game object example above had another script component also containing the property `health`. When `factory.create()` is called, the `health` property for _both_ scripts are set to the provided value.
+If you have several script components attached to a game object, it is possible to put script properties in any of the script files. Suppose that the game object example above had another script component also containing the property `health`. When `factory.create()` is called, the `health` properties for _both_ scripts are set to the provided value.
 :::
 
 

--- a/docs/en/manuals/shader.md
+++ b/docs/en/manuals/shader.md
@@ -25,7 +25,7 @@ Specifications of OpenGL ES 2.0 (OpenGL for Embedded Systems) and OpenGL ES Shad
 Note that on desktop computers it is possible to write and compile shaders using features not available on OpenGL ES 2.0. Doing so will break cross compatibility.
 
 ::: sidenote
-The site Shadertoy (https://www.shadertoy.com) contains a massive amount of user contributed shaders. It is a great source of techniques and inspiration. Many of the shaders showcased on the site can be ported to Defold with very little work.
+The site Shadertoy (https://www.shadertoy.com) contains a massive number of user contributed shaders. It is a great source of techniques and inspiration. Many of the shaders showcased on the site can be ported to Defold with very little work.
 :::
 
 ## Overview
@@ -38,34 +38,34 @@ In the engine, the vertex positions of a model's shape are stored relative to a 
 
 The world transform matrix includes information about what translation (movement), rotation and scale should be applied to the model's vertices for them to be correctly placed in the game world's coordinate system. By separating these pieces of information the game engine is able to manipulate the position, rotation and scale of each model without ever destroying the original vertex values stored in the model component.
 
-Similarly, when the game world is rendered, the 3D world coordinates of each vertex needs to be translated into actual 2D screen positions. This translation is done with two matrices: a _view matrix_ that translates world coordinates into camera relative coordinates, and a _projection matrix_ that projects the camera relative 3D coordinates onto the flat 2D screen space.
+Similarly, when the game world is rendered, the 3D world coordinates of each vertex need to be translated into actual 2D screen positions. This translation is done with two matrices: a _view matrix_ that translates world coordinates into camera relative coordinates, and a _projection matrix_ that projects the camera relative 3D coordinates onto the flat 2D screen space.
 
-Due to CPU batching of rendering primitives, the world space transformation is done on the CPU before the vertex program processes the vertices. The program processes each vertex (in world space) and computes the resulting coordinate that each vertex of a primitive should have. After that the primitive is _rasterized_. Rasterization means that primitives are divided into fragments (or pixels) and processed by a _fragment shader_ (sometimes called a _pixel shader_). The purpose of the fragment shader is to decide the color of each resulting fragment. This is done by calculation, by texture lookups (one or several) or a combination of lookups and computations.
+Due to CPU batching of rendering primitives, the world space transformation is done on the CPU before the vertex program processes the vertices. The program processes each vertex (in world space) and computes the resulting coordinate that each vertex of a primitive should have. After that the primitive is _rasterized_. Rasterization means that primitives are divided into fragments (or pixels) and processed by a _fragment shader_ (sometimes called a _pixel shader_). The purpose of the fragment shader is to decide the color of each resulting fragment. This is done by calculation, texture lookups (one or several) or a combination of lookups and computations.
 
 ![Shader pipeline](images/shader/shader_pipeline.png)
 
-Note that the vertex shader cannot create or delete vertices, just change vertex positions. Also note that the fragment shader is not able to operate on fragments outside of the primitives resulting from vertex shading.
+Note that the vertex shader cannot create or delete vertices, only change vertex positions. Also note that the fragment shader is not able to operate on fragments outside of the primitives resulting from vertex shading.
 
 ## Variables
 
 A shader program consists of code that operates on data. Data is passed to and between shader programs through variables of different types:
 
 Vertex attribute variables
-: Vertex attributes are used to send data to the vertex shader. Values are set per vertex and contain information about each vertex' position, normal, color and texture coordinate. These values are usually stored in the mesh created in a 3D modelling software and exported to Collada files that Defold can read.
+: Vertex attributes are used to send data to the vertex shader. Values are set per vertex and contain information about each vertex's position, normal, color and texture coordinates. These values are usually stored in the mesh created in a 3D modelling software and exported to Collada files that Defold can read.
 
-Attributes provided from the engine can be defined in the vertex shader using the `attribute` qualifier. Vertex attributes differs from uniforms in that they are set for each vertex. Uniforms are constant for all vertices. It is not possible to define attributes in the fragment shader.
+Attributes provided from the engine can be defined in the vertex shader using the `attribute` qualifier. Vertex attributes differ from uniforms in that they are set for each vertex. Uniforms are constant for all vertices. It is not possible to define attributes in the fragment shader.
 
 Uniform variables
 : Uniforms are values that are passed from the engine to vertex and fragment shader programs. They are declared in the shader programs with the `uniform` qualifier and must also be defined in the material file as *vertex_constant* or *fragment_constant* properties. Uniforms do not change from one execution of a shader program to the next within a particular rendering call (i.e. within a component). That is why they are called uniforms. In Defold, you define uniforms as material _constants_ in the component material file. The following constants are available:
 
 `CONSTANT_TYPE_WORLD`
-: The world matrix. Use to transform vertices into world space. For some component types, the vertices are already in world space when they arrive to the vertex program (due to batching). In those cases multiplying with the world matrix will yield the wrong results.
+: The world matrix. Used to transform vertices into world space. For some component types, the vertices are already in world space when they arrive to the vertex program (due to batching). In those cases multiplying by the world matrix will yield the wrong results.
 
 `CONSTANT_TYPE_VIEW`
-: The view matrix. Use to transform vertices to view (camera) space.
+: The view matrix. Used to transform vertices to view (camera) space.
 
 `CONSTANT_TYPE_PROJECTION`
-: The projection matrix. Use to transform vertices to screen space.
+: The projection matrix. Used to transform vertices to screen space.
 
 `CONSTANT_TYPE_VIEWPROJ`
 : A matrix with the view and projection matrices already multiplied.
@@ -80,7 +80,7 @@ Uniform variables
 : A vector4 constant that you can use for any custom data you want to pass into your shader programs. You can set the initial value of the constant in the constant definition, but it is mutable through the functions `.set_constant()` and `.reset_constant()` for each component type (`sprite`, `model`, `spine`, `particlefx` and `tilemap`)
 
 Varying variables
-: Varying variables gives you an interface between the vertex and fragment shader. It is the output of a vertex shader and the input of a fragment shader. Varying variables are declared with the `varying` qualifier and can be of type `float`, `vec2`, `vec3`, `vec4`, `mat2`, `mat3` and `mat4`.
+: Varying variables give you an interface between the vertex and fragment shader. They are the output of a vertex shader and the input of a fragment shader. Varying variables are declared with the `varying` qualifier and can be of type `float`, `vec2`, `vec3`, `vec4`, `mat2`, `mat3` and `mat4`.
 
 If you define a varying variable and set its value in the vertex shader, the value will be set for each vertex. During rasterization this value is interpolated for each fragment on the primitive being rendered. You can access the interpolated value in the fragment shader to determine what color to set on the fragment.
 
@@ -93,7 +93,7 @@ For example, suppose that you define a varying variable +v+ and set it for each 
 Apart from the above types of user defined variables, a couple of built in variables also exist in GLSL:
 
 `gl_Position`​
-: A built in variable of type `vec4` that holds the output position of the current vertex in projection space. Set the value in the vertex shader. Note that this value has 4 component. `x`, `y`, `z` and `w`. The `w` component is used to calculate perspective correct interpolation. This value is normally 1.0 for each vertex _before any transformation matrix is applied_.
+: A built in variable of type `vec4` that holds the output position of the current vertex in projection space. Set the value in the vertex shader. Note that this value has 4 components, `x`, `y`, `z` and `w`. The `w` component is used to calculate perspective-correct interpolation. This value is normally 1.0 for each vertex _before any transformation matrix is applied_.
 
 `gl_FragColor`
 : A built in variable of type `vec4` that holds the output RGBA color value for the current fragment. Set the value in the fragment shader.
@@ -108,11 +108,11 @@ UV map
 ![UV coordinates](images/shader/uv_coordinates.png)
 
 Sampler variables
-: Samplers are uniform variables that are used to sample values from an image source. `sampler2D` and `samplerCube` type samplers are supported. `sampler2D` samples from a 2D image texture (a PNG or JPEG image) whereas `samplerCube` samples from a 6 image cubemap texture (defined in a `.cubemap` Defold resource file). You can use a sampler only in the GLSL standard library's texture lookup functions. These functions access the texture referred to by the sampler and take a texture coordinate as parameters. The [Material manual](/manuals/material) explains how to specify sampler settings.
+: Samplers are uniform variables that are used to sample values from an image source. `sampler2D` and `samplerCube` type samplers are supported. `sampler2D` samples from a 2D image texture (a PNG or JPEG image) whereas `samplerCube` samples from a 6 image cubemap texture (defined in a `.cubemap` Defold resource file). You can use a sampler only in the GLSL standard library's texture lookup functions. These functions access the texture referred to by the sampler and take a texture coordinate as a parameter. The [Material manual](/manuals/material) explains how to specify sampler settings.
 
 ## Vertex shaders
 
-The simplest possible vertex shader takes the incoming vertices and simply transform them by multiplying with the appropriate matrices that are passed to the shader as uniform values:
+The simplest possible vertex shader takes the incoming vertices and simply transforms them by multiplying by the appropriate matrices that are passed to the shader as uniform values:
 
 ```glsl
 // view_proj is set as vertex constants in the material.
@@ -135,7 +135,7 @@ For a model consisting of a 32x32 flat grid of vertices, the vertices will be tr
 
 ![Flat grid](images/shader/grid_flat.png)
 
-However, the shader can do much more than staight transformations. It can freely modify the positions of the vertices and deform the model:
+However, the shader can do much more than straight transformations. It can freely modify the positions of the vertices and deform the model:
 
 ```glsl
 uniform mediump mat4 view_proj;
@@ -219,7 +219,7 @@ A common use of fragment shaders is to texture the rendered primitives. First, t
 
 ![Model texture](images/shader/model_texture.png)
 
-In this particular case the model is flat and square, so the texture would fit the model without any modification. But models are often complex and the fitting of the image needs to be done manually. To allow an arbitrary image texture to be mapped onto an arbitrary 3D model in an arbitrary manner, an _UV map_ is used. This map consists of 2D texture coordinates for each vertex in the model. A vertex shader program take the texture coordinate attribute and set a varying variable for each vertex, allowing the fragment shader to receive interpolated texture coordinate values for each fragment:
+In this particular case the model is flat and square, so the texture would fit the model without any modification. But models are often complex and the fitting of the image needs to be done manually. To allow an arbitrary image texture to be mapped onto an arbitrary 3D model in an arbitrary manner, a _UV map_ is used. This map consists of 2D texture coordinates for each vertex in the model. A vertex shader program takes the texture coordinate attribute and sets a varying variable for each vertex, allowing the fragment shader to receive interpolated texture coordinate values for each fragment:
 
 ```glsl
 // vertex shader
@@ -240,7 +240,7 @@ void main()
 }
 ```
 
-In the fragment shader program, the varying texture coordinate variable is defined. A `sampler2D` uniform variable is also defined. The sampler, together with the interpolated texture coordinates are used to perform texture lookup---the graphics hardware samples the texture at a specified position and returns the sampled color value. The function `texture2D()` performs such lookup.
+In the fragment shader program, the varying texture coordinate variable is defined. A `sampler2D` uniform variable is also defined. The sampler, together with the interpolated texture coordinates, is used to perform texture lookup---the graphics hardware samples the texture at a specified position and returns the sampled color value. The function `texture2D()` performs such lookup.
 
 ```glsl
 // fragment shader
@@ -263,7 +263,7 @@ void main()
 ![Textured deformed grid](images/shader/grid_textured.png)
 
 ::: sidenote
-Note that the above example only reposition the vertices. The texture coordinates associated with each vertex is left intact. This leads to stretching where the distance between two vertices becomes large.
+Note that the above example only repositions the vertices. The texture coordinates associated with each vertex are left intact. This leads to stretching where the distance between two vertices becomes large.
 :::
 
 We can choose fragment color based on any type of calculation. For example, it is possible to take the _normals_ of the model into account and create a simple lighting model. To get varied surface normals the example grid model has been deformed in the 3D modelling software.

--- a/docs/en/manuals/sound.md
+++ b/docs/en/manuals/sound.md
@@ -8,7 +8,7 @@ brief: This manual explains how you bring sounds into your Defold project, play 
 Defold's sound implementation is simple but powerful. There are only two concepts that you need to be aware of:
 
 Sound components
-: These components contain an actual sound that should be played and is able to play back the sound.
+: These components contain an actual sound that should be played and are able to play back the sound.
 
 Sound groups
 : Each sound component can be designated to belong to a _group_. Groups offer an easy way to manage sounds that belong together in an intuitive way. For instance, a group "sound_fx" can be set up and any sound belonging to that group can be ducked by a simple function call.
@@ -25,10 +25,10 @@ The created component has a set of properties that should be set:
 : Should be set to a sound file in your project. The file should be in _Wave_ or _Ogg Vorbis_ format (See http://en.wikipedia.org/wiki/WAV and http://en.wikipedia.org/wiki/Vorbis for details).
 
 *Looping*
-: If checked the sound will playback looping until explicitly stopped.
+: If checked the sound will play back in a loop until explicitly stopped.
 
 *Gain*
-: You can set the gain for the sound directly on the component. This allows you to easily tweak the gain for a sound without going back to your sound program and perform a re-export. See below for details on how gain is calculated.
+: You can set the gain for the sound directly on the component. This allows you to easily tweak the gain for a sound without going back to your sound program and performing a re-export. See below for details on how gain is calculated.
 
 *Group*
 : The name of the sound group the sound should belong to. If this property is left empty, the sound will be assigned to the built-in "master" group.
@@ -68,7 +68,7 @@ The groups are identified with a hash value. The string name can be retrieved wi
 ![Sound group mixer](images/sound/sound_mixer.png)
 
 ::: important
-You should not write code that relies on the string value of a sound group since it is not available in release builds.
+You should not write code that relies on the string value of a sound group since they are not available in release builds.
 :::
 
 All values are linear between 0 and 1.0 (0 dB). To convert to decibel, simply use the standard formula:
@@ -103,7 +103,7 @@ sound.set_group_gain("master", 1.995)
 
 ## Gating sounds
 
-If your game plays the same sound on an event and that event is triggered often, you run the risk of playing the same sound two times or more almost at the same time. If that happens, the sounds will be _phase shifted_ which can result in some very noticeable artifacts. 
+If your game plays the same sound on an event and that event is triggered often, you run the risk of playing the same sound two times or more almost at the same time. If that happens, the sounds will be _phase shifted_ which can result in some very noticeable artifacts.
 
 ![Phase shift](images/sound/sound_phase_shift.png)
 
@@ -114,7 +114,7 @@ The easiest way to deal with this problem is to build a gate that filters sound 
 local gate_time = 0.3
 
 function init(self)
-    -- Store played sound timers in table and count down each frame until they have been 
+    -- Store played sound timers in a table and count down each frame until they have been
     -- in the table for "gate_time" seconds. Then remove them.
     self.sounds = {}
 end
@@ -152,6 +152,6 @@ msg.post("/sound_gate#script", "play_gated_sound", { soundcomponent = "/sounds#e
 ```
 
 ::: important
-It does not work to have the gate listen to `play_sound` messages since that name is reserved by the Defold engine. You will get unexpected behavior if you do use reserved message names.
+It does not work to have the gate listen to `play_sound` messages since that name is reserved by the Defold engine. You will get unexpected behavior if you use reserved message names.
 :::
 

--- a/docs/en/manuals/spine.md
+++ b/docs/en/manuals/spine.md
@@ -85,7 +85,7 @@ This example shows files laid out in a flat structure. It is, however, possible 
 
 If you select <kbd>Add Images</kbd> Defold will automatically create animation groups with the same name as the added files, but with the file suffix stripped off. So, after having added the file *eyes.png* its animation group can be referenced by the name "eyes". This works with file names only, not paths.
 
-So how do you do if your animation references "head_parts/eyes"? The easiest way to accomplish a match is to add an animation group (right click the root node in the Atlas *Outline* view and select *Add Animation Group*). You can then name that group "head_parts/eyes" (it's just a name, not a path and `/` characters are legal) and then add the file "eyes.png" to the group.
+So what do you do if your animation references "head_parts/eyes"? The easiest way to accomplish a match is to add an animation group (right click the root node in the Atlas *Outline* view and select *Add Animation Group*). You can then name that group "head_parts/eyes" (it's just a name, not a path and `/` characters are legal) and then add the file "eyes.png" to the group.
 
 ![Atlas path names](images/spine/spine_atlas_names.png)
 

--- a/docs/en/manuals/spinemodel.md
+++ b/docs/en/manuals/spinemodel.md
@@ -9,7 +9,7 @@ The SpineModel component is used to bring _Spine_ skeletal animations to life in
 
 ## Creating SpineModel components
 
-Create a game object and put a *SpineModel* component in the game object. You can either create the component in-place (right click the game object and select <kbd>Add Component</kbd>) or create it on file first (Select <kbd>New ▸ Spine Model File</kbd> from the menu) and then add the file to the game object (right click the game object and select <kbd>Add Component From File</kbd>).
+Create a game object and add a *SpineModel* component to it. You can either create the component in-place (right click the game object and select <kbd>Add Component</kbd>) or create it on file first (Select <kbd>New ▸ Spine Model File</kbd> from the menu) and then add the file to the game object (right click the game object and select <kbd>Add Component From File</kbd>).
 
 ![Add component](images/spinemodel/spine_add_component.png)
 
@@ -24,7 +24,7 @@ Default animation
 : Set this to the animation you want the model to start with.
 
 Skin
-: If your model have skins, select the one you want it to start with.
+: If your model has skins, select the one you want it to start with.
 
 Material
 : If you need to render the model with a custom material, change this property.

--- a/docs/en/manuals/test.md
+++ b/docs/en/manuals/test.md
@@ -7,7 +7,7 @@ brief: This document uses all Markdown features (Commonmark + extensions) that t
 
 All defold manuals and tutorials are written in Markdown. This document outlines how to use the various formatting for a consistent look on all documents.
 
-Try to write as talking to the user. Keep the language direct and active and refrain from stating opinions unless it is important to the matter. Try to write paragraphs that flow and do not break them unnecessarily.
+Try to write as if you are talking to the user. Keep the language direct and active and refrain from stating opinions unless it is important to the matter. Try to write paragraphs that flow and do not break them unnecessarily.
 
 You do have some typographic markers to your disposal. The simplest one is the *emphasis* marker. It puts some stress to a word, marking it as important. This marker should also be used to call attention to specific things that the user can encounter in Defold, like the names of properties, buttons etc. For example, a sprite component's *Position*, a button that says *Save...* etc. File names are also typed like that: *game.project* or *main/images/logo.png*.
 
@@ -49,7 +49,7 @@ end
 
 ## Two levels of headings, lists and tables
 
-Do not use more than two levels of headings. If you need to describe specific things that you feel calls for a third level heading, use a definition list instead:
+Do not use more than two levels of headings. If you need to describe specific things that you feel call for a third level heading, use a definition list instead:
 
 Some thing
 : Here you can explain what "Some thing" is, what it does and whatnot. You have access to all of markdown in the description, just make sure to indent properly:
@@ -61,7 +61,7 @@ Another thing to explain
 
 Definition lists are great when you can put a name to each item. Sometimes a bullet list is better, or a numbered list. You can mix and match these:
 
-- Bullet list, indicated with either `-` or a `*` or a `+` at the start of the line.
+- Bullet list, indicated with either a `-` or a `*` or a `+` at the start of the line.
 - Another item.
 - A third item. We can also make sub-items, either bullets or numbers:
     1. A numbered sub-item. Number list items are written either `1.` or `1)`.
@@ -91,10 +91,10 @@ Or right-aligned
 
 ## Notes and images
 
-There are two types of notes that you can insert in the text. Since this is not a printed medium the idea of a footnote doesn't really work. Instead we keep the notes together with the text. Use the `::: sidenote` block for these.
+There are two types of notes that you can insert into the text. Since this is not a printed medium the idea of a footnote doesn't really work. Instead we keep the notes together with the text. Use the `::: sidenote` block for these.
 
 ::: sidenote
-The `::: sidenote` block is good for adding footnote-like information to the text. It can be used to add further explanation that is not vital or point to other resources. They are shown to the side of the text they preceed.
+The `::: sidenote` block is good for adding footnote-like information to the text. It can be used to add further explanation that is not vital or point to other resources. They are shown to the side of the text they precede.
 :::
 
 When you really want to make the user aware of something, use the `::: important` block:
@@ -103,7 +103,7 @@ When you really want to make the user aware of something, use the `::: important
 This is a block of text that the user will not miss. Use these sparingly for things that really needs a lot of attention. If you find that your document is littered with these, you might want to group the information a bit.
 :::
 
-Images are inserted in the document like this:
+Images are inserted into the document like this:
 
 ![A large image of sorts](images/test/large.png)
 

--- a/docs/en/manuals/texture-profiles.md
+++ b/docs/en/manuals/texture-profiles.md
@@ -7,25 +7,25 @@ brief:  Defold supports automatic texture processing and compression of image da
 
 Defold supports automatic texture processing and compression of image data (in *Atlas*, *Tile sources*, *Cubemaps* and stand-alone textures used for models, GUI etc).
 
-There are two types of compression, software image compression and hardware texture compression. 
+There are two types of compression, software image compression and hardware texture compression.
 
 1. Software compression (such as PNG and JPEG) reduces the storage size of image resources. This makes the the final bundle size smaller. However, the image files need to be uncompressed when read into memory so even though an image is small on disk, it can have a large memory footprint.
- 
+
 2. Hardware texture compression also reduces the storage size of image resources. But, unlike software compression, it reduces the in-memory footprint for textures. This is because the graphics hardware is able to directly manage compressed textures without first having to uncompress them.
 
 The processing of textures is configured through a specific texture profile. In this file you create _profiles_ that express what compressed format(s) and type should be used when creating bundles for a specific platform. _Profiles_ are then tied to matching file _paths patterns_, allowing fine tuned control over what files in your project should be compressed and exactly how.
 
-Since all available hardware texture compression is lossy, you will get artifacts in your texture data. These artifacts are highly dependant on how your source material looks and what compression method is used. You should test your source material and experiment to get the best results. Google is your friend here.
+Since all available hardware texture compression is lossy, you will get artifacts in your texture data. These artifacts are highly dependent on how your source material looks and what compression method is used. You should test your source material and experiment to get the best results. Google is your friend here.
 
 You can select what software image compression is applied on the final texture data (compressed or raw) in the bundle archives. Defold supports WebP or ZLib (default). WebP supports both lossy and lossless compression and usually results in significantly better compression than ZLib, which is a general data compression algorithm
 
 ::: sidenote
-Compression is a resource intense and time consuming operation that can cause _very_ long build times depending on the amount of texture images to compress and also the chosen texture formats and type of software compression.
+Compression is a resource intensive and time consuming operation that can cause _very_ long build times depending on the number of texture images to compress and also the chosen texture formats and type of software compression.
 :::
 
 ## Texture profiles
 
-Each project contain a specific *.texture_profiles* file that contain the configuration used when compressing textures. By default, this file is *builtins/graphics/default.texture_profiles* and it has a configuration matching every texture resource to a profile using RGBA with no hardware texture compression and using the default ZLib file compression.
+Each project contains a specific *.texture_profiles* file that contains the configuration used when compressing textures. By default, this file is *builtins/graphics/default.texture_profiles* and it has a configuration matching every texture resource to a profile using RGBA with no hardware texture compression and using the default ZLib file compression.
 
 To add texture compression:
 
@@ -56,10 +56,10 @@ The *path_settings* section of the texture profiles file contains a list of path
 
 ![Paths](images/texture_profiles/texture_profiles_paths.png)
 
-This example contains two path patterns and corresponding profile.
+This example contains two path patterns and their corresponding profiles.
 
 `/gui/**/*.atlas`
-: All *.atlas* files in directory */gui* or any of its subdirectories will be processed according to profile "gui_atlas". 
+: All *.atlas* files in directory */gui* or any of its subdirectories will be processed according to profile "gui_atlas".
 
 `/**/*.atlas`
 : All *.atlas* files anywhere in the project will be process according to the profile "atlas".
@@ -78,7 +78,7 @@ The *profiles* section of the texture profiles file contains a list of named pro
 : Specifies a matching OS platform. `OS_ID_GENERIC` matches all platforms including dev-app builds on device, `OS_ID_WINDOWS` matches Windows target bundles, `OS_ID_IOS` matches iOS bundles and so on. Note that if `OS_ID_GENERIC` is specified, it will be included for all platforms.
 
 *formats*
-: One or more texture formats to generate. If several formats are specified, textures for each format is generated and included in the bundle. The engine selects textures of a format that is supported by the runtime platform.
+: One or more texture formats to generate. If several formats are specified, textures for each format are generated and included in the bundle. The engine selects textures of a format that is supported by the runtime platform.
 
 *mipmaps*
 : For each platform, specify whether mipmaps should be generated. The property can be either `true` or `false`.
@@ -86,7 +86,7 @@ The *profiles* section of the texture profiles file contains a list of named pro
 *max_texture_size*
 : If set to a non-zero value, textures are limited in pixel size to the specified number. Any texture that has a width or height larger than the specified value will be scaled down.
 
-The *formats* added to a profile each has the following properties:
+The *formats* added to a profile each have the following properties:
 
 *format*
 : The format to use when encoding the texture. See below for all available texture formats.
@@ -99,23 +99,23 @@ The *formats* added to a profile each has the following properties:
 
 ## Texture formats
 
-Graphics hardware textures can be processed into uncompressed or *lossy* compressed data with various number of channels and bit depths. Hardware compression that is fixed means that the resulting image will be of a fixed size, regardless of the image content. This means that the quality loss during compression depends on the content of the original texture.
+Graphics hardware textures can be processed into uncompressed or *lossy* compressed data with various numbers of channels and bit depths. Hardware compression that is fixed means that the resulting image will be of a fixed size, regardless of the image content. This means that the quality loss during compression depends on the content of the original texture.
 
 The following lossy compression formats are currently supported.
 
 <!--
 DXT
-: Also called S3 Texture Compression. It can be generated on Windows platform only, but OS X supports reading it and it's possible to install support for it on Linux. The format divides the image into 4x4 pixel blocks with 4 colors set to the pixels within each block. 
+: Also called S3 Texture Compression. It can be generated on Windows platform only, but OS X supports reading it and it's possible to install support for it on Linux. The format divides the image into 4x4 pixel blocks with 4 colors set to the pixels within each block.
 -->
 
 PVRTC
-: Textures are compressed in blocks. In 4 bit mode (4BPP) one block has 4×4 pixels. In 2 bit mode (2BPP) one block are 8×4 pixels. One block always occupies 64 bits (8 bytes) of memory space.  The format is used in all generations of the iPhone, iPod Touch, and iPad. (certain Android devices, that use PowerVR GPUs also support the format). Defold supports PVRTC1, as indicated by the suffix "V1" in the format identifiers.
+: Textures are compressed in blocks. In 4 bit mode (4BPP) each block is 4×4 pixels. In 2 bit mode (2BPP) each block is 8×4 pixels. Each block always occupies 64 bits (8 bytes) of memory space.  The format is used in all generations of the iPhone, iPod Touch, and iPad. (certain Android devices, that use PowerVR GPUs, also support the format). Defold supports PVRTC1, as indicated by the suffix "V1" in the format identifiers.
 
 ETC
 : Ericsson Texture Compression. Blocks of 4×4 pixels are compressed into a single 64-bit word. The 4×4 block is divided in half and each half is assigned a base color. Each pixel is then encoded as one of four offset values from the base color of its half. Android supports ETC1 since version 2.2 (Froyo). Defold compresses ETC1 textures.
 
 | Format                            | Compression | Color                            | Note |
-| --------------------------------- | ----------- | -------------------------------- | ---- | 
+| --------------------------------- | ----------- | -------------------------------- | ---- |
 | `TEXTURE_FORMAT_LUMINANCE`        | none        | One channel gray-scale, no alpha | RGB channels multiplied into one. Alpha is discarded. |
 | `TEXTURE_FORMAT_RGB`              | none        | 3 channel color                  | Alpha is discarded |
 | `TEXTURE_FORMAT_RGBA`             | none        | 3 channel color and full alpha   | |

--- a/docs/en/manuals/workflow.md
+++ b/docs/en/manuals/workflow.md
@@ -5,21 +5,21 @@ brief: This manual covers how assets are handled in Defold, how you can change t
 
 # Workflow
 
-A game project usually consist of a large number of external assets that are produced in various specialized programs for producing graphics, 3D models, sound files, animations and so forth. Defold is by default set up for a workflow that encourages you to work separately with your external tools, store the working files for those tools separately and then import the assets into Defold and the project file structure as they are finalized.
+A game project usually consists of a large number of external assets that are produced in various specialized programs for producing graphics, 3D models, sound files, animations and so forth. Defold is by default set up for a workflow that encourages you to work separately with your external tools, store the working files for those tools separately and then import the assets into Defold and the project file structure as they are finalized.
 
-Git is built primarily to handle source code and text files and stores those types of files with a very low footprint. Only the changes between each version is stored, which means that you can keep an extensive history of changes to all your project files to a relatively small cost. Binary files such as image or sound files, however, does not benefit from Git's storage scheme. Each new version you check in and synchronize takes about the same space. That is usually not a major issue with the final project assets (JPEG or PNG images, OGG sound files etc) but it can quickly become an issue with working project files (PSD files, Protools projects etc). These types of files or projects often grow very large since you usually work in much higher resolution than the target assets.
+Git is built primarily to handle source code and text files and stores those types of files with a very low footprint. Only the changes between each version are stored, which means that you can keep an extensive history of changes to all your project files to a relatively small cost. Binary files such as image or sound files, however, does not benefit from Git's storage scheme. Each new version you check in and synchronize takes about the same space. That is usually not a major issue with the final project assets (JPEG or PNG images, OGG sound files etc) but it can quickly become an issue with working project files (PSD files, Protools projects etc). These types of files or projects often grow very large since you usually work in much higher resolution than the target assets.
 
 It is generally considered best to avoid putting large working files under the control of Git and instead use a separate solution for keeping backups. If you do large scale processing or generation of asset files from a working project it is usually easy to write simple scripts that copy the final files into the proper place in the Defold project hierarchy.
 
 ## Refactoring
 
-Refactoring refers to the process of restructuring existing code and assets to improve the design. During the development of a project, the need to change or move things around often surface:
+Refactoring refers to the process of restructuring existing code and assets to improve the design. During the development of a project, the need to change or move things around often surfaces:
 
 * Names need to change to adhere to naming conventions or to improve clarity.
 * Code or asset files need to move to a more logical place in the project hierarchy.
 * New code and/or assets with better functionality are built to replace old ones, that are deleted.
 
-Defold helps you refactor efficiently by keeping track of how assets are used and automatically updates references to assets that are renamed and/or moved. As a developer, you should feel free in your work. Your project is a flexible structure that you can change at will without fearing that everything will break and fall into pieces. Defold will help you in your refactoring work making the process as effortless as possible.
+Defold helps you refactor efficiently by keeping track of how assets are used and automatically updating references to assets that are renamed and/or moved. As a developer, you should feel free in your work. Your project is a flexible structure that you can change at will without fearing that everything will break and fall to pieces. Defold will help you in your refactoring work making the process as effortless as possible.
 
 That said, there are cases where Defold is unable to automatically update references when you are doing refactoring work. In those cases, the editor can't solve the problem, but will provide helpful error signals.
 
@@ -27,7 +27,7 @@ For instance, if you add a Tilemap component to a Game Object and then delete th
 
 ![Error propagation](images/workflow/workflow_error_propagation.png)
 
-Some of these error signals Defold can add instantly as you make a change, required that you have the relevant asset open. Badges in the Project View, however, are only added when the compiler is run (i.e. when you try to run your game).
+Some of these error signals Defold can add instantly as you make a change, provided that you have the relevant asset open. Badges in the Project View, however, are only added when the compiler is run (i.e. when you try to run your game).
 
 ::: important
 If you move or rename files outside of the editor (i.e. in the OS X Finder, Windows Explorer or shell) the automatic refactoring mechanisms will not work. If you do file operations outside of the Defold editor, be aware that file references in your project assets might break.
@@ -47,13 +47,13 @@ When you start working and save changes you made to the project, these changes w
 
 ## Synchronizing
 
-Synchronizing your project branch means that it is brought in sync with the project as it looks on the master branch on the server. Whatever changes that has been made on the server are pulled to your branch and whatever changes that you have made to your local branch are pushed to the server repository.
+Synchronizing your project branch means that it is brought in sync with the project as it looks on the master branch on the server. Any changes that have been made on the server are pulled to your branch and any changes that you have made to your local branch are pushed to the server repository.
 
 When you have done some work in your current branch that you wish to share with the rest of the project team, you select <kbd>File ▸ Synchronize</kbd>. This brings up a window where you can inspect your changes and write a _useful_ commit message:
 
 ![Commit changes](images/workflow/workflow_commit.png)
 
-All files that are either changed, added or deleted from the project are listed in the top pane of the window. Each file carry an annotation:
+All files that are either changed, added or deleted from the project are listed in the top pane of the window. Each file carries an annotation:
 
 [M]
 : The file has been modified in your branch.
@@ -65,21 +65,21 @@ All files that are either changed, added or deleted from the project are listed 
 : The file has been deleted from your branch.
 
 
-To inspect the changes that has been done to a file, simply double click the file in the commit-list to open the Compare window:
+To inspect the changes that have been done to a file, simply double click the file in the commit-list to open the Compare window:
 
 ![Compare changes](images/workflow/workflow_compare_script.png)
 
-The window shows two versions of the file (in case of a modified file. Added or deleted files view differently). On the left hand side is the file as it looked on the server _when you last synchronized_. The right hand side shows your local version. Any differences are clearly highlighted so you can quickly review them.
+The window shows two versions of the file (in case of a modified file; added or deleted files are shown differently). On the left hand side is the file as it looked on the server _when you last synchronized_. The right hand side shows your local version. Any differences are clearly highlighted so you can quickly review them.
 
-The built in file comparison tool works on text files only. However, since Defold stores all working files (game objects, collections, atlases etc etc) in easily understandable JSON files, you can often figure out the meaning of the changes that has been made to such files:
+The built in file comparison tool works on text files only. However, since Defold stores all working files (game objects, collections, atlases, etc etc) in easily understandable JSON files, you can often figure out the meaning of the changes that have been made to such files:
 
 ![Compare Gameobject](images/workflow/workflow_compare_gameobject.png)
 
 ## Resolving conflicts
 
-If you are working in a team, chances are that another branch have been synchronized to the server repository _while_ you were working on your branch. Some other team member (or yourself for that matter, but on a different branch) might have previously pushed changes to the very files you are about to push to the server.
+If you are working in a team, chances are that another branch has been synchronized to the server repository _while_ you were working on your branch. Some other team member (or yourself for that matter, but on a different branch) might have previously pushed changes to the very files you are about to push to the server.
 
-This is often not a problem and most such conflicts can be automatically resolved. However, if your changes are done in the exact same positions in the working files as the changes on the server, Defold will signal a warning and ask for your help to resolve the conflict.
+This is often not a problem and most such conflicts can be automatically resolved. However, if your changes are done in the exact same positions in the working files as the changes on the server are, Defold will signal a warning and ask for your help to resolve the conflict.
 
 ![Resolve Conflict](images/workflow/workflow_resolve_conflict.png)
 
@@ -93,21 +93,21 @@ The editor does not allow you to pick changes from the two conflicting files. If
 
 ## External editors and tools
 
-Defold does not provide editing tools for drawing images, creating sound files or bone animation. Such assets need to be created outside of Defold in specialized tools. Defold is agnostic when it comes to what tools it prefers. Any image program that can produce PNG files will do, any sound program that can save WAV files will do and any program that can save or export Spine JSON files will do (refer to the [Spine documentation](/manuals/spine) for details).
+Defold does not provide editing tools for creating images, sound files or bone animations. Such assets need to be created outside of Defold in specialized tools. Defold is agnostic when it comes to what tools it prefers. Any image program that can produce PNG files will do, any sound program that can save WAV files will do and any program that can save or export Spine JSON files will do (refer to the [Spine documentation](/manuals/spine) for details).
 
 Defold automatically detects changes to any assets that are in the project hierarchy and updates the editor view accordingly. The update cycle is not instant so you might have to wait a second or two to see your changes in the editor.
 
 The automatic asset tracking allows you to customize your work flow according to your needs.
 
 Shell scripts / batch files
-: You can use external scripts to automatically rebuild assets. For instance, if your source material are of higher resolution or in a different format you can run a script or batch file that resizes or converts the files before copying them into the proper place in the project hierarchy.
+: You can use external scripts to automatically rebuild assets. For instance, if your source materials are of higher resolution or in a different format you can run a script or batch file that resizes or converts the files before copying them into the proper place in the project hierarchy.
 
 Data generation
-: You can use custom tools to create specialized data and write it into Lua script files (as table structures) 
+: You can use custom tools to create specialized data and write it into Lua script files (as table structures)
 
 ## Opening assets in the text editor
 
-Defold automatically choses the appropriate editor for the item you are trying to edit. However, it is also possible to open any project file in the Defold text editor. In some situations this possibility is extremely useful and it is advisable to, at least, familiarize yourself with the file formats which helps when resolving conflicts.
+Defold automatically chooses the appropriate editor for the item you are trying to edit. However, it is also possible to open any project file in the Defold text editor. In some situations this possibility is extremely useful and it's use is advisable to, at least, familiarize yourself with the file formats, which helps when resolving conflicts.
 
 To open a file in the text editor, right-click the file in the Project view and select <kbd>Open With ▸ Text Editor</kbd>:
 
@@ -115,7 +115,7 @@ To open a file in the text editor, right-click the file in the Project view and 
 
 Note that Defold remembers the choice of editor for the particular file. If you open a file with the Text Editor, subsequent double clicks on the file in the Project view will automatically open the file in the Text Editor. To reset the selected editor for the file, simply right-click the file and select <kbd>Open With ▸ [Filetype Editor]</kbd> where [Filetype Editor] is the type of editor used for the file type (e.g. Scene Editor for Game Objects, Tile Source Editor for Tile Sources and so forth).
 
-Extra care should be taken when working with files through the Text Editor. Easy to make errors can prevent the file from being possible to open in the designated editor. For instance, suppose you edit a Game Object file and omit an end-quote character in one of the names:
+Extra care should be taken when working with files through the Text Editor. Easy-to-make errors can prevent the file from being possible to open in the designated editor. For instance, suppose you edit a Game Object file and omit an end-quote character in one of the names:
 
 ![Missing Quote](images/workflow/workflow_texteditor_noquote.png)
 
@@ -127,7 +127,7 @@ Defold tries to provide helpful error messages and it is often easy to track dow
 
 ## Git
 
-Defold uses Git to do version tracking on all files in a simple and easily understandable manner. 
+Defold uses Git to do version tracking on all files in a simple and easily understandable manner.
 
 * Each branch you create in the editor is a clone of the remote project repository, stored in a separate folder.
 * Any changes you do locally are saved in the cloned repository.
@@ -149,7 +149,7 @@ and then do a checkout from a specific commit:
 $ git checkout <commit-hash> <file path>
 ```
 
-You can also set up a more advanced work flow if you want, allowing you to pull changes directly between team members. If you run into situations where more than one person work on an experimental branch, you might want to consider utilizing Git for that. Please visit http://git-scm.com to learn more about Git.
+You can also set up a more advanced workflow if you want, allowing you to pull changes directly between team members. If you run into situations where more than one person works on an experimental branch, you might want to consider using Git for that. Please visit http://git-scm.com to learn more about Git.
 
 ## Line endings and Windows
 
@@ -172,11 +172,11 @@ When you work together in a team with mixed operating systems, the line endings 
 
 Suppose a team member works on a Windows machine and edits a Lua script file in an external editor that saves files with Windows line endings. She then opens the file in the Defold Lua Editor. Everything looks normal so she synchronizes the changes to the server repository.
 
-Meanwhile, a second team member who works on a Mac OS X machine does some editing in the same file. The changes done by the two team members are in different parts of the script file so normally, Git should automatically resolve the conflict and merge the two sets of changes. Nevertheless, when team member two synchronizes Defold detects a conflict. Team member number two double clicks the file to compare versions and sees that a conflict is highlighted on every single line through the file:
+Meanwhile, a second team member who works on a Mac OS X machine does some editing in the same file. The changes done by the two team members are in different parts of the script file so normally, Git should automatically resolve the conflict and merge the two sets of changes. Nevertheless, when team member two synchronizes, Defold detects a conflict. Team member number two double clicks the file to compare versions and sees that a conflict is highlighted on every single line throughout the file:
 
 ![Line endings conflict](images/workflow/workflow_line_endings_conflict.png)
 
-What happened is that the two files actually differs in how they encode the line endings. Since one file uses the *LF* character at the end of each line and the other the characters *CR*+*LF*, there is a legitimate conflict on each line and you will have to resolve it. If you have team members that work a lot with external tools line endings will cause merge conflicts all the time.
+This happened because the two files actually differ in how they encode the line endings. Since one file uses the *LF* character at the end of each line and the other uses the characters *CR*+*LF*, there is a legitimate conflict on each line and you will have to resolve it. If you have team members that work a lot with external tools, line endings will cause merge conflicts all the time.
 
 ## Line endings in Defold
 
@@ -205,7 +205,7 @@ false
 : The default. The result is that Git doesn't touch the line endings of your files. You can check in files with *LF*, *CR*+*LF* line endings, or a mix and Git does not care. If you work in a mixed operating system environment you should not use this setting.
 
 true
-: Git will process all text files and turn all *LF* line endings to *CR*`*LF* when writing them into the working directory and back to *LF* when they are checked into the repository again. This is a good setting on Windows machines.
+: Git will process all text files and turn all *LF* line endings to *CR*+*LF* when writing them into the working directory and back to *LF* when they are checked into the repository again. This is a good setting on Windows machines.
 
 
 input
@@ -218,7 +218,7 @@ You can configure Git with more fine grained control on how it should deal with 
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
 
-# Explicitly declare text files we want to always be normalized and converted 
+# Explicitly declare text files we want to always be normalized and converted
 # to native line endings on checkout.
 *.c text
 *.h text


### PR DESCRIPTION
I made only two real additions, if I recall correctly:
1. Introduction - added Ogg Vorbis format to sound component blurb.
2. Scene-Editing - Added new "Viewport Navigation" header at the very top.

The majority of the fixes were for swapped singular/plural forms. Lots of instances of "its" being swapped with "their", "has" with "have", "is" with "are", etc, plus many swapped forms of verbs. 

**Acronym Plurals** - In several cases, you made the plural of an acronym with a colon (and an 's'). I'm not sure where this comes from, I've never seen it done before. Sometimes people use an apostrophe, but most guides I've seen agree that the correct form is with no punctuation, only the 's', such as "APIs", "GUIs", and "IAPs". The apostrophe is reserved, as usual, for the possessive. "The API's methods", "Your GUI's nodes", etc. So I removed the colons where I saw them. They weren't always used. I did not remove the colons from "id:s"—that's a whole other can of worms. 

In the process of doing this I came across a few areas that I think could use more extensive work, but I will report those on the website or make other pull requests for them. 