### PR TITLE
Fix typo in physics-messages.md

### DIFF
--- a/docs/en/manuals/physics-messages.md
+++ b/docs/en/manuals/physics-messages.md
@@ -1,11 +1,11 @@
 ---
 title: Collision messages in Defold
-brief: When two objects collide, the engine may call the event listener or broad cast messages.
+brief: When two objects collide, the engine will call the event callback or broadcast messages.
 ---
 
 # Collision messages
 
-When two objects collide, the engine will may send an event to the event callback, or broadcast messages to both objects.
+When two objects collide, the engine will send an event to the event callback or broadcast messages to both objects.
 
 ## Event filtering
 


### PR DESCRIPTION
Fixed a typo in the first sentence and made the brief and first sentence consistent.