### PR TITLE
Updated documentation for setting material constants

### DIFF
--- a/docs/en/faq/faq.md
+++ b/docs/en/faq/faq.md
@@ -190,7 +190,7 @@ A: The built-in sprite shader that is used by default for all sprites has a cons
   local green = 0.3
   local blue = 0.55
   local alpha = 1
-  sprite.set_constant("#sprite", "tint", vmath.vector4(red, green, blue, alpha))
+  go.set("#sprite", "tint", vmath.vector4(red, green, blue, alpha))
   ```
 
 

--- a/docs/en/manuals/material.md
+++ b/docs/en/manuals/material.md
@@ -68,7 +68,13 @@ CONSTANT_TYPE_NORMAL
 : A matrix to compute normal orientation. The world transform might include non-uniform scaling, which breaks the orthogonality of the combined world-view transform. The normal matrix is used to avoid issues with the direction when transforming normals. (The normal matrix is the transpose inverse of the world-view matrix).
 
 CONSTANT_TYPE_USER
-: A vector4 constant that you can use for any custom data you want to pass into your shader programs. You can set the initial value of the constant in the constant definition, but it is mutable through the functions `.set_constant()` and `.reset_constant()` for each component type (`sprite`, `model`, `spine`, `particlefx` and `tilemap`). Changing a material constant of a single component instance [breaks render batching and will result in additional draw calls](/manuals/render/#draw-calls-and-batching).
+: A vector4 constant that you can use for any custom data you want to pass into your shader programs. You can set the initial value of the constant in the constant definition, but it is mutable through the functions [go.set()](/ref/stable/go/#go.set) / [go.animate()](/ref/stable/go/#go.animate). You can also retrieve the value with [go.get()](/ref/stable/go/#go.get). Changing a material constant of a single component instance [breaks render batching and will result in additional draw calls](/manuals/render/#draw-calls-and-batching).
+<br>Example:
+```lua
+go.set("#sprite", "tint", vmath.vector4(1,0,0,1))
+
+go.animate("#sprite", "tint", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,0,0,1), go.EASING_LINEAR, 2)
+```
 
 ## Samplers
 

--- a/docs/en/manuals/mesh.md
+++ b/docs/en/manuals/mesh.md
@@ -48,6 +48,13 @@ With the mesh component in place you are free to edit and manipulate the compone
 
 You can manipulate meshes at runtime using Defold buffers.
 
+## Material constants
+
+{% include shared/material-constants.md component='mesh' variable='tint' %}
+
+`tint`
+: The color tint of the mesh (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint.
+
 ## Vertex local vs world space
 If the Vertex Space setting of the mesh material is set to Local Space the data will be provided as-is to you in your shader, and you will have to transform vertices/normals as usual on the GPU.
 

--- a/docs/en/manuals/model.md
+++ b/docs/en/manuals/model.md
@@ -97,10 +97,10 @@ There is a simple 3D model material available in the built-in materials folder. 
 
 ### Material constants
 
-The default model material has the following constants that can be changed using `model.set_constant()` and reset using `model.reset_constant()` (refer to the [Material manual for more details](/manuals/material/#vertex-and-fragment-constants)):
+{% include shared/material-constants.md component='model' variable='tint' %}
 
 `tint`
-: The color tint of the model (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint. Refer to the [API reference for an example](/ref/model/#model.set_constant:url-constant-value).
+: The color tint of the model (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint.
 
 
 ## Rendering

--- a/docs/en/manuals/particlefx.md
+++ b/docs/en/manuals/particlefx.md
@@ -233,10 +233,10 @@ See the [Particle FX reference documentation](/ref/particlefx) for more informat
 
 ## Material constants
 
-The default particle effect material has the following constants that can be changed using `particlefx.set_constant()` and reset using `particlefx.reset_constant()` (refer to the [Material manual for more details](/manuals/material/#vertex-and-fragment-constants)):
+{% include shared/material-constants.md component='particlefx' variable='tint' %}
 
 `tint`
-: The color tint of the particle effect (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint. Refer to the [API reference for an example](/ref/particlefx/#particlefx.set_constant:url-constant-value).
+: The color tint of the particle effect (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint.
 
 
 ## Project configuration

--- a/docs/en/manuals/particlefx.md
+++ b/docs/en/manuals/particlefx.md
@@ -233,10 +233,10 @@ See the [Particle FX reference documentation](/ref/particlefx) for more informat
 
 ## Material constants
 
-{% include shared/material-constants.md component='particlefx' variable='tint' %}
+The default particle effect material has the following constants that can be changed using `particlefx.set_constant()` and reset using `particlefx.reset_constant()` (refer to the [Material manual for more details](/manuals/material/#vertex-and-fragment-constants)):
 
 `tint`
-: The color tint of the particle effect (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint.
+: The color tint of the particle effect (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint. Refer to the [API reference for an example](/ref/particlefx/#particlefx.set_constant:url-constant-value).
 
 
 ## Project configuration

--- a/docs/en/manuals/spinemodel.md
+++ b/docs/en/manuals/spinemodel.md
@@ -84,10 +84,10 @@ A spine model also has a number of different properties that can be manipulated 
 
 ## Material constants
 
-The default spine material has the following constants that can be changed using `spine.set_constant()` and reset using `spine.reset_constant()` (refer to the [Material manual for more details](/manuals/material/#vertex-and-fragment-constants)):
+{% include shared/material-constants.md component='spine' variable='tint' %}
 
 `tint`
-: The color tint of the spine model (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint. Refer to the [API reference for an example](/ref/spine/#spine.set_constant:url-constant-value).
+: The color tint of the spine model (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint.
 
 ## Project configuration
 

--- a/docs/en/manuals/sprite.md
+++ b/docs/en/manuals/sprite.md
@@ -59,10 +59,10 @@ A sprite also has a number of different properties that can be manipulated using
 
 ## Material constants
 
-The default sprite material has the following constants that can be changed using `sprite.set_constant()` and reset using `sprite.reset_constant()` (refer to the [Material manual for more details](/manuals/material/#vertex-and-fragment-constants)):
+{% include shared/material-constants.md component='sprite' variable='tint' %}
 
 `tint`
-: The color tint of the sprite (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint. Refer to the [API reference for an example](/ref/sprite/#sprite.set_constant:url-constant-value).
+: The color tint of the sprite (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint.
 
 ## Project configuration
 

--- a/docs/en/manuals/tilemap.md
+++ b/docs/en/manuals/tilemap.md
@@ -91,10 +91,10 @@ A tilemap has a number of different properties that can be manipulated using `go
 
 ### Material constants
 
