### PR TITLE
Broken link in FAQ

### DIFF
--- a/docs/en/shared/install.md
+++ b/docs/en/shared/install.md
@@ -53,4 +53,4 @@ Installation on Linux
   $ ./Defold
   ``` 
 
-  If you run into any problems starting the editor, opening a project or running a Defold game please refer to the [Linux section of the FAQ](../faq/faq.md).
+  If you run into any problems starting the editor, opening a project or running a Defold game please refer to the [Linux section of the FAQ](../faq/faq.md#linux-issues).


### PR DESCRIPTION
Broken link on https://www.defold.com/manuals/install/. On the bottom of the page is link to Linux FAQ: https://www.defold.com/manuals/faq/faq.md. Should be (if I am not mistaken): https://www.defold.com/faq/#_linux_issues