### PR TITLE
Fix small editor-script typo

### DIFF
--- a/docs/en/manuals/editor-scripts-ui.md
+++ b/docs/en/manuals/editor-scripts-ui.md
@@ -153,7 +153,7 @@ local create_file = editor.ui.show_dialog(editor.ui.dialog({
                 grow = true,
                 text = file_name,
                 -- Typing callback:
-                on_text_changed = function(new_text)
+                on_value_changed = function(new_text)
                     file_name = new_text
                 end
             })


### PR DESCRIPTION
There is no **on_text_changed** callback, only **on_value_changed**

```lua
-- initial file name, will be replaced by the dialog
local file_name = ""
local create_file = editor.ui.show_dialog(editor.ui.dialog({
    title = "Create New File",
    content = editor.ui.horizontal({
        padding = editor.ui.PADDING.LARGE,
        spacing = editor.ui.SPACING.MEDIUM,
        children = {
            editor.ui.label({
                text = "New File Name",
                alignment = editor.ui.ALIGNMENT.CENTER
            }),
            editor.ui.string_field({
                grow = true,
                text = file_name,
                -- Typing callback:
                on_text_changed = function(new_text)
                    file_name = new_text
                end
            })
        }
    }),
    buttons = {
        editor.ui.dialog_button({ text = "Cancel", cancel = true, result = false }),
        editor.ui.dialog_button({ text = "Create File", default = true, result = true })
    }
}))
if create_file then
    print("create", file_name)
end
```