-The default tile map material has the following constants that can be changed using `tilemap.set_constant()` and reset using `tilemap.reset_constant()` (refer to the [Material manual for more details](/manuals/material/#vertex-and-fragment-constants)):
+{% include shared/material-constants.md component='tilemap' variable='tint' %}
 
 `tint`
-: The color tint of the tile map (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint. Refer to the [API reference for an example](/ref/tilemap/#tilemap.set_constant:url-constant-value).
+: The color tint of the tile map (`vector4`). The vector4 is used to represent the tint with x, y, z, and w corresponding to the red, green, blue and alpha tint.
 
 ## Project configuration
 

--- a/docs/en/shared/blend-modes.md
+++ b/docs/en/shared/blend-modes.md
@@ -1,10 +1,10 @@
 The *Blend Mode* property defines how the component graphics should be blended with the graphics behind it. These are the available blend modes and how they are calculated:
 
 Alpha
-: Normal blending: a~0~ * rgb~0~ + (1 - a~0~) * rgb~1~
+: Normal blending: `src.a * src.rgb + (1 - src.a) * dst.rgb`
 
 Add
-: Brighten the background with the color values of the corresponding pixels of the component: rgb~0~ + rgb~1~
+: Brighten the background with the color values of the corresponding pixels of the component: `src.rgb + dst.rgb`
 
 Multiply
-: Darken the background with values of the the corresponding pixels of the component: rgb~0~ * rgb~1~
+: Darken the background with values of the the corresponding pixels of the component: `src.rgb * dst.rgb`

--- a/docs/en/shared/material-constants.md
+++ b/docs/en/shared/material-constants.md
@@ -1,0 +1,6 @@
+
+The default {{ include.component }} material has the following constants that can be changed using [go.set()](/ref/stable/go/#go.set) or [go.animate()](/ref/stable/go/#go.animate) (refer to the [Material manual for more details](/manuals/material/#vertex-and-fragment-constants)). Examples:
+```lua
+go.set("#{{ include.component }}", "{{ include.variable }}", vmath.vector4(1,0,0,1))
+go.animate("#{{ include.component }}", "{{ include.variable }}", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,0,0,1), go.EASING_LINEAR, 2)
+```

--- a/docs/en/tutorials/shadertoy.md
+++ b/docs/en/tutorials/shadertoy.md
@@ -241,7 +241,7 @@ end
 
 function update(self, dt)
     self.t = self.t + dt -- <2>
-    model.set_constant("#model", "time", vmath.vector4(self.t, 0, 0, 0)) -- <3>
+    go.set("#model", "time", vmath.vector4(self.t, 0, 0, 0)) -- <3>
 end
 ```
 1. Store a value `t` in the script component (`self`) and intialize to 0.


### PR DESCRIPTION
Removed references to "set_constant" et al in favor of "go.set()"