### PR TITLE
Fix typo in Spanish translation

### DIFF
--- a/docs/es/manuals/building-blocks.md
+++ b/docs/es/manuals/building-blocks.md
@@ -30,7 +30,7 @@ Una colección puede contener objetos y otras colecciones (por referencia al arc
 
 ![Colección](images/building_blocks/collection.png)
 
-Fíjate que la sub-colección con la id "bean" está guardada en su propio arcivo, llamado "/main/bean.collection" y es únicamente referenciado en "main.collection":
+Fíjate que la sub-colección con la id "bean" está guardada en su propio archivo, llamado "/main/bean.collection" y es únicamente referenciado en "main.collection":
 
 ![Colección Bean](images/building_blocks/bean_collection.png)
 


### PR DESCRIPTION
Se corrigió 'arcivo' por 'archivo' en la sección de colecciones.