### PR TITLE
Fixes for documentation

### DIFF
--- a/docs/en/manuals/extensions-details.md
+++ b/docs/en/manuals/extensions-details.md
@@ -40,9 +40,33 @@ GCC - Android, Linux
 * Win32: `Microsoft Visual Studio 14.0` alt `clang-6.0`
 * iOS/MacOS: `apple-clang` alt `clang-6.0`
 
-For iOS/MacOS, we use `-miphoneos-version-min=6.0` and `-mmacosx-version-min=10.7` respectively.
+For iOS/MacOS, we use `-miphoneos-version-min=8.0` and `-mmacosx-version-min=10.7` respectively.
 
 We don't specify a specific C++ version, so we use the default of each compiler.
+
+## Android
+
+We include the following libraries and its dependencies into the Android bundle:
+```
+com.google.firebase:firebase-messaging:17.3.4
+com.google.firebase:firebase-core:16.0.7
+com.google.android.gms:play-services-base:16.0.1
+com.android.support:support-v4:27.1.1
+com.android.support:support-compat:27.1.1
+com.android.support:support-core-utils:27.1.1
+com.android.support:support-core-ui:27.1.1
+com.android.support:support-media-compat:27.1.1
+com.android.support:support-fragment:27.1.1
+com.android.support:support-annotations:27.1.1
+android.arch.core:common:1.1.0
+android.arch.core:runtime:1.1.0
+android.arch.lifecycle:common:1.1.1
+android.arch.lifecycle:compiler:1.1.1
+android.arch.lifecycle:extensions:1.1.1
+android.arch.lifecycle:reactivestreams:1.1.1
+android.arch.lifecycle:runtime:1.1.1
+```
+*We plan to move Firebase messages and Google Play Services to its own extensions.*
 
 ## Win32 + Clang
 

--- a/docs/en/manuals/project-settings.md
+++ b/docs/en/manuals/project-settings.md
@@ -40,7 +40,7 @@ Custom Resources
 Bundle Resources
 : A comma separated list of directories containing resource files and folders that should be copied as-is into the resulting package when bundling. The directories must be specified with an absolute path from the project root, for example `/res`. The resource directory must contain subfolders named by `platform`, or `architecure-platform`.
 
-  :[platforms](../shared/platforms.md)
+  Supported platforms are `ios`, `android`, `osx`, `win32`, `linux`, `web`.
 
   A subfolder named `common` is also allowed, containing resource files common for all platforms.
 


### PR DESCRIPTION
- Now we are using 8.0 as value for miphoneos-version-min
- Added list of included Android dependencies
- We don't really support `armv7-android` and other platform specific libraries for `Bundled resources`