### PR TITLE
Add back shorthands section in message-passing manual

### DIFF
--- a/docs/en/manuals/message-passing.md
+++ b/docs/en/manuals/message-passing.md
@@ -246,3 +246,24 @@ DEBUG:SCRIPT: 75 dispatch passes before this update.
 
 We see that this particular Defold engine version performs 10 dispatch passes on the message queue between `init()` and the first call to `update()`. It then performs 75 passes during each subsequent update loop.
 
+## Shorthands
+
+Defold provides two handy shorthands that you can use to send message without specifying a complete URL:
+
+`.`
+: A URL shorthand for the current game object.
+
+`#`
+: A URL shorthand for the current script.
+
+For example:
+
+```lua
+ -- Post "acquire_input_focus" to this game object
+ msg.post(".", "acquire_input_focus")
+```
+
+```lua
+ -- Post "reset" to this script
+ msg.post("#", "reset")
+```


### PR DESCRIPTION
Modified from previous revision of [message-passing.md](https://github.com/defold/doc/blob/404dacfba4193e9564d21f18c52a46a29040259c/docs/en/manuals/message-passing.md) when it still contained Shorthands section.

I originally looked up what's the difference between posting message to "." and "#", but unable to find the information in the doc. I found it in the old revision linked above, which got removed in commit 5a2236968cc9313442b0c112440c9d57cb1753a6. To my limited knowledge, it is still applicable and useful, so I'd like to see if we can add it back.

