### PR TITLE
clarify export compliance information for ios

### DIFF
--- a/docs/en/manuals/ios.md
+++ b/docs/en/manuals/ios.md
@@ -251,15 +251,14 @@ When you submit your game to the App Store you will be asked to provide Export C
 
 "When you submit your app to TestFlight or the App Store, you upload your app to a server in the United States. If you distribute your app outside the U.S. or Canada, your app is subject to U.S. export laws, regardless of where your legal entity is based. If your app uses, accesses, contains, implements, or incorporates encryption, this is considered an export of encryption software, which means your app is subject to U.S. export compliance requirements, as well as the import compliance requirements of the countries where you distribute your app."
 
-Additional documentation:
-
-* Export compliance overview - https://help.apple.com/app-store-connect/#/dev88f5c7bf9
-* Determining your export compliance requirements - https://help.apple.com/app-store-connect/#/dev63c95e436
-
-The Defold game engine use encryption for the following purposes:
+The Defold game engine uses encryption for the following purposes:
 
 * Making calls over secure channels (i.e. HTTPS and SSL)
-* Copyright protection of Lua code
+* Copyright protection of Lua code (to prevent duplication)
+
+These uses of encyption in the Defold engine are exempt from export compliance document requirements under United States and European Union law. Most Defold projects will remain exempt, but the addition of other cryptographic methods may change this status. It is your responsiblity to ensure that your project meets the requirements of these laws and the App Store's rules. See Apple's [Export Compliance Overview](https://help.apple.com/app-store-connect/#/dev88f5c7bf9) for more information.
+
+Some users have reported being asked to upload a French Encryption Delaration when uploading to the App Store in France. Despite your app being exempt, Apple may still require you to submit a form to the French Cybersecurity Agency and upload their response. The form and directions are available directly from the [French Cybersecurity Agency](https://cyber.gouv.fr/controle-reglementaire-sur-la-cryptographie-les-formulaires).
 
 
 ## FAQ

--- a/docs/en/manuals/ios.md
+++ b/docs/en/manuals/ios.md
@@ -258,8 +258,7 @@ The Defold game engine uses encryption for the following purposes:
 
 These uses of encyption in the Defold engine are exempt from export compliance document requirements under United States and European Union law. Most Defold projects will remain exempt, but the addition of other cryptographic methods may change this status. It is your responsiblity to ensure that your project meets the requirements of these laws and the App Store's rules. See Apple's [Export Compliance Overview](https://help.apple.com/app-store-connect/#/dev88f5c7bf9) for more information.
 
-Some users have reported being asked to upload a French Encryption Delaration when uploading to the App Store in France. Despite your app being exempt, Apple may still require you to submit a form to the French Cybersecurity Agency and upload their response. The form and directions are available directly from the [French Cybersecurity Agency](https://cyber.gouv.fr/controle-reglementaire-sur-la-cryptographie-les-formulaires).
-
+If you believe your project is exempt, set the [ITSAppUsesNonExemptEncryption](https://developer.apple.com/documentation/bundleresources/information-property-list/itsappusesnonexemptencryption) key to `False` in the project's `Info.plist` see [Application Manifests](/manuals/extensions-manifest-merge-tool) for more details.
 
 ## FAQ
 :[iOS FAQ](../shared/ios-faq.md)


### PR DESCRIPTION
I think something like this should address the ios issues. Defold-engine only code meets the exemption requirements for the US, EU, and France. It's unlikely but possible that someone creates a project that would change that. 

As for the French declaration - an in-depth look of the requirements are in the details below. But it is a mistake on Apple's part to be requiring the document for all apps with cryptography in France.

I included the link to the form, because it's more than Apple provides, but I didn't feel instructions for filling it out were appropriate for the manual - where would it go best?

Closes #322 

<details>
<summary>Analysis of each country's law</summary>

### US Rules
Per https://www.bis.doc.gov/index.php/all-articles/15-policy-guidance/encryption/560-encryption-faqs#15
>Examples of items that are excluded from [Category 5, Part 2](http://ecfr.gpoaccess.gov/cgi/t/text/text-idx?c=ecfr&sid=c5cc9a1c749a6f225283bdfa124431d0&rgn=div9&view=text&node=15:2.1.3.4.45.0.1.3.87&idno=15) by Note 4 include, but are not limited to, the following:   
>Consumer applications.  Some examples:
>**piracy and theft prevention for software or music;**
>music, movies, tunes/music, digital photos – players, recorders and organizers
>**games/gaming – devices, runtime software, HDMI and other component interfaces, development tools**
>printers, copiers, scanners, digital cameras, Internet cameras – including parts and sub-assemblies
>household utilities and appliances

Additionally, the use of industry standard algorithms means US export requirements do not apply to Defold. 

### French Rules
Per https://cyber.gouv.fr/controle-reglementaire-sur-la-cryptographie-demarches-accomplir
*Use* in France requires no declaration to ANSSI (Utilisation en France).  *Import* might (Importation en France).

Either way, the table of exceptions specifies that Protection against duplication is exempt for any operation (Protection contre la duplication - Exemption pour toute opération). 

For confirmation: [Décret n°2007-663 du 2 mai 2007](https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000646995)

Chapter 1 Article 1 states that usage of cryptology in Annex 1 is exempt from the processes of the law. 
>Sont dispensées des formalités préalables prévues aux chapitres II et III du présent décret les opérations de fourniture, de transfert, d'importation ou d'exportation des moyens et prestations de cryptologie mentionnées à l'annexe 1 du présent décret.

Annex 1, Category 6: Equipment designed to limit the protection of software or computer data against copying or illegal use and the cryptography is not accessible to the user. 
>Equipements spécialement conçus et limités pour assurer la protection de logiciels ou de données informatiques contre la copie ou l'utilisation illicite et dont la capacité cryptographique n'est pas accessible à l'utilisateur.

French law is of course also compliant to EU law:
[Delegated Regulation (EU) No 1382/2014](https://eur-lex.europa.eu/eli/reg_del/2014/1382/oj/eng)

>Category 5 – Part 2 does not control items incorporating or using “cryptography” and meeting all of the following:
>a. The primary function or set of functions is not any of the following: 
>1. “Information security”;
>2. A computer, including operating systems, parts and components therefor;
>4. Sending,  receiving or storing information (except in support of entertainment,  mass commercial broadcasts, digital rights management or medical records  management); or
>5.  Networking (includes operation, administration, management and provisioning);
>b. The cryptographic functionality is limited to supporting their primary function or set of functions;
</details>