### PR TITLE
Added missing aquire_input_focus call in snake tutorial

### DIFF
--- a/docs/en/tutorials/snake.md
+++ b/docs/en/tutorials/snake.md
@@ -226,6 +226,8 @@ A proper solution to this problem is to store the input in a queue and pull entr
 
 ```lua
 function init(self)
+    msg.post(".", "acquire_input_focus")
+
     self.segments = {
         {x = 7, y = 24},
         {x = 8, y = 24},


### PR DESCRIPTION
One of the script examples was missing the `msg.post(".", "acquire_input_focus")` after it was introduced in a script above.