### PR TITLE
Update libffi link

### DIFF
--- a/docs/en/shared/linux-faq.md
+++ b/docs/en/shared/linux-faq.md
@@ -69,7 +69,7 @@ $ MESA_LOADER_DRIVER_OVERRIDE=i965 ./Defold
 A: The [libffi](https://sourceware.org/libffi/) version of your distribution and the one required by Defold (version 6 or 7) does not match. Make sure `libffi.so.6` or `libffi.so.7` is installed under `/usr/lib/x86_64-linux-gnu`. You can download `libffi.so.7` like this:  
 
 ```bash
-$ http://ftp.br.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb
+$ wget http://ftp.br.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb
 $ sudo dpkg -i libffi7_3.3-6_amd64.deb
 ```
 

--- a/docs/en/shared/linux-faq.md
+++ b/docs/en/shared/linux-faq.md
@@ -69,8 +69,8 @@ $ MESA_LOADER_DRIVER_OVERRIDE=i965 ./Defold
 A: The [libffi](https://sourceware.org/libffi/) version of your distribution and the one required by Defold (version 6 or 7) does not match. Make sure `libffi.so.6` or `libffi.so.7` is installed under `/usr/lib/x86_64-linux-gnu`. You can download `libffi.so.7` like this:  
 
 ```bash
-$ wget http://ftp.br.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-5_amd64.deb
-$ sudo dpkg -i libffi7_3.3-5_amd64.deb
+$ http://ftp.br.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb
+$ sudo dpkg -i libffi7_3.3-6_amd64.deb
 ```
 
 Next you specify the path to this version in the `LD_PRELOAD` environment variable when running Defold:


### PR DESCRIPTION
Old libffi link doesn't seem to exist anymore (404). Updated the link with a newer minor version of libffi. Tested it on Pop_os 21.04.