### PR TITLE
Remove `persistent_storage` from docs

### DIFF
--- a/docs/en/manuals/html5.md
+++ b/docs/en/manuals/html5.md
@@ -201,9 +201,6 @@ Object `extra_params` is an optional object that can have the following fields:
 'engine_arguments':
     List of arguments (strings) that will be passed to the engine.
 
-'persistent_storage':
-    Boolean toggling the usage of persistent storage.
-
 'custom_heap_size':
     Number of bytes specifying the memory heap size.
 

--- a/docs/zh/manuals/html5.md
+++ b/docs/zh/manuals/html5.md
@@ -201,9 +201,6 @@ DEFOLD_ENGINE_ARGUMENTS
 'engine_arguments':
     传入引擎的参数列表 (字符串).
 
-'persistent_storage':
-    是否使用持久化存储的布尔值.
-
 'custom_heap_size':
     自定义内存使用的大小.
 


### PR DESCRIPTION
It doesn't work this way https://forum.defold.com/t/how-html-flag-persistent-storage-worked/64253/4?u=agulev