### PR TITLE
Fix debugging-game-logic menu items

### DIFF
--- a/docs/en/manuals/debugging-game-logic.md
+++ b/docs/en/manuals/debugging-game-logic.md
@@ -38,7 +38,7 @@ Note that you probably want to update this data every frame so posting the messa
 
 ## Running the debugger
 
-To run the debugger, either <kbd>Debug ▸ Run with Debugger</kbd> which starts up the game with the debugger attached, or select <kbd>Debug ▸ Attach Debugger</kbd> to attach the debugger to an already running game.
+To run the debugger, select <kbd>Debug ▸ Start/Attach</kbd> which either starts up the game with the debugger attached or attaches the debugger to an already running game.
 
 ![overview](images/debugging/overview.png)
 


### PR DESCRIPTION
It seems `Run With Debugger` and `Attach Debugger` used to be separate, but they've been unified since this PR: https://github.com/defold/defold/pull/2950