### PR TITLE
Shader.md sample code correction

### DIFF
--- a/docs/en/manuals/shader.md
+++ b/docs/en/manuals/shader.md
@@ -246,7 +246,7 @@ in vec2 var_texcoord0;
 
 out vec4 color_out;
 
-uniform sampler texture_sampler;
+uniform sampler2D texture_sampler;
 
 uniform fs_uniforms
 {


### PR DESCRIPTION
- small fix to code sample in Shader.md

- uniform sampler should be sampler2D keyword. Otherwise code sample may confuse some users copying the example.