### PR TITLE
Note that the round collision shape is labeled Circle in 2D physics p…

### DIFF
--- a/docs/en/manuals/physics-objects.md
+++ b/docs/en/manuals/physics-objects.md
@@ -27,7 +27,7 @@ A collision object component has a set of *Properties* that sets its type and ph
 To add a collision object component to a game object:
 
 1. In the *Outline* view, <kbd>right click</kbd> the game object and select <kbd>Add Component ▸ Collision Object</kbd> from the context menu. This creates a new component with no shapes.
-2. <kbd>Right click</kbd> the new component and select <kbd>Add Shape ▸ Box / Capsule / Sphere</kbd>. This adds a new shape to the collision object component. You can add any number of shapes to the component. You can also use a tilemap or a convex hull to define the shape of the physics object.
+2. <kbd>Right click</kbd> the new component and select <kbd>Add Shape ▸ Box / Capsule / Sphere</kbd> (*Circle* instead of *Sphere* in projects using 2D physics). This adds a new shape to the collision object component. You can add any number of shapes to the component. You can also use a tilemap or a convex hull to define the shape of the physics object.
 3. Use the move, rotate and scale tools to edit the shapes.
 4. Select the component in the *Outline* and edit the collision object's *Properties*.
 

--- a/docs/en/manuals/physics-objects.md
+++ b/docs/en/manuals/physics-objects.md
@@ -27,7 +27,7 @@ A collision object component has a set of *Properties* that sets its type and ph
 To add a collision object component to a game object:
 
 1. In the *Outline* view, <kbd>right click</kbd> the game object and select <kbd>Add Component ▸ Collision Object</kbd> from the context menu. This creates a new component with no shapes.
-2. <kbd>Right click</kbd> the new component and select <kbd>Add Shape ▸ Box / Capsule / Sphere</kbd> (*Circle* instead of *Sphere* in projects using 2D physics). This adds a new shape to the collision object component. You can add any number of shapes to the component. You can also use a tilemap or a convex hull to define the shape of the physics object.
+2. <kbd>Right click</kbd> the new component and select <kbd>Add Shape</kbd>, then choose a shape: <kbd>Box</kbd>, <kbd>Capsule</kbd> or <kbd>Sphere</kbd> in projects using 3D physics, <kbd>Box</kbd> or <kbd>Circle</kbd> in projects using 2D physics. This adds a new shape to the collision object component. You can add any number of shapes to the component. You can also use a tilemap or a convex hull to define the shape of the physics object.
 3. Use the move, rotate and scale tools to edit the shapes.
 4. Select the component in the *Outline* and edit the collision object's *Properties*.
 


### PR DESCRIPTION
Updates the collision object component steps to mention that the <kbd>Add Shape</kbd> menu shows Circle instead of Sphere in projects using 2D physics.

Documents the change in defold/defold#12919