### PR TITLE
Update macos minimum supported version

### DIFF
--- a/docs/en/faq/faq.md
+++ b/docs/en/faq/faq.md
@@ -96,10 +96,11 @@ A: The following platforms are supported for the editor/tools and the engine run
 
   | System             | Version            | Architectures      | Supported          |
   | ------------------ | ------------------ | ------------------ | ------------------ |
-  | macOS              | 11 Big Sur         | `x86-64`, `arm-64` | Editor and Engine  |
+  | macOS              | 11 Big Sur         | `x86-64`, `arm-64` | Editor             |
+  | macOS              | 10.15              | `x86-64`, `arm-64` | Engine             |
   | Windows            | Vista              | `x86-32`, `x86-64` | Editor and Engine  |
   | Ubuntu (1)         | 18.04              | `x86-64`           | Editor             |
-  | Linux (2)          | Any                | `x86-64`           |  Engine            |
+  | Linux (2)          | Any                | `x86-64`, `arm-64` | Engine             |
   | iOS                | 11.0               | `arm-64`           | Engine             |
   | Android            | 4.4 (API level 19) | `arm-32`, `arm-64` | Engine             |
   | HTML5              |                    | `asm.js`, `wasm`   | Engine             |

--- a/docs/es/faq/faq.md
+++ b/docs/es/faq/faq.md
@@ -54,15 +54,16 @@ shaders.
 
 A: Las siguientes plataformas tienen soporte para el editor/herramientas y el runtime del motor:
 
-  | System             | Version            | Architectures  | Supported            |
-  | ------------------ | ------------------ | -------------- | -------------------- |
-  | macOS              | 11 Big Sur         | x86-64, arm-64 | Editor and Engine    |
-  | Windows            | Vista              | x86-32, x86-64 | Editor and Engine    |
-  | Ubuntu (1)         | 18.04              | x86-64         | Editor               |
-  | Linux (2)          | Any                | x86-64         | Engine               |
-  | iOS                | 11.0               | arm-64         | Engine               |
-  | Android            | 4.4 (API level 19) | arm-32, arm-64 | Engine               |
-  | HTML5              |                    | asm.js, wasm   | Engine               |
+  | System             | Version            | Architectures      | Supported            |
+  | ------------------ | ------------------ | ------------------ | -------------------- |
+  | macOS              | 11 Big Sur         | `x86-64`, `arm-64` | Editor               |
+  | macOS              | 10.15              | `x86-64`, `arm-64` | Engine               |
+  | Windows            | Vista              | `x86-32`, `x86-64` | Editor and Engine    |
+  | Ubuntu (1)         | 18.04              | `x86-64`           | Editor               |
+  | Linux (2)          | Any                | `x86-64`, `arm-64` | Engine               |
+  | iOS                | 11.0               | `arm-64`           | Engine               |
+  | Android            | 4.4 (API level 19) | `arm-32`, `arm-64` | Engine               |
+  | HTML5              |                    | `asm.js`, `wasm`   | Engine               |
 
   (1 El editor fue creado y probad para 64-bit Ubuntu 18.04. Debe funcionar en otras distribuciones pero no damos garantía de ello.)
 

--- a/docs/it/faq/faq.md
+++ b/docs/it/faq/faq.md
@@ -53,15 +53,16 @@ R: La logica di gioco nel tuo progetto Defold è scritta principalmente utilizza
 
 R: Le seguenti piattaforme sono supportate per l'editor/strumenti e il runtime del motore:
 
-  | Sistema            | Versione           | Architetture   | Supportato           |
-  | ------------------ | ------------------ | -------------- | -------------------- |
-  | macOS              | 11 Big Sur         | x86-64, arm-64 | Editor e Motore      |
-  | Windows            | Vista              | x86-32, x86-64 | Editor e Motore      |
-  | Ubuntu (1)         | 18.04              | x86-64         | Editor               |
-  | Linux (2)          | Qualsiasi          | x86-64         | Motore               |
-  | iOS                | 11.0               | arm-64         | Motore               |
-  | Android            | 4.4 (API level 19) | arm-32, arm-64 | Motore               |
-  | HTML5              |                    | asm.js, wasm   | Motore               |
+  | Sistema            | Versione           | Architetture       | Supportato           |
+  | ------------------ | ------------------ | ------------------ | -------------------- |
+  | macOS              | 11 Big Sur         | `x86-64`, `arm-64` | Editor               |
+  | macOS              | 10.15              | `x86-64`, `arm-64` | Motore               |
+  | Windows            | Vista              | `x86-32`, `x86-64` | Editor e Motore      |
+  | Ubuntu (1)         | 18.04              | `x86-64`           | Editor               |
+  | Linux (2)          | Qualsiasi          | `x86-64`, `arm-64` | Motore               |
+  | iOS                | 11.0               | `arm-64`           | Motore               |
+  | Android            | 4.4 (API level 19) | `arm-32`, `arm-64` | Motore               |
+  | HTML5              |                    | `asm.js`, `wasm`   | Motore               |
 
   (1 L'editor è costruito e testato per Ubuntu 18.04 a 64 bit. Dovrebbe funzionare anche su altre distribuzioni ma non diamo garanzie.)
 

--- a/docs/zh/faq/faq.md
+++ b/docs/zh/faq/faq.md
@@ -53,15 +53,16 @@ brief: 有关 Defold 游戏引擎和编辑器及平台的常见问题和解答.
 
 答: 下表列出了编辑器工具与游戏引擎运行环境的支持情况:
 
-  | System             | Version            | Architectures  | Supported            |
-  | ------------------ | ------------------ | -------------- | -------------------- |
-  | macOS              | 11 Big Sur         | x86-64, arm-64 | Editor and Engine    |
-  | Windows            | Vista              | x86-32, x86-64 | Editor and Engine    |
-  | Ubuntu (1)         | 18.04              | x86-64         | Editor               |
-  | Linux (2)          | Any                | x86-64         | Engine               |
-  | iOS                | 11.0               | arm-64         | Engine               |
-  | Android            | 4.4 (API level 19) | arm-32, arm-64 | Engine               |
-  | HTML5              |                    | asm.js, wasm   | Engine               |
+  | System             | Version            | Architectures      | Supported            |
+  | ------------------ | ------------------ | ------------------ | -------------------- |
+  | macOS              | 11 Big Sur         | `x86-64`, `arm-64` | Editor               |
+  | macOS              | 10.15              | `x86-64`, `arm-64` | Engine               |
+  | Windows            | Vista              | `x86-32`, `x86-64` | Editor and Engine    |
+  | Ubuntu (1)         | 18.04              | `x86-64`           | Editor               |
+  | Linux (2)          | Any                | `x86-64`, `arm-64` | Engine               |
+  | iOS                | 11.0               | `arm-64`           | Engine               |
+  | Android            | 4.4 (API level 19) | `arm-32`, `arm-64` | Engine               |
+  | HTML5              |                    | `asm.js`, `wasm`   | Engine               |
 
   (1 编辑器在 64-bit Ubuntu 18.04 平台上通过编译和测试. 其他版本应该同样可以运行但是未经过测试.)
 


### PR DESCRIPTION
* Added separate row for engine's macos minimum supported version
* Added arm-64 as supported platform for Linux