### PR TITLE
HTML5: document host-set Module opt-outs (defold/defold#12396 follow-up)

### DIFF
--- a/docs/en/manuals/html5.md
+++ b/docs/en/manuals/html5.md
@@ -284,6 +284,44 @@ print(foo2) -- bar2
 ```
 
 
+### Host-set Module properties
+
+Embedding hosts can fine-tune the loader's behaviour by pre-setting properties on the global `Module` object *before* the `<script src="dmloader.js">` tag runs. This is the standard Emscripten pattern; `dmloader.js` captures each host-set value before its own `var Module = {...}` redefinition discards the global. Default behaviour is byte-identical when nothing is pre-set.
+
+```html
+<script>
+var Module = {
+    isWASMPthreadSupported: false,
+    isWebGL2Supported: false,
+    webGLContextAttributes: { preserveDrawingBuffer: true },
+    webGLExtensionFilter: function (name) {
+        return name.toLowerCase().includes("compressed_texture");
+    },
+    showButtonStrip: false,
+    autoReloadOnWebGLContextRestore: true
+};
+</script>
+<script src="dmloader.js"></script>
+```
+
+| Property | Type | Effect |
+| --- | --- | --- |
+| `isWASMPthreadSupported` | `=== false` | Force the single-threaded WASM variant. Useful when the page passes the `crossOriginIsolated` + `SharedArrayBuffer` probe but still can't construct same-origin Workers (e.g. a WebView wrapper serving the bundle from a custom URL scheme — Chromium rejects `new Worker('myscheme://...')` with `SecurityError: cannot be accessed from origin 'null'`). |
+| `isWebGL2Supported` | `=== false` | Downgrade `getContext('webgl2')` to `'webgl'`. Useful when the embedded GLES driver advertises WebGL2 but trips inside the engine's VAO / instancing init. |
+| `webGLContextAttributes` | `Object` | Merged (`Object.assign`) into the attrs argument of the WebGL context creation. Notably useful for forcing `preserveDrawingBuffer:true` when the host compositor is flaky and `eglSwapBuffers` may fail between renders. |
+| `webGLExtensionFilter` | `(name) => boolean` | Strip names from `getSupportedExtensions` / `getExtension`. Returning `true` for a name removes it. Useful when the driver falsely advertises compressed-texture / float-texture / depth-texture extensions then rejects the actual upload. |
+| `showButtonStrip` | `=== false` | Hide the engine_template footer (`.buttons-background`). [project setting]`html5.show_fullscreen_button = 0` + `html5.show_made_with_defold = 0` suppresses the inner anchors but leaves a 42 px white bar behind; this opt-out finishes the job for hosts that want a true-fullscreen canvas. |
+| `autoReloadOnWebGLContextRestore` | `=== true` | Attach `webglcontextlost` / `webglcontextrestored` listeners to the canvas. `preventDefault()` on lost asks the browser to restore; on restored, `location.reload()` so the engine boots cleanly. The player lands on the title screen and resumes from autosave. |
+
+::: important
+Use a `var` declaration or `window.Module = {...}`. Top-level `let Module = ...` creates a script-scoped binding that the loader's global `var Module` can't see — the host-set values will be invisible to the captures.
+:::
+
+::: important
+The checks are strict — only the literal sentinel triggers the opt-out (`=== false` for the booleans, `=== true` for `autoReloadOnWebGLContextRestore`, a `function` typeof for the filter, a truthy object for the attrs). Truthy/falsy values like `0`, `null`, `""`, or `undefined` are ignored.
+:::
+
+
 ### Query arguments in the URL
 
 You can pass arguments as part of the query parameters in the page URL and read these at runtime:

--- a/docs/en/manuals/html5.md
+++ b/docs/en/manuals/html5.md
@@ -284,7 +284,8 @@ print(foo2) -- bar2
 ```
 
 
-### Host-set Module properties
+### Advanced HTML5 embedding: Host-set Module properties
+These options are intended for advanced HTML5 embedding scenarios, such as WebView wrappers or custom host pages. Most games should not need them.
 
 Embedding hosts can fine-tune the loader's behaviour by pre-setting properties on the global `Module` object *before* the `<script src="dmloader.js">` tag runs. This is the standard Emscripten pattern; `dmloader.js` captures each host-set value before its own `var Module = {...}` redefinition discards the global. Default behaviour is byte-identical when nothing is pre-set.
 
@@ -295,7 +296,7 @@ var Module = {
     isWebGL2Supported: false,
     webGLContextAttributes: { preserveDrawingBuffer: true },
     webGLExtensionFilter: function (name) {
-        return name.toLowerCase().includes("compressed_texture");
+        return typeof name === "string" && name.toLowerCase().includes("compressed_texture");
     },
     showButtonStrip: false,
     autoReloadOnWebGLContextRestore: true
@@ -310,15 +311,19 @@ var Module = {
 | `isWebGL2Supported` | `=== false` | Downgrade `getContext('webgl2')` to `'webgl'`. Useful when the embedded GLES driver advertises WebGL2 but trips inside the engine's VAO / instancing init. |
 | `webGLContextAttributes` | `Object` | Merged (`Object.assign`) into the attrs argument of the WebGL context creation. Notably useful for forcing `preserveDrawingBuffer:true` when the host compositor is flaky and `eglSwapBuffers` may fail between renders. |
 | `webGLExtensionFilter` | `(name) => boolean` | Strip names from `getSupportedExtensions` / `getExtension`. Returning `true` for a name removes it. Useful when the driver falsely advertises compressed-texture / float-texture / depth-texture extensions then rejects the actual upload. |
-| `showButtonStrip` | `=== false` | Hide the engine_template footer (`.buttons-background`). [project setting]`html5.show_fullscreen_button = 0` + `html5.show_made_with_defold = 0` suppresses the inner anchors but leaves a 42 px white bar behind; this opt-out finishes the job for hosts that want a true-fullscreen canvas. |
-| `autoReloadOnWebGLContextRestore` | `=== true` | Attach `webglcontextlost` / `webglcontextrestored` listeners to the canvas. `preventDefault()` on lost asks the browser to restore; on restored, `location.reload()` so the engine boots cleanly. The player lands on the title screen and resumes from autosave. |
+| `showButtonStrip` | `=== false` | Hide the engine_template footer (`.buttons-background`). This can be used in addition to the existing html5.show_fullscreen_button and html5.show_made_with_defold project settings - `html5.show_fullscreen_button = 0` + `html5.show_made_with_defold = 0` suppresses the inner anchors but leaves a 42 px white bar behind; this opt-out finishes the job for hosts that want a true-fullscreen canvas. |
+| `autoReloadOnWebGLContextRestore` | `=== true` | Attach `webglcontextlost` / `webglcontextrestored` listeners to the canvas. `preventDefault()` on lost asks the browser to restore; on restored, `location.reload()` so the engine boots cleanly. On restore, the page is reloaded so the engine can initialise a fresh WebGL context. Any game state that should survive the reload must be persisted by the game.|
+
+::: important
+Some of these options patch browser prototypes and may affect other WebGL canvases on the same page. Use them only on controlled host pages dedicated to the Defold game.
+:::
 
 ::: important
 Use a `var` declaration or `window.Module = {...}`. Top-level `let Module = ...` creates a script-scoped binding that the loader's global `var Module` can't see — the host-set values will be invisible to the captures.
 :::
 
 ::: important
-The checks are strict — only the literal sentinel triggers the opt-out (`=== false` for the booleans, `=== true` for `autoReloadOnWebGLContextRestore`, a `function` typeof for the filter, a truthy object for the attrs). Truthy/falsy values like `0`, `null`, `""`, or `undefined` are ignored.
+The checks are strict — only the literal sentinel triggers the opt-out (`=== false` for the booleans, `=== true` for `autoReloadOnWebGLContextRestore`, a `function` typeof for the filter, a truthy object for the attrs). Must be a plain object. Other truthy/falsy values like `0`, `null`, `""`, or `undefined` are unsupported, ignored, and should not be used.
 :::
 
 


### PR DESCRIPTION
Follow-up documentation for [defold/defold#12396](https://github.com/defold/defold/pull/12396), which expands `dmloader.js` to respect six host-set properties on the global `Module` object:

* `Module.isWASMPthreadSupported`
* `Module.isWebGL2Supported`
* `Module.webGLContextAttributes`
* `Module.webGLExtensionFilter`
* `Module.showButtonStrip`
* `Module.autoReloadOnWebGLContextRestore`

Each is captured before the loader's own `var Module = {...}` redefinition and applied in an IIFE that runs at the same site. Default behaviour is byte-identical when nothing is pre-set.

This PR adds a new \"Host-set Module properties\" subsection to `docs/en/manuals/html5.md`, placed between the existing \"Engine arguments\" and \"Query arguments in the URL\" subsections under \"Passing arguments to an HTML5 game\". The new content includes:

* The example shape (a `var Module = { ... };` block before the `<script src=\"dmloader.js\">` tag).
* A per-property table with the type constraint, the effect, and the concrete failure mode each opt-out addresses.
* Two callouts: the `let` vs `var` binding gotcha (top-level `let Module` is invisible to the loader's `var Module`), and the strict sentinel-value semantics (`=== false` / `=== true` / `function` typeof, no coercion).

Should land after defold/defold#12396 merges, since this references behaviour the engine doesn't have yet. Adjustable to whatever the final API surface looks like if the engine PR shrinks during review.

## PR checklist

* [x] Documentation
  * [x] Docs change matches the new engine-side behaviour described in defold/defold#12396.
  * [x] New section inserted into the existing manual structure rather than a new file, so navigation / links stay consistent.
  * [x] Markdown anchors and code fences validated locally.