### PR TITLE
Added further Polish translation for manuals

### DIFF
--- a/docs/pl/manuals/atlas.md
+++ b/docs/pl/manuals/atlas.md
@@ -1,0 +1,211 @@
+---
+title: Atlas (Galeria obrazów)
+brief: Ta instrukcja wyjaśnia jak działa atlas w Defoldzie.
+---
+
+# Atlas (Galeria obrazów)
+
+Chociaż pojedyncze obrazy często są używane jako źródło dla sprite'ów, ze względów wydajnościowych obrazy muszą być łączone w większe zestawy obrazów, nazywane atlasy. Kombinowanie zestawów mniejszych obrazów w atlasy jest szczególnie ważne na urządzeniach mobilnych, gdzie pamięć i moc obliczeniowa są przeważnie mniejsze niż na komputerach stacjonarnych lub dedykowanych konsolach do gier.
+
+W Defoldzie zasób atlasu to lista oddzielnych plików obrazów, które automatycznie są łączone w większy obraz.
+
+
+## Tworzenie Atlasu
+
+Wybierz <kbd>New... ▸ Atlas</kbd> z menu kontekstowego w panelu *Assets*. Nazwij nowy plik atlasu. Edytor otworzy teraz plik w edytorze atlasu. Właściwości atlasu są widoczne w
+panelu *Properties* (Właściwości), dzięki czemu możesz je edytować (szczegóły poniżej).
+
+Musisz wypełnić atlas obrazami lub animacjami, zanim będziesz mógł go użyć jako źródła grafiki dla komponentów obiektu, takich jak Sprite'y i komponenty ParticleFX.
+
+Upewnij się, że dodałeś obrazy do projektu (przeciągnij i upuść pliki obrazów we właściwe miejsce w panelu *Assets*).
+
+Dodawanie pojedynczych obrazów
+: Kliknij <kbd>prawym przyciskiem myszy</kbd> główny wpis Atlas w panelu *Outline*.
+
+  Wybierz <kbd>Add Images</kbd> z menu kontekstowego, aby dodać pojedyncze obrazy.
+
+  Pojawi się okno dialogowe, z którego możesz znaleźć i wybrać obrazy, które chcesz dodać do atlasu. Zauważ, że możesz filtrować pliki obrazów i wybierać je wielokrotnie.
+
+  ![Creating an atlas, adding images](images/atlas/add.png){srcset="images/atlas/add@2x.png 2x"}
+
+  Dodane obrazy są wymienione w *Outline*, a pełny atlas można zobaczyć w centrum widoku edytora. Może być konieczne naciśnięcie <kbd>F</kbd> (<kbd>View ▸ Frame Selection</kbd> w menu), aby dopasować zaznaczenie.
+
+  ![Images added](images/atlas/single_images.png){srcset="images/atlas/single_images@2x.png 2x"}
+
+Dodawanie animacji flipbook
+: Kliknij <kbd>przyciskiem myszy</kbd> główny wpis Atlas w panelu *Outline*.
+
+  Wybierz <kbd>Add Animation Group</kbd> z menu kontekstowego, aby utworzyć grupę animacji flipbook.
+
+  Nowa, pusta grupa animacji o domyślnej nazwie ("New Animation") zostaje dodana do atlasu.
+
+  Kliknij <kbd>prawym przyciskiem myszy</kbd> na nową grupę i wybierz <kbd>dd Images</kbd> z menu kontekstowego.
+
+  Pojawi się okno dialogowe, z którego możesz znaleźć i wybrać obrazy, które chcesz dodać do grupy animacji.
+
+  ![Creating an atlas, adding images](images/atlas/add_animation.png){srcset="images/atlas/add_animation@2x.png 2x"}
+
+  Naciśnij <kbd>Spację</kbd> z wybraną grupą animacji, aby ją obejrzeć. Dostosuj właściwości animacji w obszarze *Properties* według potrzeb (patrz poniżej).
+
+  ![Animation group](images/atlas/animation_group.png){srcset="images/atlas/animation_group@2x.png 2x"}
+
+Możesz zmieniać kolejność obrazów w Outline, wybierając je i naciskając <kbd>Alt + W górę/w dół</kbd>. Możesz również łatwo tworzyć duplikaty, kopiując i wklejając obrazy w zarysie (z menu <kbd>Edit</kbd>, menu kontekstowego po kliknięciu prawym przyciskiem myszy lub za pomocą skrótów klawiszowych).
+
+## Właściwości Atlasu
+
+Każdy zasób atlasu posiada zestaw właściwości, które są widoczne w obszarze *Properties*, gdy wybierasz główny element w panelu *Outline*.
+
+Size (Rozmiar)
+: Pokazuje obliczony łączny rozmiar wynikowego zasobu tekstury. Szerokość i wysokość są ustawiane na najbliższą potęgę dwójki. Zauważ, że jeśli włączysz kompresję tekstury, niektóre formaty wymagają tekstur kwadratowych. Niekwadratowe tekstury zostaną wtedy zmienione rozmiarem i wypełnione pustą przestrzenią, aby stworzyć teksturę kwadratową. Szczegóły można znaleźć w [instrukcji do profilów tekstur](/manuals/texture-profiles/)
+
+Margin (Margines)
+: Liczba pikseli, która powinna być dodawana między każdym obrazem.
+
+Inner Padding (Wewnętrzny margines)
+: Liczba pustych pikseli, która powinna być wypełniana wokół każdego obrazu.
+
+Extrude Borders (Wytłoczenie granic)
+: Liczba krawędziowych pikseli, która powinna być wielokrotnie dodawana wokół każdego obrazu. Kiedy fragment shader próbuje pobierać piksele na krawędzi obrazu, piksele z obrazu sąsiada (na tym samym atlasie tekstury) mogą się przeniknąć. Wydłużenie krawędzi rozwiązuje ten problem.
+
+Oto przykłady różnych ustawień właściwości z czterema kwadratowymi obrazami o wymiarach 64x64 pikseli dodanymi do atlasu. Zauważ, jak atlas przeskakuje do rozmiaru 256x256, kiedy tylko obrazy nie mieszczą się w 128x128, co skutkuje marnowaniem dużej przestrzeni tekstury.
+
+![Atlas properties](images/atlas/atlas_properties.png){srcset="images/atlas/atlas_properties@2x.png 2x"}
+
+## Właściwości Obrazu
+
+Każdy obraz w atlasie posiada zestaw właściwości:
+
+Id
+: Identyfikator obrazu (tylko do odczytu).
+
+Size (Rozmiar)
+: Szerokość i wysokość obrazu (tylko do odczytu).
+
+Sprite Trim Mode (Trymowanie Sprite'a)
+: Sposób renderowania sprite'a. Domyślnie sprite jest renderowany jako prostokąt (Trymowanie Sprite'a ustawione na Off - Wyłączone). Jeśli sprite zawiera wiele przezroczystych pikseli, może być bardziej wydajne, aby renderować sprite jako kształt nierektangularny, używając od 4 do 8 wierzchołków. Zauważ, że trymowanie sprite'a nie działa razem z sprite'ami typu slice-9.
+
+Image (Obraz)
+: Ścieżka do samego obrazu.
+
+![Image properties](images/atlas/image_properties.png){srcset="images/atlas/image_properties@2x.png 2x"}
+
+## Właściwości Animacji
+
+Oprócz listy obrazów, które są częścią grupy animacyjnej (Animation Group), dostępny jest zestaw właściwości:
+
+Id
+: Identyfikator/nazwa animacji.
+
+Fps
+: Szybkość odtwarzania animacji wyrażona w klatkach na sekundę (Frames Per Second).
+
+Flip horizontal (Odbicie w poziomie)
+: Odbija animację w poziomie.
+
+Flip vertical (Odbicie w pionie)
+: Odbija animację w pionie.
+
+Playback (Odtwarzanie)
+: Określa, w jaki sposób animacja ma być odtwarzana:
+
+  - `None` - animacja nie jest odtwarzana wcale, wyświetlany jest pierwszy obraz.
+  - `Once Forward` - odtwarza animację raz od pierwszego do ostatniego obrazu.
+  - `Once Backward` - odtwarza animację raz od ostatniego do pierwszego obrazu.
+  - `Once Ping Pong` - odtwarza animację raz od pierwszego do ostatniego obrazu, a następnie z powrotem do pierwszego obrazu.
+  - `Loop Forward` - odtwarza animację cyklicznie od pierwszego do ostatniego obrazu.
+  - `Loop Backward` - odtwarza animację cyklicznie od ostatniego do pierwszego obrazu.
+  - `Loop Ping Pong` - odtwarza animację cyklicznie od pierwszego do ostatniego obrazu, a następnie z powrotem do pierwszego obrazu.
+
+## Tworzenie tekstury i atlasu w czasie wykonania programu (Runtime)
+
+Począwszy od Defold 1.4.2 możliwe jest tworzenie zasobu tekstury i atlasu w czasie wykonania.
+
+### Tworzenie zasobu tekstury w czasie wykonania
+
+Użyj funkcji [`resource.create_texture(path, params)`](https://defold.com/ref/stable/resource/#resource.create_texture:path-table), aby utworzyć nowy zasób tekstury:
+
+```lua
+  local params = {
+    width  = 128,
+    height = 128,
+    type   = resource.TEXTURE_TYPE_2D,
+    format = resource.TEXTURE_FORMAT_RGBA,
+  }
+  local my_texture_id = resource.create_texture("/my_custom_texture.texturec", params)
+```
+
+Kiedy tekstura jest utworzona użyj funkcji [`resource.set_texture(path, params, buffer)`](https://defold.com/ref/stable/resource/#resource.set_texture:path-table-buffer) w celu ustawienia pikseli tekstury:
+
+```lua
+  local width = 128
+  local height = 128
+  local buf = buffer.create(width * height, { { name=hash("rgba"), type=buffer.VALUE_TYPE_UINT8, count=4 } } )
+  local stream = buffer.get_stream(buf, hash("rgba"))
+
+  for y=1, height do
+      for x=1, width do
+          local index = (y-1) * width * 4 + (x-1) * 4 + 1
+          stream[index + 0] = 0xff
+          stream[index + 1] = 0x80
+          stream[index + 2] = 0x10
+          stream[index + 3] = 0xFF
+      end
+  end
+
+  local params = { width=width, height=height, x=0, y=0, type=resource.TEXTURE_TYPE_2D, format=resource.TEXTURE_FORMAT_RGBA, num_mip_maps=1 }
+  resource.set_texture(my_texture_id, params, buf)
+```
+
+::: sidenote
+Istnieje także możliwość użycia funkcji `resource.set_texture()`, aby zaktualizować podregion tekstury, korzystając z szerokości i wysokości bufora mniejszych niż pełny rozmiar tekstury i zmieniając parametry x i y w funkcji resource.set_texture().
+:::
+
+Teksturę można użyć bezpośrednio na [komponencie modelu](/manuals/model/) za pomocą `go.set()`:
+
+```lua
+  go.set("#model", "texture0", my_texture_id)
+```
+
+### Tworzenie atlasu w czasie wykonania
+
+Jeśli tekstura ma być używana na [komponencie sprite'a](/manuals/sprite/), musi najpierw zostać użyta w atlasie. Użyj funckji [`resource.create_atlas(path, params)`](https://defold.com/ref/stable/resource/#resource.create_atlas:path-table), aby utworzyć atlas:
+
+```lua
+  local params = {
+    texture = texture_id,
+    animations = {
+      {
+        id          = "my_animation",
+        width       = width,
+        height      = height,
+        frame_start = 1,
+        frame_end   = 2,
+      }
+    },
+    geometries = {
+      {
+        vertices  = {
+          0,     0,
+          0,     height,
+          width, height,
+          width, 0
+        },
+        uvs = {
+          0,     0,
+          0,     height,
+          width, height,
+          width, 0
+        },
+        indices = {0,1,2,0,2,3}
+      }
+    }
+  }
+  local my_atlas_id = resource.create_atlas("/my_atlas.texturesetc", params)
+
+  -- assign the atlas to the 'sprite' component on the same go
+  go.set("#sprite", "image", my_atlas_id)
+
+  -- play the "animation"
+  sprite.play_flipbook("#sprite", "my_animation")
+
+```

--- a/docs/pl/manuals/caching-assets.md
+++ b/docs/pl/manuals/caching-assets.md
@@ -1,0 +1,49 @@
+---
+title: Buforowanie zasobów
+brief: Ta instrukcja wyjaśnia jak korzystać z buforowania zasobów w celu przyspieszenia budowania.
+---
+
+# Buforowanie zasobów
+
+Gry tworzone w Defold zazwyczaj budują się w kilka sekund, ale w miarę rozwoju projektu rośnie też liczba zasobów. Kompilacja czcionek i kompresja tekstur może zajmować znaczną ilość czasu w dużym projekcie, a bufor zasobów (asset cache) służy do przyspieszenia kompilacji poprzez rekompilowanie tylko tych zasobów, które uległy zmianie, jednocześnie korzystając z już skompilowanych zasobów z bufora dla tych, które nie uległy zmianie.
+
+Defold wykorzystuje trzy poziomy bufora:
+
+1. Project cache (Bufor projektu)
+2. Local cache (Bufor lokalny)
+3. Remote cache (Bufor zdalny)
+
+## Project cache (Bufor projektu)
+
+Defold domyślnie buforuje skompilowane zasoby w katalogu `build/default` projektu w Defoldzie. Bufor projektu przyspieszy kolejne kompilacje, ponieważ będą ponownie kompilowane tylko zmienione zasoby, podczas gdy zasoby bez zmian będą wykorzystywane z bufora projektu. Ten bufor jest zawsze włączony i używany zarówno przez edytor, jak i narzędzia wiersza poleceń.
+
+Bufor projektu można usunąć ręcznie, usuwając pliki w katalogu `build/default`, lub wydając polecenie `clean` za pomocą [narzędzia do kompilacji wiersza poleceń Bob](/manuals/bob).
+
+## Local cache (Bufor lokalny)
+
+Dodano w wersji Defold 1.2.187.
+
+Bufor lokalny to opcjonalny, drugi bufor, w którym skompilowane zasoby są przechowywane w zewnętrznym miejscu na tym samym komputerze lub na dysku sieciowym. Dzięki swojemu zewnętrznemu położeniu zawartość bufora przetrwa oczyszczenie bufora projektu. Może być również współdzielony przez kilku programistów pracujących nad tym samym projektem. Bufor jest obecnie dostępny tylko podczas kompilacji za pomocą narzędzi wiersza poleceń. Jest aktywowany za pomocą opcji `resource-cache-local`:
+
+
+```sh
+java -jar bob.jar --resource-cache-local /Users/john.doe/defold_local_cache
+```
+Skompilowane zasoby są pobierane z bufora lokalnego na podstawie obliczonej sumy kontrolnej, która uwzględnia wersję silnika Defold, nazwy i treść źródłowych zasobów oraz opcje kompilacji projektu. Zapewnia to unikalność buforowanych zasobów i umożliwia współdzielenie bufora między różnymi wersjami Defold.
+
+::: sidenote
+Pliki przechowywane w buforze lokalnym są przechowywane na stałe. To programista jest odpowiedzialny za ręczne usuwanie starych/niewykorzystywanych plików.
+:::
+
+
+## Remote cache (Bufor zdalny)
+
+Dodano w wersji Defold 1.2.187.
+
+Bufor zdalny to opcjonalny, trzeci bufor, w którym skompilowane zasoby są przechowywane na serwerze i dostępne za pomocą żądania HTTP. Bufor jest obecnie dostępny tylko podczas kompilacji za pomocą narzędzi wiersza poleceń. Jest aktywowany za pomocą opcji `resource-cache-remote`:
+
+```sh
+java -jar bob.jar --resource-cache-remote http://192.168.0.100/
+```
+
+Podobnie jak w przypadku bufora lokalnego, wszystkie zasoby są pobierane z bufora zdalnego na podstawie obliczonej sumy kontrolnej. Buforowane zasoby są dostępne za pomocą metod żądania HTTP GET, PUT i HEAD. Defold nie dostarcza serwera bufora zdalnego. Każdy programista, który chce korzystać z tego rozwiązania, jest odpowiedzialny za jego konfigurację. Przykładowo implementację podstawowego serwera Pythona można znaleźć [tutaj](https://github.com/britzl/httpserver-python).

--- a/docs/pl/manuals/debugging-game-logic.md
+++ b/docs/pl/manuals/debugging-game-logic.md
@@ -1,0 +1,138 @@
+---
+title: Debugowanie w Defoldzie
+brief: Ta instrukcja wyjaśnia narzędzia do debugowania dostępne w Defoldzie.
+---
+
+# Debugowanie logiki gry
+
+Defold zawiera zintegrowany debugger Lua z narzędziem do inspekcji. Razem z wbudowanymi [narzędziami profilowania](/manuals/profiling) stanowi potężne narzędzie, które może pomóc w znalezieniu przyczyny błędów w logice gry lub analizie problemów wydajnościowych.
+
+## Debugowanie za pomocą wydruków i wizualne
+
+Najprostszym sposobem debugowania w Defold jest korzystanie z [debugowania za pomocą wydruków](http://en.wikipedia.org/wiki/Debugging#Techniques). Używaj funkcji `print()` lub [`pprint()`](/ref/builtins#pprint) do monitorowania zmiennych lub wskazywania przepływu wykonania. Jeśli obiekt gry bez skryptu działa dziwnie, możesz dołączyć do niego skrypt wyłącznie w celu debugowania. Korzystanie z dowolnej z funkcji drukowania spowoduje wydruk na panelu *Console* (konsola) w Edytorze oraz w [logach gry](/manuals/debugging-game-and-system-logs).
+
+Oprócz drukowania/wyświetlania, silnik może również rysować teksty debugowania i proste linie na ekranie. To jest realizowane poprzez przesyłanie wiadomości do gniazda (socket) `@render`:
+
+
+```lua
+-- Draw value of "my_val" with debug text on the screen
+msg.post("@render:", "draw_text", { text = "My value: " .. my_val, position = vmath.vector3(200, 200, 0) })
+
+-- Draw colored text on the screen
+local color_green = vmath.vector4(0, 1, 0, 1)
+msg.post("@render:", "draw_debug_text", { text = "Custom color", position = vmath.vector3(200, 180, 0), color = color_green })
+
+-- Draw debug line between player and enemy on the screen
+local start_p = go.get_position("player")
+local end_p = go.get_position("enemy")
+local color_red = vmath.vector4(1, 0, 0, 1)
+msg.post("@render:", "draw_line", { start_point = start_p, end_point = end_p, color = color_red })
+```
+Wizualne komunikaty debugowania dodają dane do potoku (pipeline) renderowania i są rysowane jako część standardowego potoku renderowania, czyli wyświetlane.
+
+* `"draw_line"` dodaje dane, które są renderowane za pomocą funkcji `render.draw_debug3d()` w skrypcie renderowania (render script).
+* `"draw_text"` jest renderowany z użyciem `"/builtins/fonts/system_font.font"`, który wykorzystuje materiał `"/builtins/fonts/system_font.material"`.
+* `"draw_debug_text"` jest to to samo co `"draw_text"`, ale jest renderowany w kolorze niestandardowym.
+Zauważ, że prawdopodobnie chcesz aktualizować te dane co klatkę, więc przesyłanie wiadomości do skryptu renderowania w funkcji `update()` jest dobrym pomysłem.
+
+## Uruchamianie debugger
+
+Aby uruchomić wbudowany debugger wraz z grą klkinij menu <kbd>Debug ▸ Run with Debugger</kbd> lub wybierz <kbd>Debug ▸ Attach Debugger</kbd>, aby dołączyć debugger do aktualnie uruchomionej gry.
+
+![overview](images/debugging/overview.png){srcset="images/debugging/overview@2x.png 2x"}
+
+Gdy debugger jest podłączony, masz kontrolę nad wykonaniem gry za pomocą przycisków sterowania debugerem w konsoli lub za pomocą menu <kbd>Debug</kbd>:
+
+Break
+: ![pause](images/debugging/pause.svg){width=60px .left}
+  Natychmiastowa przerwa wykonania gry. Gra zostanie zatrzymana w bieżącym punkcie. Teraz można sprawdzić stan gry, przejść do przodu krok po kroku lub kontynuować jej działanie do kolejnego punktu przerwania (breakpoint). Aktualny punkt wykonania jest oznaczony w edytorze kodu:
+
+  ![script](images/debugging/script.png){srcset="images/debugging/script@2x.png 2x"}
+
+Continue
+: ![play](images/debugging/play.svg){width=60px .left}
+  Kontynuuj działanie gry. Kod gry będzie kontynuował działanie, aż naciśniesz pauzę lub wykonanie dojdzie do ustawionego punktu przerwania (breakpoint). Jeśli wykonanie zostanie przerwane na ustawionym punkcie przerwania, punkt wykonania jest oznaczony w edytorze kodu na szczycie znacznika punktu przerwania:
+
+  ![break](images/debugging/break.png){srcset="images/debugging/break@2x.png 2x"}
+
+Stop
+: ![stop](images/debugging/stop.svg){width=60px .left}
+  Stop the debugger. Pressing this button will immediately stop the debugger, detach it from the game and terminate the running game.
+
+Step Over
+: ![step over](images/debugging/step_over.svg){width=60px .left}
+  Przesuń wykonanie programu o jeden krok. Jeśli wykonanie obejmuje uruchomienie innego skryptu Lua, wykonanie *nie* wejdzie do funkcji , ale będzie kontynuować działanie i zatrzyma się na kolejnej linii poniżej wywołania funkcji. W tym przykładzie, jeśli użytkownik naciśnie "Step Over", debugger wykonuje kod i zatrzymuje się na instrukcji `end` poniżej linii z wywołaniem funkcji `nextspawn()`:
+
+  ![step](images/debugging/step.png){srcset="images/debugging/step@2x.png 2x"}
+
+::: sidenote
+Jedna linia kodu Lua nie odpowiada jednemu wyrażeniu. Krok w debuggerze przesuwa się o jedno wyrażenie naraz, co oznacza, że obecnie możesz musieć nacisnąć przycisk kroku więcej niż raz, aby przejść do następnej linii.
+:::
+
+Step Into
+: ![step in](images/debugging/step_in.svg){width=60px .left}
+  Przesuń wykonanie programu o jeden krok. Jeśli wykonanie obejmuje uruchomienie innej funkcji Lua, wykonanie wejdzie do funkcji. Wywołanie funkcji dodaje wpis na stosie wywołań. Możesz kliknąć każdy wpis na liście stosu wywołań, aby wyświetlić punkt wejścia i zawartość wszystkich zmiennych w tej zamknięciu. Tutaj użytkownik wszedł do funkcji `nextspawn()`:
+
+  ![step into](images/debugging/step_into.png){srcset="images/debugging/step_into@2x.png 2x"}
+
+Step Out
+: ![step out](images/debugging/step_out.svg){width=60px .left}
+  Kontynuuj działanie do momentu zakończenia bieżącej funkcji. Jeśli wykonanie jest w funkcji, naciśnięcie przycisku "Step Out" spowoduje kontynuowanie działania do momentu zakończenia funkcji.
+
+Ustawianie i usuwanie punktów przerwania (breakpoints)
+: Możesz ustawić dowolną liczbę punktów przerwania w kodzie Lua. Gdy gra działa z podłączonym debugerem, zatrzyma się na następnym punkcie przerwania i poczeka na dalsze interakcje z tobą.
+
+  ![add breakpoint](images/debugging/add_breakpoint.png){srcset="images/debugging/add_breakpoint@2x.png 2x"}
+
+  Aby ustawić lub usunąć punkt przerwania, kliknij w kolumnie tuż po prawej stronie numerów wierszy w edytorze kodu. Możesz także wybrać opcję <kbd>Edit ▸ Toggle Breakpoint</kbd> z menu.
+
+Ustawianie punktów przerwania warunkowych
+: Możesz skonfigurować punkt przerwania tak, aby zawierał warunek, który musi być spełniony, aby punkt przerwania został uruchomiony. Warunek może uzyskiwać dostęp do zmiennych lokalnych dostępnych w danym momencie wykonania kodu.
+
+  ![edit breakpoint](images/debugging/edit_breakpoint.png){srcset="images/debugging/edit_breakpoint@2x.png 2x"}
+
+  Aby edytować warunek punktu przerwania, kliknij prawym przyciskiem myszy w kolumnie tuż po prawej stronie numerów wierszy w edytorze kodu lub wybierz opcję <kbd>Edit ▸ Edit Breakpoint</kbd> z menu.
+
+Wykonywanie wyrażeń Lua
+: Z podłączonym debuggerem i zatrzymaną grą na punkcie przerwania dostępna jest przestrzeń wykonawcza Lua z bieżącym kontekstem. Wpisz wyrażenia Lua na dole konsoli i naciśnij <kbd>Enter</kbd>, aby je wykonać:
+
+  ![console](images/debugging/console.png){srcset="images/debugging/console@2x.png 2x"}
+
+  Obecnie nie można modyfikować zmiennych za pomocą ewaluatora.
+
+Odłączanie debuggera
+: Wybierz <kbd>Debug ▸ Detach Debugger</kbd>, aby odłączyć debuggera od gry. Gra zostanie natychmiast wznowiona.
+
+## Biblioteka debugowania Lua
+
+Lua zawiera bibliotekę debugowania przydatną w niektórych sytuacjach, szczególnie jeśli potrzebujesz zbadać wewnętrzne aspekty swojego środowiska Lua. Więcej informacji na ten temat znajdziesz [tutaj](http://www.lua.org/pil/contents.html#23).
+
+## Lista kontrolna debugowania
+
+Jeśli napotkasz błąd lub gra nie działa zgodnie z oczekiwaniami, oto lista kontrolna debugowania:
+
+1. Sprawdź wyświetlenia w konsoli (Console) i zweryfikuj, czy nie ma błędów czasu wykonania.
+
+2. Dodaj instrukcje `print` do swojego kodu, aby sprawdzić, czy kod faktycznie się wykonuje.
+
+3. Jeśli kod nie jest wykonywany, sprawdź, czy w edytorze została dokonana właściwa konfiguracja niezbędna do uruchomienia kodu. Czy skrypt został dodany do odpowiedniego obiektu gry? Czy skrypt uzyskał focus wejścia (acquired input focus), jeśli chcesz obsługiwać wejścia sterowania? Czy wejścia są zdefiniowane poprawnie? Czy kod shadera został dodany do materiału? I tak dalej.
+
+4. Jeśli twój kod zależy od wartości zmiennych (na przykład w instrukcji warunkowej), użyj instrukcji `print` w miejscach, gdzie są używane lub sprawdzane, lub zbadaj je za pomocą debuggera.
+
+Czasem znalezienie błędu może być trudnym i czasochłonnym procesem, który wymaga przeglądania kodu kawałek po kawałku, sprawdzania wszystkiego i zawężania błędnego kodu oraz eliminowania źródeł błędów. Najlepiej jest to robić za pomocą metody "dziel i rządź":
+
+1. Znajdź połowę (lub mniej) kodu, który podejrzewasz, że może zawierać błąd.
+2. Ponownie znajdź połowę, z tej połowy, która musi zawierać błąd.
+3. Kontynuuj zawężanie kodu, który musi spowodować błąd, aż go znajdziesz.
+
+Udanego polowania!
+
+## Rozwiązywanie problemów z fizyką
+
+Jeśli masz problemy z fizyką i kolizje nie działają zgodnie z oczekiwaniami, zaleca się włączenie debugowania fizyki. Zaznacz pole wyboru *"Debug"* w sekcji *"Physics"* pliku `"game.project"`:
+
+![physics debug setting](images/debugging/physics_debug_setting.png)
+
+Gdy to pole jest zaznaczone, Defold będzie rysował wszystkie kształty kolizji i punkty kontaktu kolizji:
+
+![physics debug visualisation](images/debugging/physics_debug_visualisation.png)

--- a/docs/pl/manuals/editor-keyboard-shortcuts.md
+++ b/docs/pl/manuals/editor-keyboard-shortcuts.md
@@ -1,0 +1,124 @@
+---
+title: Skróty klawiszowe Edytora
+brief: Ta instrukcja pokazuje obecne skróty klawiszowe Edytora Defold i jak je zmodyfikować.
+---
+
+# Skróty klawiszowe Edytora
+
+## Domyślne skróty klawiszowe Edytora
+
+Nazwy komend nie są przetłumaczone ze względu na użycie ich oryginalnych nazw z Edytora. Pamiętaj, że różne komendy działają w różnych kontekstach.
+
+| Komenda | Windows | macOS | Linux |
+|---------|---------|-------|-------|
+| Add | <kbd>A</kbd> | <kbd>A</kbd> | <kbd>A</kbd> |
+| Add secondary | <kbd>Shift</kbd>+<kbd>A</kbd> | <kbd>Shift</kbd>+<kbd>A</kbd> | <kbd>Shift</kbd>+<kbd>A</kbd> |
+| Backwards tab trigger | <kbd>Shift</kbd>+<kbd>Tab</kbd> | <kbd>Shift</kbd>+<kbd>Tab</kbd> | <kbd>Shift</kbd>+<kbd>Tab</kbd> |
+| Beginning of file | <kbd>Ctrl</kbd>+<kbd>Home</kbd> | <kbd>Cmd</kbd>+<kbd>Up</kbd> | <kbd>Ctrl</kbd>+<kbd>Home</kbd> |
+| Beginning of line |  | <kbd>Ctrl</kbd>+<kbd>A</kbd> |  |
+| Beginning of line text | <kbd>Home</kbd> | <kbd>Home</kbd> | <kbd>Home</kbd> |
+| Build | <kbd>Ctrl</kbd>+<kbd>B</kbd> | <kbd>Cmd</kbd>+<kbd>B</kbd> | <kbd>Ctrl</kbd>+<kbd>B</kbd> |
+| Close | <kbd>Ctrl</kbd>+<kbd>W</kbd> | <kbd>Cmd</kbd>+<kbd>W</kbd> | <kbd>Ctrl</kbd>+<kbd>W</kbd> |
+| Close all | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>W</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>W</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>W</kbd> |
+| Continue | <kbd>F5</kbd> | <kbd>F5</kbd> | <kbd>F5</kbd> |
+| Copy | <kbd>Ctrl</kbd>+<kbd>C</kbd> | <kbd>Cmd</kbd>+<kbd>C</kbd> | <kbd>Ctrl</kbd>+<kbd>C</kbd> |
+| Cut | <kbd>Ctrl</kbd>+<kbd>X</kbd> | <kbd>Cmd</kbd>+<kbd>X</kbd> | <kbd>Ctrl</kbd>+<kbd>X</kbd> |
+| Delete | <kbd>Delete</kbd> | <kbd>Delete</kbd> | <kbd>Delete</kbd> |
+| Delete backward | <kbd>Backspace</kbd> | <kbd>Backspace</kbd> | <kbd>Backspace</kbd> |
+| Delete line |  | <kbd>Ctrl</kbd>+<kbd>D</kbd> |  |
+| Delete next word | <kbd>Ctrl</kbd>+<kbd>Delete</kbd> | <kbd>Alt</kbd>+<kbd>Delete</kbd> | <kbd>Ctrl</kbd>+<kbd>Delete</kbd> |
+| Delete prev word | <kbd>Ctrl</kbd>+<kbd>Backspace</kbd> | <kbd>Alt</kbd>+<kbd>Backspace</kbd> | <kbd>Ctrl</kbd>+<kbd>Backspace</kbd> |
+| Delete to end of line | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Delete</kbd> | <kbd>Cmd</kbd>+<kbd>Delete</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Delete</kbd> |
+| Documentation | <kbd>F1</kbd> | <kbd>F1</kbd> | <kbd>F1</kbd> |
+| Down | <kbd>Down</kbd> | <kbd>Down</kbd> | <kbd>Down</kbd> |
+| Edit breakpoint | <kbd>Alt</kbd>+<kbd>F9</kbd> | <kbd>Alt</kbd>+<kbd>F9</kbd> | <kbd>Alt</kbd>+<kbd>F9</kbd> |
+| End of file | <kbd>Ctrl</kbd>+<kbd>End</kbd> | <kbd>Cmd</kbd>+<kbd>Down</kbd> | <kbd>Ctrl</kbd>+<kbd>End</kbd> |
+| End of line | <kbd>End</kbd> | <kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>End</kbd> |
+| Enter | <kbd>Enter</kbd> | <kbd>Enter</kbd> | <kbd>Enter</kbd> |
+| Erase tool | <kbd>Shift</kbd>+<kbd>E</kbd> | <kbd>Shift</kbd>+<kbd>E</kbd> | <kbd>Shift</kbd>+<kbd>E</kbd> |
+| Escape | <kbd>Esc</kbd> | <kbd>Esc</kbd> | <kbd>Esc</kbd> |
+| Find next | <kbd>Ctrl</kbd>+<kbd>G</kbd>, <kbd>Enter</kbd> | <kbd>Cmd</kbd>+<kbd>G</kbd>, <kbd>Enter</kbd> | <kbd>Ctrl</kbd>+<kbd>G</kbd>, <kbd>Enter</kbd> |
+| Find prev | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>G</kbd>, <kbd>Shift</kbd>+<kbd>Enter</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>G</kbd>, <kbd>Shift</kbd>+<kbd>Enter</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>G</kbd>, <kbd>Shift</kbd>+<kbd>Enter</kbd> |
+| Find references | <kbd>Shift</kbd>+<kbd>F12</kbd> | <kbd>Shift</kbd>+<kbd>F12</kbd> | <kbd>Shift</kbd>+<kbd>F12</kbd> |
+| Find text | <kbd>Ctrl</kbd>+<kbd>F</kbd> | <kbd>Cmd</kbd>+<kbd>F</kbd> | <kbd>Ctrl</kbd>+<kbd>F</kbd> |
+| Frame selection | <kbd>F</kbd> | <kbd>F</kbd> | <kbd>F</kbd> |
+| Goto definition | <kbd>F12</kbd> | <kbd>F12</kbd> | <kbd>F12</kbd> |
+| Goto line | <kbd>Ctrl</kbd>+<kbd>L</kbd> | <kbd>Cmd</kbd>+<kbd>L</kbd> | <kbd>Ctrl</kbd>+<kbd>L</kbd> |
+| Hide selected | <kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Cmd</kbd>+<kbd>E</kbd> | <kbd>Ctrl</kbd>+<kbd>E</kbd> |
+| Hot reload | <kbd>Ctrl</kbd>+<kbd>R</kbd> | <kbd>Cmd</kbd>+<kbd>R</kbd> | <kbd>Ctrl</kbd>+<kbd>R</kbd> |
+| Left | <kbd>Left</kbd> | <kbd>Left</kbd> | <kbd>Left</kbd> |
+| Move down | <kbd>Alt</kbd>+<kbd>Down</kbd> | <kbd>Alt</kbd>+<kbd>Down</kbd> | <kbd>Alt</kbd>+<kbd>Down</kbd> |
+| Move tool | <kbd>W</kbd> | <kbd>W</kbd> | <kbd>W</kbd> |
+| Move up | <kbd>Alt</kbd>+<kbd>Up</kbd> | <kbd>Alt</kbd>+<kbd>Up</kbd> | <kbd>Alt</kbd>+<kbd>Up</kbd> |
+| New file | <kbd>Ctrl</kbd>+<kbd>N</kbd> | <kbd>Cmd</kbd>+<kbd>N</kbd> | <kbd>Ctrl</kbd>+<kbd>N</kbd> |
+| Next word | <kbd>Ctrl</kbd>+<kbd>Right</kbd> | <kbd>Alt</kbd>+<kbd>Right</kbd> | <kbd>Ctrl</kbd>+<kbd>Right</kbd> |
+| Open | <kbd>Ctrl</kbd>+<kbd>O</kbd> | <kbd>Cmd</kbd>+<kbd>O</kbd> | <kbd>Ctrl</kbd>+<kbd>O</kbd> |
+| Open asset | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>R</kbd> | <kbd>Cmd</kbd>+<kbd>P</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>R</kbd> |
+| Page down | <kbd>Page Down</kbd> | <kbd>Page Down</kbd> | <kbd>Page Down</kbd> |
+| Page up | <kbd>Page Up</kbd> | <kbd>Page Up</kbd> | <kbd>Page Up</kbd> |
+| Paste | <kbd>Ctrl</kbd>+<kbd>V</kbd> | <kbd>Cmd</kbd>+<kbd>V</kbd> | <kbd>Ctrl</kbd>+<kbd>V</kbd> |
+| Preferences | <kbd>Ctrl</kbd>+<kbd>Comma</kbd> | <kbd>Cmd</kbd>+<kbd>Comma</kbd> | <kbd>Ctrl</kbd>+<kbd>Comma</kbd> |
+| Prev word | <kbd>Ctrl</kbd>+<kbd>Left</kbd> | <kbd>Alt</kbd>+<kbd>Left</kbd> | <kbd>Ctrl</kbd>+<kbd>Left</kbd> |
+| Proposals | <kbd>Ctrl</kbd>+<kbd>Space</kbd> | <kbd>Ctrl</kbd>+<kbd>Space</kbd> | <kbd>Ctrl</kbd>+<kbd>Space</kbd> |
+| Quit | <kbd>Ctrl</kbd>+<kbd>Q</kbd> | <kbd>Cmd</kbd>+<kbd>Q</kbd> | <kbd>Ctrl</kbd>+<kbd>Q</kbd> |
+| Realign camera | <kbd>Period</kbd> | <kbd>Period</kbd> | <kbd>Period</kbd> |
+| Rebuild | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>B</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>B</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>B</kbd> |
+| Rebundle | <kbd>Ctrl</kbd>+<kbd>U</kbd> | <kbd>Cmd</kbd>+<kbd>U</kbd> | <kbd>Ctrl</kbd>+<kbd>U</kbd> |
+| Recent files | <kbd>Alt</kbd>+<kbd>R</kbd> | <kbd>Ctrl</kbd>+<kbd>R</kbd> | <kbd>Alt</kbd>+<kbd>R</kbd> |
+| Redo | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Z</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>Z</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Z</kbd> |
+| Reindent | <kbd>Ctrl</kbd>+<kbd>I</kbd> | <kbd>Ctrl</kbd>+<kbd>I</kbd> | <kbd>Ctrl</kbd>+<kbd>I</kbd> |
+| Rename | <kbd>F2</kbd> | <kbd>F2</kbd> | <kbd>F2</kbd> |
+| Reopen closed file | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>T</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>T</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>T</kbd> |
+| Replace next | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>H</kbd> | <kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>G</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>H</kbd> |
+| Replace text |  | <kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>F</kbd> |  |
+| Right | <kbd>Right</kbd> | <kbd>Right</kbd> | <kbd>Right</kbd> |
+| Rotate tool | <kbd>E</kbd> | <kbd>E</kbd> | <kbd>E</kbd> |
+| Save all | <kbd>Ctrl</kbd>+<kbd>S</kbd> | <kbd>Cmd</kbd>+<kbd>S</kbd> | <kbd>Ctrl</kbd>+<kbd>S</kbd> |
+| Scale tool | <kbd>R</kbd> | <kbd>R</kbd> | <kbd>R</kbd> |
+| Scene stop | <kbd>Ctrl</kbd>+<kbd>T</kbd> | <kbd>Cmd</kbd>+<kbd>T</kbd> | <kbd>Ctrl</kbd>+<kbd>T</kbd> |
+| Search in files | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>F</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>F</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>F</kbd> |
+| Select all | <kbd>Ctrl</kbd>+<kbd>A</kbd> | <kbd>Cmd</kbd>+<kbd>A</kbd> | <kbd>Ctrl</kbd>+<kbd>A</kbd> |
+| Select beginning of file | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Home</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>Up</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Home</kbd> |
+| Select beginning of line |  | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>A</kbd> |  |
+| Select beginning of line text | <kbd>Shift</kbd>+<kbd>Home</kbd> | <kbd>Shift</kbd>+<kbd>Home</kbd> | <kbd>Shift</kbd>+<kbd>Home</kbd> |
+| Select down | <kbd>Shift</kbd>+<kbd>Down</kbd> | <kbd>Shift</kbd>+<kbd>Down</kbd> | <kbd>Shift</kbd>+<kbd>Down</kbd> |
+| Select end of file | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>End</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>Down</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>End</kbd> |
+| Select end of line | <kbd>Shift</kbd>+<kbd>End</kbd> | <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>Down</kbd> | <kbd>Shift</kbd>+<kbd>End</kbd> |
+| Select left | <kbd>Shift</kbd>+<kbd>Left</kbd> | <kbd>Shift</kbd>+<kbd>Left</kbd> | <kbd>Shift</kbd>+<kbd>Left</kbd> |
+| Select next occurrence | <kbd>Ctrl</kbd>+<kbd>D</kbd> | <kbd>Cmd</kbd>+<kbd>D</kbd> | <kbd>Ctrl</kbd>+<kbd>D</kbd> |
+| Select next word | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Right</kbd> | <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>Right</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Right</kbd> |
+| Select page down | <kbd>Shift</kbd>+<kbd>Page Down</kbd> | <kbd>Shift</kbd>+<kbd>Page Down</kbd> | <kbd>Shift</kbd>+<kbd>Page Down</kbd> |
+| Select page up | <kbd>Shift</kbd>+<kbd>Page Up</kbd> | <kbd>Shift</kbd>+<kbd>Page Up</kbd> | <kbd>Shift</kbd>+<kbd>Page Up</kbd> |
+| Select prev word | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Left</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Left</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Left</kbd> |
+| Select right | <kbd>Shift</kbd>+<kbd>Right</kbd> | <kbd>Shift</kbd>+<kbd>Right</kbd> | <kbd>Shift</kbd>+<kbd>Right</kbd> |
+| Show last hidden | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>E</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>E</kbd> |
+| Show palette | <kbd>Space</kbd> | <kbd>Space</kbd> | <kbd>Space</kbd> |
+| Split selection into lines | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>L</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>L</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>L</kbd> |
+| Step into | <kbd>F11</kbd> | <kbd>F11</kbd> | <kbd>F11</kbd> |
+| Step out | <kbd>Shift</kbd>+<kbd>F11</kbd> | <kbd>Shift</kbd>+<kbd>F11</kbd> | <kbd>Shift</kbd>+<kbd>F11</kbd> |
+| Step over | <kbd>F10</kbd> | <kbd>F10</kbd> | <kbd>F10</kbd> |
+| Stop debugger | <kbd>Shift</kbd>+<kbd>F5</kbd> |  | <kbd>Shift</kbd>+<kbd>F5</kbd> |
+| Switch to next tab | <kbd>Ctrl</kbd>+<kbd>Tab</kbd> | <kbd>Ctrl</kbd>+<kbd>Tab</kbd> | <kbd>Ctrl</kbd>+<kbd>Tab</kbd> |
+| Switch to previous tab | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Tab</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Tab</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Tab</kbd> |
+| Tab | <kbd>Tab</kbd> | <kbd>Tab</kbd> | <kbd>Tab</kbd> |
+| Toggle breakpoint | <kbd>F9</kbd> | <kbd>F9</kbd> | <kbd>F9</kbd> |
+| Toggle comment | <kbd>Ctrl</kbd>+<kbd>Slash</kbd> | <kbd>Cmd</kbd>+<kbd>Slash</kbd> | <kbd>Ctrl</kbd>+<kbd>Slash</kbd> |
+| Toggle component guides | <kbd>Ctrl</kbd>+<kbd>H</kbd> | <kbd>Ctrl</kbd>+<kbd>Cmd</kbd>+<kbd>H</kbd> | <kbd>Ctrl</kbd>+<kbd>H</kbd> |
+| Toggle pane bottom | <kbd>F7</kbd> | <kbd>F7</kbd> | <kbd>F7</kbd> |
+| Toggle pane left | <kbd>F6</kbd> | <kbd>F6</kbd> | <kbd>F6</kbd> |
+| Toggle pane right | <kbd>F8</kbd> | <kbd>F8</kbd> | <kbd>F8</kbd> |
+| Toggle visibility filters | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>I</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>I</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>I</kbd> |
+| Undo | <kbd>Ctrl</kbd>+<kbd>Z</kbd> | <kbd>Cmd</kbd>+<kbd>Z</kbd> | <kbd>Ctrl</kbd>+<kbd>Z</kbd> |
+| Up | <kbd>Up</kbd> | <kbd>Up</kbd> | <kbd>Up</kbd> |
+| Up major | <kbd>Shift</kbd>+<kbd>Up</kbd> | <kbd>Shift</kbd>+<kbd>Up</kbd> | <kbd>Shift</kbd>+<kbd>Up</kbd> |
+| Zoom in | <kbd>Ctrl</kbd>+<kbd>'</kbd>+<kbd>'</kbd> | <kbd>Cmd</kbd>+<kbd>'</kbd>+<kbd>'</kbd> | <kbd>Ctrl</kbd>+<kbd>'</kbd>+<kbd>'</kbd> |
+| Zoom out | <kbd>Ctrl</kbd>+<kbd>'-'</kbd> | <kbd>Cmd</kbd>+<kbd>'-'</kbd> | <kbd>Ctrl</kbd>+<kbd>'-'</kbd> |
+
+
+## Modyfikowanie skrótów klawiszowych
+
+Możesz dowolnie zmodyfikować skróty klawiszowe tworząc plik konfiguracyjny (np. `keymap.edn` w katalogu domowym). Następnie wybierz <kbd>File ▸ Preferences</kbd> i ustaw <kbd>Path to Custom Keymap</kbd> wpisując ścieżkę do stworzonego pliku. Musisz uruchomić ponownie Edytor po tym ustawieniu i za każdym razem kiedy zmieniasz zawartość pliku konfiguracyjnego, aby nowe zmiany działały.
+
+![custom keymap](images/editor/preferences_general.png)
+
+Domyślne pliki konfiguracyjne są do pobrania dla danych systemów: [Windows](examples/keymap_win.edn), [MacOS](examples/keymap_macos.edn) i [Linux](examples/keymap_linux.edn)

--- a/docs/pl/manuals/editor-preferences.md
+++ b/docs/pl/manuals/editor-preferences.md
@@ -1,0 +1,83 @@
+---
+title: Preferencje Edytora
+brief: Ta instrukcja przedstawia co oznaczają i jak zmodyfikować Preferencje Edytora.
+---
+
+# Preferencje Edytora
+
+Możesz dostosować ustawienia Edytora z poziomu okna Preferencji. Okno Preferencji otwiera się z menu <kbd>File -> Preferences</kbd>.
+
+## General (Ogólne)
+
+![](images/editor/preferences_general.png)
+
+Load External Changes on App Focus (Wczytaj zewnętrzne zmiany po aktywowaniu aplikacji)
+: Umożliwia skanowanie zewnętrznych zmian, gdy Edytor zostaje aktywnie wybrany w systemie.
+
+Open Bundle Target Folder (Otwórz folder docelowy pakietu)
+: Umożliwia otwarcie folderu docelowego pakietu po zakończeniu procesu pakowania.
+
+Enable Texture Compression (Włącz kompresję tekstur)
+: Umożliwia kompresję tekstur dla wszystkich kompilacji utworzonych z Edytora.
+
+Escape Quits Game (Klawisz Escape zamyka grę)
+: Zatrzymuje działającą kompilację twojej gry za pomocą klawisza <kbd>Esc</kbd>.
+
+Track Active Tab in Asset Browser (Śledź aktywną kartę w przeglądarce zasobów)
+: Plik edytowany na wybranej karcie w panelu Edytor zostanie zaznaczony w Przeglądarce Zasobów (znanej również jako panel *Assets*).
+
+Path to custom keymap (Ścieżka do niestandardowej mapy klawiszy)
+: Absolutna ścieżka do pliku zawierającego niestandardowe skróty klawiaturowe.
+
+## Code (Kod)
+
+![](images/editor/preferences_code.png)
+
+Custom Editor (Niestandardowy Edytor)
+: Absolutna ścieżka do zewnętrznego Edytora. Na macOS powinna to być ścieżka do pliku wykonywalnego wewnątrz .app (np. `/Applications/Atom.app/Contents/MacOS/Atom`).
+
+Open File (Otwórz plik)
+: Wzorzec używany przez niestandardowy Edytor do określenia, który plik ma być otwarty. Wzorzec `{file}` zostanie zastąpiony nazwą pliku do otwarcia.
+
+Open File at Line (Otwórz plik w linii)
+: Wzorzec używany przez niestandardowy edytor do określenia, który plik ma być otwarty i na której linii. Wzorzec `{file}` zostanie zastąpiony nazwą pliku do otwarcia, a `{line}` numerem linii.
+
+Code editor font (Czcionka edytora kodu)
+: Nazwa zainstalowanej systemowej czcionki do użycia w edytorze kodu.
+
+### Otwieranie plików skryptów w programie Visual Studio Code
+
+![](images/editor/preferences_vscode.png)
+
+Aby otworzyć pliki skryptów bezpośrednio z Edytora Defold w programie Microsoft Visual Studio Code, musisz ustawić następujące ustawienia, określając ścieżkę do pliku wykonywalnego:
+
+- macOS: /Applications/Visual Studio Code.app/Contents/MacOS/Electron
+- Linux: /usr/bin/code
+- Windows: C:\Program Files\Microsoft VS Code\Code.exe
+
+Ustaw te parametry, aby otwierać konkretne pliki i linie:
+
+- Open File: `. {file}`
+- Open File at Line: `. -g {file}:{line}`
+
+Znak . jest wymagany, aby otworzyć cały workspace, a nie pojedynczy plik.
+
+## Rozszerzenia
+
+![](images/editor/preferences_extensions.png)
+
+Serwer budowania (Build Server)
+: URL serwera budowania używanego podczas kompilacji projektu zawierającego rozszerzenia natywne (native extensions). Możliwe jest dodanie nazwy użytkownika i tokena dostępowego do URL w celu autoryzowanego dostępu do serwera budowania. Aby określić nazwę użytkownika (username) i token dostępowy, użyj następującej notacji: `username:token@build.defold.com`. Autoryzowany dostęp jest wymagany dla kompilacji na platformę Nintendo Switch oraz w przypadku uruchamiania własnej instancji serwera kompilacji z włączoną autoryzacją (dokładne informacje znajdziesz w [dokumentacji serwera budowania](https://github.com/defold/extender/blob/dev/README_SECURITY.md). Nazwę użytkownika i hasło można także ustawić jako zmienne środowiskowe systemu `DM_EXTENDER_USERNAME` i `DM_EXTENDER_PASSWORD`.
+
+Nagłówki serwera budowania
+: dodatkowe nagłówki serwera budowania przy budowaniu rozszerzeń natywnych. Jest to ważne, jeśli korzystasz z usługi CloudFlare lub podobnych usług z extenderem.
+
+## Narzędzia
+
+![](images/editor/preferences_tools.png)
+
+Ścieżka ADB
+: Ścieżka do narzędzia linii komend [ADB](https://developer.android.com/tools/adb) zainstalowanego na tym systemie. Jeśli masz zainstalowane ADB na swoim systemie, edytor Defold użyje go do instalacji i uruchamiania spakowanych plików APK na połączonym urządzeniu z systemem Android. Domyślnie edytor sprawdza, czy ADB jest zainstalowane w znanych lokalizacjach, więc musisz podać ścieżkę tylko wtedy, gdy masz zainstalowane ADB w niestandardowym miejscu.
+
+Ścieżka ios-deploy
+: Ścieżka do narzędzi linii komend ios-deploy zainstalowanych na tym systemie (dotyczy tylko macOS). Podobnie jak w przypadku ścieżki ADB, edytor Defold będzie używać tego narzędzia do instalacji i uruchamiania spakowanych aplikacji iOS na połączonym iPhone. Domyślnie edytor sprawdza, czy ios-deploy jest zainstalowane w znanych lokalizacjach, więc musisz podać ścieżkę tylko wtedy, gdy korzystasz z niestandardowej lokalizacji własnej instalacji ios-deploy.

--- a/docs/pl/manuals/editor-scripts.md
+++ b/docs/pl/manuals/editor-scripts.md
@@ -1,0 +1,253 @@
+---
+title: Skrypty Edytora
+brief: Ta instrukcja wyjaśnia, jak rozszerzać Edytor za pomocą Lua.
+---
+
+# Skrypty Edytora
+
+Możesz tworzyć niestandardowe pozycje menu oraz rozszerzać cyklu życia Edytora, używając plików Lua o specjalnym rozszerzeniu: `.editor_script`. Dzięki temu systemowi możesz dostosować dowolnie Edytor, aby zwiększyć swoją wydajność w procesie tworzenia gier.
+
+## Uruchamianie skryptów Edytora
+
+Skrypty Edytora (editor scripts) działają wewnątrz Edytora, w maszynie wirtualnej Lua emulowanej przez maszynę wirtualną Java. Wszystkie skrypty współdzielą to samo środowisko, co oznacza, że mogą ze sobą współdziałać. Możesz wymagać (require) modułów Lua, tak samo jak w przypadku plików `.script`, ale wersja Lua uruchamiana wewnątrz Edytora jest inna, więc upewnij się, że twój współdzielony kod jest zgodny. Edytor używa wersji Lua 5.2.x, a dokładniej [silnika luaj](https://github.com/luaj/luaj), który jest obecnie jedynym dostępnym rozwiązaniem do uruchamiania Lua w JVM. Oprócz tego istnieją pewne ograniczenia:
+- brak pakietów `debug` i `coroutine`;
+- brak funkcji `os.execute` — zapewniamy bardziej przyjazny i bezpieczny sposób wykonywania skryptów powłoki (shell scripts) w sekcji "akcje" - [actions](#actions);
+- brak funkcji `os.tmpname` i `io.tmpfile` — obecnie skrypty Edytora mają dostęp tylko do plików wewnątrz katalogu projektu;
+- obecnie brak funkcji `os.rename`, choć zamierzamy ją dodać;
+- brak funkcji `os.exit` i `os.setlocale`.
+
+Wszystkie rozszerzenia Edytora zdefiniowane w skryptach Edytora są ładowane podczas otwierania projektu. Podczas pobierania bibliotek rozszerzenia są ponownie ładowane, ponieważ w bibliotekach, od których zależysz, mogą znajdować się nowe skrypty Edytora. Podczas tego ponownego ładowania nie są wykrywane żadne zmiany w twoich własnych skryptach Edytora, ponieważ mogłeś być w trakcie ich zmian. Aby również je ponownie załadować, musisz uruchomić komendę Project → Reload Editor Scripts (Przeładuj skrypty Edytora).
+
+## Anatomia skryptu `.editor_script`
+
+Każdy skrypt Edytora powinien zwracać moduł, na przykład:
+```lua
+local M = {}
+
+function M.get_commands()
+  -- TODO - define editor commands
+end
+
+function M.get_language_servers()
+  -- TODO - define language servers
+end
+
+return M
+```
+
+Edytor zbiera wszystkie skrypty Edytora zdefiniowane w projekcie i bibliotekach, ładuje je do pojedynczej maszyny Lua i wywołuje je w odpowiednich momentach (więcej na ten temat w sekcjach "komendy": [commands](#commands) i "haki cyklu życia": [lifecycle hooks](#lifecycle-hooks)).
+
+## Edytor API
+
+Możesz komunikować się z Edytorem za pomocą pakietu `editor`, który definiuje to API:
+
+- `editor.platform` — string oznaczający platformę: `"x86_64-win32"` dla systemu Windows, `"x86_64-macos"` dla macOS lub `"x86_64-linux"` dla systemu Linux.
+- `editor.version` — string - nazwa wersji Defold, na przykład `"1.4.8"`.
+- `editor.engine_sha1` — string - SHA1 silnika Defold.
+- `editor.editor_sha1` — string - SHA1 Edytora Defold.
+- `editor.get(node_id, property)` — pobierz wartość węzła (node) w Edytorze. Węzły w kontekście Edytora Defold to różne elementy, takie jak pliki skryptów, pliki kolekcji, obiekty gry w kolekcjach, pliki JSON wczytywane jako zasoby itp. `"node_id"` to userdata przekazywane do Skryptu Edytora przez sam Edytor. Możesz również podać ścieżkę zasobu zamiast identyfikatora węzła, na przykład `"/main/game.script"`. `"property"` to string. Obecnie obsługiwane są tylko te właściwości:
+  - `"path"` — ścieżka pliku od katalogu projektu dla zasobów — elementów, które istnieją jako pliki. Przykład zwracanej wartości: `"/main/game.script"`
+  - `"text"` — treść tekstowa zasobu edytowalna jako tekst (na przykład pliki skryptów lub pliki JSON). Przykład zwracanej wartości: `"function init(self)\nend"`. Należy zauważyć, że to nie jest to samo co odczytywanie pliku za pomocą `io.open()`, ponieważ możesz edytować plik bez zapisywania go, a te edycje są dostępne tylko podczas dostępu do właściwości `"text"`.
+  - niektóre właściwości wyświetlane w widoku Properties (Właściwości), gdy coś jest zaznaczone w panelu Outline. Obsługiwane są następujące typy właściwości:
+    - string - ciągi znaków
+    - boolean - zmienne logiczne
+    - number - liczby
+    - vec2/vec3/vec4 - wektory
+    - resource - zasoby
+    
+Należy zauważyć, że niektóre z tych właściwości mogą być tylko do odczytu (read-only), a niektóre mogą być niedostępne w różnych kontekstach, więc przed ich odczytaniem powinieneś użyć `editor.can_get`, a przed ich zmianą - `editor.can_set`, które zwrócą informację, czy daną właściwość można odczytać i czy można zmienić i zapisać. Najedź wskaźnikiem myszki na właściwość w panelu Properties (właściwości), żeby zobaczyć tooltop z informacją o jej nazwie w skryptach Edytora. Możesz ustawić właściwości zasobów jako `nil` używając pustej wartości `""`.
+- `editor.can_get(node_id, property)` — sprawdź czy można odczytać daną właściwość w danym kontekście. Jeśli tak (true), to `editor.get()` nie zwróci błędu.
+- `editor.can_set(node_id, property)` — sprawdź czy można zmienić i zapisać daną właściwość w danym kontekście. Jeśli tak (true), to akcja `"set"` na tej właściwości nie zwróci błędu.
+
+## Komendy
+
+Jeśli Skrypt Edytora definiuje funckję `get_commands`, to będzie one wywołana podczas przeładowania rozszerzenia i zwróci komendy możliwe do użycia w Edytorze w pasku menu lub w kontekstowym menu w panelach Assets i Outline. Przykład:
+
+```lua
+local M = {}
+
+function M.get_commands()
+  return {
+    {
+      label = "Remove Comments",
+      locations = {"Edit", "Assets"},
+      query = {
+        selection = {type = "resource", cardinality = "one"}
+      },
+      active = function(opts)
+        local path = editor.get(opts.selection, "path")
+        return ends_with(path, ".lua") or ends_with(path, ".script")
+      end,
+      run = function(opts)
+        local text = editor.get(opts.selection, "text")
+        return {
+          {
+            action = "set",
+            node_id = opts.selection,
+            property = "text",
+            value = strip_comments(text)
+          }
+        }
+      end
+    },
+    {
+      label = "Minify JSON"
+      locations = {"Assets"},
+      query = {
+        selection = {type = "resource", cardinality = "one"}
+      },
+      active = function(opts)
+        return ends_with(editor.get(opts.selection, "path"), ".json")
+      end,
+      run = function(opts)
+        local path = editor.get(opts.selection, "path")
+        return {
+          {
+            action = "shell",
+            command = {"./scripts/minify-json.sh", path:sub(2)}
+          }
+        }
+      end
+    }
+  }
+end
+
+return M
+```
+
+Edytor oczekuje, że funkcja `get_commands()` zwróci tablicę tablic, z których każda opisuje osobne polecenie. Opis polecenia składa się z:
+
+- `label` (wymagane) — tekst, który zostanie wyświetlony użytkownikowi jako pozycja w menu.
+- `locations` (wymagane) — tablica zawierająca jedno z poniższych: `"Edit"`, `"View"`, `"Assets"` lub `"Outline"` - określa, w jakim miejscu Edytora menu powinno być dostępne. `"Edit"` i `"View"` oznaczają pasek menu na górze, `"Assets"` oznacza menu kontekstowe w panelu `"Assets"`, a `"Outline"` oznacza menu kontekstowe w panelu `"Outline"`.
+- `query` — sposób, w jaki polecenie pyta Edytor o odpowiednie informacje i definiuje, na jakich danych operuje. Dla każdego klucza w tabeli `query` istnieje odpowiadający klucz w tabeli `opts`, który jest przekazywany jako argument do funkcji `active` i `run`. Obsługiwane klucze to:
+  - `selection` — oznacza, że polecenie jest ważne, gdy coś w Edytorze jest zaznaczone, i działa na tym zaznaczeniu.
+    - `type` — określa typ zaznaczonych węzłów, na które polecenie jest zainteresowane. Obecnie dozwolone są następujące rodzaje:
+      - `"resource"` — w panelach `"Assets"` i `"Outline"` oznacza zaznaczony element, który ma odpowiadający plik. W pasku menu (`Edit` lub `View`), `"resource"` to aktualnie otwarty plik;
+      - `"outline"` — coś, co może być wyświetlane w `"Outline"`. W `"Outline"` to zaznaczony element, w pasku menu to aktualnie otwarty plik;
+    - `cardinality` — określa, ile zaznaczonych elementów powinno być. Jeśli jest to `"one"`, zaznaczenie przekazywane do funkcji obsługującej polecenie będzie zawierać tylko jeden identyfikator węzła. Jeśli jest to `"many"`, przekazywana tablica będzie zawierać jeden lub więcej identyfikatorów węzła.
+- `active` - funkcja wywoływana w celu sprawdzenia, czy polecenie jest aktywne, powinna zwracać wartość logiczną. Jeśli w locations zawarte są `"Assets"` lub `"Outline"`, funkcja `active` zostanie wywołana podczas wyświetlania menu kontekstowego. Jeśli w `locations` zawarte są `"Edit"` lub `"View"`, funkcja `active` zostanie wywołana przy każdej interakcji użytkownika, takiej jak pisanie na klawiaturze lub klikanie myszą, dlatego upewnij się, że funkcja `active` działa stosunkowo szybko.
+- `run` - funkcja wywoływana, gdy użytkownik wybierze pozycję z menu, i powinna zwrócić tablicę akcji - [actions](#actions).
+
+## Actions
+
+Action (akcja) to tabela opisująca, co Edytor powinien zrobić. Każda akcja zawiera klucz `action`. Akcje dzielą się na dwa rodzaje: możliwe do cofnięcia (undoable) i niemożliwe do cofnięcia (non-undoable).
+
+### Akcje możliwe do cofnięcia
+
+Undoable action - możliwa do cofnięcia akcja może zostać cofnięta po jej wykonaniu (Undo or Ctrl + Z). Jeśli polecenie zwraca wiele akcji możliwych do cofnięcia, są one wykonywane razem i cofane razem. Należy używać akcji możliwych do cofnięcia, jeśli to możliwe. Ich wadą są większe ograniczenia.
+
+Istniejące działania możliwe do cofnięcia to:
+
+- `"set"` — ustawienie właściwości węzła w Edytorze na określoną wartość. Przykład:
+  ```lua
+  {
+    action = "set",
+    node_id = opts.selection,
+    property = "text",
+    value = "current time is " .. os.date()
+  }
+  ```
+Akcja `"set"` wymaga podania tych parametrów:
+  - `node_id` — identyfikator węzła jako userdata. Alternatywnie, można użyć ścieżki zasobu zamiast identyfikatora węzła otrzymanego od Edytora, na przykład `"/main/game.script"`;
+  - `property` — właściwość węzła do ustawienia, obecnie obsługiwane jes tylko `"text"`;
+  - `value` — nowa wartość właściwości. Dla właściwości `"text"` powinno to być łańcuchem znaków (string).
+
+### Akcje niemożliwe do cofnięcia
+
+Akcje możliwe do cofnięcia czyszczą historię cofnięć (undo), więc z poziomu Edytora nie można ich cofnąć i jeśli użytkownik chce to zrobić, musi użyć innych środków, np. systemów kontroli wersji.
+
+Istniejące działania niemożliwe do cofnięcia to:
+- `"shell"` — wykonanie skryptu powłoki. Przykład:
+  ```lua
+  {
+    action = "shell",
+    command = {
+      "./scripts/minify-json.sh",
+      editor.get(opts.selection, "path"):sub(2) -- trim leading "/"
+    }
+  }
+  ```
+Działanie `"shell"` wymaga parametru `command`, który jest tablicą polecenia, oraz jego argumentów. Główna różnica w porównaniu do `os.execute` polega na tym, że jest to potencjalnie niebezpieczna operacja, dlatego Edytor wyświetli okno dialogowe z pytaniem do użytkownika czy na pewno chce wywołać daną komendę. Edytor zapamięta, jeśli użytkownik już wyraził zgodę na wykonanie takiej komendy.
+
+### Łączenie akcji i efekty uboczne
+
+Możesz łączyć akcje możliwe do cofnięcia (undoable) i akcje niemożliwe do cofnięcia (non-undoable). Akcje są wykonywane sekwencyjnie, dlatego w zależności od kolejności działań możesz stracić możliwość cofania części tego polecenia.
+
+Zamiast zwracać akcje z funkcji, które ich oczekują, możesz po prostu czytać i zapisywać dane bezpośrednio do plików, korzystając z funkcji `io.open()`. Spowoduje to ponowne załadowanie zasobów, co wyczyści historię cofania (undo history).
+
+## Haki cyklu życia (Lifecycle Hooks)
+
+Istnieje jeden, specjalnie traktowany plik Skryptu Edytora: `hooks.editor_script`, znajdujący się w głównym katalogu twojego projektu, w tym samym katalogu co `game.project`. Tylko ten plik Skryptu Edytora otrzyma zdarzenia cyklu życia od Edytora. Oto przykład takiego pliku:
+
+```lua
+local M = {}
+
+function M.on_build_started(opts)
+  local file = io.open("assets/build.json", "w")
+  file:write("{\"build_time\": \"".. os.date() .."\"}")
+  file:close()
+end
+
+return M
+```
+
+Zdecydowaliśmy się ograniczyć haki cyklu życia do jednego pliku Skryptu Edytora, ponieważ kolejność wykonywania haków budowania (build hooks) jest ważniejsza niż łatwość dodawania kolejnego kroku buildu. Polecenia są niezależne od siebie, więc nie ma znaczenia, w jakiej kolejności są wyświetlane w menu. W końcu to użytkownik wykonuje konkretne polecenie, które wybrał. Gdyby można było określać haki cyklu życia w różnych plikach Skryptu Edytora, stworzyłoby to problem: w jakiej kolejności mają się wykonywać haki? Chcesz prawdopodobnie utworzyć sumy kontrolne zawartości po jej skompresowaniu... Dlatego posiadanie jednego pliku, który ustala kolejność kroków buildu, wywołując każdą funkcję kroku, jest sposobem na rozwiązanie tego problemu.
+
+Każdy hak cyklu życia może zwracać akcje lub zapisywać pliki w katalogu projektu.
+
+Istniejące haki cyklu życia, które plik `hooks.editor_script` może określić:
+- `on_build_started(opts)` — wykonywane, gdy gra jest budowana w celu uruchomienia jej lokalnie lub na zdalnym, docelowym urządzeniu, używając opcji `"Project Build"` lub `"Debug Start"`. Twoje zmiany, czy to zwracane akcje czy zaktualizowane zawartości pliku, pojawią się w zbudowanej grze. Wyrzucenie błędu z tego haka spowoduje przerwanie budowy. `opts` to tabela zawierająca obecnie następujący klucz:
+  - `platform` — łańcuch w formacie `%arch%-%os%`, opisujący platformę, dla której budowana jest gra, zawsze taki sam jak `editor.platform`.
+- `on_build_finished(opts)` — wykonywane, gdy budowa zostanie zakończona, niezależnie od tego, czy zakończyła się sukcesem czy nie. `opts` w tym przypadku to tabela zawierająca następujące klucze:
+  - `platform` — to samo, co w `on_build_started`.
+  - `success` — czy budowa zakończyła się sukcesem, true lub false.
+- `on_bundle_started(opts)` — wykonywane, gdy tworzysz paczkę z grą lub budujesz wersję HTML5 gry. Podobnie jak `on_build_started`, zmiany wywołane przez ten hak pojawią się w paczce, a błędy spowodują przerwanie procesu pakowania (bundle). `opts` zawiera tutaj następujące klucze:
+  - `output_directory — ścieżka do katalogu wyjściowego paczki, na przykład `"/path/to/project/build/default/__htmlLaunchDir"`
+  - `platform` — platforma, dla której paczka jest tworzona. Zobacz listę możliwych wartości platform w podręczniku Boba (narzędzia do budowania i pakowania).
+  - `variant` — wariant paczki, `"debug"`, `"release"` lub `"headless"`.  
+- `on_bundle_finished(opts)` — wykonywane, gdy budowanie paczki (bundle) zostanie ukończone, niezależnie od tego, czy zakończyło się sukcesem. `opts` w tym przypadku to tabela zawierająca te same dane co `opts` w `on_bundle_started`, oraz dodatkowo klucz `success`, który wskazuje, czy budowa zakończyła się sukcesem.
+  - `on_target_launched(opts)` — wykonywane, gdy użytkownik uruchomił grę i uruchomienie zakończyło się sukcesem. `opts` zawiera klucz `url` wskazujący na uruchomioną usługę silnika, na przykład `"http://127.0.0.1:35405"`.
+  - `on_target_terminated(opts)` — wykonywane, gdy uruchomiona gra zostaje zamknięta. `opts` ma te same klucze co `on_target_launched`.
+
+Należy zauważyć, że haki cyklu życia są obecnie funkcją dostępną tylko w Edytorze i nie są wykonywane przez Boba podczas pakowania z wiersza poleceń.
+
+## Skrypty Edytora w bibliotekach
+
+Możesz publikować biblioteki dla użytku przez inne osoby, które zawierają polecenia, i zostaną one automatycznie wykryte przez Edytor. Haki cyklu życia nie mogą być jednak automatycznie wykrywane, ponieważ muszą być zdefiniowane w pliku znajdującym się w głównym katalogu projektu, a biblioteki wystawiają tylko podkatalogi. Ma to na celu umożliwienie większej kontroli nad procesem budowy: nadal możesz tworzyć haki cyklu życia jako proste funkcje w plikach `.lua`, więc użytkownicy twojej biblioteki mogą je zaimportować i używać w swoim pliku `hooks.editor_script`.
+
+Należy również zauważyć, że chociaż zależności są wyświetlane w widoku `"Assets"`, to nie istnieją one jako pliki (są wpisami w archiwum zip), więc obecnie nie ma łatwego sposobu na wykonanie skryptu powłoki dostarczonego jako zależności (biblioteki). Jeśli jest to absolutnie konieczne, będziesz musiał wydobyć dostarczone skrypty, pobierając ich tekst za pomocą `editor.get()` i zapisując go gdzieś za pomocą `file:write()`, na przykład w katalogu `build/editor-scripts/your-extension-name`.
+
+Prostszym sposobem na wydobycie niezbędnych plików jest wykorzystanie systemu wtyczek rozszerzeń natywnych (native extensions). Aby to zrobić, musisz utworzyć plik `ext.manifest` w katalogu twojej biblioteki, a następnie utworzyć katalog `plugins/bin/${platform}` w tym samym katalogu, w którym znajduje się plik `ext.manifest`. Pliki w tym katalogu zostaną automatycznie wydobyte do katalogu `/build/plugins/${extension-path}/plugins/bin/${platform}`, dzięki czemu twoje Skrypty Edytora mogą się do nich odnosić.
+
+## Serwery językowy (language servers)
+
+Edytor obsługuje niewielki podzbiór protokołu [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). Chociaż zamierzamy rozwijać obsługę Edytora dla funkcji LSP w przyszłości, obecnie obsługuje on tylko wykrywanie diagnoz (lints) w edytowanych plikach.
+
+Aby zdefiniować serwer językowy, musisz edytować funkcję `get_language_servers` w swoim Skrypcie Edytora, jak w poniższym przykładzie:
+
+
+```lua
+function M.get_language_servers()
+  local command = 'build/plugins/my-ext/plugins/bin/' .. editor.platform .. '/lua-lsp'
+  if editor.platform == 'x86_64-win32' then
+    command = command .. '.exe'
+  end
+  return {
+    {
+      languages = {'lua'},
+      watched_files = {
+        { pattern = '**/.luacheckrc' }
+      },
+      command = {command, '--stdio'}
+    }
+  }
+end
+```
+
+Edytor uruchomi serwer językowy, korzystając z określonej komendy, używając standardowego wejścia i wyjścia procesu serwera do komunikacji.
+
+Tabela definicji serwera językowego może określać:
+
+- `languages` (wymagane) — listę języków, których serwer dotyczy, zdefiniowanych [tutaj](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers)  (rozszerzenia plików także działają);
+- `command` (wymagane) - tablicę komendy i jej argumentów
+- `watched_files` - tablicę tablic z kluczami `pattern` (glob), które będą powiadomiać serwer o zmianie plików, zgodnie z powiadomieniami o [zmianie plików śledzonych](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles).

--- a/docs/pl/manuals/editor-styling.md
+++ b/docs/pl/manuals/editor-styling.md
@@ -1,0 +1,129 @@
+---
+title: Stylizacja Edytora
+brief: Ta instrukcja opisuje jak modyifkować kolorystykę, typografię i inne wizualne aspekty Edytora Defold używając własnych stylesheetów.
+---
+
+# Stylizacja Edytora
+
+Możesz modyfikować kolorystykę, typografię i inne aspekty wizualne Edytora Defold za pomocą niestandardowego arkusza stylów (stylesheet):
+
+* Utwórz folder o nazwie `.defold` w katalogu domowym użytkownika.
+  * W systemie Windows `C:\Users\**Twoja Nazwa Użytkownika**\.defold`
+  * W systemie macOS `/Users/**Twoja Nazwa Użytkownika**/.defold`
+  * W systemie Linux `~/.defold`
+* Utwórz plik `editor.css` w folderze `.defold`.
+
+Podczas uruchamiania Edytor automatycznie wczytuje niestandardowy arkusz stylów i zastosuje go wobec domyślnego stylu. Edytor używa JavaFX do interfejsu użytkownika, a arkusze stylów są prawie identyczne z plikami CSS używanymi w przeglądarce do definiowania atrybutów stylu elementów strony internetowej. Domyślne arkusze stylów edytora są [dostępne do wglądu na GitHubie](https://github.com/defold/defold/tree/editor-dev/editor/styling/stylesheets/base).
+
+## Zmiana kolorystyki
+
+Domyślne kolory są zdefiniowane w pliku [`_palette.scss`](https://github.com/defold/defold/blob/editor-dev/editor/styling/stylesheets/base/_palette.scss) i wyglądają następująco:
+
+```
+* {
+	// Background
+	-df-background-darker:    derive(#212428, -10%);
+	-df-background-dark:      derive(#212428, -5%);
+	-df-background:           #212428;
+	-df-background-light:     derive(#212428, 10%);
+	-df-background-lighter:   derive(#212428, 20%);
+
+	// Component
+	-df-component-darker:     derive(#464c55, -20%);
+	-df-component-dark:       derive(#464c55, -10%);
+	-df-component:            #464c55;
+	-df-component-light:      derive(#464c55, 10%);
+	-df-component-lighter:    derive(#464c55, 20%);
+
+	// Text & icons
+	-df-text-dark:            derive(#b4bac1, -10%);
+	-df-text:                 #b4bac1;
+	-df-text-selected:        derive(#b4bac1, 20%);
+
+  and so on...
+```
+
+Podstawowa paleta kolorów jest podzielona na trzy grupy kolorów (z ciemniejszymi i jaśniejszymi wariantami):
+
+* Background color (kolor tła) - kolor tła w panelach, oknach, oknach dialogowych
+* Component color (kolor komponentu) - przyciski, uchwyty paska przewijania, obrysy pola tekstowego
+* Text color (Kolor tekstu) - tekst i ikony
+
+Jako przykład, jeśli dodasz to do niestandardowego arkusza stylów `editor.css` w folderze `.defold` w katalogu domowym użytkownika:
+
+```
+* {
+	-df-background-darker:    derive(#0a0a42, -10%);
+	-df-background-dark:      derive(#0a0a42, -5%);
+	-df-background:           #0a0a42;
+	-df-background-light:     derive(#0a0a42, 10%);
+	-df-background-lighter:   derive(#0a0a42, 20%);
+}
+```
+
+Otrzymasz następujący wygląd Edytora:
+
+![](images/editor/editor-styling-color.png)
+
+
+## Zmiana czcionek
+
+Edytor Defold używa domyślnie dwóch czcionek: `Dejavu Sans Mono` dla kodu i tekstu o stałej szerokości (np. błędów) oraz `Source Sans Pro` dla reszty interfejsu użytkownika. Definicje czcionek znajdują się przeważnie w pliku [`_typography.scss`](https://github.com/defold/defold/blob/editor-dev/editor/styling/stylesheets/base/_typography.scss) i wyglądają tak:
+
+```
+@font-face {
+  src: url("SourceSansPro-Light.ttf");
+}
+
+@font-face {
+  src: url("DejaVuSansMono.ttf");
+}
+
+$default-font-mono: 'Dejavu Sans Mono';
+$default-font: 'Source Sans Pro';
+$default-font-bold: 'Source Sans Pro Semibold';
+$default-font-italic: 'Source Sans Pro Italic';
+$default-font-light: 'Source Sans Pro Light';
+
+.root {
+    -fx-font-size: 13px;
+    -fx-font-family: $default-font;
+}
+
+Text.strong {
+  -fx-font-family: $default-font-bold;
+}
+
+and so on...
+```
+
+Główna czcionka jest zdefiniowana w elemencie głównym (root), co sprawia, że jest dość łatwo zamienić czcionkę w większości miejsc. Dodaj to do swojego arkusza stylów `editor.css`:
+
+```
+@import url('https://fonts.googleapis.com/css2?family=Architects+Daughter&display=swap');
+
+.root {
+    -fx-font-family: "Architects Daughter";
+}
+```
+
+Otrzymasz następujący wygląd Edytora:
+
+![](images/editor/editor-styling-fonts.png)
+
+Jest również możliwość użycia lokalnej czcionki zamiast czcionki internetowej:
+
+```
+@font-face {
+  font-family: 'Comic Sans MS';
+  src: local("cs.ttf");
+}
+
+.root {
+  -fx-font-family: 'Comic Sans MS';
+}
+```
+
+::: sidenote
+Czcionka edytora kodu jest zdefiniowana osobno w preferencjach edytora!
+:::

--- a/docs/pl/manuals/editor-templates.md
+++ b/docs/pl/manuals/editor-templates.md
@@ -1,0 +1,46 @@
+---
+title: Szablony w Edytorze
+brief: Możesz dodać własne niestandardowe szablony projektów do okna Nowy projekt.
+---
+
+# Szablony w Edytorze
+
+Możesz dodać własne niestandardowe szablony projektów do okna Nowy projekt (New Project):
+
+![niestandardowe szablony projektów](images/editor/custom_project_templates.png)
+
+Aby dodać jedną lub więcej nowych zakładek z niestandardowymi szablonami projektów, musisz dodać plik `welcome.edn` w folderze `.defold` w katalogu domowym użytkownika:
+
+* Utwórz folder o nazwie `.defold` w katalogu domowym użytkownika.
+  * W systemie Windows `C:\Użytkownicy\**Twoja Nazwa Użytkownika**\.defold` (ang: `C:\Users\**Your Username**\.defold`)
+  * Na systemie macOS `/Użytkownicy/**Twoja Nazwa Użytkownika**/.defold` (ang: `/Users/**Your Username**/.defold`)
+  * Na systemie Linux `~/.defold`
+* Utwórz plik `welcome.edn` w folderze `.defold`.
+
+Plik `welcome.edn` używa formatu Extensible Data Notation. Przykład:
+
+```
+{:new-project
+  {:categories [
+    {:label "Mój szablon"
+     :templates [
+          {:name "Mój projekt"
+           :description "Mój szablon z moimi własnymi ustawieniami."
+           :image "empty.svg"
+           :zip-url "https://github.com/britzl/template-project/archive/master.zip"
+           :skip-root? true},
+          {:name "Mój inny projekt"
+           :description "Mój inny szablon z moimi własnymi ustawieniami."
+           :image "empty.svg"
+           :zip-url "https://github.com/britzl/template-other-project/archive/master.zip"
+           :skip-root? true}]
+    }]
+  }
+}
+```
+
+To stworzy listę szablonów widocznych na zrzucie ekranu powyżej (na screenshocie nazwy i opisy są w języku angielskim).
+
+::: sidenote
+Obecnie można używać tylko obrazów szablonów [dołączonych do Edytora](https://github.com/defold/defold/tree/dev/editor/resources/welcome/images).
+:::

--- a/docs/pl/manuals/editor.md
+++ b/docs/pl/manuals/editor.md
@@ -1,15 +1,15 @@
 ---
 title: Edytor Defold
-brief: This manual gives an overview on how the Defold editor look and works, and how to navigate in it.
+brief: Ta instrukcja opisuje ogólnie Edytor Defold, jak wygląda i działa oraz jak w nim się poruszać.
 ---
 
 # Edytor Defold
 
 Edytor Defold pozwala przeglądać i zarządzać plikami w Twoim projekcie w wydajny sposób. Edytowanie różnych plików otwiera odpowiednie widoki ukazujące wszystkie niezbędne informacje.
 
-## Uruchamianie edytora
+## Uruchamianie Edytora
 
-Kiedy uruchamiasz edytor Defold zostaje najpierw otwarte okno wyboru i tworzenia projektu. Wybierz spośród:
+Kiedy uruchamiasz Edytor Defold zostaje najpierw otwarte okno wyboru i tworzenia projektu. Wybierz spośród:
 
 Home (Strona domowa)
 : Kliknij, żeby zobaczyć swoje ostatnio otwierane projekty. To jest domyślny widok.
@@ -23,7 +23,7 @@ New Project (Nowy Projekt)
 
 Szczegóły dotyczące różnych zakładek znajdziesz w [instrukcji do rozpoczynania projektu](https://www.defold.com/manuals/project-setup/).
 
-## Widoki w edytorze
+## Widoki w Edytorze
 
 Edytor Defold jest podzielony na oddzielne widoki/sekcje, które zawierają specyficzne informacje.
 
@@ -32,24 +32,24 @@ Edytor Defold jest podzielony na oddzielne widoki/sekcje, które zawierają spec
 Widok *Assets* (Zasoby)
 : Zawiera listę wszystkich plików projektu, reprezentowaną podobnie do systemowego eksploratora plików, zgodnie z hierarchią katalogów. Możesz klikać, przewijać i rozwijać elementy:
 
-   - <kbd>Kliknij dwukrotnie lewym przyciskem myszki</kbd> nazwę pliku, żeby otworzyć go w edytorze.
+   - <kbd>Kliknij dwukrotnie lewym przyciskem myszki</kbd> nazwę pliku, żeby otworzyć go w Edytorze.
    - <kbd>Przeciągaj i upuszczaj</kbd> pliki, aby zmieniać ich lokalizację w strukturze projektu lub dodawać nowe pliki z dysku.
    - <kbd>Kliknij prawy przycisk myszki</kbd>, żeby otworzyć _menu kontekstowe_, z którego możesz utworzyć nowe pliki i foldery, zmienić nazwę, usunąć czy śledzić zależności i wiele więcej.
 
 Widok *Editor* (Edytor)
 
-: Centralna sekcja wyświetla aktualnie otwarty plik w edytorze odpowiedniem dla danego typu pliku. Wszystkie rodzaje takich edytorów, które są wizualne pozwalają na manipulację widokiem kamery:
+: Centralna sekcja wyświetla aktualnie otwarty plik w Edytorze odpowiedniem dla danego typu pliku. Wszystkie rodzaje takich Edytorów, które są wizualne pozwalają na manipulację widokiem kamery:
 
 - Przesuwanie: <kbd>Alt + Lewy przycisk myszki</kbd>.
 - Oddalanie/przybliżanie: <kbd>Alt + Prawy przycisk myszki</kbd> (myszki trójprzyciskowe) lub <kbd>Ctrl + Lewy przycisk myszki</kbd> (jeden przycisk). Jeśli myszka ma kółko, może ono być również używane do przybliżania i oddalania.
 - Obracaj w 3D: <kbd>Ctrl + Lewy przycisk myszki</kbd>.
 
-W prawym górnym rogu edytora aktualnie otwartego pliku (sceny) znajduje się zestaw narzędzi obsługi widoku kamery: *Move* (Przesuwanie), *Rotate* (Obracanie) and *Scale* (Skalowanie).
+W prawym górnym rogu Edytora aktualnie otwartego pliku (sceny) znajduje się zestaw narzędzi obsługi widoku kamery: *Move* (Przesuwanie), *Rotate* (Obracanie) and *Scale* (Skalowanie).
 
 ![toolbar](images/editor/toolbar.png){srcset="images/editor/toolbar@2x.png 2x"}
 
 Widok *Outline* (Zawartość pliku)
-: Widok ten pokazuje zawartość aktualnie otwartego pliku, w strukturze drzewa. Odzwierciedla widok edytora i pozwala na wykonywanie operacji na zawartości:
+: Widok ten pokazuje zawartość aktualnie otwartego pliku, w strukturze drzewa. Odzwierciedla widok Edytora i pozwala na wykonywanie operacji na zawartości:
 
    - <kbd>Kliknij lewym przyciskem myszki</kbd> aby wybrać wskazany element. Przytrzymaj klawisz <kbd>Shift</kbd> lub <kbd>Option</kbd>, żeby zaznaczyć wiele elementów.
    - <kbd>Przeciągaj i upuszczaj</kbd> elementy, żeby zmieniać ich położenie w strukturze. Upuść obiekty gry (game object) na innym obiekcie w kolekcji, żeby stworzyć relację rodzic-dziecko.
@@ -59,7 +59,7 @@ Widok *Properties* (Właściwości))
 : Widok ten pokazuje właściwości aktualnie wybranego komponentu, takie jak Pozycja, Rotacja, Animacja, Id, etc.
 
 Widok *Tools* (Narzędzia)
-: Dolny widok pokazuje w zależności od wybranej zakładki: konsolę (ang. *Console*) wyświetlającą logi działającego programu, edytor krzywych (ang. *Curve Editor*) umożliwiający edytowanie wykresu krzywej, używany np. przy tworzeniu efektów cząsteczkowych (particle fx), błędy budowania (ang. *Build Errors*) i wyniki wyszukiwania (ang. *Search Results*). Konsola jest również używana podczas używania zintegrowanego debuggera.
+: Dolny widok pokazuje w zależności od wybranej zakładki: konsolę (ang. *Console*) wyświetlającą logi działającego programu, Edytor krzywych (ang. *Curve Editor*) umożliwiający edytowanie wykresu krzywej, używany np. przy tworzeniu efektów cząsteczkowych (particle fx), błędy budowania (ang. *Build Errors*) i wyniki wyszukiwania (ang. *Search Results*). Konsola jest również używana podczas używania zintegrowanego debuggera.
 
 Widok *Changed Files* (Zmienione pliki):
 : Widok pokazuje wszystkie pliki, które zostały zmienione, dodane lub usunięte z Twojego projektu od ostatniej zapisanej w systemie kontroli wersji zmiany (commit). This view lists any files that has been changed, added or deleted in your project. By synchronizing the project regularly you can bring your local copy in sync with what is stored in the project Git repository, that way you can collaborate within a team, and you won’t lose your work if unfortune strikes. Some file oriented operations can be performed in this view:
@@ -69,7 +69,7 @@ Widok *Changed Files* (Zmienione pliki):
 
 ## Edytowanie równolegle (Side-by-side)
 
-Jeśli masz otwartych kilka plików jednocześnie, dla każdego z nich pokazywana jest osobna zakładka na górnym pasku edytora Defold. Możliwe jest również otworzenie dwóch edytorów/.paneli naraz, jeden obok drugiego. Wybierz plik, <kbd>klikająć prawym przyciskiem myszy</kbd> na danej zakładce w górnym pasku i wybierz <kbd>Move to Other Tab Pane</kbd> z menu kontekstowego.
+Jeśli masz otwartych kilka plików jednocześnie, dla każdego z nich pokazywana jest osobna zakładka na górnym pasku Edytora Defold. Możliwe jest również otworzenie dwóch Edytorów/.paneli naraz, jeden obok drugiego. Wybierz plik, <kbd>klikająć prawym przyciskiem myszy</kbd> na danej zakładce w górnym pasku i wybierz <kbd>Move to Other Tab Pane</kbd> z menu kontekstowego.
 
 ![2 panes](images/editor/2-panes.png){srcset="images/editor/2-panes@2x.png 2x"}
 
@@ -93,7 +93,7 @@ Wybieranie obiektów:
 
 Narzędzie przesuwania (Move)
 : ![Move tool](images/editor/icon_move.png){.left}
-  Do przesuwania obiektów można użyć narzędzia przesuwania *Move*. Znajdziesz je w pasku narzędzi w prawym górnym rogu edytora sceny lub klikając klawisz <kbd>W</kbd>.
+  Do przesuwania obiektów można użyć narzędzia przesuwania *Move*. Znajdziesz je w pasku narzędzi w prawym górnym rogu Edytora sceny lub klikając klawisz <kbd>W</kbd>.
 
   ![Move object](images/editor/move.png)
 
@@ -133,103 +133,31 @@ Aby dodać pliki (obrazki, dźwięki, modele, itp.) do Twojego projektu, po pros
 
 ![Import files](images/editor/import.png){srcset="images/editor/import@2x.png 2x"}
 
+## Aktualizowanie Edytora
+
+Edytor automatycznie wyszukuje aktualizacje, jeśli ma dostęp do internetu. Kiedy aktualizacja jest dostępna, informacja o możliwości zaktualizowania pojawi się w prawym dolnym rogu Edytora i na stronie startowej z wyborem projektu. Naciśnięcie przycisku `Update Available` spowoduje pobranie aktualizacji i zainstalowanie jej.
+
+![Update from project selection](images/editor/update-project-selection.png){srcset="images/editor/update-project-selection@2x.png 2x"}
+
+![Update from editor](images/editor/update-main.png){srcset="images/editor/update-main@2x.png 2x"}
+
 ## Skróty klawiszowe
 
-| Command | Windows | macOS | Linux |
-|---------|---------|-------|-------|
-| Add (Dodaj) | <kbd>A</kbd> | <kbd>A</kbd> | <kbd>A</kbd> |
-| Add secondary (Dodaj następny) | <kbd>Shift</kbd>+<kbd>A</kbd> | <kbd>Shift</kbd>+<kbd>A</kbd> | <kbd>Shift</kbd>+<kbd>A</kbd> |
-| Backwards tab trigger (Powracanie o odstęp) | <kbd>Shift</kbd>+<kbd>Tab</kbd> | <kbd>Shift</kbd>+<kbd>Tab</kbd> | <kbd>Shift</kbd>+<kbd>Tab</kbd> |
-| Beginning of file (Skocz do początku pliku) | <kbd>Ctrl</kbd>+<kbd>Home</kbd> | <kbd>Cmd</kbd>+<kbd>Up</kbd> | <kbd>Ctrl</kbd>+<kbd>Home</kbd> |
-| Beginning of line (Skocz do początku linii) |  | <kbd>Ctrl</kbd>+<kbd>A</kbd> |  |
-| Beginning of line text (Skocz do początku tekstu) | <kbd>Home</kbd> | <kbd>Home</kbd> | <kbd>Home</kbd> |
-| Build (Zbuduj) | <kbd>Ctrl</kbd>+<kbd>B</kbd> | <kbd>Cmd</kbd>+<kbd>B</kbd> | <kbd>Ctrl</kbd>+<kbd>B</kbd> |
-| Close (Zamknij) | <kbd>Ctrl</kbd>+<kbd>W</kbd> | <kbd>Cmd</kbd>+<kbd>W</kbd> | <kbd>Ctrl</kbd>+<kbd>W</kbd> |
-| Close all (Zamknij wszystko) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>W</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>W</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>W</kbd> |
-| Continue (Kontynuuj) | <kbd>F5</kbd> | <kbd>F5</kbd> | <kbd>F5</kbd> |
-| Copy (Kopiuj) | <kbd>Ctrl</kbd>+<kbd>C</kbd> | <kbd>Cmd</kbd>+<kbd>C</kbd> | <kbd>Ctrl</kbd>+<kbd>C</kbd> |
-| Cut (Wytnij) | <kbd>Ctrl</kbd>+<kbd>X</kbd> | <kbd>Cmd</kbd>+<kbd>X</kbd> | <kbd>Ctrl</kbd>+<kbd>X</kbd> |
-| Delete (Usuń) | <kbd>Delete</kbd> | <kbd>Delete</kbd> | <kbd>Delete</kbd> |
-| Delete backward (Wymaż) | <kbd>Backspace</kbd> | <kbd>Backspace</kbd> | <kbd>Backspace</kbd> |
-| Delete line (Usuń linię) |  | <kbd>Ctrl</kbd>+<kbd>D</kbd> |  |
-| Delete next word (Usuń następne słowo) | <kbd>Ctrl</kbd>+<kbd>Delete</kbd> | <kbd>Alt</kbd>+<kbd>Delete</kbd> | <kbd>Ctrl</kbd>+<kbd>Delete</kbd> |
-| Delete prev word (Usuń kolejne słowo) | <kbd>Ctrl</kbd>+<kbd>Backspace</kbd> | <kbd>Alt</kbd>+<kbd>Backspace</kbd> | <kbd>Ctrl</kbd>+<kbd>Backspace</kbd> |
-| Delete to end of line (Usuń do końca linii) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Delete</kbd> | <kbd>Cmd</kbd>+<kbd>Delete</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Delete</kbd> |
-| Documentation (Dokumentacja) | <kbd>F1</kbd> | <kbd>F1</kbd> | <kbd>F1</kbd> |
-| Down (W dół) | <kbd>Down</kbd> | <kbd>Down</kbd> | <kbd>Down</kbd> |
-| End of file (Skocz do końca pliku) | <kbd>Ctrl</kbd>+<kbd>End</kbd> | <kbd>Cmd</kbd>+<kbd>Down</kbd> | <kbd>Ctrl</kbd>+<kbd>End</kbd> |
-| End of line (Skocz do końca linii) | <kbd>End</kbd> | <kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>End</kbd> |
-| Enter (Wybierz/Wprowadź) | <kbd>Enter</kbd> | <kbd>Enter</kbd> | <kbd>Enter</kbd> |
-| Erase tool (Narzędzie usuwania) | <kbd>Shift</kbd>+<kbd>E</kbd> | <kbd>Shift</kbd>+<kbd>E</kbd> | <kbd>Shift</kbd>+<kbd>E</kbd> |
-| Escape (Wróć) | <kbd>Esc</kbd> | <kbd>Esc</kbd> | <kbd>Esc</kbd> |
-| Find next (Znajdź następne) | <kbd>Ctrl</kbd>+<kbd>G</kbd> | <kbd>Cmd</kbd>+<kbd>G</kbd> | <kbd>Ctrl</kbd>+<kbd>G</kbd> |
-| Find prev (Znajdź poprzednie) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>G</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>G</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>G</kbd> |
-| Find text (Znajdź tekst) | <kbd>Ctrl</kbd>+<kbd>F</kbd> | <kbd>Cmd</kbd>+<kbd>F</kbd> | <kbd>Ctrl</kbd>+<kbd>F</kbd> |
-| Frame selection (Przystosuj widok) | <kbd>F</kbd> | <kbd>F</kbd> | <kbd>F</kbd> |
-| Goto line (Idź do linii) | <kbd>Ctrl</kbd>+<kbd>L</kbd> | <kbd>Cmd</kbd>+<kbd>L</kbd> | <kbd>Ctrl</kbd>+<kbd>L</kbd> |
-| Hide selected (Ukryj wybrane) | <kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Cmd</kbd>+<kbd>E</kbd> | <kbd>Ctrl</kbd>+<kbd>E</kbd> |
-| Hot reload (Przeładuj) | <kbd>Ctrl</kbd>+<kbd>R</kbd> | <kbd>Cmd</kbd>+<kbd>R</kbd> | <kbd>Ctrl</kbd>+<kbd>R</kbd> |
-| Left (W lewo) | <kbd>Left</kbd> | <kbd>Left</kbd> | <kbd>Left</kbd> |
-| Move down (Przesuń w dół) | <kbd>Alt</kbd>+<kbd>Down</kbd> | <kbd>Alt</kbd>+<kbd>Down</kbd> | <kbd>Alt</kbd>+<kbd>Down</kbd> |
-| Move tool (Narzędzie przesuwania) | <kbd>W</kbd> | <kbd>W</kbd> | <kbd>W</kbd> |
-| Move up (Przesuń w górę) | <kbd>Alt</kbd>+<kbd>Up</kbd> | <kbd>Alt</kbd>+<kbd>Up</kbd> | <kbd>Alt</kbd>+<kbd>Up</kbd> |
-| New file (Nowy plik) | <kbd>Ctrl</kbd>+<kbd>N</kbd> | <kbd>Cmd</kbd>+<kbd>N</kbd> | <kbd>Ctrl</kbd>+<kbd>N</kbd> |
-| Next word (Następne słowo) | <kbd>Ctrl</kbd>+<kbd>Right</kbd> | <kbd>Alt</kbd>+<kbd>Right</kbd> | <kbd>Ctrl</kbd>+<kbd>Right</kbd> |
-| Open (Otwórz) | <kbd>Ctrl</kbd>+<kbd>O</kbd> | <kbd>Cmd</kbd>+<kbd>O</kbd> | <kbd>Ctrl</kbd>+<kbd>O</kbd> |
-| Open asset (Otwórz zasób) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>R</kbd> | <kbd>Cmd</kbd>+<kbd>P</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>R</kbd> |
-| Page down (Strona w dół) | <kbd>Page Down</kbd> | <kbd>Page Down</kbd> | <kbd>Page Down</kbd> |
-| Page up (Strona w górę) | <kbd>Page Up</kbd> | <kbd>Page Up</kbd> | <kbd>Page Up</kbd> |
-| Paste (Wklej) | <kbd>Ctrl</kbd>+<kbd>V</kbd> | <kbd>Cmd</kbd>+<kbd>V</kbd> | <kbd>Ctrl</kbd>+<kbd>V</kbd> |
-| Preferences (Preferencje) | <kbd>Ctrl</kbd>+<kbd>Comma</kbd> | <kbd>Cmd</kbd>+<kbd>Comma</kbd> | <kbd>Ctrl</kbd>+<kbd>Comma</kbd> |
-| Prev word (Poprzednie słowo) | <kbd>Ctrl</kbd>+<kbd>Left</kbd> | <kbd>Alt</kbd>+<kbd>Left</kbd> | <kbd>Ctrl</kbd>+<kbd>Left</kbd> |
-| Proposals (Propozycje/podpowiedzi) | <kbd>Ctrl</kbd>+<kbd>Space</kbd> | <kbd>Ctrl</kbd>+<kbd>Space</kbd> | <kbd>Ctrl</kbd>+<kbd>Space</kbd> |
-| Quit (Wyjdź) | <kbd>Ctrl</kbd>+<kbd>Q</kbd> | <kbd>Cmd</kbd>+<kbd>Q</kbd> | <kbd>Ctrl</kbd>+<kbd>Q</kbd> |
-| Realign camera (Przywróć kamerę) | <kbd>Period</kbd> | <kbd>Period</kbd> | <kbd>Period</kbd> |
-| Rebuild (Przebuduj) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>B</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>B</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>B</kbd> |
-| Rebundle (Przepakuj) | <kbd>Ctrl</kbd>+<kbd>U</kbd> | <kbd>Cmd</kbd>+<kbd>U</kbd> | <kbd>Ctrl</kbd>+<kbd>U</kbd> |
-| Redo (Powtórz) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Z</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>Z</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Z</kbd> |
-| Reindent (Powtórz wcięcie) | <kbd>Ctrl</kbd>+<kbd>I</kbd> | <kbd>Ctrl</kbd>+<kbd>I</kbd> | <kbd>Ctrl</kbd>+<kbd>I</kbd> |
-| Reload stylesheet (Przeładuj style) |  | <kbd>Ctrl</kbd>+<kbd>R</kbd> |  |
-| Rename (Zmień nazwę) | <kbd>F2</kbd> | <kbd>F2</kbd> | <kbd>F2</kbd> |
-| Replace next (Zamień następny) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>H</kbd> | <kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>G</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>H</kbd> |
-| Replace text (Zamień tekst) |  | <kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>F</kbd> |  |
-| Right (W prawo) | <kbd>Right</kbd> | <kbd>Right</kbd> | <kbd>Right</kbd> |
-| Rotate tool (Narzędzie obracania) | <kbd>E</kbd> | <kbd>E</kbd> | <kbd>E</kbd> |
-| Save all (Zapisz wszystko) | <kbd>Ctrl</kbd>+<kbd>S</kbd> | <kbd>Cmd</kbd>+<kbd>S</kbd> | <kbd>Ctrl</kbd>+<kbd>S</kbd> |
-| Scale tool (Narzędzie skalowania) | <kbd>R</kbd> | <kbd>R</kbd> | <kbd>R</kbd> |
-| Scene stop (Zatrzymaj/uruchom scenę) | <kbd>Ctrl</kbd>+<kbd>T</kbd> | <kbd>Cmd</kbd>+<kbd>T</kbd> | <kbd>Ctrl</kbd>+<kbd>T</kbd> |
-| Search in files (Szukaj w plikach) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>F</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>F</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>F</kbd> |
-| Select all (Wybierz wszystko) | <kbd>Ctrl</kbd>+<kbd>A</kbd> | <kbd>Cmd</kbd>+<kbd>A</kbd> | <kbd>Ctrl</kbd>+<kbd>A</kbd> |
-| Select beginning of file (Wybierz początek pliku) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Home</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>Up</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Home</kbd> |
-| Select beginning of line (Wybierz początek linii) |  | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>A</kbd> |  |
-| Select beginning of line text  (Wybierz początek tekstu) | <kbd>Shift</kbd>+<kbd>Home</kbd> | <kbd>Shift</kbd>+<kbd>Home</kbd> | <kbd>Shift</kbd>+<kbd>Home</kbd> |
-| Select down (Wybierz w dół) | <kbd>Shift</kbd>+<kbd>Down</kbd> | <kbd>Shift</kbd>+<kbd>Down</kbd> | <kbd>Shift</kbd>+<kbd>Down</kbd> |
-| Select end of file  (Wybierz koniec pliku) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>End</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>Down</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>End</kbd> |
-| Select end of line (Wybierz koniec linii) | <kbd>Shift</kbd>+<kbd>End</kbd> | <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>Down</kbd> | <kbd>Shift</kbd>+<kbd>End</kbd> |
-| Select left (Wybierz w lewo) | <kbd>Shift</kbd>+<kbd>Left</kbd> | <kbd>Shift</kbd>+<kbd>Left</kbd> | <kbd>Shift</kbd>+<kbd>Left</kbd> |
-| Select next occurrence (Wybierz następne wystąpienie) | <kbd>Ctrl</kbd>+<kbd>D</kbd> | <kbd>Cmd</kbd>+<kbd>D</kbd> | <kbd>Ctrl</kbd>+<kbd>D</kbd> |
-| Select next word (Wybierz następne słowo) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Right</kbd> | <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>Right</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Right</kbd> |
-| Select page down (Wybierz do strony w dół) | <kbd>Shift</kbd>+<kbd>Page Down</kbd> | <kbd>Shift</kbd>+<kbd>Page Down</kbd> | <kbd>Shift</kbd>+<kbd>Page Down</kbd> |
-| Select page up (Wybierz do strony w górę) | <kbd>Shift</kbd>+<kbd>Page Up</kbd> | <kbd>Shift</kbd>+<kbd>Page Up</kbd> | <kbd>Shift</kbd>+<kbd>Page Up</kbd> |
-| Select prev word (Wybierz poprzednie słowo) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Left</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Left</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Left</kbd> |
-| Select right (Wybierz w prawo) | <kbd>Shift</kbd>+<kbd>Right</kbd> | <kbd>Shift</kbd>+<kbd>Right</kbd> | <kbd>Shift</kbd>+<kbd>Right</kbd> |
-| Show last hidden (Pokaż ostatni ukryty) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>E</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>E</kbd> |
-| Show palette (Pokaż paletę) | <kbd>Space</kbd> | <kbd>Space</kbd> | <kbd>Space</kbd> |
-| Split selection into lines (Podziel wybrane na linie) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>L</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>L</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>L</kbd> |
-| Step into (Wejdź do) | <kbd>F11</kbd> | <kbd>F11</kbd> | <kbd>F11</kbd> |
-| Step out (Wyjdź z) | <kbd>Shift</kbd>+<kbd>F11</kbd> | <kbd>Shift</kbd>+<kbd>F11</kbd> | <kbd>Shift</kbd>+<kbd>F11</kbd> |
-| Step over (Przejdź ponad) | <kbd>F10</kbd> | <kbd>F10</kbd> | <kbd>F10</kbd> |
-| Stop debugger (Zatrzymaj debugger) | <kbd>Shift</kbd>+<kbd>F5</kbd> |  | <kbd>Shift</kbd>+<kbd>F5</kbd> |
-| Tab | <kbd>Tab</kbd> | <kbd>Tab</kbd> | <kbd>Tab</kbd> |
-| Toggle breakpoint (Przełącz punkt przerywający) | <kbd>F9</kbd> | <kbd>F9</kbd> | <kbd>F9</kbd> |
-| Toggle comment (Przełącz komentarz) | <kbd>Ctrl</kbd>+<kbd>Slash</kbd> | <kbd>Cmd</kbd>+<kbd>Slash</kbd> | <kbd>Ctrl</kbd>+<kbd>Slash</kbd> |
-| Toggle component guides (Przełącz zaznaczenia komponentów) | <kbd>Ctrl</kbd>+<kbd>H</kbd> | <kbd>Ctrl</kbd>+<kbd>Cmd</kbd>+<kbd>H</kbd> | <kbd>Ctrl</kbd>+<kbd>H</kbd> |
-| Toggle pane bottom (Przełącz dolny panel) | <kbd>F7</kbd> | <kbd>F7</kbd> | <kbd>F7</kbd> |
-| Toggle pane left (Przełącz lewy panel) | <kbd>F6</kbd> | <kbd>F6</kbd> | <kbd>F6</kbd> |
-| Toggle pane right (Przełącz prawy panel) | <kbd>F8</kbd> | <kbd>F8</kbd> | <kbd>F8</kbd> |
-| Toggle visibility filters (Przełącz filtry widoczności) | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>I</kbd> | <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>I</kbd> | <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>I</kbd> |
-| Undo (Cofnij) | <kbd>Ctrl</kbd>+<kbd>Z</kbd> | <kbd>Cmd</kbd>+<kbd>Z</kbd> | <kbd>Ctrl</kbd>+<kbd>Z</kbd> |
-| Up (W górę) | <kbd>Up</kbd> | <kbd>Up</kbd> | <kbd>Up</kbd> |
-| Up major | <kbd>Shift</kbd>+<kbd>Up</kbd> | <kbd>Shift</kbd>+<kbd>Up</kbd> | <kbd>Shift</kbd>+<kbd>Up</kbd> |
-| Zoom in (Przybliż) | <kbd>Ctrl</kbd>+<kbd>'</kbd>+<kbd>'</kbd> | <kbd>Cmd</kbd>+<kbd>'</kbd>+<kbd>'</kbd> | <kbd>Ctrl</kbd>+<kbd>'</kbd>+<kbd>'</kbd> |
-| Zoom out (Oddal) | <kbd>Ctrl</kbd>+<kbd>'-'</kbd> | <kbd>Cmd</kbd>+<kbd>'-'</kbd> | <kbd>Ctrl</kbd>+<kbd>'-'</kbd> |
+Skróty opisane są w [instrukcji o skrótach klawiszowych](/manuals/editor-keyboard-shortcuts).
+
+## Logi Edytora
+Jeśli napotkasz jakiekolwiek problemy z Edytorem Defold warto [to zaraportować](/manuals/getting-help/#getting-help). Dobrą pkratyką jest dodanie plików z logami z Edytora. Można je znaleźć tutaj:
+
+  * Windows: `C:\Użytkownicy\ **Twoja nazwa użytkownika** \AppData\Local\Defold` (ang: `C:\Users\ **Your Username** \AppData\Local\Defold`)
+  * macOS: `/Users/ **Your Username** /Library/Application Support/` or `~/Library/Application Support/Defold`
+  * Linux: `~/.Defold`
+
+Można też dostać się do logów, kiedy Edytor jest uruchomiony z linii poleceń lub terminalu. Aby uruchomić Edytor z terminalu w systemie macOS użyj komendy:
+
+```
+$ > ./path/to/Defold.app/Contents/MacOS/Defold
+```
+
+
+## FAQ
+:[Editor FAQ](../shared/editor-faq.md)

--- a/docs/pl/manuals/font.md
+++ b/docs/pl/manuals/font.md
@@ -1,0 +1,164 @@
+---
+title: Fonty w Defoldzie
+brief: Ta instrukcja opisuje jak używać fontów w Twoich grach.
+---
+
+# Pliki fontów
+
+Fonty (w odróżnieniu od czcionki będącej jedynie określeniem materiału zecerskiego) są używane do wyświetlania tekstu w kompoentach typu Label (etykieta) i węzłów tekstowych GUI. Defold wspiera poniższe formaty plików określających fonty:
+
+- TrueType
+- OpenType
+- BMFont
+
+Fonty dodane do projektu są automatycznie konwertowane na format tekstury, który może być renderowany przez Defolda. Dostępne są dwie techniki renderowania czcionek, z własnymi korzyściami i wadami:
+
+- Bitmap
+- Distance field (Pole odległości)
+
+## Tworzenie fontów
+
+Aby stworzyć czcionkę do użycia w Defold, utwórz nowy plik fontu, wybierając opcję <kbd>File ▸ New...</kbd> z menu, a następnie wybierz <kbd>Font</kbd>. Możesz również kliknąć <kbd>prawy przycisk myszy</kbd> w lokalizacji w panelu *Assets* i wybrać <kbd>New... ▸ Font</kbd>.
+
+![New font name](images/font/new_font_name.png){srcset="images/font/new_font_name@2x.png 2x"}
+
+Nadaj nowemu plikowi fontu nazwę i kliknij <kbd>OK</kbd>. Nowy plik fontu otworzy się teraz w edytorze.
+
+![New font](images/font/new_font.png){srcset="images/font/new_font@2x.png 2x"}
+
+Przeciągnij font, który chcesz użyć do panelu *Assets* i upuść ją we właściwym miejscu.
+
+Ustaw właściwość *Font* na plik fontu i dostosuj właściwości czcionki, jak to konieczne.
+
+## Właściwości (Properties)
+
+*Font*
+: Plik TTF, OTF lub *.fnt*, który ma zostać użyty do generowania danych czcionki.
+
+*Material*
+: Materiał, który ma zostać użyty podczas renderowania fontu. Upewnij się, że zmieniasz to dla czcionek Distance Field i BMFonts (patrz poniżej, aby uzyskać szczegóły).
+
+*Output Format*
+: Rodzaj danych czcionki, który jest generowany.
+
+  - `TYPE_BITMAP` konwertuje importowany plik OTF lub TTF na teksturę arkusza fontu, gdzie dane bitmapy są używane do renderowania tekstu. Kanały koloru służą do kodowania kształtu twarzy (face shape), obrysu (outline) i cienia (shadow). Dla plików *.fnt* używana jest oryginalna bitmapa źródłowa.
+  - `TYPE_DISTANCE_FIELD` importowany font jest konwertowana na teksturę arkusza fontu, gdzie dane pikseli reprezentują nie piksele ekranu, ale odległości do krawędzi czcionki. Patrz poniżej po szczegóły.
+
+*Render Mode*
+: Tryb renderowania dla glifów.
+
+  - `MODE_SINGLE_LAYER` generuje pojedynczy kwadrat (quad) dla każdego znaku.
+  - `MODE_MULTI_LAYER` generuje osobne kwadraty (quady) dla kształtu glifu, obrysu i cieni, odpowiednio. Warstwy są renderowane od tyłu do przodu, co zapobiega zasłanianiu wcześniej renderowanych znaków, jeśli obrys jest szerszy niż odległość między glifami. Ten tryb renderowania umożliwia również prawidłowe przesunięcie cienia, zgodnie z właściwościami cienia X/Y w zasobie fontu.
+
+*Size*
+: Docelowy rozmiar glifów w pikselach.
+
+*Antialias*
+: Określa, czy czcionka ma być wygładzana (antyaliasing), gdy jest wypalana na docelowej bitmapie. Ustaw na 0, jeśli chcesz uzyskać dokładne renderowanie czcionki piksel po pikselu.
+
+*Alpha*
+: Przezroczystość glifu. Od 0,0 do 1,0, gdzie 0,0 oznacza przezroczystość, a 1,0 nieprzezroczystość.
+
+*Outline Alpha*
+: Przezroczystość generowanego obrysu. Od 0,0 do 1,0.
+
+*Outline Width*
+: Szerokość generowanego obrysu w pikselach. Ustaw na 0, jeśli nie chcesz obrysu.
+
+*Shadow Alpha*
+: Przezroczystość generowanego cienia. Od 0,0 do 1,0.
+
+::: sidenote
+Wsparcie dla cieni jest aktywowane przez wbudowane shadery materiałów czcionek i obsługuje zarówno tryb renderowania warstwowego, jak i jednowarstwowego. Jeśli nie potrzebujesz warstwowego renderowania czcionek ani obsługi cieni, lepiej jest użyć prostszego shadera, takiego jak wbudowany shader `builtins/font-singlelayer.fp`.
+:::
+
+*Shadow Blur*
+: Dla czcionek bitmapowych to ustawienie określa liczbę razy, jaka ma być zastosowane małe jądro rozmazywania do każdego glifu czcionki. Dla czcionek pola odległości (distance field) to ustawienie odpowiada rzeczywistej szerokości w pikselach rozmycia.
+
+*Shadow X/Y*
+: Poziome i pionowe przesunięcie w pikselach generowanego cienia. To ustawienie wpłynie tylko na cień glifu, gdy tryb renderowania jest ustawiony na `MODE_MULTI_LAYER`.
+
+*Extra Characters*
+: Domyślnie font będzie zawierać drukowalne znaki ASCII (kody znaków 32-126). Aby ręcznie dodać dodatkowe znaki, wymień je w polu właściwości.
+
+::: sidenote
+Znaki ASCII do druku:
+space ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ \` a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~
+:::
+
+*All Chars*
+: Jeśli zaznaczysz tę właściwość, wszystkie glify dostępne w pliku źródłowym zostaną uwzględnione w wyniku.
+
+*Cache Width/Height*
+: Ogranicza rozmiar mapy bitowej pamięci podręcznej glifów. Kiedy silnik renderuje tekst, przeszukuje mapę bitową, aby znaleźć glif z pamięci podręcznej. Jeśli glifu tam nie ma, zostanie on dodany do pamięci podręcznej przed renderowaniem. Jeśli mapa bitowa pamięci podręcznej jest zbyt mała, aby pomieścić wszystkie glify, które silnik ma zrenderować, zostanie wygenerowany błąd (`ERROR:RENDER: Out of available cache cells! Consider increasing cache_width or cache_height for the font.`), czyli "Brak dostępnych komórek w pamięci podręcznej! Rozważ zwiększenie `cache_width` lub `cache_height` dla fontu".
+
+  Jeśli ustawisz to na 0, rozmiar pamięci podręcznej będzie ustawiany automatycznie.
+
+## Fonty pola odległości (Distance field)
+
+Fonty pola odległości przechowują odległość od krawędzi glifu w teksturze zamiast danych w postaci mapy bitowej. Gdy silnik renderuje font, wymagany jest specjalny shader do interpretowania danych odległości i ich wykorzystania do rysowania glifu. Fonty pola odległości są bardziej wymagające pod względem zasobów niż fonty bitmapowe, ale pozwalają na większą elastyczność skalowania.
+
+![Distance field font](images/font/df_font.png){srcset="images/font/df_font@2x.png 2x"}
+
+Upewnij się, że zmieniasz właściwość *Material* czcionki na *builtins/fonts/font-df.material* (lub inny materiał, który może obsługiwać dane pola odległości) podczas tworzenia fontu, w przeciwnym razie czcionka nie będzie używać odpowiedniego shadera podczas renderowania na ekranie.
+
+## Fonty bitmapowe BMFonts
+
+Oprócz generowanych map bitowych, Defold obsługuje fonty w formacie bitmapowym "BMFont". Te fonty składają się z arkusza fontu PNG z glifami. Ponadto plik *.fnt* zawiera informacje o tym, gdzie na arkuszu znajduje się każdy glif, a także informacje o rozmiarze i kerningu. (Należy pamiętać, że Defold nie obsługuje wersji XML pliku *.fnt*, która jest używana przez Phaser i niektóre inne narzędzia).
+
+Te rodzaje fontów nie przynoszą żadnej poprawy wydajności w porównaniu do fontów bitmapowych generowanych z plików czcionek TrueType lub OpenType, ale pozwalają na dowolne grafiki, kolorowanie i cienie bezpośrednio w obrazie.
+
+Dodaj wygenerowane pliki *.fnt* i *.png* do swojego projektu Defold. Te pliki powinny znajdować się w tym samym folderze. Utwórz nowy plik fontu i ustaw właściwość *font* na plik *.fnt*. Upewnij się, że *output_format* jest ustawiony na `TYPE_BITMAP`. Defold nie wygeneruje mapy bitowej, ale użyje tej dostarczonej w formacie PNG.
+
+::: sidenote
+Aby stworzyć font BMFont, musisz użyć narzędzia, które może generować odpowiednie pliki. Istnieje kilka opcji:
+
+* [Bitmap Font Generator](http://www.angelcode.com/products/bmfont/), narzędzie dostępne tylko na platformę Windows, dostarczone przez AngelCode.
+* [Shoebox](http://renderhjs.net/shoebox/), darmowa aplikacja oparta na Adobe Air dla platformy Windows i macOS.
+* [Hiero](https://github.com/libgdx/libgdx/wiki/Hiero), narzędzie typu open source oparte na Java.
+* [Glyph Designer](https://71squared.com/glyphdesigner), komercyjne narzędzie dla platformy macOS od 71 Squared.
+* [bmGlyph](https://www.bmglyph.com), komercyjne narzędzie dla platformy macOS od Sovapps.
+:::
+
+![BMfont](images/font/bm_font.png){srcset="images/font/bm_font@2x.png 2x"}
+
+Aby font renderował się poprawnie, nie zapomnij ustawić właściwości materiału na *builtins/fonts/font-fnt.material* podczas tworzenia czcionki.
+
+## Artefakty i najlepsze praktyki
+
+Ogólnie rzecz biorąc, fonty bitmapowe są najlepsze, gdy font jest renderowany bez skalowania. Są szybsze do renderowania na ekranie niż fonty pola odległości (Distance Field).
+
+Fonty pola odległości bardzo dobrze reagują na skalowanie w górę. Z kolei fonty bitmapowe, będąc jedynie pikselowymi obrazami, zwiększają swoją wielkość wraz ze skalowaniem czcionki, co prowadzi do efektów blokowych artefaktów. Oto przykład fontu o rozmiarze 48 pikseli, powiększonej 4-krotnie.
+
+![Fonts scaled up](images/font/scale_up.png){srcset="images/font/scale_up@2x.png 2x"}
+
+Podczas zmniejszania rozmiaru, tekstury fontów bitmapowych mogą być ładnie i efektywnie zmniejszone i wygładzone przez GPU. Font bitmapowy lepiej utrzymuje swoją kolorystykę niż font pola odległości. Oto przybliżenie tej samej próbki fontu o rozmiarze 48 pikseli, zmniejszonego do 1/5 rozmiaru:
+
+![Fonts scaled down](images/font/scale_down.png){srcset="images/font/scale_down@2x.png 2x"}
+
+Fonty pola odległości muszą być renderowane w celu uzyskania docelowego rozmiaru, który jest wystarczająco duży, aby pomieścić informacje o odległości, które mogą wyrazić krzywizny glifów fontu. To ta sama czcionka, co powyżej, ale o rozmiarze 18 pikseli i powiększona 10-krotnie. Wyraźnie widać, że jest to zbyt małe, aby zakodować kształty tego fontu:
+
+![Distance field artifacts](images/font/df_artifacts.png){srcset="images/font/df_artifacts@2x.png 2x"}
+
+Jeśli nie potrzebujesz obsługi cieni lub konturów, ustaw ich odpowiednie wartości alfa na zero. W przeciwnym razie dane cienia i konturu nadal zostaną generowane, zajmując zbędną pamięć.
+
+## Pamięć podręczna fontu
+
+Zasób fontu w Defoldzie składa się z dwóch elementów w czasie rzeczywistym: tekstury i danych fontu.
+* Dane fontu składają się z listy wpisów glifów, z których każdy zawiera podstawowe informacje o kerningu oraz dane mapy bitowej glifu.
+* Tekstura jest wewnętrznie nazywana "teksturą pamięci podręcznej glifów" i jest używana podczas renderowania tekstu dla konkretnego fontu.
+
+Podczas renderowania tekstu w czasie rzeczywistym, silnik najpierw przeszukuje glify do renderowania, aby sprawdzić, które glify są dostępne w pamięci podręcznej (cache) tekstury. Każdy glif, którego brakuje w pamięci podręcznej tekstury glifów, spowoduje przekazanie tekstury z bitmapowymi danymi zapisanymi w danych fontu.
+
+Każdy glif jest umieszczany wewnętrznie w pamięci podręcznej zgodnie z bazą fontu, co pozwala na obliczanie lokalnych współrzędnych tekstury glifu w odpowiedniej komórce pamięci podręcznej w shaderze. Oznacza to, że można osiągnąć pewne efekty tekstowe, takie jak gradienty lub nakładki tekstury dynamicznie. Silnik udostępnia metryki dotyczące pamięci podręcznej tekstury dla shadera za pośrednictwem specjalnej stałej shadera o nazwie `texture_size_recip`, która zawiera następujące informacje w komponentach wektora:
+
+* `texture_size_recip.x` to odwrotność szerokości pamięci podręcznej
+* `texture_size_recip.y` to odwrotność wysokości pamięci podręcznej
+* `texture_size_recip.z` to stosunek szerokości komórki pamięci podręcznej do szerokości pamięci podręcznej
+* `texture_size_recip.w` to stosunek wysokości komórki pamięci podręcznej do wysokości pamięci podręcznej
+
+Na przykład, aby wygenerować gradient w fragmencie shadera, wystarczy napisać:
+
+`float horizontal_gradient = fract(var_texcoord0.y / texture_size_recip.w);`
+
+Aby uzyskać więcej informacji na temat jednolitych shaderów, zobacz [instrukcje do shaderów](/manuals/shader).

--- a/docs/pl/manuals/live-update.md
+++ b/docs/pl/manuals/live-update.md
@@ -1,0 +1,364 @@
+---
+title: Aktualizacja na żywo (Live update) w Defoldzie
+brief: Ta instrukcja opisuje i wyjaśnia funkcjonalność Live update umożliwiającą aplikacjom pobieranie i przetrzymywanie danych, które początkowo były celowo nie dołączone do zbudowanej paczki.
+---
+
+# Aktualizacja na żywo (Live Update)
+
+Podczas pakowania gry, Defold pakuje wszystkie zasoby gry do końcowego pakietu specyficznego dla platformy. W większości przypadków jest to preferowane rozwiązanie, ponieważ działający silnik ma natychmiastowy dostęp do wszystkich zasobów i może szybko je ładować. Jednak istnieją sytuacje, w których chcielibyśmy odłożyć ładowanie zasobów na późniejszy etap. Na przykład:
+
+- Twoja gra zawiera serię odcinków/części, a chcesz uwzględnić tylko pierwszy, aby gracze mogli go wypróbować, zanim zdecydują, czy chcą kontynuować resztę gry.
+- Twoja gra jest przeznaczona na HTML5. W przeglądarce ładowanie aplikacji z pamięci oznacza, że cały pakiet aplikacji musi zostać pobrany przed uruchomieniem. Na takiej platformie możesz chcieć wysłać minimalny pakiet startowy i uruchomić aplikację szybko, zanim pobierzesz pozostałe zasoby gry, dzięki czemu gracze wypróbują grę, a gdy będzie wymagane pobranie dodatkowej zawartości może to być wykonane na późniejszym etapie.
+- Twoja gra zawiera bardzo duże zasoby (obrazy, filmy itp.), których pobieranie chciałbyś odłożyć do momentu, gdy są gotowe do wyświetlenia w grze. Jest to celem utrzymania rozmiaru instalacji na niskim poziomie.
+
+Funkcja Aktualizacji na żywo Live Update) rozszerza koncepcję pełnomocnika kolekcji (collection proxy), oferując mechanizm, który pozwala na pobieranie i przechowywanie zasobów w pakiecie aplikacji, które celowo zostały pominięte podczas tworzenia pakietu na etapie kompilacji.
+
+## Przygotowanie treści do Aktualizacji na żywo
+
+Załóżmy, że tworzymy grę zawierającą duże zasoby graficzne o wysokiej rozdzielczości. Gra przechowuje te obrazy w kolekcjach z obiektami gry i sprite'ami wykorzystującymi te obrazy:
+
+![Mona Lisa collection](images/live-update/mona-lisa.png)
+
+Aby silnik mógł dynamicznie ładować taką kolekcję, możemy po prostu dodać komponent pełnomocnika kolekcji, będącego pełnomocnikiem właśnie kolekcji `monalisa.collection`. Teraz gra może wybrać, kiedy załadować zawartość kolekcji do pamięci, wysyłając komunikat `load` do pełnomocnika kolekcji. Jeśli chcielibyśmy pójść dalej i kontrolować ładowanie zasobów zawartych w kolekcji samodzielnie możemy to zrobić, zaznaczając opcję *Exclude* w właściwościach pełnomocnika kolekcji, informując kompilator, że zawartość w `monalisa.collection` powinna być pominięta podczas tworzenia pakietu aplikacji.
+
+![Collection proxy excluded](images/live-update/proxy-excluded.png)
+
+## Ustawienia Aktualizacji na żywo
+
+Kiedy kompilator tworzy pakiet aplikacji, musi gdzieś przechować te wykluczone zasoby. Ustawienia projektu dla Aktualizacji na żywo (Live update settings) określają lokalizację tych zasobów. Ustawienia te znajdują się w <kbd>Project ▸ Live update Settings...</kbd>. Kliknięcie w tę opcję spowoduje utworzenie pliku ustawień, jeśli jeszcze nie istnieje. W pliku `game.project` wybierz, które ustawienia Aktualizacji na żywo chcesz użyć podczas kompilacji. Dzięki temu można używać różnych ustawień Aktualizacji na żywo w różnych środowiskach, na przykład na żywo, w QA, w trybie deweloperskim itp.
+
+When the bundler creates an application bundle it needs to store any excluded resources somewhere. The project settings for Live update govern the location for those resources. The settings are found under <kbd>Project ▸ Live update Settings...</kbd>. This will create a settings file if none exists. In *game.project*, select which liveupdate settings file to use when bundling. This allows for using different liveupdate settings for different environments, for example for live, QA, dev etc.
+
+![Live update settings](images/live-update/aws-settings.png)
+
+Obecnie istnieją dwie metody, które Defold może wykorzystać do przechowywania zasobów. Wybierz metodę z rozwijanego menu *Mode* w oknie ustawień:
+
+`Amazon`
+: Ta opcja mówi Defoldowi, aby automatycznie przesyłał wykluczone zasoby do Amazon Web Service (AWS) S3 bucket. Wprowadź nazwę swojego *Credential profile* (profilu uwierzytelnienia) AWS, wybierz odpowiedni *Bucket* (Kubełek) i podaj *Prefix*. Zobacz [szczegóły dotyczące](#setting_up_amazon_web_service).
+
+`Zip`
+: Ta opcja mówi Defoldowi, aby utworzyć plik archiwum Zip z wykluczonymi zasobami. Archiwum jest zapisywane w lokalizacji określonej w ustawieniu *Export path* (ścieżka eksportu).
+
+## Programowanie z wykluczonymi pełnomocnikami kolekcji
+
+Pełnomocnik kolekcji (collection proxy), które zostały wykluczone z kompilacji, działają jak zwykłe proksy kolekcji, z jedną ważną różnicą. Wysłanie im komunikatu `load`, podczas gdy wciąż mają zasoby, które nie są dostępne w składzie pakietu, spowoduje ich niepowodzenie.
+
+Dlatego zanim wyślemy komunikat `load`, musimy sprawdzić, czy brakuje jakichkolwiek zasobów. Jeśli tak, musimy je pobrać, a następnie przechować. Poniższy, przykładowy kod zakłada, że zasoby są przechowywane w Amazon S3, w kubełku o nazwie `"my-game-bucket"` z prefiksem `my-resources`.
+
+```lua
+function init(self)
+    self.resources_pending = 0 -- <1>
+    msg.post("#", "attempt_load_resources")
+end
+
+-- This function is called whenever we have tried to store a downloaded resource
+-- necessary for our collection proxy to load.
+local function resource_store_response(self, hexdigest, status)
+    if status == true then
+        -- Successfully loaded resource
+        print("Resource data stored: " .. hexdigest)
+
+        -- One less resource to go...
+        self.resources_pending = self.resources_pending - 1
+
+        -- That was all of them, time to load the proxied collection.
+        if self.resources_pending == 0 then
+            msg.post("#proxy", "load") -- <8>
+        end
+    else
+        -- ERROR! Failed to store the data!
+        print("Failed to store resource data: " .. hexdigest)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("attempt_load_resources") then
+        local missing_resources = collectionproxy.missing_resources("#proxy") -- <2>
+
+        -- initiate a download request for each of the missing resources that has not yet been tried.
+        for _,resource_hash in ipairs(missing_resources) do
+            msg.post("#", "attempt_download", { resource_hash = resource_hash})
+        end
+
+        self.resources_pending = #missing_resources -- <3>
+
+        -- if we're running from editor all resources are there from the start.
+        if self.resources_pending == 0 then
+            msg.post("#proxy", "load")
+        end
+    elseif message_id == hash("attempt_download") then
+        local manifest = resource.get_current_manifest() -- <4>
+        local base_url = "https://my-game-bucket.s3.amazonaws.com/my-resources/" -- <5>
+        http.request(base_url .. message.resource_hash, "GET", function(self, id, response)
+            if response.status == 200 or response.status == 304 then -- <6>
+                -- We got the response ok.
+                print("storing " .. message.resource_hash)
+                resource.store_resource(manifest, response.response, message.resource_hash, resource_store_response) -- <7>
+            else
+                -- ERROR! Failed to download resource!
+                print("Failed to download resource: " .. message.resource_hash)
+            end
+        end)
+    elseif message_id == hash("proxy_loaded") then
+        msg.post(sender, "init")
+        msg.post(sender, "enable")
+    end
+end
+```
+1. Prosty licznik mówiący nam, ile zasobów musimy jeszcze pobrać i przechować, zanim będziemy mogli załadować kolekcję proxy. Należy zauważyć, że ten kod w ogóle nie zajmuje się obsługą błędów, więc w kodzie produkcyjnym należy śledzić operacje pobierania i przechowywania.
+2. Pobierz wszelkie zasoby, które musimy pobrać i przechować.
+3. Przechowaj liczbę brakujących zasobów, abyśmy mogli je zliczyć.
+4. Potrzebujemy bieżącego manifestu, ponieważ zawiera on listę wszystkich zasobów w bundlu oraz informacje, czy są dostępne, czy nie.
+5. Przechowujemy nasze zasoby na Amazon S3. Jeśli tworzysz archiwum Zip z zasobami, musisz hostować pliki w określonym miejscu i odnosić się do ich lokalizacji podczas pobierania ich za pomocą `http.request()`.
+6. Amazon zwraca status 304, gdy pliki są w pamięci podręcznej.
+7. Mamy dane w tym punkcie. Spróbujmy je przechować.
+8. Przechowywanie było udane, a liczba brakujących zasobów spadła do zera. Teraz bezpiecznie możemy wysłać komunikat `"load"` do kolekcji proxy. Należy zauważyć, że jeśli pobieranie lub przechowywanie zawiedzie w którymś momencie, licznik nigdy nie osiągnie zera.
+
+Z kodem ładowania możemy przetestować aplikację. Jednak uruchamianie jej z edytora nie spowoduje pobierania niczego. Dzieje się tak, ponieważ funkcja Live update to funkcja paczki. W środowisku edytora nie wyklucza się żadnych zasobów. Aby upewnić się, że wszystko działa prawidłowo, trzeba utworzyć paczkę (bundle).
+
+## Pakowanie z funkcją Live update
+
+Pakowanie (bundle) z funkcją aktualizacji na żywo jest proste. Wybierz <kbd>Project ▸ Bundle ▸ ...</kbd>, a następnie platformę, dla której chcesz utworzyć pakiet aplikacji. Otwiera to okno dialogowe do pakowania:
+
+![Bundle Live application](images/live-update/bundle-app.png)
+
+Podczas pakowania wszelkie wykluczone zasoby zostaną pominięte w pakiecie aplikacji. Zaznaczając pole wyboru *Publish Live update content* (Opublikuj zawartość aktualizacji na żywo), informujesz Defolda, żeby albo przesyłał wykluczone zasoby na Amazon, albo tworzył archiwum Zip, w zależności od tego, jak skonfigurowałeś ustawienia aktualizacji na żywo (patrz wyżej). Plik manifestu dla paczki zostanie również uwzględniony w wykluczonych zasobach.
+
+Kliknij *Package* i wybierz lokalizację pakietu aplikacji. Teraz możesz uruchomić aplikację i sprawdzić, czy wszystko działa zgodnie z oczekiwaniami.
+
+## Manifest
+
+Manifest to wewnętrzna struktura danych zawierająca listę wszystkich zasobów zawartych w buildzie oraz wartość skrótu każdego zasobu. Funkcjonalność Live update wykorzystuje manifest do śledzenia, co jest częścią zbudowanej gry, co można załadować z zewnętrznych źródeł i, jeśli tak się stanie, sprawdzenie, czy załadowane dane są nietknięte.
+
+Z perspektywy użytkownika manifest to liczbowy uchwyt, ukrywający detale, jak jest zarządzany, w silniku.
+
+## Aktualizacja manifestu w funkcji Live update
+
+Z funkcją aktualizacji na żywo nowy manifest można przechowywać lokalnie w trakcie działania programu. Manifest lokalny zostanie użyty podczas uruchamiania aplikacji zamiast tego, który jest dołączony w pakiecie aplikacji. Jest to przydatne do modyfikowania lub dodawania zasobów aktualizacji na żywo do opublikowanej gry, które nie były znane podczas budowy, bez konieczności publikowania pełnej wersji.
+
+Podczas publikowania zasobów aktualizacji na żywo na Amazon Web Service lub do archiwum ZIP, manifest będzie uwzględniony w pakiecie obok zasobów. Nazwa pliku manifestu to `liveupdate.game.dmanifest`.
+
+Rozpoczęcie pracy z silnikiem Defold po raz pierwszy po przechowywaniu manifestu spowoduje utworzenie pliku identyfikatora paczki `bundle.ver` obok manifestu. Służy to do wykrywania, czy paczka uległa zmianie od czasu przechowywania manifestu, na przykład po pełnej aktualizacji sklepu z aplikacjami. Jeśli tak się stanie, przechowany manifest zostanie usunięty z systemu plików, a nowszy manifest z paczki zastąpi go. Oznacza to, że pełna aktualizacja sklepu z aplikacjami usunie wcześniej przechowywany manifest. Wszystkie istniejące zasoby aktualizacji na żywo pozostaną jednak nietknięte.
+
+### Weryfikacja manifestu
+
+Podczas przechowywania nowego manifestu jego dane zostaną zweryfikowane, zanim zostaną faktycznie zapisane na dysku. Weryfikacja składa się z kilku sprawdzeń:
+
+* Poprawny format pliku binarnego.
+* Obsługuje obecną wersję silnika lub jakąkolwiek inną obsługiwaną wersję z ustawień.
+* Sygnatura kryptograficzna.
+* Podpisany przy użyciu tej samej pary kluczy publicznych i prywatnych co załączony manifest.
+* Zweryfikowanie, że wszystkie zasoby, których manifest oczekuje w paczce, rzeczywiście znajdują się w niej.
+
+Z perspektywy użytkownika proces weryfikacji jest zupełnie niewidoczny, ale ważne jest zrozumienie kroków, które są zaangażowane, aby uniknąć najczęstszych problemów.
+
+::: important
+Jeśli widzisz błąd `"ERROR:RESOURCE: Byte mismatch in decrypted manifest signature. Different keys used for signing?"` w konsoli w trakcie budowania gry na HTML5, to prawdopodobnie oznacza, że Twój serwer WWW nie serwuje wykluczonych zasobów, ani zaktualizowanego pliku manifestu z właściwym typem MIME. Upewnij się, że typ MIME to `application/octet-stream`. Możesz dodać plik `.htaccess` z pojedynczą linią `AddType application/octet-stream .` do folderu, z którego pobierane są zasoby aktualizacji na żywo.
+:::
+
+### Obsługiwane wersje silnika Defold
+
+Manifest zawsze będzie obsługiwać wersję Defolda używaną do jego generowania. Jeśli chcesz obsługiwać dodatkowe wersje silnika, dodaj je do listy w ustawieniach aktualizacji na żywo. Jest to przydatne, jeśli Twoja gra na żywo używa innej wersji Defolda niż ta, którą używasz do generowania manifestu.
+
+![Manifest supported engine versions](images/live-update/engine-versions-settings.png)
+
+### Generowanie kluczy do podpisu
+
+Sygnatura manifestu służy do weryfikowania, że nikt ze złymi zamiarami nie będzie mógł grzebać w jego treści, i że załączony manifest i nowy manifest były podpisane tymi samymi kluczami. Podpisanie jest wykonywane w procesie budowania paczki (bundlowania).
+
+Do kryptograficznego podpisywania manifestu używa się pary kluczy publicznych/prywatnych. Podpisanie jest realizowane przy użyciu kluczy RSA o długości 512/1024/2048 bitów w formacie `.der`, które użytkownik musi dostarczyć. Możesz wygenerować je przykładowo za pomocą narzędzia `openssl`:
+
+```sh
+$ openssl genrsa -out private_raw.key 1024
+$ openssl pkcs8 -topk8 -inform pem -in private_raw.key -outform der -nocrypt -out private.der
+$ openssl rsa -in private_raw.key -outform DER -RSAPublicKey_out -pubout -out public.der
+```
+
+To spowoduje wygenerowanie plików `private_raw.key` (można go bezpiecznie usunąć), `private.der` i `public.der`. Aby użyć kluczy do podpisywania, otwórz widok ustawień aktualizacji na żywo (live update settings) i wskaz odpowiednie pola na wygenerowane klucze.
+
+![Manifest signature key-pair](images/live-update/manifest-keys.png)
+
+### Programowanie z manifestem aktualizacji na żywo
+Dodając do powyższego przykładu skryptu, dodajmy poniższą funkcję zwrotną:
+
+```lua
+local function store_manifest_cb(self, status)
+    if status == resource.LIVEUPDATE_OK then
+        print("Successfully stored manifest!")
+    else
+        print("Failed to store manifest, status: ", status)
+    end
+end
+```
+i następujący kod do funkcji `on_message`, aby obsłużyć wiadomość `attempt_download_manifest`:
+
+```lua
+...
+elseif message_id == hash("attempt_download_manifest") then
+    local base_url = "https://my-game-bucket.s3.amazonaws.com/my-resources/" -- <1>
+    http.request(base_url .. MANIFEST_FILENAME, "GET", function(self, id, response)
+        if response.status == 200 or response.status == 304 then
+            -- We got the response ok.
+            print("verifying and storing manifest " .. MANIFEST_FILENAME)
+            resource.store_manifest(response.response, store_manifest_cb) -- <2>
+        else
+            -- ERROR! Failed to download manifest!
+            print("Failed to download manifest: " .. MANIFEST_FILENAME)
+        end
+    end)
+end
+```
+
+1. Manifest zostanie przechowywany na Amazon S3 obok reszty zasobów aktualizacji na żywo. Tak, jak poprzedniu, jeśli tworzysz archiwum Zip z zasobami, musisz hostować je gdzieś i podać referencję do ich lokalizacji podczas pobierania przy użyciu `http.request()`.
+2. Podobnie jak w przypadku pobierania i przechowywania zasobów, wywołanie `resource.store_manifest` przyjmuje dane manifestu do pobrania i funkcję zwrotną jako argumenty. Funkcja zwrotna zweryfikuje manifest i zapisze go w pamięci lokalnej.
+
+Jeśli `resource.store_manifest` zakończy się powodzeniem, nowy manifest będzie teraz w pamięci lokalnej. Następnym razem, gdy silnik zostanie uruchomiony, używany będzie ten nowy manifest zamiast tego, który był dołączony do gry.
+
+### Uwagi
+
+Istnieją pewne rzeczy, o których warto wiedzieć, jeśli planujesz użyć tej funkcji do przechowywania nowego manifestu z aktualizacją na żywo.
+
+* Możliwe jest tylko dodawanie lub modyfikowanie zasobów używanych przez kolekcje proxy oznaczone jako `Exclude` w nowym manifeście. Nie można dokonywać zmian w już dodanych zasobach lub zasobach, które nie znajdują się w wykluczonych pełnomocnikach kolekcji. Na przykład, wprowadzenie zmian w skrypcie używanym przez dołączoną kolekcję spowoduje, że system zasobów będzie szukał tego zasobu w archiwum danych paczki. Jednak ponieważ paczka gry nie zmieniła się (zmienił się tylko manifest), zmienionego skryptu nie można odnaleźć i w konsekwencji nie można go załadować.
+
+* Nawet jeśli funkcjonalność ta pozwala na bardzo szybkie wprowadzanie zmian lub łatanie błędów bez pełnego, nowego release aplikacji w sklepie, live update należy używać z zachowaniem szczególnej ostrożności. Dołączenie nowego manifestu powinno poprzedzać wszystko, co jest potrzebne przy faktycznym wydaniu nowej wersji gry (testowanie, QA, itd.).
+
+## Konfiguracja Amazon Web Service
+
+Aby korzystać z funkcji Defold Live Update razem z usługami Amazon, potrzebujesz konta Amazon Web Services. Jeśli jeszcze nie masz konta, możesz je utworzyć [tutaj](https://aws.amazon.com/).
+
+W tej sekcji wyjaśnimy, jak utworzyć nowego użytkownika z ograniczonym dostępem w usługach Amazon Web Services, który może być wykorzystywany razem z edytorem Defold do automatycznego przesyłania zasobów aktualizacji na żywo podczas pakowania gry oraz jak skonfigurować Amazon S3, aby umożliwić klientom gier pobieranie zasobów. Dodatkowe informacje na temat konfigurowania Amazon S3 znajdziesz w [dokumentacji Amazon S3](http://docs.aws.amazon.com/AmazonS3/latest/dev/Welcome.html).
+
+1. Utwórz bucket (kubełek) na zasoby aktualizacji na żywo
+
+    Otwórz menu `Services` i wybierz `S3`, które znajduje się w kategorii _Storage_ ([Amazon S3 Console](https://console.aws.amazon.com/s3)). Zobaczysz swoje istniejące kubełki wraz z opcją utworzenia nowego kubełka. Choć możliwe jest użycie istniejącego kubełka, zalecamy utworzenie nowego kubełka na zasoby aktualizacji na żywo, aby łatwo ograniczyć dostęp.
+
+    ![Create a bucket](images/live-update/01-create-bucket.png)
+
+2. Dodaj politykę kubełka (bucket policy) do swojego kubełka
+
+    Wybierz kubełek, który chcesz użyć, otwórz panel *Properties* i rozwiń opcje *Permissions* w panelu. Otwórz politykę kubełka, klikając przycisk *Add bucket policy*. Polityka kubełka w tym przykładzie umożliwi anonimowemu użytkownikowi pobieranie plików z kubełka, co umożliwi graczowi pobieranie zasobów aktualizacji na żywo wymaganych przez grę. Dodatkowe informacje na temat polityk kubełka znajdziesz w [dokumentacji Amazon o polityce](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html).
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AddPerm",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::defold-liveupdate-example/*"
+            }
+        ]
+    }
+    ```
+
+    ![Bucket policy](images/live-update/02-bucket-policy.png)
+
+3. Dodaj konfigurację CORS do swojego kubełka (opcjonalnie)
+
+    Udostępnianie zasobów z różnych domen ([Cross-Origin Resource Sharing - CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)) to mechanizm, który umożliwia witrynie pobieranie zasobu z innej domeny za pomocą JavaScript. Jeśli planujesz opublikować swoją grę jako klienta HTML5, będziesz musiał dodać konfigurację CORS do swojego kubełka.
+
+    Wybierz kubełek, który chcesz użyć, otwórz panel *Properties* i rozwiń opcje *Permissions*. Otwórz konfigurację CORS klikając przycisk *Add CORS Configuration*. Konfiguracja w tym przykładzie umożliwi dostęp z dowolnej witryny, określając domenę wieloznaczną, choć możliwe jest bardziej restrykcyjne ograniczenie dostępu, jeśli wiesz, na jakich domenach zamierzasz udostępnić swoją grę. Dodatkowe informacje na temat konfiguracji CORS w Amazonie znajdziesz w [dokumentacji Amazono CORS](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
+
+    ```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <CORSRule>
+            <AllowedOrigin>*</AllowedOrigin>
+            <AllowedMethod>GET</AllowedMethod>
+        </CORSRule>
+    </CORSConfiguration>
+    ```
+
+    ![CORS configuration](images/live-update/03-cors-configuration.png)
+
+4. Utwórz politykę IAM
+
+    Otwórz menu *Services* i wybierz *IAM*, które znajduje się w kategorii _Security, Identity & Compliance_ category ([Amazon IAM Console](https://console.aws.amazon.com/iam)). Wybierz *Policies* w menu po lewej stronie i zobaczysz swoje istniejące polityki, wraz z opcją utworzenia nowej polityki.
+
+    Kliknij przycisk *Create Policy* i wybierz _Create Your Own Policy_. Polityka w tym przykładzie umożliwi użytkownikowi wyświetlenie wszystkich kubełków, co jest wymagane tylko podczas konfigurowania projektu Defold dla aktualizacji na żywo. Będzie również umożliwiać użytkownikowi uzyskanie listy kontroli dostępu (Access Control List - ACL) i przesyłanie zasobów do konkretnej nazwy kubełka używanej do zasobów aktualizacji na żywo. Dodatkowe informacje na temat Amazon Identity and Access Management (IAM) znajdziesz w [dokumentacji Amazon](http://docs.aws.amazon.com/IAM/latest/UserGuide/access.html).
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListAllMyBuckets"
+                ],
+                "Resource": "arn:aws:s3:::*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetBucketAcl"
+                ],
+                "Resource": "arn:aws:s3:::defold-liveupdate-example"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:PutObject"
+                ],
+                "Resource": "arn:aws:s3:::defold-liveupdate-example/*"
+            }
+        ]
+    }
+    ```
+
+    ![IAM policy](images/live-update/04-create-policy.png)
+
+5. Utwórz użytkownika do dostępu programistycznego
+
+    Otwórz menu *Services* i wybierz *IAM*, które znajduje się w kategorii _Security, Identity & Compliance_ category ([Amazon IAM Console](https://console.aws.amazon.com/iam)). Wybierz *Users* w menu po lewej stronie i zobaczysz swoich istniejących użytkowników wraz z opcją dodania nowego użytkownika. Choć możliwe jest użycie istniejącego użytkownika, zalecamy dodanie nowego użytkownika do zasobów aktualizacji na żywo, aby łatwo ograniczyć dostęp.
+
+    Kliknij przycisk *Add User*, podaj nazwę użytkownika i wybierz *Programmatic access* jako *Access type*, a następnie kliknij *Next: Permissions*. Wybierz *Attach existing policies directly* i wybierz politykę, którą utworzyłeś w kroku 4.
+
+    Po zakończeniu procesu zostaniesz dostarczony z *Access key ID* i *Secret access key*.
+
+    ::: important
+    *Bardzo ważne* jest, aby zachować te klucze, ponieważ nie będziesz w stanie ich odzyskać z Amazon po opuszczeniu strony.
+    :::
+
+6. Utwórz plik profilu poświadczeń
+
+    W tym momencie powinieneś już mieć kubełek (bucket), skonfigurowaną politykę kubełka, dodaną konfigurację CORS, utworzoną politykę użytkownika i utworzonego nowego użytkownika. Jedyną rzeczą, która pozostała, jest utworzenie [pliku profilu poświadczeń](https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks), aby Defold mógł uzyskać dostęp do kubełka w twoim imieniu.
+
+Utwórz nowy katalog `~/.aws` w folderze domowym i utwórz w nim plik o nazwie `credentials`.
+
+    ```bash
+    $ mkdir ~/.aws
+    $ touch ~/.aws/credentials
+    ```
+    Plik `~/.aws/credentials` zawiera twoje poświadczenia dostępu do Amazon Web Services poprzez dostęp programistyczny i jest standaryzowany sposób na zarządzanie poświadczeniami AWS. Otwórz plik w edytorze tekstowym i wprowadź swoje *Access key ID* i *Secret access key* w formacie pokazanym poniżej.
+
+    ```ini
+    [defold-liveupdate-example]
+    aws_access_key_id = <Access key ID>
+    aws_secret_access_key = <Secret access key>
+    ```
+    Identyfikator określony w nawiasach kwadratowych, w tym przykładzie `_defold-liveupdate-example_`, jest taki sam jak identyfikator, który powinieneś podać podczas konfigurowania ustawień aktualizacji na żywo projektu w edytorze Defold.
+
+    ![Live update settings](images/live-update/05-liveupdate-settings.png)
+
+## Uwagi dotyczące rozwoju oprogramowania
+
+Debugowanie
+: Podczas uruchamiania spakowanej wersji swojej gry nie masz bezpośredniego dostępu do konsoli. To może sprawić problemy z debugowaniem. Niemniej jednak, możesz uruchomić aplikację z wiersza poleceń lub podwójnie klikając na plik wykonywalny w paczce:
+
+  ![Running a bundle application](images/live-update/run-bundle.png)
+
+  Teraz gra zaczyna się z oknem konsoli, które będzie wyświetlać wszystkie instrukcje `print()`:
+
+  ![Console output](images/live-update/run-bundle-console.png)
+
+Wymuszanie ponownego pobierania zasobów
+: Gdy aplikacja przechowuje zasoby, trafiają one na dysk lokalny komputera lub urządzenia przenośnego. Gdy zrestartujesz aplikację, zasoby są dostępne i gotowe do użycia. Podczas pracy nad projektem gry może być potrzeba usunięcia zasobów i wymuszenia na aplikacji ich ponownego pobrania.
+
+  Defold tworzy folder o nazwie hasha stworzonej paczki na urządzeniu w folderze obsługi aplikacji. Jeśli usuniesz pliki z tego folderu, aplikacja unieważni zasoby z manifestu, dzięki czemu będziesz mógł je pobrać i ponownie przechować.
+
+  ![Local storage](images/live-update/local-storage.png)
+  
+  Lokalizacja folderu obsługi aplikacji zależy od systemu operacyjnego. Możesz ją znaleźć, używając polecenia `print(sys.get_save_file("", ""))`.

--- a/docs/pl/manuals/refactoring.md
+++ b/docs/pl/manuals/refactoring.md
@@ -1,0 +1,20 @@
+---
+title: Refaktoryzacja
+brief: Ta instrukcja opisuje jak organizować swój projekt z pomocą narzędzi do refaktoryzacji.
+---
+
+# Refaktoryzacja
+
+Refaktoryzacja (Refactoring) odnosi się do procesu restrukturyzacji istniejącego kodu i zasobów. W trakcie rozwoju projektu często pojawia się potrzeba zmiany lub przeniesienia elementów: nazwy muszą być zmieniane, aby odpowiadać konwencjom nazewniczym lub zwiększyć czytelność, a pliki kodu lub zasobów muszą być przenoszone do bardziej logicznych miejsc w hierarchii projektu.
+
+Defold pomaga w efektywnej refaktoryzacji, śledząc, jakie zasoby są używane. Automatycznie aktualizuje odwołania do zasobów, które zostały zmienione lub przeniesione. Jako programista, powinieneś czuć się swobodnie w swojej pracy. Twój projekt to elastyczna struktura, którą możesz dowolnie zmieniać, nie obawiając się, że wszystko ulegnie awarii i rozpadnie się na kawałki.
+
+::: important
+Automatyczna refaktoryzacja będzie działać tylko wtedy, gdy zmiany zostaną dokonane wewnątrz Edytora Defold. Jeśli zmienisz nazwę lub przeniesiesz plik poza Edytorem, odwołania do tego pliku nie zostaną automatycznie zmienione.
+:::
+
+Jednakże, jeśli uszkodzisz odwołanie, na przykład usuwając zasób z posiomu systemu operacyjnego, Edytor nie będzie w stanie rozwiązać problemu, ale dostarczy pomocne sygnały błędów. Na przykład, jeśli usuniesz animację z atlasu, a ta animacja jest używana gdzieś, Defold zasygnalizuje błąd podczas próby uruchomienia gry. Edytor również oznaczy, gdzie występują błędy, aby pomóc Ci szybko zlokalizować problem:
+
+![Refactoring error](images/workflow/delete_error.png){srcset="images/workflow/delete_error@2x.png 2x"}
+
+Błędy kompilacji pojawiają się w panelu *Build Errors* na dole edytora. <kbd>Double clicking</kbd> na błędzie, który jest linkiem, przenosi cię do miejsca, gdzie wystąpił problem.

--- a/docs/pl/manuals/writing-code.md
+++ b/docs/pl/manuals/writing-code.md
@@ -1,0 +1,59 @@
+---
+title: Pisanie kodu
+brief: Ta instrukcja krótko omawia, jak pracować z kodem w Defold.
+---
+
+# Pisanie kodu
+
+Podczas gdy Defold pozwala tworzyć wiele zawartości gry za pomocą narzędzi wizualnych, takich jak Edytory map kafelków (tilemap) i efektów cząsteczkowych (particle FX), logikę gry tworzysz za pomocą Edytora kodu. Logikę gry pisze się za pomocą języka programowania [Lua](https://www.lua.org/), podczas gdy rozszerzenia samego silnika pisze się przy użyciu języków niskopoziomowych dedykowanych dla docelowej platformy.
+
+## Pisanie kodu Lua
+
+Defold używa Lua 5.1 i LuaJIT (w zależności od docelowej platformy) i należy stosować specyfikację tego języka dla konkretnych wersji Lua podczas pisania logiki gry. Aby uzyskać więcej szczegółów na temat pracy z Lua w Defoldzie, zobacz nasz [podręcznik Lua w Defold](/manuals/lua).
+
+## Pisanie kodu natywnego
+
+Defold pozwala na rozszerzenie silnika gry kodem natywnym (native extensions), aby uzyskać dostęp do funkcji specyficznych dla danej platformy, których nie dostarcza sam silnik. Możesz również użyć kodu natywnego, gdy wydajność Lua nie jest wystarczająca (obliczenia wymagające dużych zasobów, przetwarzanie obrazów itp.). Aby dowiedzieć się więcej, zajrzyj do naszych [podręczników dotyczących Rozszerzeń Natywnych](/manuals/extensions/).
+
+## Używanie wbudowanego Edytora kodu
+
+Defold posiada wbudowany Edytor kodu, który pozwala na otwieranie i edytowanie plików Lua (.lua), plików skryptów Defold (.script, .gui_script i .render_script) oraz innych plików z rozszerzeniem, które nie są obsługiwane natywnie przez Edytor. Dodatkowo Edytor ten oferuje podświetlanie składni dla plików Lua i skryptów oraz podręczny dostęp do dokumentacji dla funkcji API.
+
+![](/images/editor/code-editor.png)
+
+
+### Dodawanie sprawdzania poprawności kodu Lua za pomocą LSP
+
+Defold obsługuje część protokołu Language Server Protocol (LSP), który można użyć do analizy kodu i wskazywania błędów programistycznych i stylowych. Proces ten jest również znany jako sprawdzanie poprawności kodu (linting).
+
+Serwer języka Lua i linter kodu są dostępne jako wtyczka (plugin). Zainstaluj wtyczkę, [dodając ją jako zależność](/manuals/libraries/#setting-up-library-dependencies):
+
+```
+https://github.com/defold/lua-language-server/releases/download/v0.0.5/release.zip
+```
+Dostępne wersje można znaleźć na [stronie wydań](https://github.com/defold/lua-language-server/releases) wtyczki. Dowiedz się więcej na temat tej wtyczki na [stronie wsparcia na forum Defold](https://forum.defold.com/t/linting-in-the-code-editor/72465).
+
+
+## Użycie zewnętrznego Edytora kodu
+
+Edytor kodu w Defoldzie zapewnia podstawową funkcjonalność do pisania kodu, ale dla bardziej zaawansowanych przypadków użycia lub dla użytkowników z ulubionym Edytorem kodu, można pozwolić Defoldowi otwierać pliki za pomocą zewnętrznego Edytora, ponieważ skrypty i pliki tworzone przez Defolda w projekcie są edytowalnymi plikami tekstowymi. W [oknie preferencji w zakładce "Code"](/manuals/editor-preferences/#code) można zdefiniować zewnętrzny Edytor, który ma być używany podczas edycji kodu.
+
+### Visual Studio Code - Defold Kit
+
+Defold Kit to wtyczka dla Visual Studio Code z następującymi funkcjami:
+
+* Instalowanie zalecanych rozszerzeń
+* Podświetlanie, autouzupełnianie i sprawdzanie poprawności (linting) Lua
+* Zastosowanie odpowiednich ustawień do przestrzeni roboczej
+* Adnotacje Lua dla interfejsu API Defold
+* Adnotacje Lua dla zależności
+* Budowanie i uruchamianie
+* Debugowanie z punktami przerwania (breakpoints)
+* Budowanie i pakowanie dla wszystkich platform
+* Wdrażanie na podłączone urządzenia mobilne
+
+Dowiedz się więcej i zainstaluj Defold Kit z [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astronachos.defold).
+
+## Oprogramowanie dokumentacyjne
+
+Dostępne są paczki przygotowane przez społeczność Defolda do generowania dokumentacji API dla [Dash i Zeal](https://forum.defold.com/t/defold-docset-for-dash/2417).


### PR DESCRIPTION
Added polish translation for further manuals about editor, live update, caching and writing code.
Added manuals for resources - atlas and fonts.
Updated manual for Editor to match English version (removed list of shortcuts and referenced separate one).