### PR TITLE
Wheel joint description fix in physics-joints.md

### DIFF
--- a/docs/en/manuals/physics-joints.md
+++ b/docs/en/manuals/physics-joints.md
@@ -12,7 +12,7 @@ Defold supports joints for 2D physics. A joint connects two collision objects us
 * **Weld (physics.JOINT_TYPE_WELD)** - A weld joint attempts to constrain all relative movement between two collision objects. The weld joint can be made soft like a spring with a frequency and damping ratio. In Box2D referred to as a Weld joint.
 * **Spring (physics.JOINT_TYPE_SPRING)** - A spring joint keeps two collision objects at a constant distance from each other. The spring joint can be made soft like a spring with a frequency and damping ratio. In Box2D referred to as a Distance joint.
 * **Slider (physics.JOINT_TYPE_SLIDER)** - A slider joint allows for relative translation of two collision objects along a specified axis and prevents relative rotation. In Box2D referred to as a Prismatic joint.
-* **Wheel (physics.JOINT_TYPE_WHEEL)** - A wheel joint restricts a point on bodyB to a line on bodyA. The wheel joint also provides a suspension spring. In Box2D referred to as a Weld joint.
+* **Wheel (physics.JOINT_TYPE_WHEEL)** - A wheel joint restricts a point on bodyB to a line on bodyA. The wheel joint also provides a suspension spring. In Box2D referred to as a wheel joint.
 
 ## Creating joints
 

--- a/docs/en/manuals/physics-joints.md
+++ b/docs/en/manuals/physics-joints.md
@@ -8,11 +8,11 @@ brief: Defold supports joints for 2D physics. This manual explains how to create
 Defold supports joints for 2D physics. A joint connects two collision objects using some kind of constraint. The supported joint types are:
 
 * **Fixed (physics.JOINT_TYPE_FIXED)** - A rope joint that restricts the maximum distance between two points. In Box2D referred to as a Rope joint.
-* **Hinge (physics.JOINT_TYPE_HINGE)** - A hinge joint specifies an anchor point on two collision objects and moves them so that the two collision objects are always in the same place, and the relative rotation of the collision objects is not restricted. The hinge joint can enable a motor with a defined maximum engine torque and speed. In Box2D referred to as a Revolute joint.
-* **Weld (physics.JOINT_TYPE_WELD)** - A weld joint attempts to constrain all relative movement between two collision objects. The weld joint can be made soft like a spring with a frequency and damping ratio. In Box2D referred to as a Weld joint.
-* **Spring (physics.JOINT_TYPE_SPRING)** - A spring joint keeps two collision objects at a constant distance from each other. The spring joint can be made soft like a spring with a frequency and damping ratio. In Box2D referred to as a Distance joint.
-* **Slider (physics.JOINT_TYPE_SLIDER)** - A slider joint allows for relative translation of two collision objects along a specified axis and prevents relative rotation. In Box2D referred to as a Prismatic joint.
-* **Wheel (physics.JOINT_TYPE_WHEEL)** - A wheel joint restricts a point on bodyB to a line on bodyA. The wheel joint also provides a suspension spring. In Box2D referred to as a wheel joint.
+* **Hinge (physics.JOINT_TYPE_HINGE)** - A hinge joint specifies an anchor point on two collision objects and moves them so that the two collision objects are always in the same place, and the relative rotation of the collision objects is not restricted. The hinge joint can enable a motor with a defined maximum engine torque and speed. In Box2D referred to as a [Revolute joint](https://box2d.org/documentation/group__revolute__joint.html#details).
+* **Weld (physics.JOINT_TYPE_WELD)** - A weld joint attempts to constrain all relative movement between two collision objects. The weld joint can be made soft like a spring with a frequency and damping ratio. In Box2D referred to as a [Weld joint](https://box2d.org/documentation/group__weld__joint.html#details).
+* **Spring (physics.JOINT_TYPE_SPRING)** - A spring joint keeps two collision objects at a constant distance from each other. The spring joint can be made soft like a spring with a frequency and damping ratio. In Box2D referred to as a [Distance joint](https://box2d.org/documentation/group__distance__joint.html#details).
+* **Slider (physics.JOINT_TYPE_SLIDER)** - A slider joint allows for relative translation of two collision objects along a specified axis and prevents relative rotation. In Box2D referred to as a [Prismatic joint](https://box2d.org/documentation/group__prismatic__joint.html#details).
+* **Wheel (physics.JOINT_TYPE_WHEEL)** - A wheel joint restricts a point on bodyB to a line on bodyA. The wheel joint also provides a suspension spring. In Box2D referred to as a  [Wheel joint](https://box2d.org/documentation/group__wheel__joint.html#details).
 
 ## Creating joints
 


### PR DESCRIPTION
- Rectify miss description. "weld" should be referred to as "wheel" joint.

reference: https://box2d.org/documentation/group__wheel__joint.html