### PR TITLE
Remove Rendercam mention from camera manual

### DIFF
--- a/docs/en/manuals/camera.md
+++ b/docs/en/manuals/camera.md
@@ -150,7 +150,6 @@ A camera has a number of different properties that can be manipulated using `go.
 
 ## Third-party camera solutions
 
-There are a few library camera solutions that implements common camera features such as game object follow, screen shake, screen to world coordinate conversion and so on. They are available from the Defold community assets portal:
+There is a library camera solution that implements common camera features such as game object follow, screen shake, screen to world coordinate conversion and so on. It is available from the Defold community assets portal:
 
-- [Rendercam](https://defold.com/assets/rendercam/) (2D & 3D) by Ross Grams.
-- [Ortographic camera](https://defold.com/assets/orthographic/) (2D only) by Björn Ritzl.
+- [Orthographic camera](https://defold.com/assets/orthographic/) (2D only) by Björn Ritzl.


### PR DESCRIPTION
I would like the link to RenderCam to be removed from the official manual. I've adjusted the paragraph text to match the new singular status of the list (and also fixed a typo in "Orthographic"). I did *not* change the plural in the heading, in case anyone has used it as a link. I also didn't update the translated manuals.