### PR TITLE
Add German and Turkish documentation

### DIFF
--- a/docs/de/faq/faq.md
+++ b/docs/de/faq/faq.md
@@ -1,0 +1,313 @@
+---
+title: FAQ zur Defold-Engine und zum Editor
+brief: Häufig gestellte Fragen zur Game-Engine, zum Editor und zur Plattform Defold.
+---
+
+# Häufig gestellte Fragen {#frequently-asked-questions}
+
+## Allgemeine Fragen {#general-questions}
+
+#### Q: Ist Defold wirklich kostenlos? {#q-is-defold-really-free}
+
+A: Ja, die Defold-Engine und der Editor sind mit ihrem gesamten Funktionsumfang völlig kostenlos. Keine versteckten Kosten, Gebühren oder Lizenzgebühren. Einfach kostenlos.
+
+
+#### Q: Warum um alles in der Welt sollte die Defold Foundation Defold kostenlos bereitstellen? {#q-why-on-earth-would-the-defold-foundation-give-defold-away}
+
+A: Eines der Ziele der [Defold Foundation](/foundation) ist es, sicherzustellen, dass die Defold-Software Entwicklerinnen und Entwicklern weltweit zur Verfügung steht und der Quellcode kostenlos verfügbar ist.
+
+
+#### Q: Wie lange werdet ihr Defold unterstützen? {#q-how-long-will-you-support-defold}
+
+A: Wir setzen uns mit voller Überzeugung für Defold ein. Die [Defold Foundation](/foundation) wurde so aufgebaut, dass sie garantiert noch viele Jahre als verantwortliche Eigentümerin von Defold bestehen wird. Sie wird nicht verschwinden.
+
+
+#### Q: Kann ich mich bei der professionellen Entwicklung auf Defold verlassen? {#q-can-i-trust-defold-for-professional-development}
+
+A: Auf jeden Fall. Defold wird von immer mehr professionellen Spieleentwicklern und Spielestudios verwendet. In der [Spielegalerie](/showcase) findest du Beispiele für Spiele, die mit Defold erstellt wurden.
+
+
+#### Q: Welche Art von Nutzertracking betreibt ihr? {#q-what-kind-of-user-tracking-are-you-doing}
+
+A: Wir protokollieren anonyme Nutzungsdaten unserer Websites und des Defold-Editors, um unsere Dienste und unser Produkt zu verbessern. In den Spielen, die du erstellst, findet kein Nutzertracking statt (es sei denn, du fügst selbst einen Analysedienst hinzu). Mehr dazu erfährst du in unserer [Datenschutzerklärung](/privacy-policy).
+
+
+#### Q: Wer hat Defold entwickelt? {#q-who-made-defold}
+
+A: Defold wurde von Ragnar Svensson und Christian Murray entwickelt. Sie begannen 2009 mit der Arbeit an der Engine, dem Editor und den Servern. King und Defold gingen 2013 eine Partnerschaft ein, und 2014 übernahm King Defold. Die vollständige Geschichte kannst du [hier](/about) nachlesen.
+
+
+## Fragen zur Spieleentwicklung {#game-development-questions}
+
+#### Q: Kann ich mit Defold 3D-Spiele erstellen? {#q-can-i-do-3d-games-in-defold}
+
+A: Auf jeden Fall! Die Engine ist eine vollwertige 3D-Engine. Die Werkzeuge sind allerdings für 2D ausgelegt, weshalb du vieles selbst erledigen musst. Eine bessere 3D-Unterstützung ist geplant.
+
+
+## Fragen zu Programmiersprachen {#programming-language-questions}
+
+#### Q: Mit welcher Programmiersprache arbeite ich in Defold? {#q-what-programming-language-do-i-work-with-in-defold}
+
+A: Die Spiellogik in deinem Defold-Projekt wird hauptsächlich in Lua geschrieben (genauer gesagt Lua 5.1/LuaJIT; Einzelheiten findest du im [Lua-Handbuch](/manuals/lua)). Lua ist eine schlanke dynamische Sprache, die schnell und sehr leistungsfähig ist. Defold unterstützt Transpiler, die Lua-Code erzeugen. Wenn eine Transpiler-Erweiterung installiert ist, kannst du alternative Sprachen wie [Teal](https://github.com/defold/extension-teal) verwenden, um statisch geprüftes Lua zu schreiben. Du kannst auch nativen Code verwenden (je nach Plattform C/C++, Objective-C, Java und JavaScript), um [die Defold-Engine um neue Funktionen zu erweitern](/manuals/extensions/). Beim Erstellen [benutzerdefinierter Materialien](/manuals/material/) werden Vertex- und Fragment-Shader in der Shader-Sprache OpenGL ES SL geschrieben.
+
+
+#### Q: Kann ich C++ verwenden, um Spiellogik zu schreiben? {#q-can-i-use-c-to-write-game-logic}
+
+A: Die C++-Unterstützung in Defold dient hauptsächlich dazu, native Erweiterungen zu schreiben, die Schnittstellen zu SDKs von Drittanbietern oder plattformspezifischen APIs bereitstellen. Das [dmSDK](https://defold.com/ref/stable/dmGameObject/) (die C++-API für Defold, die in nativen Erweiterungen verwendet wird) wird schrittweise um weitere Funktionen erweitert, sodass sich auf Wunsch die gesamte Spiellogik in C++ schreiben lässt. Lua bleibt die Hauptsprache für die Spiellogik, aber mit der erweiterten C++-API wird es auch möglich sein, Spiellogik in C++ zu schreiben. Die Erweiterung der C++-API besteht hauptsächlich darin, vorhandene private Headerdateien in den öffentlichen Bereich zu verschieben und APIs für die öffentliche Nutzung zu bereinigen.
+
+
+#### Q: Kann ich TypeScript mit Defold verwenden? {#q-can-i-use-typescript-with-defold}
+
+A: TypeScript wird nicht offiziell unterstützt. Die Community pflegt die Werkzeugsammlung [ts-defold](https://ts-defold.dev/), mit der du TypeScript schreiben und direkt aus VSCode nach Lua transpilieren kannst.
+
+
+#### Q: Kann ich Haxe mit Defold verwenden? {#q-can-i-use-haxe-with-defold}
+
+A: Haxe wird nicht offiziell unterstützt. Die Community pflegt [hxdefold](https://github.com/hxdefold/hxdefold), mit dem du Haxe schreiben und nach Lua transpilieren kannst.
+
+
+#### Q: Kann ich C# mit Defold verwenden? {#q-can-i-use-c-with-defold}
+
+A: Die Defold Foundation hat C#-Unterstützung hinzugefügt und als Abhängigkeit von einer Bibliothek verfügbar gemacht. C# ist eine weitverbreitete Programmiersprache. Die Unterstützung erleichtert Studios und Entwicklern, die stark auf C# setzen, den Wechsel zu Defold.
+
+
+#### Q: Ich befürchte, dass sich die zusätzliche C#-Unterstützung negativ auf Defold auswirkt. Muss ich mir Sorgen machen? {#q-i-am-concerned-that-adding-c-support-will-have-a-negative-impact-on-defold-should-i-be-worried}
+
+Defold wendet sich NICHT von Lua als primärer Skriptsprache ab. C# wird als neue Sprache für Erweiterungen hinzugefügt. Das wirkt sich nur dann auf die Engine aus, wenn du dich dafür entscheidest, C#-Erweiterungen in deinem Projekt zu verwenden.
+
+Die C#-Unterstützung hat ihren Preis (Größe der ausführbaren Datei, Leistung zur Laufzeit usw.), aber diese Entscheidung liegt beim jeweiligen Entwickler oder Studio.
+
+Was C# selbst betrifft, handelt es sich um eine relativ kleine Änderung, da das Erweiterungssystem bereits viele Sprachen unterstützt (C/C++/Java/Objective-C/Zig). Die SDKs werden durch das Generieren der C#-Anbindungen synchron gehalten. So bleiben die Anbindungen mit minimalem Aufwand aktuell.
+
+Die Defold Foundation war zuvor gegen die Aufnahme von C#-Unterstützung in Defold, hat ihre Meinung aber aus mehreren Gründen geändert:
+
+* Studios und Entwickler fragen weiterhin nach C#-Unterstützung.
+* Der Umfang der C#-Unterstützung wurde auf Erweiterungen beschränkt (also geringer Aufwand).
+* Die Kern-Engine wird nicht beeinträchtigt.
+* Die C#-APIs lassen sich mit minimalem Aufwand synchron halten, wenn sie generiert werden.
+* Die C#-Unterstützung wird auf DotNet 9 mit NativeAOT basieren und somit statische Bibliotheken erzeugen, gegen die die bestehende Build-Pipeline linken kann (wie bei jeder anderen Defold-Erweiterung).
+
+
+## Fragen zu Plattformen {#platform-questions}
+
+#### Q: Auf welchen Plattformen läuft Defold? {#q-what-platforms-does-defold-run-on}
+
+A: Für den Editor und die Werkzeuge sowie für die Laufzeitumgebung der Engine werden folgende Plattformen unterstützt:
+
+  | System             | Version            | Architekturen      | Unterstützung      |
+  | ------------------ | ------------------ | ------------------ | ------------------ |
+  | macOS              | 11 Big Sur         | `x86-64`, `arm-64` | Editor und Engine  |
+  | Windows            | Vista              | `x86-32`, `x86-64` | Editor und Engine  |
+  | Ubuntu (1)         | 22.04 LTS          | `x86-64`           | Editor             |
+  | Linux (2)          | Beliebig           | `x86-64`, `arm-64` | Engine             |
+  | iOS                | 15.0               | `arm-64`  `x86_64` | Engine             |
+  | Android            | 5.0 (API-Level 21) | `arm-32`, `arm-64` | Engine             |
+  | HTML5              |                    | `wasm-web`, `wasm_pthread-web` | Engine       |
+
+  (1 Der Editor wird für 64-Bit-Ubuntu erstellt und getestet. Er sollte auch auf anderen Distributionen funktionieren, aber dafür geben wir keine Garantie.)
+
+  (2 Die Laufzeitumgebung der Engine sollte auf den meisten 64-Bit-Linux-Distributionen laufen, solange die Grafiktreiber aktuell sind. Weitere Informationen zu Grafik-APIs findest du unten.)
+
+
+#### Q: Für welche Zielplattformen kann ich mit Defold Spiele entwickeln? {#q-what-target-platforms-can-i-develop-games-for-with-defold}
+
+A: Mit einem Klick kannst du für PS4™, PS5™, Nintendo Switch, iOS (64-Bit), Android (32-Bit und 64-Bit) und HTML5 sowie macOS (x86-64 und arm64), Windows (32-Bit und 64-Bit) und Linux (x86-64 und arm64) veröffentlichen. Es ist tatsächlich eine einzige Codebasis mit Unterstützung für mehrere Plattformen.
+
+
+#### Q: Auf welcher Rendering-API basiert Defold? {#q-what-rendering-api-does-defold-rely-on}
+
+A: Bei der Entwicklung musst du dich nur mit einer einzigen Render-API befassen, die eine [vollständig skriptgesteuerte Rendering-Pipeline](/manuals/render/) verwendet. Die Render-Skript-API von Defold übersetzt Renderoperationen in die folgenden Grafik-APIs:
+
+:[Graphics API](../shared/graphics-api.md)
+
+#### Q: Kann ich herausfinden, welche Version ich verwende? {#q-is-there-a-way-to-know-what-version-im-running}
+
+A: Ja, wähle die Option „About“ im Menü Help. Das Popup zeigt die Defold-Betaversion und vor allem den SHA1-Wert der jeweiligen Veröffentlichung deutlich an. Um die Version zur Laufzeit abzufragen, verwende [`sys.get_engine_info()`](/ref/sys/#sys.get_engine_info).
+
+Die neueste Betaversion, die unter [http://d.defold.com/beta](http://d.defold.com/beta) zum Herunterladen verfügbar ist, kannst du durch Öffnen von [http://d.defold.com/beta/info.json](http://d.defold.com/beta/info.json) ermitteln (dieselbe Datei gibt es auch für stabile Versionen: [http://d.defold.com/stable/info.json](http://d.defold.com/stable/info.json)).
+
+
+#### Q: Kann ich zur Laufzeit herausfinden, auf welcher Plattform das Spiel läuft? {#q-is-there-a-way-to-know-what-platform-the-game-is-running-on-at-runtime}
+
+A: Ja, sieh dir [`sys.get_sys_info()`](/ref/sys#sys.get_sys_info) an.
+
+
+## Fragen zum Editor {#editor-questions}
+:[Editor FAQ](../shared/editor-faq.md)
+
+
+## Fragen zu Linux {#linux-questions}
+:[Linux FAQ](../shared/linux-faq.md)
+
+
+## Fragen zu Android {#android-questions}
+:[Android FAQ](../shared/android-faq.md)
+
+
+## Fragen zu HTML5 {#html5-questions}
+:[HTML5 FAQ](../shared/html5-faq.md)
+
+
+## Fragen zu iOS {#ios-questions}
+:[iOS FAQ](../shared/ios-faq.md)
+
+
+## Fragen zu Windows {#windows-questions}
+:[Windows FAQ](../shared/windows-faq.md)
+
+
+## Fragen zu Konsolen {#console-questions}
+:[Consoles FAQ](../shared/consoles-faq.md)
+
+
+## Spiele veröffentlichen {#publishing-games}
+
+#### Q: Ich versuche, mein Spiel im App Store zu veröffentlichen. Wie soll ich die Frage zur IDFA beantworten? {#q-im-trying-to-publish-my-game-to-appstore-how-should-i-respond-to-idfa}
+
+A: Beim Einreichen bietet Apple drei Kontrollkästchen für die drei zulässigen Anwendungsfälle der IDFA an:
+
+  1. Werbung innerhalb der App anzeigen
+  2. Installationen Werbeanzeigen zuordnen
+  3. Nutzeraktionen Werbeanzeigen zuordnen
+
+  Wenn du Option 1 auswählst, wird bei der App-Prüfung darauf geachtet, ob Werbeanzeigen in der App erscheinen. Wenn dein Spiel keine Werbung anzeigt, kann es abgelehnt werden. Defold selbst verwendet die Werbe-ID nicht.
+
+
+#### Q: Wie kann ich mein Spiel monetarisieren? {#q-how-do-i-monetize-my-game}
+
+A: Defold unterstützt In-App-Käufe und verschiedene Werbelösungen. In der [Kategorie Monetization im Asset Portal](https://defold.com/tags/stars/monetization/) findest du eine aktuelle Liste der verfügbaren Möglichkeiten zur Monetarisierung.
+
+
+## Fehler bei der Verwendung von Defold {#errors-using-defold}
+
+#### Q: Ich kann das Spiel nicht starten, und es gibt keinen Build-Fehler. Was stimmt nicht? {#q-i-cant-start-the-game-and-there-is-no-build-error-whats-wrong}
+
+A: In seltenen Fällen erstellt der Build-Vorgang Dateien nicht neu, nachdem zuvor Build-Fehler aufgetreten sind, die du inzwischen behoben hast. Erzwinge einen vollständigen neuen Build, indem du im Menü *Project > Rebuild And Launch* auswählst.
+
+
+
+## Spielinhalte {#game-content}
+
+#### Q: Unterstützt Defold Prefabs? {#q-does-defold-support-prefabs}
+
+A: Ja. Sie heißen [Sammlungen](/manuals/building-blocks/#collections) (collections). Damit kannst du komplexe Hierarchien von Spielobjekten (game objects) erstellen und als separate Bausteine speichern, die du im Editor oder zur Laufzeit instanziieren kannst (indem du die Inhalte einer Sammlung dynamisch erzeugst). Für GUI-Knoten werden GUI-Vorlagen unterstützt.
+
+
+#### Q: Warum kann ich ein Spielobjekt nicht einem anderen Spielobjekt unterordnen? {#q-i-cant-add-a-game-object-as-a-child-to-another-game-object-why}
+
+A: Wahrscheinlich versuchst du, ein untergeordnetes Objekt in der Spielobjektdatei hinzuzufügen, und das ist nicht möglich. Es ist nur in der Sammlungsdatei möglich. Um zu verstehen, warum, musst du dir vor Augen halten, dass Eltern-Kind-Hierarchien ausschließlich eine Transformationshierarchie des _Szenengraphen_ darstellen. Ein Spielobjekt, das noch nicht in einer Szene (Sammlung) platziert oder dynamisch erzeugt wurde, ist kein Teil eines Szenengraphen und kann deshalb auch nicht Teil einer Szenengraphenhierarchie sein. Mit [`go.get_parent()`](https://defold.com/ref/stable/go-lua/#go.get_parent:id) kannst du den Bezeichner des übergeordneten Spielobjekts abrufen.
+
+
+#### Q: Warum kann ich Nachrichten nicht an alle untergeordneten Objekte eines Spielobjekts senden? {#q-why-cant-i-broadcast-messages-to-all-children-of-a-game-object}
+
+A: Eltern-Kind-Beziehungen drücken ausschließlich die Transformationsbeziehungen im Szenengraphen aus und sollten nicht mit Aggregaten aus der Objektorientierung verwechselt werden. Wenn du dich auf deine Spieldaten konzentrierst und darauf, wie du sie bei Zustandsänderungen deines Spiels am besten veränderst, wirst du wahrscheinlich weniger Bedarf haben, ständig Nachrichten mit Zustandsdaten an viele Objekte zu senden. In den Fällen, in denen du Datenhierarchien benötigst, lassen sich diese in Lua leicht erstellen und verwalten.
+
+
+#### Q: Warum sehe ich Bildartefakte an den Rändern meiner Sprites? {#q-why-am-i-experiencing-visual-artifacts-around-the-edges-of-my-sprites}
+
+A: Dieses Bildartefakt heißt „Übergreifen benachbarter Texturpixel“ (edge bleeding). Dabei greifen benachbarte Randpixel im Atlas in das Bild über, das deinem Sprite zugewiesen ist. Die Lösung besteht darin, den Rand deiner Atlasbilder um zusätzliche Zeilen und Spalten identischer Pixel zu erweitern. Glücklicherweise kann der Atlas-Editor in Defold dies automatisch erledigen. Öffne deinen Atlas und setze den Wert *Extrude Borders* auf 1.
+
+
+#### Q: Kann ich meine Sprites einfärben oder transparent machen, oder muss ich dafür einen eigenen Shader schreiben? {#q-can-i-tint-my-sprites-or-make-them-transparent-or-do-i-have-to-write-my-own-shader-for-it}
+
+A: Der integrierte Sprite-Shader, der standardmäßig für alle Sprites verwendet wird, definiert eine Konstante namens „tint“:
+
+  ```lua
+  local red = 1
+  local green = 0.3
+  local blue = 0.55
+  local alpha = 1
+  go.set("#sprite", "tint", vmath.vector4(red, green, blue, alpha))
+  ```
+
+
+#### Q: Wenn ich die z-Koordinate eines Sprites auf 100 setze, wird es nicht gerendert. Warum? {#q-if-i-set-the-z-coordinate-of-a-sprite-to-100-then-its-not-rendered-why}
+
+A: Die Z-Position eines Spielobjekts steuert die Zeichenreihenfolge. Niedrige Werte werden vor höheren Werten gezeichnet. Im standardmäßigen Render-Skript werden Spielobjekte mit einer Tiefe zwischen -1 und 1 gezeichnet; alles darunter oder darüber wird nicht gezeichnet. Mehr zum Render-Skript erfährst du in der offiziellen [Rendering-Dokumentation](/manuals/render). Bei GUI-Knoten wird der Z-Wert ignoriert und hat keinerlei Einfluss auf die Zeichenreihenfolge. Stattdessen werden Knoten in der Reihenfolge gerendert, in der sie aufgelistet sind, sowie entsprechend den Hierarchien untergeordneter Knoten (und den Ebenen). Mehr über das GUI-Rendering und die Optimierung von Zeichenaufrufen (draw calls) mithilfe von Ebenen erfährst du in der offiziellen [GUI-Dokumentation](/manuals/gui).
+
+
+#### Q: Würde es die Leistung beeinflussen, wenn ich den Z-Bereich der Ansichtsprojektion auf -100 bis 100 ändere? {#q-would-changing-the-view-projection-z-range-to-100-to-100-impact-performance}
+
+A: Nein. Die einzige Auswirkung betrifft die Genauigkeit. Der Z-Puffer ist logarithmisch und bietet für z-Werte nahe 0 eine sehr feine Auflösung, während die Auflösung mit zunehmendem Abstand von 0 abnimmt. Beispielsweise lassen sich mit einem 24-Bit-Puffer die Werte 10,0 und 10,000005 unterscheiden, 10000 und 10005 dagegen nicht.
+
+
+#### Q: Warum werden Winkel nicht einheitlich dargestellt? {#q-there-is-no-consistency-to-how-angles-are-represented-why}
+
+A: Tatsächlich ist die Darstellung einheitlich. Überall im Editor und in den Spiel-APIs werden Winkel in Grad angegeben. Die Mathematikbibliotheken verwenden das Bogenmaß. Derzeit weicht die Physikeigenschaft `angular_velocity` von dieser Konvention ab: Sie wird aktuell in Radiant/s angegeben. Das soll sich ändern.
+
+
+#### Q: Wie wird ein GUI-Box-Knoten gerendert, der nur eine Farbe und keine Textur hat? {#q-when-creating-a-gui-box-node-with-only-color-no-texture-how-will-it-be-rendered}
+
+A: Er ist einfach eine Form mit Vertex-Farben. Denke daran, dass er trotzdem Füllrate beansprucht.
+
+
+#### Q: Entlädt die Engine Assets automatisch, wenn ich sie im laufenden Betrieb austausche? {#q-if-i-change-assets-on-the-fly-will-the-engine-automatically-unload-them}
+
+A: Für alle Ressourcen wird intern ein Referenzzähler geführt. Sobald der Referenzzähler null erreicht, wird die Ressource freigegeben.
+
+
+#### Q: Kann ich Audio wiedergeben, ohne eine Audiokomponente zu verwenden, die an ein Spielobjekt angehängt ist? {#q-is-it-possible-to-play-audio-without-the-use-of-an-audio-component-attached-to-a-game-object}
+
+A: Alles basiert auf Komponenten (components). Du kannst ein Spielobjekt ohne grafische Darstellung mit mehreren Klängen erstellen und die Klänge wiedergeben, indem du Nachrichten an das Objekt zur Audiosteuerung sendest.
+
+
+#### Q: Kann ich die Audiodatei, die einer Audiokomponente zugeordnet ist, zur Laufzeit ändern? {#q-is-it-possible-to-change-the-audio-file-associated-with-an-audio-component-at-run-time}
+
+A: Im Allgemeinen werden alle Ressourcen statisch deklariert. Das hat den Vorteil, dass du die Ressourcenverwaltung ohne weiteren Aufwand erhältst. Mit [Ressourceneigenschaften](/manuals/script-properties/#resource-properties) kannst du ändern, welche Ressource einer Komponente zugewiesen ist.
+
+
+#### Q: Kann ich auf die Eigenschaften der physikalischen Kollisionsformen zugreifen? {#q-is-there-a-way-to-access-the-physics-collision-shape-properties}
+
+A: Ja, sieh dir die Physik-API an, insbesondere [`physics.get_shape()`](https://defold.com/ref/stable/physics-lua/#physics.get_shape:url-shape) und [`physics.set_shape()`](https://defold.com/ref/stable/physics-lua/#physics.set_shape:url-shape-table). 
+
+
+#### Q: Gibt es eine schnelle Möglichkeit, die Kollisionsobjekte in meiner Szene zu rendern? (Wie beim Debug-Zeichnen von Box2D) {#q-is-there-any-quick-way-to-render-the-collision-objects-in-my-scene-like-box2ds-debug-draw}
+
+A: Ja, setze das Flag *physics.debug* in *game.project*. (Siehe die offizielle [Dokumentation der Projekteinstellungen](/manuals/project-settings/#debug))
+
+
+#### Q: Wie wirken sich viele Kontakte und Kollisionen auf die Leistung aus? {#q-what-are-the-performance-costs-of-having-many-contactscollisions}
+
+A: Defold führt im Hintergrund eine angepasste Version von Box2D aus, und der Leistungsaufwand sollte sehr ähnlich sein. Du kannst jederzeit sehen, wie viel Zeit die Engine für die Physik benötigt, indem du den [Profiler](/manuals/debugging) öffnest. Du solltest auch berücksichtigen, welche Arten von Kollisionsobjekten du verwendest. Statische Objekte benötigen beispielsweise weniger Rechenleistung. Weitere Einzelheiten findest du in der offiziellen [Physik-Dokumentation](/manuals/physics) von Defold.
+
+
+#### Q: Wie wirken sich viele Partikeleffektkomponenten auf die Leistung aus? {#q-whats-the-performance-impact-of-having-many-particle-effect-components}
+
+A: Das hängt davon ab, ob sie abgespielt werden. Ein ParticleFx, der nicht abgespielt wird, beansprucht keine Rechenleistung. Die Auswirkungen eines abgespielten ParticleFx auf die Leistung musst du mit dem Profiler ermitteln, da sie von seiner Konfiguration abhängen. Wie bei den meisten anderen Dingen wird der Speicher im Voraus für die Anzahl an ParticleFx reserviert, die als max_count in *game.project* definiert ist.
+
+
+#### Q: Wie empfange ich Eingaben in einem Spielobjekt innerhalb einer Sammlung, die über einen Sammlungs-Proxy geladen wurde? {#q-how-do-i-receive-input-to-a-game-object-inside-a-collection-loaded-via-a-collection-proxy}
+
+A: Jede über einen Sammlungs-Proxy (collection proxy) geladene Sammlung hat ihren eigenen Eingabestapel. Eingaben werden vom Eingabestapel der Hauptsammlung über die Proxy-Komponente an die Objekte in der Sammlung weitergeleitet. Deshalb reicht es nicht aus, wenn das Spielobjekt in der geladenen Sammlung den Eingabefokus anfordert. Auch das Spielobjekt, das die Proxy-Komponente _enthält_, muss den Eingabefokus anfordern. Einzelheiten findest du in der [Eingabedokumentation](/manuals/input).
+
+
+#### Q: Kann ich Skripteigenschaften vom Typ string verwenden? {#q-can-i-use-string-type-script-properties}
+
+A: Nein. Defold unterstützt Eigenschaften vom Typ [hash](/ref/builtins#hash). Damit kannst du Typen, Zustandsbezeichner oder beliebige Schlüssel angeben. Hashes können auch zum Speichern von Spielobjektbezeichnern (Pfaden) verwendet werden. Häufig sind jedoch [url](/ref/msg#msg.url)-Eigenschaften vorzuziehen, da der Editor automatisch eine Auswahlliste mit passenden URLs für dich füllt. Einzelheiten findest du in der [Dokumentation der Skripteigenschaften](/manuals/script-properties).
+
+
+#### Q: Wie greife ich auf die einzelnen Zellen einer Matrix zu (die mit [`vmath.matrix4()`](/ref/vmath/#vmath.matrix4:m1) oder einer ähnlichen Funktion erstellt wurde)? {#q-how-do-i-access-the-individual-cells-of-a-matrix-created-using-vmathmatrix4refvmathvmathmatrix4m1-or-similar}
+
+A: Du greifst mit `mymatrix.m11`, `mymatrix.m12`, `mymatrix.m21` usw. auf die Zellen zu.
+
+
+#### Q: Ich erhalte `Not enough resources to clone the node`, wenn ich [gui.clone()](/ref/gui/#gui.clone:node) oder [gui.clone_tree()](/ref/gui/#gui.clone_tree:node) verwende. {#q-i-am-getting-not-enough-resources-to-clone-the-node-when-using-guiclonerefguiguiclonenode-or-guiclone_treerefguiguiclone_treenode}
+
+A: Erhöhe den Wert `Max Nodes` der GUI-Komponente. Du findest diesen Wert im Bereich Properties, wenn du die Wurzel der Komponente in der Ansicht Outline auswählst.
+
+
+## Das Forum {#the-forum}
+
+#### Q: Darf ich ein Thema erstellen, in dem ich für meine Arbeit werbe? {#q-can-i-post-a-thread-where-i-advertise-my-work}
+
+A: Natürlich! Dafür haben wir eine eigene [Kategorie „Work for hire“](https://forum.defold.com/c/work-for-hire). Wir fördern immer alles, was der Community zugutekommt. Der Community deine Dienste anzubieten – ob gegen Bezahlung oder nicht – ist ein gutes Beispiel dafür.
+
+
+#### Q: Ich habe ein Thema erstellt und meine Arbeit hinzugefügt. Darf ich weitere Arbeiten ergänzen? {#q-i-made-a-thread-and-added-my-workcan-i-add-more}
+
+A: Damit Themen in „Work for hire“ seltener durch neue Beiträge nach oben rücken, darfst du in deinem eigenen Thema höchstens einmal alle 14 Tage einen Beitrag veröffentlichen (es sei denn, es handelt sich um eine direkte Antwort auf einen Kommentar im Thema; in diesem Fall darfst du antworten). Wenn du innerhalb der 14 Tage weitere Arbeiten zu deinem Thema hinzufügen möchtest, musst du deine bestehenden Beiträge bearbeiten und den zusätzlichen Inhalt dort ergänzen.
+
+
+#### Q: Darf ich die Kategorie Work for Hire nutzen, um Stellenangebote zu veröffentlichen? {#q-can-i-use-the-work-for-hire-category-to-post-job-offerings}
+
+A: Klar, nur zu! Du kannst dort sowohl Angebote als auch Gesuche veröffentlichen, zum Beispiel: „Programmierer sucht 2D-Pixelkünstler; ich bin reich und bezahle dich gut“.

--- a/docs/de/glossary.txt
+++ b/docs/de/glossary.txt
@@ -1,0 +1,729 @@
+---
+title: Deutsches Glossar zur Defold-Dokumentation
+brief: Empfohlene deutsche Fachbegriffe für Defold mit Verwendungshinweisen und Belegen aus offiziellen deutschsprachigen Dokumentationen.
+---
+
+# Deutsches Glossar zur Defold-Dokumentation
+
+Dieses Glossar dient als Grundlage für neue deutsche Übersetzungen. Untersucht wurden alle vorhandenen `glossary.txt` und `translation-guidelines.txt` unter `docs/es`, `docs/fr`, `docs/gr`, `docs/it`, `docs/ja`, `docs/ko`, `docs/pl`, `docs/pt` und `docs/uk`. Ihr Wortschatz wurde nach Themen und Bedeutungen zusammengeführt und mit englischen Defold-Handbüchern sowie offiziellen deutschsprachigen Dokumentationen verglichen. Erstellt und Quellen geprüft am: 2026-09-12.
+
+Verwende die empfohlenen Formen in Erklärungen. UI-Beschriftungen, API-Namen, Befehle, Konfigurationsschlüssel, Dateinamen, Pfade und andere genaue Zeichenfolgen bleiben in ihrer Originalschreibweise. Führe wichtige Begriffe beim ersten Auftreten eines Artikels mit Englisch in Klammern ein, etwa `Spielobjekt (game object)`. Weitere Regeln stehen in den [Übersetzungsrichtlinien](translation-guidelines.txt).
+
+Quellenverweise belegen den deutschen Sprachgebrauch, keine Übereinstimmung der Produktsysteme. Die Begriffe und Erklärungen zu Defold richten sich nach `docs/en`. Insbesondere Sammlung, Startsammlung, Fabrik, Sammlungsfabrik und Sammlungs-Proxy sind hier festgelegte Erklärbegriffe. Einträge ohne externen Beleg sind ebenfalls redaktionelle Empfehlungen für diese deutsche Fassung.
+
+## Defold und allgemeine Begriffe
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| Defold | Defold; Produktname unverändert |
+| Defold Foundation | Defold Foundation; Name der Organisation unverändert |
+| Defold Editor | Defold-Editor in der Prosa; als genau zitierter Produktname `Defold Editor` |
+| editor | Editor; der Editor, die Editoren. [Godot][G1] |
+| engine | Engine; die Engine, die Engines. [Godot][G1] |
+| game engine | Game-Engine |
+| engine instance | Engine-Instanz |
+| game | Spiel |
+| gameplay | Gameplay; Spielablauf, wenn der konkrete Ablauf gemeint ist |
+| game logic | Spiellogik |
+| application / app | Anwendung; bei mobilen Anwendungen auch App |
+| software | Software |
+| feature | Funktion; bei einer allgemeinen Produkteigenschaft auch Merkmal |
+| tool | Werkzeug; genaue Produktnamen erhalten |
+| documentation | Dokumentation |
+| manual | Handbuch; bei einer einzelnen Seite auch Handbuchartikel |
+| API documentation | API-Dokumentation |
+| API reference | API-Referenz |
+| tutorial | Tutorial; das Tutorial, die Tutorials |
+| example / sample | Beispiel; genaue Namen von Beispielprojekten erhalten |
+| product overview | Produktübersicht |
+| FAQ | häufig gestellte Fragen; Abkürzung FAQ erhalten |
+| community | Community |
+| forum | Forum; die Foren |
+
+## Projekte, Dateien und Ressourcen
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| project | Projekt |
+| project settings | Projekteinstellungen; genaue UI-Namen und Schlüssel erhalten |
+| project file | Projektdatei; `game.project` bleibt unverändert |
+| project template | Projektvorlage |
+| file | Datei |
+| folder | Ordner; insbesondere im Zusammenhang mit einer Benutzeroberfläche |
+| directory | Verzeichnis; insbesondere bei Dateisystemen und Pfaden |
+| root directory | Stammverzeichnis |
+| file extension | Dateierweiterung; beispielsweise `.collection` |
+| source file | Quelldatei |
+| source code | Quellcode |
+| codebase | Codebasis |
+| resource | Ressource; Daten im Defold-Ressourcensystem |
+| resource file | Ressourcendatei |
+| resource path | Ressourcenpfad |
+| resource tree | Ressourcenbaum |
+| resource graph | Ressourcengraph |
+| resource management | Ressourcenverwaltung |
+| resource property | Ressourceneigenschaft; Bedeutung anhand der beschriebenen API prüfen |
+| custom resource | benutzerdefinierte Ressource; `Custom Resources` als Einstellung erhalten |
+| bundle resource | Bundle-Ressource; zusätzlich im Bundle enthaltene Datei |
+| built-in resource | integrierte Ressource; Verzeichnisname `builtins` bleibt erhalten |
+| asset | Asset; das Asset, die Assets. Produktionsmaterial wie Bilder, Modelle und Audiodateien. [Unreal Engine][E2] |
+| Asset Portal | Asset Portal; offizieller Name erhalten |
+| content | Inhalt; im Plural Inhalte |
+| library | Bibliothek |
+| dependency | Abhängigkeit |
+| library dependency | Abhängigkeit von einer Bibliothek |
+| repository | Repository; das Repository, die Repositorys |
+| branch | Branch; der Branch, die Branches; Git-Namen erhalten |
+| version control | Versionsverwaltung |
+| archive | Archiv |
+| cache | Cache; der Cache, die Caches; zur Erklärung Zwischenspeicher |
+| caching | Zwischenspeichern |
+| resource cache | Ressourcen-Cache |
+| local cache / remote cache | lokaler Cache / entfernter Cache |
+| reference | Referenz auf ein Objekt oder eine Ressource; Verweis bei einem Dokumentationslink |
+| file reference | Dateireferenz |
+| reference count | Referenzzähler, wenn der Zähler gemeint ist; Anzahl der Referenzen für seinen Wert |
+| reference counting | Referenzzählung |
+| broken reference | ungültige Referenz; bei fehlendem Ziel ausdrücklich darauf hinweisen |
+| extension | Erweiterung; eine Dateierweiterung und eine Softwareerweiterung unterscheiden |
+| native extension | native Erweiterung |
+| checksum | Prüfsumme |
+| read-only | schreibgeschützt bei Dateien und Ansichten; nur lesend bei Zugriffen |
+
+## Spielstruktur und Instanzen
+
+Bedeutungsgrundlage: [Bausteine](../en/manuals/building-blocks.md), [Sammlungsfabriken](../en/manuals/collection-factory.md) und [Sammlungs-Proxys](../en/manuals/collection-proxy.md).
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| building blocks | Bausteine |
+| game object | Spielobjekt; erstmals Spielobjekt (game object). Kein Defold-Typ namens `GameObject` daraus ableiten |
+| current game object | aktuelles Spielobjekt |
+| component | Komponente; Baustein eines Spielobjekts. Deutscher Sprachgebrauch auch bei [Unreal Engine][E2] |
+| component type | Komponententyp; genaue Typnamen und Beschriftungen erhalten |
+| component property | Komponenteneigenschaft |
+| collection | Sammlung; Definition von Spielobjekten und ihrer Hierarchie in einer Datei |
+| collection file | Sammlungsdatei; Erweiterung `.collection` erhalten |
+| sub-collection | Untersammlung |
+| collection hierarchy | Sammlungshierarchie; von der Eltern-Kind-Hierarchie unterscheiden |
+| bootstrap collection | Startsammlung; erstmals Startsammlung (bootstrap collection) |
+| main collection | Hauptsammlung; wenn die beim Start geladene Sammlung gemeint ist, mit Startsammlung abgleichen |
+| root collection | Sammlung auf oberster Ebene; den jeweiligen Bezug im Original erhalten |
+| collection instance | Instanz einer Sammlung; ihre Inhalte nicht als eigenständig adressierbares Sammlungsobjekt beschreiben |
+| factory | Fabrik; Komponente zum dynamischen Erzeugen von Spielobjekten; erstmals Fabrik (factory) |
+| factory component | Fabrikkomponente; genaue UI-Beschriftung `Factory` erhalten |
+| collection factory | Sammlungsfabrik; erzeugt Inhalte einer Sammlung in der aktuellen Spielwelt |
+| collection proxy | Sammlungs-Proxy; lädt und verwaltet eine separate Spielwelt aus einer Sammlung |
+| prototype | Prototyp; im Defold-Kontext eine Definition, auf der Instanzen beruhen |
+| prefab | Prefab; Begriff bei Vergleichen mit anderen Engines; keine zusätzliche Defold-Ressourcenart |
+| blueprint | Bauplan als allgemeine Metapher; Unreal Engines `Blueprint` bleibt als Funktionsname erhalten |
+| template | Vorlage; konkrete Defold-Ressourcen entsprechend ihrem Kontext benennen |
+| instance | Instanz; die Instanz, die Instanzen. [Godot][G1] |
+| instantiate / instantiation | instanziieren / Instanziierung; in Anleitungen auch eine Instanz erstellen |
+| spawn | dynamisch erzeugen; das erzeugte Objekt benennen |
+| in-place | direkt in der aktuellen Datei definiert; beim Hinzufügen direkt einfügen (in-place) |
+| embedded game object / component | eingebettetes Spielobjekt / eingebettete Komponente |
+| by reference | als Referenz; beim Hinzufügen als Dateireferenz einfügen |
+| parent | übergeordnetes Objekt; bei Bedarf übergeordnetes Spielobjekt oder übergeordneter Knoten |
+| child | untergeordnetes Objekt; bei Bedarf untergeordnetes Spielobjekt oder untergeordneter Knoten |
+| parent-child hierarchy | Eltern-Kind-Hierarchie |
+| childing | einem übergeordneten Spielobjekt zuordnen; Herstellen dieser Hierarchie |
+| root | Wurzel eines Baums; bei Objekten und Knoten auch oberstes Objekt oder oberster Knoten |
+| scene | Szene; eine Defold-Sammlung nicht pauschal so umbenennen |
+| scene graph | Szenengraph |
+| game world | Spielwelt |
+| physics world | Physikwelt |
+| lifetime / lifespan | Lebensdauer; Zeitraum der Existenz eines Objekts |
+| lifecycle | Lebenszyklus; Folge der Zustände und Ereignisse |
+
+## Komponenten und Ressourcentypen
+
+Die deutschen Bezeichnungen erklären die Funktion. Genaue Typnamen, Dateierweiterungen und Einträge in Dialogen behalten ihre Originalschreibweise.
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| sprite | Sprite; das Sprite, die Sprites |
+| sprite component | Sprite-Komponente |
+| script | Skript; das Skript, die Skripte; `.script` und die UI-Beschriftung `Script` erhalten |
+| script component | Skriptkomponente |
+| game object script | Spielobjekt-Skript |
+| GUI component | GUI-Komponente |
+| GUI scene | GUI-Szene |
+| GUI script | GUI-Skript |
+| editor script | Editor-Skript |
+| render script | Render-Skript |
+| model | Modell; bei Geometrie auch 3D-Modell |
+| model component | Modellkomponente |
+| mesh | Mesh; das Mesh, die Meshes; Geometrie aus Vertices und Primitiven. [Unreal Engine][E2] |
+| mesh component | Mesh-Komponente |
+| camera | Kamera |
+| camera component | Kamerakomponente |
+| collision object | Kollisionsobjekt; in Defold eine Komponente mit physikalischen Eigenschaften |
+| sound component | Audiokomponente; genaue UI-Beschriftung `Sound` erhalten |
+| particle effect / Particle FX | Partikeleffekt; genaue UI-Beschriftung `Particle FX` erhalten |
+| tile map / tilemap | Kachelkarte; erstmals Kachelkarte (tile map); `.tilemap` erhalten |
+| tile source | Kachelquelle; Ressource zur Definition von Kacheln; `.tilesource` erhalten |
+| tile set / tileset | Kachelsatz; von der Defold-Kachelquelle unterscheiden |
+| tile | Kachel |
+| atlas | Atlas; erstmals bei Bedarf Texturatlas; der Atlas, die Atlanten |
+| animation set | Animationssatz |
+| material | Material; von Textur und Shader unterscheiden. [Unreal Engine][E1] |
+| texture | Textur. [Unreal Engine][E1] |
+| cubemap | Cubemap; die Cubemap, die Cubemaps; Textur mit sechs Würfelseiten |
+| font | Schriftart; für die Defold-Datei Schriftressource |
+| label | Beschriftung; als Komponente Beschriftungskomponente; `Label` als UI-Name erhalten |
+| GUI template | GUI-Vorlage |
+| texture profile | Texturprofil |
+| display profile | Anzeigeprofil |
+
+## Adressierung und Nachrichten
+
+Bedeutungsgrundlage: [Adressierung](../en/manuals/addressing.md) und [Nachrichtenübermittlung](../en/manuals/message-passing.md).
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| identifier / ID | Bezeichner; die Abkürzung ID kann nach der Einführung verwendet werden; ein Feld `id` bleibt erhalten |
+| unique identifier | eindeutiger Bezeichner |
+| addressing | Adressierung |
+| address | Adresse |
+| relative address / addressing | relative Adresse / relative Adressierung |
+| absolute address / addressing | absolute Adresse / absolute Adressierung |
+| target address | Zieladresse; bei Nachrichten auch Empfängeradresse |
+| naming context | Namenskontext |
+| namespace | Namensraum |
+| name collision | Namenskonflikt |
+| path | Pfad; das Feld `path` bleibt erhalten |
+| relative path / absolute path | relativer Pfad / absoluter Pfad |
+| URL | URL; die URL, die URLs; hier auch Defolds Objektadressierung |
+| URL object | URL-Objekt |
+| socket | Socket; der Socket, die Sockets; im Defold-URL-Kontext Bezeichnung der Spielwelt, kein Netzwerkport |
+| fragment | Fragment; in einer Defold-URL der Bestandteil für die Komponente; Feld `fragment` erhalten |
+| separator | Trennzeichen |
+| hash | Hash; je nach Bedeutung Hashwert oder Hashfunktion |
+| hash value / hashed value | Hashwert |
+| hashed identifier | gehashter Bezeichner |
+| shorthand | Kurzform |
+| message | Nachricht |
+| message passing | Nachrichtenübermittlung |
+| send / post a message | eine Nachricht senden; Funktionsname `msg.post()` erhalten |
+| receive a message | eine Nachricht empfangen |
+| sender | Absender; Parameter `sender` erhalten |
+| receiver / recipient | Empfänger |
+| message ID | Nachrichtenbezeichner; Parameter `message_id` erhalten |
+| message data | Nachrichtendaten |
+| message queue | Nachrichtenwarteschlange |
+| message chain | Nachrichtenkette |
+| dispatch messages | Nachrichten zustellen; beim Durchlaufen der Warteschlange Nachrichten abarbeiten |
+| dispatch pass | Durchlauf der Nachrichtenverarbeitung |
+| message handler | Nachrichtenhandler; Funktion zur Verarbeitung einer Nachricht |
+| broadcast | an alle betreffenden Empfänger senden; den im Original angegebenen Empfängerkreis erhalten |
+| system message | Systemnachricht |
+| user message | benutzerdefinierte Nachricht; bei vom Spielcode definierten Nachrichten |
+| current component | aktuelle Komponente |
+
+## Lua, Programmierung und Lebenszyklus
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| Lua | Lua; niemals LUA |
+| Lua script | Lua-Skript |
+| Lua module | Lua-Modul |
+| Lua context | Lua-Kontext |
+| programming language | Programmiersprache |
+| high-level language | höhere Programmiersprache |
+| native code | nativer Code |
+| code | Code; der Code |
+| module | Modul; das Modul |
+| function | Funktion |
+| method | Methode |
+| callback | Callback; der Callback, die Callbacks; bei Bedarf Callback-Funktion |
+| event | Ereignis; von einer Nachricht unterscheiden |
+| event handler | Ereignishandler |
+| variable | Variable |
+| argument | Argument; beim Aufruf übergebener Wert |
+| parameter | Parameter; benannte Stelle einer Funktionsschnittstelle |
+| return value | Rückgabewert |
+| property | Eigenschaft; in der Prosa keine wechselnde Verwendung von Property. [Unreal Engine][E2] |
+| script property | Skripteigenschaft |
+| field | Feld; genaue Feldnamen erhalten |
+| constant | Konstante |
+| enum / enumeration | Aufzählungstyp; Namen und Werte erhalten |
+| type | Typ; bei Werten Datentyp |
+| number | Zahl; Lua-Typname `number` erhalten |
+| string | Zeichenfolge; Lua-Typname `string` erhalten |
+| boolean | boolescher Wert; `boolean`, `true` und `false` im Code erhalten |
+| nil | `nil`; Lua-Wert unverändert; nicht als `null` oder `false` wiedergeben |
+| userdata | `userdata`; Lua-Typname erhalten und bei Bedarf die betreffenden Daten erklären |
+| table / Lua table | Tabelle / Lua-Tabelle; Typname `table` erhalten |
+| key-value pair | Schlüssel-Wert-Paar |
+| array | Array; das Array, die Arrays |
+| scope | Gültigkeitsbereich |
+| local scope / global scope | lokaler Gültigkeitsbereich / globaler Gültigkeitsbereich |
+| state | Zustand |
+| stateful / stateless | zustandsbehaftet / zustandslos |
+| coroutine | Koroutine |
+| closure | Closure; die Closure, die Closures; Funktion mit Zugriff auf ihren lexikalischen Kontext |
+| metatable | Metatabelle; Lua-Funktionsnamen erhalten |
+| garbage collection | automatische Speicherbereinigung; erstmals bei Bedarf Garbage Collection ergänzen |
+| allocation / deallocation | Speicherzuweisung / Speicherfreigabe |
+| application lifecycle | Anwendungslebenszyklus |
+| initialization | Initialisierung |
+| finalization | Finalisierung; zugehörigen Callback `final()` erhalten |
+| cleanup | Aufräumen; je nach Vorgang beispielsweise Ressourcen freigeben |
+| update loop | Aktualisierungsschleife |
+| update | Aktualisierung; bei einer Aktion aktualisieren; `update()` erhalten |
+| fixed update | Aktualisierung mit festem Zeitschritt; `fixed_update()` erhalten |
+| late update | späte Aktualisierung; `late_update()` erhalten |
+| post update | Phase nach der Aktualisierung; von late update unterscheiden |
+| time step / timestep | Zeitschritt |
+| delta time | Zeitdifferenz; im Aktualisierungskontext Länge des Zeitschritts; `dt` erhalten |
+| runtime | Laufzeitumgebung, wenn die ausführende Software gemeint ist; zur Laufzeit für den Zeitpunkt |
+| at runtime | zur Laufzeit |
+| execution time | Ausführungszeit; Dauer einer Ausführung |
+| load / unload | laden / entladen |
+| enable / disable | aktivieren / deaktivieren; Nachrichtennamen `enable` und `disable` erhalten |
+| delete | löschen; von deaktivieren und entladen unterscheiden |
+
+## Koordinaten, Kamera und Bildschirm
+
+Die deutschen Begriffe für Transformationen sind unter anderem in [Godots Dokumentation][G2] belegt. Koordinatenkonventionen folgen weiterhin dem jeweiligen Defold-Artikel.
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| transform / transformation | Transformation; Oberbegriff für räumliche Abbildungen |
+| translation (spatial) | Verschiebung; bei Bedarf Translation als mathematischen Begriff ergänzen |
+| translation (language) | Übersetzung |
+| position | Position |
+| rotation | Drehung |
+| scale | Skalierung; bei einem Zahlenwert Skalierungsfaktor |
+| scaling | Skalieren / Skalierung |
+| movement | Bewegung |
+| coordinate system | Koordinatensystem |
+| local space | lokales Koordinatensystem; Koordinaten relativ zum beschriebenen Bezug |
+| world space | Weltkoordinatensystem |
+| screen space | Bildschirmkoordinatensystem |
+| origin | Ursprung |
+| axis | Achse; die Achsen |
+| vector | Vektor |
+| vector component | Vektorkomponente; von einer Defold-Komponente unterscheiden |
+| matrix | Matrix; die Matrizen |
+| quaternion | Quaternion; das Quaternion, die Quaternionen |
+| projection | Projektion |
+| orthographic projection | orthografische Projektion |
+| perspective projection | perspektivische Projektion |
+| projection matrix | Projektionsmatrix |
+| view matrix | Ansichtsmatrix |
+| view-projection matrix | kombinierte Ansichts- und Projektionsmatrix |
+| view frustum | Sichtvolumen; bei perspektivischer Projektion Sichtpyramidenstumpf |
+| field of view / FOV | Sichtfeld; beim Winkel Sichtwinkel; Abkürzung FOV erhalten |
+| near plane / far plane | nahe Begrenzungsebene / ferne Begrenzungsebene |
+| viewport | Ansichtsbereich; erstmals Ansichtsbereich (viewport); genaue UI-Namen erhalten |
+| zoom | Zoom; als Handlung vergrößern oder verkleinern |
+| screen size | Bildschirmgröße; bei Pixelmaßen Größe der Ausgabefläche aus dem Kontext bestimmen |
+| resolution | Auflösung |
+| aspect ratio | Seitenverhältnis |
+| orientation | Ausrichtung; bei Bildschirmen beispielsweise Hoch- oder Querformat |
+| portrait / landscape | Hochformat / Querformat |
+| fullscreen | Vollbild; im Vollbildmodus |
+| high DPI | hohe Pixeldichte; exakte Einstellung `High DPI` erhalten |
+| pixel | Pixel; das Pixel, die Pixel |
+| subpixel | Subpixel; Einstellung `Subpixels` erhalten |
+| pixel-perfect | pixelgenau |
+
+## Rendering, Shader und Texturen
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| graphics | Grafik; beispielsweise 2D-Grafik und 3D-Grafik |
+| render / rendering | rendern / Rendering; das Rendering |
+| renderer | Renderer; der Renderer, die Renderer |
+| graphics API / render API | Grafik-API / Render-API |
+| rendering pipeline / render pipeline | Rendering-Pipeline |
+| render target | Renderziel |
+| render predicate | Render-Prädikat; Auswahl über Material-Tags |
+| material tag | Material-Tag; das Tag, die Tags |
+| render pass | Renderdurchlauf |
+| draw call | Zeichenaufruf; erstmals Zeichenaufruf (draw call) |
+| draw order | Zeichenreihenfolge |
+| batching / batch rendering | Bündelung von Zeichenoperationen / gebündeltes Rendern; erstmals Batching ergänzen |
+| vertex | Vertex; der Vertex, die Vertices; in Erklärungen auch Eckpunkt |
+| vertex attribute | Vertex-Attribut |
+| fragment (graphics) | Fragment; Ergebnis der Rasterisierung, das weiterverarbeitet wird; von einem URL-Fragment unterscheiden |
+| shader | Shader; der Shader, die Shader. [Unreal Engine][E1] |
+| vertex shader / fragment shader | Vertex-Shader / Fragment-Shader |
+| compute shader | Compute-Shader |
+| shader program | Shader-Programm |
+| shader constant / uniform | Shader-Konstante / Uniform; genaue API- und GLSL-Bezeichnungen erhalten |
+| sampler | Sampler; der Sampler, die Sampler |
+| texture sampling | Texturabtastung |
+| texel | Texel; das Texel, die Texel; Element einer Textur |
+| UV coordinates / UV mapping | UV-Koordinaten / UV-Abbildung |
+| texture filtering | Texturfilterung |
+| nearest-neighbor filtering | Nächster-Nachbar-Filterung; exakten Wert `nearest` erhalten |
+| linear filtering | lineare Filterung; exakten Wert `linear` erhalten |
+| mipmap | Mipmap; die Mipmap, die Mipmaps |
+| texture compression | Texturkomprimierung |
+| wrap mode | Texturadressierungsmodus; beispielsweise Wiederholen oder Begrenzen; genaue Werte erhalten |
+| blend mode | Mischmodus; genaue Modusnamen erhalten |
+| alpha / alpha channel | Alpha / Alphakanal |
+| premultiplied alpha | vormultipliziertes Alpha |
+| tint | Einfärbung; Eigenschaft `tint` erhalten |
+| depth buffer / depth test | Tiefenpuffer / Tiefentest |
+| stencil buffer / stencil test | Stencil-Puffer / Stencil-Test; erstmals bei Bedarf Maskenpuffer erklären |
+| back buffer | Backbuffer; der Backbuffer; Puffer für das nächste auszugebende Bild |
+| culling / frustum culling | Aussondern von Geometrie / Aussondern von Geometrie außerhalb des Sichtvolumens; erstmals Culling bzw. Frustum Culling ergänzen |
+| clipping | Beschneiden; im Grafikzusammenhang Clipping bei der ersten Nennung ergänzen |
+| texture bleeding / edge bleeding | Übergreifen benachbarter Texturpixel; erstmals den englischen Begriff ergänzen |
+| extrude borders | Randpixel nach außen erweitern; exakte UI-Beschriftung `Extrude Borders` erhalten |
+| sprite sheet | Sprite-Bogen; erstmals Sprite-Bogen (sprite sheet) |
+
+## GUI, Layout und Text
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| user interface / UI | Benutzeroberfläche; Abkürzung UI erhalten |
+| graphical user interface / GUI | grafische Benutzeroberfläche; die GUI; für Defolds System GUI verwenden |
+| HUD | HUD; bei der ersten Nennung bei Bedarf eingeblendete Spielinformationen erklären |
+| node / GUI node | Knoten / GUI-Knoten; der Knoten, die Knoten |
+| node tree | Knotenbaum |
+| box node | Box-Knoten; genaue Typbezeichnung `Box` erhalten |
+| text node | Textknoten |
+| pie node | Kreissektor-Knoten; genaue Typbezeichnung `Pie` erhalten |
+| template node | Vorlagenknoten |
+| particle effect node | Partikeleffektknoten |
+| layer | Ebene; deutscher Grafikbegriff auch bei [GIMP][I1] |
+| layout | Layout; das Layout, die Layouts |
+| adaptive GUI | anpassungsfähige GUI |
+| pivot | Bezugspunkt; erstmals Bezugspunkt (pivot); nicht pauschal als Mittelpunkt übersetzen |
+| anchor | Verankerung; genaue Namen wie `X Anchor` erhalten |
+| adjust mode | Anpassungsmodus; genaue UI-Beschriftung `Adjust Mode` erhalten |
+| slice-9 / 9-slice | Neun-Segment-Skalierung; bei der ersten Nennung 9-slice ergänzen |
+| bounding box | Begrenzungsrechteck in 2D; Begrenzungsquader in 3D |
+| visibility / visible | Sichtbarkeit / sichtbar; von aktiviert unterscheiden. [GIMP][I1] |
+| opacity / transparency | Deckkraft / Transparenz; beide Größen unterscheiden. [GIMP][I1] |
+| glyph | Glyphe |
+| bitmap font | Bitmap-Schrift |
+| distance field font | Distanzfeldschrift; erstmals bei Bedarf distance field font ergänzen |
+| alignment | Ausrichtung; bei Text beispielsweise linksbündig |
+| line break | Zeilenumbruch |
+| leading / tracking | Zeilenabstand / Zeichenabstand |
+
+## Animation, Partikel und Audio
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| animation / animate | Animation / animieren |
+| flipbook animation / flip-book animation | Flipbook-Animation; Animation aus aufeinanderfolgenden Einzelbildern |
+| property animation | Eigenschaftsanimation |
+| model animation | Modellanimation |
+| skeletal animation / bone animation | Skelettanimation |
+| animation clip | Animationsclip |
+| frame | Frame in Spielschleife und Rendering; Einzelbild bei einer Bildfolge |
+| frame rate / FPS | Bildrate; erstmals Bilder pro Sekunde (FPS) |
+| keyframe | Schlüsselbild; erstmals Schlüsselbild (keyframe) |
+| interpolation | Interpolation |
+| easing | Easing; Verlauf der zeitlichen Interpolation; genaue Kurvennamen erhalten |
+| playback / playback rate | Wiedergabe / Wiedergabegeschwindigkeit |
+| loop / looping | Schleife / wiederholte Wiedergabe |
+| ping-pong playback | abwechselnde Vorwärts- und Rückwärtswiedergabe; exakte Wiedergabemodi erhalten |
+| skeleton / bone | Skelett / Knochen |
+| skinning | Skinning; Verformung eines Meshes anhand des Skeletts |
+| rig | Rig; das Rig, die Rigs; Steuerstruktur für die Animation |
+| particle | Partikel; der Partikel, die Partikel |
+| emitter | Emitter; der Emitter, die Emitter; erzeugt Partikel |
+| modifier | Modifikator |
+| spawn rate | Erzeugungsrate; bei Partikeln Partikelerzeugungsrate |
+| sound / audio | Ton / Audio; einen Klang oder die Audioverarbeitung entsprechend dem Kontext benennen |
+| sound effect | Soundeffekt |
+| sound group | Audiogruppe |
+| gain | Verstärkungsfaktor; keinen Dezibelwert aus einem linearen Faktor ableiten |
+| pan | Stereopanorama; räumliche Verteilung zwischen linkem und rechtem Kanal |
+| streaming audio | Audiostreaming; als Handlung Audiodaten streamen |
+
+## Eingabe
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| input | Eingabe |
+| input binding | Eingabebindung; erstmals Eingabebindung (input binding) |
+| input action | Eingabeaktion |
+| input trigger | Eingabeauslöser; von einem physikalischen Trigger unterscheiden |
+| input focus | Eingabefokus |
+| input stack | Eingabestapel |
+| consume input | Eingabe abfangen; ihre Weitergabe im Eingabestapel beenden |
+| pressed / released / repeated | gedrückt / losgelassen / wiederholt; gleichnamige Felder erhalten |
+| gamepad | Gamepad; das Gamepad, die Gamepads |
+| controller | Controller bei einem Eingabegerät; Steuerung bei einer Softwarefunktion; Bezeichner `controller` erhalten |
+| analog stick / dead zone | Analogstick / Totzone |
+| mouse button / mouse wheel | Maustaste / Mausrad |
+| touch / multitouch | Berührungseingabe / Mehrfacheingabe per Berührung |
+| text input | Texteingabe |
+| marked text | markierter Text im Texteingabeverfahren; noch nicht bestätigte Eingabe nach Original erläutern |
+| accelerometer input | Eingabe des Beschleunigungssensors |
+
+## Physik und Kollisionen
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| physics | Physik |
+| physics engine | Physik-Engine |
+| collision | Kollision |
+| collision detection | Kollisionserkennung |
+| collision response | Kollisionsreaktion; Nachricht `collision_response` erhalten |
+| collision shape | Kollisionsform |
+| collision group / collision mask | Kollisionsgruppe / Kollisionsmaske |
+| dynamic object | dynamisches Objekt; im Physikkontext dynamisches Kollisionsobjekt |
+| kinematic object | kinematisches Objekt; im Physikkontext kinematisches Kollisionsobjekt |
+| static object | statisches Objekt; im Physikkontext statisches Kollisionsobjekt |
+| rigid body | starrer Körper |
+| trigger (physics) | Trigger; der Trigger, die Trigger; erkennt Überlappungen entsprechend dem Physiksystem |
+| ray cast / raycast | Strahlabfrage; erstmals Strahlabfrage (raycast); von Raytracing unterscheiden |
+| hit | Treffer |
+| contact point | Kontaktpunkt |
+| normal | Normale; bei Bedarf Normalenvektor |
+| penetration depth / penetration distance | Eindringtiefe |
+| velocity / angular velocity | Geschwindigkeit / Winkelgeschwindigkeit |
+| force / torque / impulse | Kraft / Drehmoment / Impuls |
+| mass / friction / restitution | Masse / Reibung / Rückprallkoeffizient |
+| damping | Dämpfung |
+| joint / constraint | Gelenk / Zwangsbedingung; bei Gelenken den tatsächlichen Typ erhalten |
+| hinge joint / spring joint | Scharniergelenk / Federgelenk; API-Konstanten erhalten |
+| convex hull | konvexe Hülle |
+| box / sphere / capsule | Quader / Kugel / Kapsel; in 2D passende Geometriebezeichnung anhand des Originals wählen |
+
+## Builds, Bundles und Plattformen
+
+Begriffe wie Build, Erstellen und Kompilieren sind auch bei [Visual Studio][M1] belegt. Die Arbeitsschritte und Artefakte richten sich nach Defold.
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| build (process) | Build-Vorgang; als Handlung einen Build erstellen |
+| build (result) | Build; der Build, die Builds |
+| compile / compilation | kompilieren / Kompilierung; kein Synonym für den gesamten Build-Vorgang |
+| compiler | Compiler |
+| rebuild / clean build | neu erstellen / Build nach Bereinigung; genaue Befehle erhalten |
+| build and launch | Build erstellen und starten |
+| build target / target platform | Build-Ziel / Zielplattform |
+| build variant | Build-Variante; exakte Variantenwerte erhalten |
+| debug build / release build | Debug-Build / Release-Build |
+| build error / build report | Build-Fehler / Build-Bericht |
+| build cache | Build-Cache |
+| build server | Build-Server |
+| bundle | Bundle; das Bundle, die Bundles; eigenständiges Plattformpaket von Defold |
+| bundling / to bundle | Bundle-Erstellung / ein Bundle erstellen |
+| package | Paket im allgemeinen Sinn; ein Defold-Bundle gezielt Bundle nennen |
+| standalone | eigenständig; bei einer Anwendung ohne den Editor ausführbar |
+| headless | ohne grafische Oberfläche; erstmals bei Bedarf headless ergänzen; Variantenwerte erhalten |
+| operating system / OS | Betriebssystem; Abkürzung OS bei Bedarf erhalten |
+| device | Gerät |
+| development app | Entwicklungs-App |
+| executable / binary | ausführbare Datei / Binärdatei; den jeweiligen Dateityp beachten |
+| deployment | Bereitstellung |
+| distribution / publishing | Verteilung / Veröffentlichung |
+| stable version / beta version | stabile Version / Betaversion |
+| hot reload | Hot Reload; beim Entwickeln Änderungen in das laufende Spiel laden |
+| Live Update | Live Update; Defold-Funktionsname; von Hot Reload unterscheiden |
+| app manifest / application manifest | Anwendungsmanifest; genaue Dateinamen erhalten |
+| Android App Bundle / AAB | Android App Bundle / AAB; Formatname, kein Synonym für jedes Defold-Bundle |
+| APK | APK; Abkürzung und Erweiterung erhalten |
+| app signing | Signieren der Anwendung |
+| certificate / signing key / keystore | Zertifikat / Signaturschlüssel / Schlüsselspeicher; Namen und Werte erhalten |
+| bundle identifier | Bundle-ID; genaue Bezeichner und Einstellungsnamen erhalten |
+| provisioning profile | Bereitstellungsprofil; erstmals bei Bedarf provisioning profile ergänzen |
+| entitlement | Berechtigung im Signierungs- und Plattformkontext; technische Schlüssel erhalten |
+| SDK | SDK; bei Bedarf Software Development Kit erklären |
+| environment variable | Umgebungsvariable |
+
+## Editorbedienung, Fehlersuche und Leistung
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| UI label | UI-Beschriftung; von der Beschriftungskomponente `Label` unterscheiden |
+| panel / pane | Bereich; benannte UI-Bereiche mit ihrem exakten Namen nennen |
+| view | Ansicht |
+| inspector | Inspektor, wenn ein Werkzeug allgemein erklärt wird; `Properties` nicht umbenennen |
+| menu / context menu | Menü / Kontextmenü |
+| dialog / popup | Dialogfeld / Popup |
+| tab / button / checkbox | Registerkarte / Schaltfläche / Kontrollkästchen |
+| dropdown | Auswahlliste |
+| select / create / add | auswählen / erstellen / hinzufügen |
+| click / right-click / double-click | klicken / mit der rechten Maustaste klicken / doppelklicken |
+| drag / drop / drag and drop | ziehen / ablegen / ziehen und ablegen |
+| press and hold | gedrückt halten |
+| copy and paste | kopieren und einfügen |
+| save / undo / redo | speichern / rückgängig machen / wiederholen; genaue Befehlsnamen erhalten |
+| import / export | importieren / exportieren |
+| keyboard shortcut | Tastenkombination; genaue Tastenfolge erhalten |
+| preferences | Editoreinstellungen, wenn die Einstellungen des Editors gemeint sind |
+| console / console output | Konsole / Konsolenausgabe; Bereichsname `Console` erhalten |
+| log / logging | Protokoll / Protokollierung |
+| log file | Protokolldatei |
+| debugging / debugger | Debugging / Debugger; allgemein auch Fehlersuche. [Visual Studio][M2] |
+| breakpoint / conditional breakpoint | Haltepunkt / bedingter Haltepunkt. [Visual Studio][M2] |
+| call stack | Aufrufstapel |
+| step into / step over / step out | in einen Aufruf einsteigen / Aufruf ohne Einsteigen ausführen / bis zum Rücksprung ausführen; UI-Befehle erhalten |
+| profiling / profiler | Profiling / Profiler; Laufzeit- und Ressourcenverhalten untersuchen |
+| performance / optimization | Leistung / Optimierung |
+| memory usage / memory footprint | Speicherverbrauch / Speicherbedarf |
+| stack / heap | Stack / Heap; jeweiliger Speicherbereich |
+| bottleneck | Engpass |
+| fill rate | Füllrate |
+| crash / crash log | Absturz / Absturzprotokoll |
+| bug / workaround | Fehler / Behelfslösung |
+| minimal reproduction project | minimales Beispielprojekt zum Nachstellen des Fehlers |
+| deprecated / removed / outdated | veraltet und zur Ablösung vorgesehen / entfernt / nicht mehr aktuell; Status anhand des Originals erhalten |
+| code completion / code linting | Codevervollständigung / statische Codeprüfung |
+| refactoring | Refactoring; strukturelle Überarbeitung des Codes |
+
+## Automatisierung und HTTP
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| automation | Automatisierung |
+| deterministic automation | deterministische Automatisierung |
+| automation loop | Automatisierungsschleife |
+| workflow | Arbeitsablauf |
+| inspect / modify / verify / evaluate | untersuchen / ändern / überprüfen / bewerten; einzelne Schritte unterscheiden |
+| command-line tool / CLI | Kommandozeilenwerkzeug / Kommandozeilenschnittstelle; CLI erhalten |
+| command / shell / terminal | Befehl / Shell / Terminal |
+| server / client | Server / Client |
+| editor server | Editorserver |
+| engine service | Engine-Dienst; vom Editorserver unterscheiden |
+| editor HTTP API | HTTP-API des Editors |
+| runtime API | Laufzeit-API; bei Bedarf API der laufenden Engine |
+| source of truth | maßgebliche Quelle |
+| service discovery / port discovery | Diensterkennung / Ermitteln des Ports |
+| port / localhost | Port / localhost; numerische Adressen unverändert lassen |
+| endpoint / route | Endpunkt / Route; konkrete HTTP-Pfade erhalten |
+| request / response | Anfrage / Antwort; bei HTTP HTTP-Anfrage und HTTP-Antwort. [MDN][W1] |
+| request body / response body | Anfrageinhalt / Antwortinhalt; jeweils der Body der HTTP-Nachricht |
+| header / status code | Header / Statuscode; tatsächliche Headernamen erhalten. [MDN][W1] |
+| schema / OpenAPI document | Schema / OpenAPI-Dokument |
+| authentication / authorization | Authentifizierung / Autorisierung; Identitätsnachweis und Zugriffsentscheidung unterscheiden |
+| access token / bearer token | Zugriffstoken / Bearer-Token; das Token, die Tokens |
+| asynchronous operation | asynchroner Vorgang |
+| timeout / retry / polling | Zeitüberschreitung / erneuter Versuch / wiederholtes Abfragen |
+| structured result / structured error | strukturiertes Ergebnis / strukturierte Fehlerinformation |
+| editor transaction | Editortransaktion |
+| lifecycle hook | Lebenszyklus-Hook; genaue Funktionsnamen erhalten |
+| stream | Datenstrom; bei Audio und anderen Fachbegriffen auch Stream gemäß Kontext |
+| screenshot | Bildschirmaufnahme |
+| editor preview / scene preview | Editorvorschau / Szenenvorschau |
+| canvas | Zeichenfläche; HTML-Element `canvas` erhalten |
+| injected input | eingespeiste Eingabe |
+| capability / capability negotiation | unterstützte Funktion / Aushandeln unterstützter Funktionen |
+| version compatibility | Versionskompatibilität |
+
+## Tests und Überprüfung
+
+[Microsoft .NET][M3] verwendet unter anderem Komponententest und Integrationstest. Für die deutsche Defold-Dokumentation wird unit test als Unit-Test wiedergegeben, um den Begriff von Defold-Komponenten abzugrenzen.
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| automated testing | automatisiertes Testen |
+| unit test | Unit-Test; Test einer einzelnen Softwareeinheit |
+| integration test | Integrationstest |
+| end-to-end test / E2E test | Ende-zu-Ende-Test / E2E-Test |
+| regression test / visual regression test | Regressionstest / visueller Regressionstest |
+| browser test / platform test | Browsertest / Plattformtest |
+| test collection | Testsammlung; im Defold-Kontext eine zum Testen verwendete Sammlung |
+| test framework / test runner | Testframework / Testrunner |
+| test suite / test case | Testsuite / Testfall |
+| test fixture | Test-Fixture; definierte Ausgangsumgebung eines Tests |
+| setup / teardown | Testvorbereitung / Testnachbereitung; Funktionsnamen erhalten |
+| assertion | Assertion; Prüfung einer erwarteten Bedingung; `assert` erhalten |
+| mock / stub | Mock / Stub; beide Arten von Testersatzobjekten entsprechend ihrer Rolle unterscheiden |
+| expected result / test result | erwartetes Ergebnis / Testergebnis |
+| pass / failure | bestanden / fehlgeschlagen; technische Statuswerte erhalten |
+| exit code / exit status | Rückgabecode des Prozesses / Beendigungsstatus |
+| code coverage | Codeabdeckung |
+| acceptance criteria | Abnahmekriterien |
+| evidence | Nachweise; beispielsweise Protokolle, Messergebnisse oder Aufnahmen |
+| artifact | Artefakt; etwa ein Build-Ergebnis oder Testbericht |
+| verification / validation | Überprüfung / Validierung; Nachweis einer Vorgabe und Eignungsprüfung nach Kontext unterscheiden |
+| baseline image / difference image | Referenzbild / Differenzbild |
+| image comparison / visual inspection | Bildvergleich / visuelle Prüfung |
+| deterministic / reproducible | deterministisch / reproduzierbar; nicht gleichsetzen |
+| continuous integration / CI | kontinuierliche Integration; Abkürzung CI erhalten |
+| completion event / run ID | Abschlussereignis / Lauf-ID; technische Ereignis- und Feldnamen erhalten |
+
+## KI und Entwicklungswerkzeuge
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| artificial intelligence / AI | künstliche Intelligenz / KI; `AI` in genauen Produktnamen und Literalen erhalten |
+| AI agent / coding agent | KI-Agent / Programmieragent |
+| large language model / LLM | großes Sprachmodell; erstmals großes Sprachmodell (Large Language Model, LLM) |
+| multimodal model | multimodales Modell |
+| model-neutral | modellunabhängig |
+| prompt | Prompt; der Prompt, die Prompts; Eingabe oder Anweisung an ein Modell |
+| token (LLM) | Token; Verarbeitungseinheit des Sprachmodells; von einem Zugriffstoken unterscheiden |
+| skill | Skill bei einem benannten Anweisungsartefakt für einen Agenten; erstmals dessen Funktion erklären |
+| Model Context Protocol / MCP | Model Context Protocol / MCP; offizieller Protokollname erhalten |
+| Automation Bridge | Automation Bridge; offizieller Werkzeugname erhalten |
+| retrieval-augmented generation / RAG | Retrieval-Augmented Generation (RAG); bei der ersten Nennung Generierung mit abgerufenen Zusatzinformationen erklären |
+| adapter / wrapper / integration layer | Adapter / Wrapper / Integrationsschicht; Anpassung und bloße Kapselung unterscheiden |
+| permission / approval | Berechtigung / Zustimmung; technische Zugriffserlaubnis und menschliche Zustimmung unterscheiden |
+| credential / secret | Zugangsdaten / Geheimnis; konkrete Schlüssel, Tokens und Kennwörter nicht umbenennen |
+| sandbox / isolation | Sandbox / Isolation; bei Bedarf abgeschirmte Ausführungsumgebung erklären |
+| untrusted input | nicht vertrauenswürdige Eingabe |
+| worktree / container | Worktree / Container; technische Begriffe erhalten |
+
+## Veröffentlichung, Monetarisierung und FAQ
+
+| English term | Deutsche Form / Verwendung |
+|---|---|
+| monetization | Monetarisierung |
+| advertisement / ad | Werbung; einzelne Einblendung als Werbeanzeige |
+| ad network / ad provider | Werbenetzwerk / Werbeanbieter |
+| banner ad / interstitial ad | Banneranzeige / Interstitial-Anzeige |
+| rewarded ad / incentivized ad | Werbung gegen Belohnung |
+| ad revenue | Werbeeinnahmen |
+| in-app purchase | In-App-Kauf |
+| privacy policy | Datenschutzerklärung |
+| anonymous usage data | anonyme Nutzungsdaten; den tatsächlichen Grad der Anonymisierung nicht verstärken |
+| user tracking | Nutzertracking; bei Bedarf Erfassung des Nutzungsverhaltens erklären |
+| free / royalty-free | kostenlos / lizenzgebührenfrei; Bedingungen des Originals erhalten |
+| open source / source available | Open Source / mit einsehbarem Quellcode; unterschiedliche Lizenzmerkmale |
+| question / answer | Frage / Antwort; in FAQ die Kürzel `Q:` und `A:` erhalten |
+
+## Zeichenfolgen, die unverändert bleiben
+
+Wende die Übersetzungen nicht auf die folgenden Literale an. Beispielsweise kann die Erklärung von einem untergeordneten Spielobjekt sprechen, während der genaue Beispielname weiterhin `child_bean` lautet.
+
+| Kategorie | Beispiele |
+|---|---|
+| Produkte, Sprachen und Werkzeuge | `Defold`, `Lua`, `LuaJIT`, `Bob`, `Spine`, `Rive`, `JavaScript`, `OpenAPI`, `Protobuf`, `Automation Bridge` |
+| Plattformen, Formate und Dienste | `Windows`, `macOS`, `Linux`, `Android`, `iOS`, `HTML5`, `Nintendo Switch`, `Google Play`, `App Store`, `GitHub`, `WebAssembly`, `glTF`, `PNG`, `JSON` |
+| API und Callbacks | `msg.post()`, `go.get_id()`, `factory.create()`, `collectionfactory.create()`, `gui.get_node()`, `init()`, `update()`, `fixed_update()`, `late_update()`, `final()`, `on_message()`, `on_input()` |
+| Nachrichten, Konstanten und Felder | `enable`, `disable`, `set_parent`, `proxy_loaded`, `acquire_input_focus`, `PLAYBACK_LOOP_PINGPONG`, `self`, `message_id`, `socket`, `path`, `fragment` |
+| Dateien, Pfade und Einstellungen | `game.project`, `main.collection`, `.gui_script`, `.internal/editor.port`, `/builtins/render/default.render`, `display.width`, `max_count` |
+| Adressen und Beispielbezeichner | `main:/manager#controller`, `@render`, `@system`, `bean`, `buddy`, `controller`, `team_1` |
+| UI und Menüpfade | `Assets`, `Outline`, `Properties`, `Add Game Object`, `Add Collection File`, `Edit ▸ World Space`, `Help ▸ Open Editor Server` |
+| Befehle, HTTP und Ergebnisdaten | `build`, `clean-build`, `build-html5`, `GET /ping`, `POST /eval`, `/openapi.json`, `200`, `202`, `422`, `success`, `pass`, `duration_ms` |
+
+Für Artikel über eine ausdrücklich deutsche Oberfläche gelten die Regeln zu überprüften offiziellen Beschriftungen in den [Übersetzungsrichtlinien](translation-guidelines.txt). Übersetzte Erklärbegriffe sind keine UI-Nachweise.
+
+## Offizielle deutschsprachige Quellen
+
+Geprüft am 2026-09-12. Verwendet wurden deutsche Textstellen; englische Resttexte und produktspezifische Bedienabläufe begründen keine deutschen Defold-Regeln. Versionsangaben kennzeichnen die untersuchten Fassungen.
+
+- [G1: Godot 4.5 — Nodes und Szenen][G1]. Sprachgebrauch für Engine, Editor, Instanz, Node und Property.
+- [G2: Godot 4.5 — Viewport- und Canvas-Transformationen][G2]. Transformationen und Koordinatensysteme.
+- [E1: Unreal Engine — Materialien][E1]. Material, Shader und Textur.
+- [E2: Unreal Engine — Blueprint-Grundlagen][E2]. Komponente, Eigenschaft, Knoten, Asset und Mesh; Defold-Prototypen behalten ihre eigene Bedeutung.
+- [I1: GIMP 3.0 — Bilder kombinieren][I1]. Ebene, Deckkraft, Transparenz und Sichtbarkeit.
+- [M1: Visual Studio — Kompilieren und Erstellen][M1]. Build, Kompilieren und Erstellen.
+- [M2: Visual Studio — Übersicht über den Debugger][M2]. Haltepunkte und Debugging.
+- [M3: .NET — Testen in .NET][M3]. Testarten; Abweichung zu `Unit-Test` oben erläutert.
+- [W1: MDN — Überblick über HTTP][W1]. HTTP-Anfragen, Antworten, Header und Statuscodes.
+
+[G1]: https://docs.godotengine.org/de/4.5/getting_started/step_by_step/nodes_and_scenes.html
+[G2]: https://docs.godotengine.org/de/4.5/tutorials/2d/2d_transforms.html
+[E1]: https://dev.epicgames.com/documentation/de-de/unreal-engine/unreal-engine-materials
+[E2]: https://dev.epicgames.com/documentation/de-de/unreal-engine/blueprint-foundations
+[I1]: https://docs.gimp.org/3.0/de/gimp-image-combining.html
+[M1]: https://learn.microsoft.com/de-de/visualstudio/ide/compiling-and-building-in-visual-studio?view=visualstudio
+[M2]: https://learn.microsoft.com/de-de/visualstudio/debugger/debugger-feature-tour?view=visualstudio
+[M3]: https://learn.microsoft.com/de-de/dotnet/core/testing/
+[W1]: https://developer.mozilla.org/de/docs/Web/HTTP/Guides/Overview

--- a/docs/de/manuals/2dgraphics.md
+++ b/docs/de/manuals/2dgraphics.md
@@ -1,0 +1,8 @@
+---
+title: Defold-Handbuch zur 2D-Grafik
+brief: Dieses Handbuch ist nicht mehr aktuell
+---
+
+# 2D-Grafik {#2d-graphics}
+
+Dieses Handbuch wurde durch das [Handbuch zur Grafikübersicht](/manuals/graphics) ersetzt.

--- a/docs/de/manuals/3dgraphics.md
+++ b/docs/de/manuals/3dgraphics.md
@@ -1,0 +1,8 @@
+---
+title: Defold-Handbuch zu 3D-Grafik
+brief: Dieses Handbuch ist nicht mehr aktuell
+---
+
+# 3D-Grafik {#3d-graphics}
+
+Dieses Handbuch wurde durch das [Handbuch zur Grafikübersicht](/manuals/graphics) ersetzt.

--- a/docs/de/manuals/adapting-graphics-to-screen-size.md
+++ b/docs/de/manuals/adapting-graphics-to-screen-size.md
@@ -1,0 +1,126 @@
+---
+title: Grafiken an unterschiedliche Bildschirmgrößen anpassen
+brief: Dieses Handbuch erklärt, wie du dein Spiel und deine Grafiken an unterschiedliche Bildschirmgrößen anpasst.
+---
+
+# Einführung {#introduction}
+
+Wenn du dein Spiel und deine Grafiken an unterschiedliche Bildschirmgrößen anpasst, gibt es einiges zu beachten:
+
+* Ist es ein Retrospiel mit niedrig aufgelöster, pixelgenauer Grafik oder ein modernes Spiel mit Grafik in HD-Qualität?
+* Wie soll sich das Spiel im Vollbildmodus auf unterschiedlich großen Bildschirmen verhalten?
+  * Soll der Spieler auf einem hochauflösenden Bildschirm mehr vom Spielinhalt sehen, oder soll sich der Zoom der Grafik so anpassen, dass immer derselbe Inhalt angezeigt wird?
+* Wie soll das Spiel mit Seitenverhältnissen umgehen, die von dem in *game.project* festgelegten Seitenverhältnis abweichen?
+  * Soll der Spieler mehr vom Spielinhalt sehen? Oder soll es vielleicht schwarze Balken geben? Oder GUI-Elemente, deren Größe angepasst wird?
+* Welche Menüs und GUI-Komponenten (GUI components) benötigst du auf dem Bildschirm, und wie sollen sie sich an unterschiedliche Bildschirmgrößen und Bildschirmausrichtungen anpassen?
+  * Sollen Menüs und andere GUI-Komponenten bei einem Wechsel der Ausrichtung ihr Layout ändern oder unabhängig von der Ausrichtung dasselbe Layout behalten?
+
+Dieses Handbuch behandelt einige dieser Fragen und schlägt bewährte Vorgehensweisen vor.
+
+
+## Ändern, wie deine Inhalte gerendert werden {#how-to-change-how-your-content-is-rendered}
+
+Das Render-Skript (render script) von Defold gibt dir die vollständige Kontrolle über die gesamte Rendering-Pipeline. Das Render-Skript legt die Reihenfolge fest und entscheidet, was und wie gezeichnet wird. Standardmäßig zeichnet das Render-Skript immer denselben Pixelbereich, der durch die Breite und Höhe in der Datei *game.project* definiert ist. Das gilt unabhängig davon, ob die Fenstergröße geändert wird oder die tatsächliche Bildschirmauflösung davon abweicht. Dadurch wird der Inhalt bei einer Änderung des Seitenverhältnisses gestreckt und bei einer Änderung der Fenstergröße vergrößert oder verkleinert. Für manche Spiele ist das möglicherweise akzeptabel. Wahrscheinlicher ist jedoch, dass du bei einer anderen Bildschirmauflösung oder einem anderen Seitenverhältnis mehr oder weniger Spielinhalt anzeigen möchtest oder zumindest sicherstellen willst, dass der Inhalt vergrößert oder verkleinert wird, ohne sein Seitenverhältnis zu ändern. Das standardmäßige Strecken lässt sich leicht ändern. Wie das geht, erfährst du im [Rendering-Handbuch](https://www.defold.com/manuals/render/#default-view-projection).
+
+
+## Retro-/8-Bit-Grafik {#retro8-bit-graphics}
+
+Retro-/8-Bit-Grafik bezeichnet häufig Spiele, die den Grafikstil alter Spielkonsolen oder Computer mit ihrer niedrigen Auflösung und begrenzten Farbpalette nachahmen. Beispielsweise hatte das Nintendo Entertainment System (NES) eine Bildschirmauflösung von 256 × 240, der Commodore 64 von 320 × 200 und der Gameboy von 160 × 144. All diese Auflösungen entsprechen nur einem Bruchteil der Größe moderner Bildschirme. Damit Spiele, die diesen Grafikstil und diese Bildschirmauflösungen nachahmen, auf einem modernen hochauflösenden Bildschirm spielbar sind, muss die Grafik um ein Mehrfaches hochskaliert oder vergrößert werden. Eine einfache Möglichkeit besteht darin, alle Grafiken in der niedrigen Auflösung und dem Stil zu zeichnen, die du nachahmen möchtest, und sie beim Rendern zu vergrößern. In Defold lässt sich das leicht mit dem Render-Skript und der [festen Projektion](/manuals/render/#fixed-projection) erreichen, die auf einen geeigneten Zoomwert eingestellt wird.
+
+Verwenden wir diesen Kachelsatz (tileset) und diese Spielfigur ([Quelle](https://ansimuz.itch.io/grotto-escape-game-art-pack)) für ein 8-Bit-Retrospiel mit einer Auflösung von 320 × 200:
+
+![](images/screen_size/retro-player.png)
+
+![](images/screen_size/retro-tiles.png)
+
+Wenn du in der Datei *game.project* 320 × 200 einstellst und das Spiel startest, sieht es so aus:
+
+![](images/screen_size/retro-original_320x200.png)
+
+Auf einem modernen hochauflösenden Bildschirm ist das Fenster winzig! Wenn du die Fenstergröße auf das Vierfache, also 1280 × 800, erhöhst, passt es besser zu einem modernen Bildschirm:
+
+![](images/screen_size/retro-original_1280x800.png)
+
+Jetzt hat das Fenster eine vernünftigere Größe, aber auch an der Grafik müssen wir etwas ändern. Sie ist so klein, dass man kaum erkennen kann, was im Spiel passiert. Mit dem Render-Skript können wir eine feste, vergrößerte Projektion einstellen:
+
+```Lua
+msg.post("@render:", "use_fixed_projection", { zoom = 4 })
+```
+
+::: sidenote
+Du kannst dasselbe Ergebnis erzielen, indem du einem Spielobjekt (game object) eine [Kamerakomponente (camera component)](/manuals/camera/) hinzufügst, *Orthographic Projection* aktivierst und *Orthographic Zoom* auf 4.0 setzt:
+
+![](images/screen_size/retro-camera_zoom.png)
+:::
+
+Das führt zu folgendem Ergebnis:
+
+![](images/screen_size/retro-zoomed_1280x800.png)
+
+Das ist besser. Sowohl das Fenster als auch die Grafik haben eine gute Größe. Bei genauerem Hinsehen gibt es jedoch ein offensichtliches Problem:
+
+![](images/screen_size/retro-zoomed_linear.png)
+
+Die Grafik sieht unscharf aus! Das liegt daran, wie die vergrößerte Grafik beim Rendern durch die GPU aus der Textur abgetastet wird. Die Standardeinstellung in der Datei *game.project* im Abschnitt *Graphics* ist *linear*:
+
+![](images/screen_size/retro-settings_linear.png)
+
+Wenn du sie auf *nearest* änderst, erhalten wir das gewünschte Ergebnis:
+
+![](images/screen_size/retro-settings_nearest.png)
+
+![](images/screen_size/retro-zoomed_nearest.png)
+
+Jetzt haben wir scharfe, *pixelgenaue* Grafik für unser Retrospiel. Es gibt noch weitere Dinge zu beachten, etwa das Deaktivieren von Subpixeln für Sprites in *game.project*:
+
+![](images/screen_size/retro-subpixels.png)
+
+Wenn die Option *Subpixels* deaktiviert ist, werden Sprites nie auf halben Pixeln gerendert, sondern rasten immer am nächsten ganzen Pixel ein.
+
+## Hochauflösende Grafik {#high-resolution-graphics}
+
+Bei hochauflösender Grafik müssen wir Projekt und Inhalte anders einrichten als bei Retro-/8-Bit-Grafik. Bei Bitmap-Grafik musst du deine Inhalte so erstellen, dass sie auf einem hochauflösenden Bildschirm im Maßstab 1:1 gut aussehen.
+
+Wie bei Retro-/8-Bit-Grafik musst du das Render-Skript ändern. In diesem Fall soll die Grafik mit der Bildschirmgröße skaliert werden, während das ursprüngliche Seitenverhältnis erhalten bleibt:
+
+```Lua
+msg.post("@render:", "use_fixed_fit_projection")
+```
+
+Dadurch wird die Darstellung auf dem Bildschirm so angepasst, dass immer der in der Datei *game.project* festgelegte Inhaltsumfang angezeigt wird. Je nachdem, ob das Seitenverhältnis abweicht, können darüber und darunter oder an den Seiten zusätzliche Inhalte angezeigt werden.
+
+Du solltest die Breite und Höhe in der Datei *game.project* so einstellen, dass du deine Spielinhalte unskaliert anzeigen kannst.
+
+### Einstellung für hohe Pixeldichte und Retina-Bildschirme {#high-dpi-setting-and-retina-screens}
+
+Wenn du auch hochauflösende Retina-Bildschirme unterstützen möchtest, kannst du dies in der Datei *game.project* im Abschnitt Display aktivieren:
+
+![](images/screen_size/highdpi-enabled.png)
+
+Dadurch wird auf Bildschirmen, die dies unterstützen, ein Backbuffer mit hoher Pixeldichte erstellt. Das Spiel rendert mit der doppelten Auflösung der Werte in den Einstellungen Width und Height. Diese Werte bleiben weiterhin die logische Auflösung, die in Skripten und Eigenschaften verwendet wird. Das bedeutet, dass alle Maße gleich bleiben und Inhalte, die mit dem Skalierungsfaktor 1x gerendert werden, gleich aussehen. Wenn du jedoch hochauflösende Bilder importierst und sie auf 0,5x skalierst, werden sie auf dem Bildschirm mit hoher Pixeldichte angezeigt.
+
+
+## Eine anpassungsfähige GUI erstellen {#creating-an-adaptive-gui}
+
+Das System zum Erstellen von GUI-Komponenten basiert auf einer Reihe grundlegender Bausteine, den [Knoten (nodes)](/manuals/gui/#node-types). Auch wenn es übermäßig einfach erscheinen mag, kannst du damit alles von Schaltflächen bis hin zu komplexen Menüs und Popups erstellen. Die von dir erstellten GUIs lassen sich so konfigurieren, dass sie sich automatisch an Änderungen der Bildschirmgröße und -ausrichtung anpassen. Beispielsweise kannst du *Knoten* am oberen, unteren oder an den seitlichen Bildschirmrändern verankern. Knoten können dabei entweder ihre Größe beibehalten oder gestreckt werden. Auch die Beziehungen zwischen *Knoten* sowie ihre Größe und ihr Aussehen lassen sich so konfigurieren, dass sie sich bei einer Änderung der Bildschirmgröße oder -ausrichtung ändern.
+
+### Eigenschaften von *Knoten* {#node-properties}
+
+Jeder *Knoten* in einer GUI hat einen Bezugspunkt (pivot), eine horizontale und vertikale Verankerung sowie einen Anpassungsmodus.
+
+* Der Bezugspunkt definiert den Mittelpunkt eines Knotens.
+* Der Verankerungsmodus steuert, wie sich die vertikale und horizontale Position des Knotens ändert, wenn die Grenzen der Szene oder des übergeordneten Knotens gestreckt werden, um sie an die physische Bildschirmgröße anzupassen.
+* Der Anpassungsmodus steuert, was mit einem Knoten geschieht, wenn die Grenzen der Szene oder des übergeordneten Knotens an die physische Bildschirmgröße angepasst werden.
+
+Mehr über diese Eigenschaften erfährst du [im GUI-Handbuch](/manuals/gui/#node-properties).
+
+### Layouts
+
+Defold unterstützt GUIs, die sich auf Mobilgeräten automatisch an Änderungen der Bildschirmausrichtung anpassen. Mit dieser Funktion kannst du eine GUI gestalten, die sich an die Ausrichtung und das Seitenverhältnis verschiedener Bildschirmgrößen anpasst. Du kannst auch Layouts erstellen, die auf bestimmte Gerätemodelle abgestimmt sind. Mehr über dieses System erfährst du im [Handbuch zu GUI-Layouts](/manuals/gui-layouts/)
+
+
+## Unterschiedliche Bildschirmgrößen testen {#testing-different-screen-sizes}
+
+Das Menü *Debug* enthält eine Option, mit der du die Auflösung eines bestimmten Gerätemodells oder eine benutzerdefinierte Auflösung simulieren kannst. Während die Anwendung läuft, kannst du <kbd>Debug->Simulate Resolution</kbd> wählen und eines der Gerätemodelle aus der Liste auswählen. Die Größe des Fensters der laufenden Anwendung wird angepasst, und du kannst sehen, wie dein Spiel bei einer anderen Auflösung oder einem anderen Seitenverhältnis aussieht.
+
+![](images/screen_size/simulate-resolution.png)

--- a/docs/de/manuals/addressing.md
+++ b/docs/de/manuals/addressing.md
@@ -1,0 +1,246 @@
+---
+title: Adressierung in Defold
+brief: Dieses Handbuch erklärt, wie Defold das Problem der Adressierung gelöst hat.
+---
+
+# Adressierung {#addressing}
+
+Code, der ein laufendes Spiel steuert, muss jedes Spielobjekt (game object) und jede Komponente (component) erreichen können, um das, was Spieler sehen und hören, zu bewegen, zu skalieren, zu animieren, zu löschen und zu verändern. Der Adressierungsmechanismus von Defold macht dies möglich.
+
+## Bezeichner {#identifiers}
+
+Defold verwendet Adressen (oder URLs, aber das lassen wir vorerst außer Acht), um auf Spielobjekte und Komponenten zu verweisen. Diese Adressen bestehen aus Bezeichnern. Im Folgenden siehst du einige Beispiele dafür, wie Defold Adressen verwendet. In diesem Handbuch untersuchen wir im Detail, wie sie funktionieren:
+
+```lua
+local id = factory.create("#enemy_factory")
+go.set("my_gameobject#my_label", "text", "Hello World!")
+
+local pos = go.get_position("my_gameobject")
+go.set_position(pos, "/level/stuff/other_gameobject")
+
+msg.post("#", "hello_there")
+local id = go.get_id(".")
+```
+
+Beginnen wir mit einem sehr einfachen Beispiel. Angenommen, du hast ein Spielobjekt mit einer einzelnen Sprite-Komponente. Außerdem hast du eine Skriptkomponente, um das Spielobjekt zu steuern. Der Aufbau im Editor würde ungefähr so aussehen:
+
+![bean im Editor](images/addressing/bean_editor.png)
+
+Nun möchtest du das Sprite beim Spielstart deaktivieren, damit du es später erscheinen lassen kannst. Das geht ganz einfach, indem du den folgenden Code in "controller.script" einfügst:
+
+```lua
+function init(self)
+    msg.post("#body", "disable") -- <1>
+end
+```
+1. Mach dir keine Sorgen, wenn dich das Zeichen '#' verwirrt. Darauf kommen wir gleich zurück.
+
+Das funktioniert wie erwartet. Beim Spielstart *adressiert* die Skriptkomponente die Sprite-Komponente über ihren Bezeichner "body" und verwendet diese Adresse, um ihr eine *Nachricht* namens "disable" zu senden. Diese spezielle Engine-Nachricht bewirkt, dass die Sprite-Komponente die Sprite-Grafik ausblendet. Schematisch sieht der Aufbau so aus:
+
+![bean](images/addressing/bean.png)
+
+Die Bezeichner im Aufbau legst du bei der Entwicklung fest. Sie müssen innerhalb ihres Namenskontexts eindeutig sein. Hier haben wir dem Spielobjekt den Bezeichner "bean" gegeben, seine Sprite-Komponente "body" genannt und die Skriptkomponente, die die Figur steuert, "controller" genannt. Bezeichner, die in URL-Adressen als Zeichenfolgen verwendet werden, sollten weder `:` noch `#` enthalten, da die URL-Syntax `:` als Socket-Trennzeichen und `#` als Trennzeichen zwischen Spielobjekt und Komponente reserviert. Andere Satzzeichen weist der URL-Parser nicht zurück.
+
+::: sidenote
+Wenn du keinen Namen wählst, übernimmt das der Editor. Jedes Mal, wenn du im Editor ein neues Spielobjekt oder eine neue Komponente erstellst, wird der Eigenschaft *Id* automatisch ein eindeutiger Wert zugewiesen.
+
+- Spielobjekte erhalten automatisch einen Bezeichner "go" mit fortlaufender Nummer ("go2", "go3" usw.).
+- Komponenten erhalten einen Bezeichner, der ihrem Komponententyp entspricht ("sprite", "sprite2" usw.).
+
+Du kannst diese automatisch zugewiesenen Namen beibehalten, wenn du möchtest. Wir empfehlen dir jedoch, die Bezeichner in gute, aussagekräftige Namen zu ändern.
+:::
+
+Fügen wir nun eine weitere Sprite-Komponente hinzu und geben bean einen Schild:
+
+![bean](images/addressing/bean_shield_editor.png)
+
+Die neue Komponente muss innerhalb des Spielobjekts eindeutig bezeichnet sein. Wenn du ihr den Namen "body" geben würdest, wäre für den Skriptcode nicht eindeutig, an welches Sprite er die Nachricht "disable" senden soll. Deshalb wählen wir den eindeutigen (und aussagekräftigen) Bezeichner "shield". Jetzt können wir die Sprites "body" und "shield" nach Belieben aktivieren und deaktivieren.
+
+![bean](images/addressing/bean_shield.png)
+
+::: sidenote
+Wenn du versuchst, einen Bezeichner mehr als einmal zu verwenden, meldet der Editor einen Fehler. In der Praxis stellt dies daher kein Problem dar:
+
+![bean](images/addressing/name_collision.png)
+:::
+
+Sehen wir uns nun an, was passiert, wenn du weitere Spielobjekte hinzufügst. Angenommen, du möchtest zwei „Bohnen“ zu einem kleinen Team zusammenstellen. Du beschließt, eines der Bohnen-Spielobjekte "bean" und das andere "buddy" zu nennen. Außerdem soll "bean", nachdem es eine Weile untätig war, "buddy" mitteilen, dass es anfangen soll zu tanzen. Dazu wird eine benutzerdefinierte Nachricht namens "dance" von der Skriptkomponente "controller" in "bean" an das Skript "controller" in "buddy" gesendet:
+
+![bean](images/addressing/bean_buddy.png)
+
+::: sidenote
+Es gibt zwei getrennte Komponenten namens "controller", eine in jedem Spielobjekt. Das ist völlig zulässig, da jedes Spielobjekt einen neuen Namenskontext schafft.
+:::
+
+Da sich der Empfänger der Nachricht außerhalb des sendenden Spielobjekts ("bean") befindet, muss der Code angeben, welcher "controller" die Nachricht empfangen soll. Er muss sowohl den Bezeichner des Zielspielobjekts als auch den Bezeichner der Komponente angeben. Die vollständige Adresse der Komponente lautet `"buddy#controller"` und besteht aus zwei getrennten Teilen.
+
+- Zuerst kommt der Bezeichner des Zielspielobjekts ("buddy"),
+- dann folgt das Trennzeichen zwischen Spielobjekt und Komponente ("#"),
+- und schließlich schreibst du den Bezeichner der Zielkomponente ("controller").
+
+Wenn wir zum vorherigen Beispiel mit einem einzelnen Spielobjekt zurückkehren, sehen wir: Lässt der Code den Spielobjektbezeichner in der Zieladresse weg, kann er Komponenten im *aktuellen Spielobjekt* adressieren.
+
+Zum Beispiel bezeichnet `"#body"` die Adresse der Komponente "body" im aktuellen Spielobjekt. Das ist sehr nützlich, weil dieser Code in *jedem* Spielobjekt funktioniert, solange eine Komponente "body" vorhanden ist.
+
+## Sammlungen {#collections}
+
+Sammlungen (collections) ermöglichen es, Gruppen oder Hierarchien von Spielobjekten zu erstellen und kontrolliert wiederzuverwenden. Du verwendest Sammlungsdateien als Vorlagen (oder „Prototypen“ oder „Prefabs“) im Editor, wenn du dein Spiel mit Inhalten füllst.
+
+Angenommen, du möchtest eine große Anzahl von bean/buddy-Teams erstellen. Eine gute Möglichkeit dafür ist, eine Vorlage in einer neuen *Sammlungsdatei* zu erstellen (nenne sie "team.collection"). Erstelle die Spielobjekte des Teams in der Sammlungsdatei und speichere sie. Füge dann eine Instanz des Inhalts dieser Sammlungsdatei in deine primäre Startsammlung (bootstrap collection) ein und gib der Instanz einen Bezeichner (nenne sie "team_1"):
+
+![bean](images/addressing/team_editor.png)
+
+Mit dieser Struktur kann das Spielobjekt "bean" weiterhin über die Adresse `"buddy#controller"` auf die Komponente "controller" in "buddy" verweisen.
+
+![bean](images/addressing/collection_team.png)
+
+Wenn du eine zweite Instanz von "team.collection" hinzufügst (nenne sie "team_2"), funktioniert der Code in den Skriptkomponenten von "team_2" genauso gut. Die Spielobjektinstanz "bean" aus der Sammlung "team_2" kann die Komponente "controller" in "buddy" weiterhin über die Adresse `"buddy#controller"` adressieren.
+
+![bean](images/addressing/teams_editor.png)
+
+## Relative Adressierung {#relative-addressing}
+
+Die Adresse `"buddy#controller"` funktioniert für die Spielobjekte in beiden Sammlungen, weil es sich um eine *relative* Adresse handelt. Jede der Sammlungen "team_1" und "team_2" schafft einen neuen Namenskontext, oder, wenn du so willst, einen „Namensraum“. Defold vermeidet Namenskonflikte, indem es bei der Adressierung den Namenskontext berücksichtigt, den eine Sammlung schafft:
+
+![Relativer Bezeichner](images/addressing/relative_same.png)
+
+- Innerhalb des Namenskontexts "team_1" sind die Spielobjekte "bean" und "buddy" eindeutig bezeichnet.
+- Ebenso sind innerhalb des Namenskontexts "team_2" die Spielobjekte "bean" und "buddy" eindeutig bezeichnet.
+
+Die relative Adressierung funktioniert, indem beim Auflösen einer Zieladresse automatisch der aktuelle Namenskontext vorangestellt wird. Auch das ist äußerst nützlich und leistungsfähig, weil du Gruppen von Spielobjekten mit Code erstellen und sie im gesamten Spiel effizient wiederverwenden kannst.
+
+### Kurzformen {#shorthands}
+
+Defold bietet zwei praktische Kurzformen, mit denen du Nachrichten senden kannst, ohne eine vollständige URL anzugeben:
+
+:[Shorthands](../shared/url-shorthands.md)
+
+## Spielobjektpfade {#game-object-paths}
+
+Um den Mechanismus der Namensvergabe richtig zu verstehen, sehen wir uns an, was passiert, wenn du das Projekt erstellst und ausführst:
+
+1. Der Editor liest die Startsammlung ("main.collection") und ihren gesamten Inhalt (Spielobjekte und andere Sammlungen).
+2. Für jedes statische Spielobjekt erstellt der Compiler einen Bezeichner. Diese Bezeichner werden als „Pfade“ aufgebaut, die an der Wurzel der Startsammlung beginnen und entlang der Sammlungshierarchie bis zum Objekt führen. Auf jeder Ebene wird ein Zeichen '/' hinzugefügt.
+
+In unserem obigen Beispiel läuft das Spiel mit den folgenden 4 Spielobjekten:
+
+- /team_1/bean
+- /team_1/buddy
+- /team_2/bean
+- /team_2/buddy
+
+::: sidenote
+Bezeichner werden als Hashwerte gespeichert. Die Laufzeitumgebung speichert außerdem den Hashzustand für jeden Sammlungsbezeichner. Dieser wird verwendet, um den Hashvorgang mit einer relativen Zeichenfolge fortzusetzen und so einen absoluten Bezeichner zu erhalten.
+:::
+
+Zur Laufzeit existiert die Gruppierung in Sammlungen nicht. Es gibt keine Möglichkeit herauszufinden, zu welcher Sammlung ein bestimmtes Spielobjekt vor der Kompilierung gehörte. Ebenso wenig ist es möglich, alle Objekte einer Sammlung auf einmal zu verändern. Wenn du solche Operationen benötigst, kannst du die Zuordnung leicht selbst im Code verwalten. Der Bezeichner jedes Objekts ist statisch und bleibt garantiert während der gesamten Lebensdauer des Objekts unverändert. Das bedeutet, dass du den Bezeichner eines Objekts bedenkenlos speichern und später verwenden kannst.
+
+## Absolute Adressierung {#absolute-addressing}
+
+Bei der Adressierung kannst du die oben beschriebenen vollständigen Bezeichner verwenden. In den meisten Fällen wird die relative Adressierung bevorzugt, da sie die Wiederverwendung von Inhalten ermöglicht. Es gibt jedoch Fälle, in denen die absolute Adressierung notwendig wird.
+
+Angenommen, du möchtest einen Manager für künstliche Intelligenz (KI), der den Zustand jedes Bohnenobjekts verfolgt. Die Bohnen sollen dem Manager ihren aktiven Status melden, und der Manager soll anhand ihres Status taktische Entscheidungen treffen und ihnen Befehle geben. In diesem Fall wäre es sinnvoll, ein einzelnes Manager-Spielobjekt mit einer Skriptkomponente zu erstellen und es neben den Team-Sammlungen in der Startsammlung zu platzieren.
+
+![Manager-Objekt](images/addressing/manager_editor.png)
+
+Jede Bohne ist dann dafür verantwortlich, Statusnachrichten an den Manager zu senden: "contact", wenn sie einen Feind entdeckt, oder "ouch!", wenn sie getroffen wird und Schaden nimmt. Damit das funktioniert, verwendet das Controller-Skript der Bohne die absolute Adressierung, um Nachrichten an die Komponente "controller" in "manager" zu senden.
+
+Jede Adresse, die mit '/' beginnt, wird von der Wurzel der Spielwelt aus aufgelöst. Diese entspricht der Wurzel der *Startsammlung*, die beim Spielstart geladen wird.
+
+Die absolute Adresse des Manager-Skripts lautet `"/manager#controller"`. Diese absolute Adresse wird zur richtigen Komponente aufgelöst, unabhängig davon, wo sie verwendet wird.
+
+![Teams und Manager](images/addressing/teams_manager.png)
+
+![Absolute Adressierung](images/addressing/absolute.png)
+
+## Gehashte Bezeichner {#hashed-identifiers}
+
+Die Engine speichert alle Bezeichner als Hashwerte. Alle Funktionen, die eine Komponente oder ein Spielobjekt als Argument entgegennehmen, akzeptieren eine Zeichenfolge, einen Hashwert oder ein URL-Objekt. Oben haben wir gesehen, wie Zeichenfolgen zur Adressierung verwendet werden.
+
+Wenn du den Bezeichner eines Spielobjekts abfragst, gibt die Engine immer einen gehashten Bezeichner mit absolutem Pfad zurück:
+
+```lua
+local my_id = go.get_id()
+print(my_id) --> hash: [/path/to/the/object]
+
+local spawned_id = factory.create("#some_factory")
+print(spawned_id) --> hash: [/instance42]
+```
+
+Du kannst einen solchen Bezeichner anstelle eines Bezeichners als Zeichenfolge verwenden oder selbst einen erstellen. Beachte jedoch, dass ein gehashter Bezeichner dem Pfad des Objekts entspricht, also einer absoluten Adresse:
+
+::: sidenote
+Relative Adressen müssen als Zeichenfolgen angegeben werden, weil die Engine einen neuen Hash-Bezeichner auf Grundlage des Hashzustands des aktuellen Namenskontexts (der Sammlung) berechnet. Dabei wird die angegebene Zeichenfolge zum Hash hinzugefügt.
+:::
+
+```lua
+local spawned_id = factory.create("#some_factory")
+local pos = vmath.vector3(100, 100, 0)
+go.set_position(pos, spawned_id)
+
+local other_id = hash("/path/to/the/object")
+go.set_position(pos, other_id)
+
+-- This will not work! Relative addresses must be given as strings.
+local relative_id = hash("my_object")
+go.set_position(pos, relative_id)
+```
+
+## URLs
+
+Um das Bild zu vervollständigen, sehen wir uns das vollständige Format von Defold-Adressen an: die URL.
+
+Eine URL ist ein Objekt, das üblicherweise als speziell formatierte Zeichenfolge geschrieben wird. Eine allgemeine URL besteht aus drei Teilen:
+
+`[socket:][path][#fragment]`
+
+socket
+: Bezeichnet die Spielwelt des Ziels. Das ist bei der Arbeit mit [Sammlungs-Proxys (collection proxies)](/manuals/collection-proxy) wichtig. Der Socket wird dann verwendet, um die _dynamisch geladene Sammlung_ zu bezeichnen.
+
+path
+: Dieser Teil der URL enthält den vollständigen Bezeichner des Zielspielobjekts.
+
+fragment
+: Der Bezeichner der Zielkomponente innerhalb des angegebenen Spielobjekts.
+
+Wie wir oben gesehen haben, kannst du in den meisten Fällen einige oder den Großteil dieser Angaben weglassen. Du musst fast nie den Socket angeben. Den Pfad musst du häufig, aber nicht immer angeben. Wenn du Dinge in einer anderen Spielwelt adressieren musst, musst du den Socket-Teil der URL angeben. Die vollständige URL-Zeichenfolge für das Skript "controller" im Spielobjekt "manager" aus dem obigen Beispiel lautet zum Beispiel:
+
+`"main:/manager#controller"`
+
+und für den Controller von buddy in team_2 lautet sie:
+
+`"main:/team_2/buddy#controller"`
+
+Wir können Nachrichten an sie senden:
+
+```lua
+-- Send "hello" to the manager script and team buddy bean
+msg.post("main:/manager#controller", "hello_manager")
+msg.post("main:/team_2/buddy#controller", "hello_buddy")
+```
+
+## URL-Objekte erstellen {#constructing-url-objects}
+
+URL-Objekte lassen sich auch programmgesteuert in Lua-Code erstellen:
+
+```lua
+-- Construct URL object from a string:
+local my_url = msg.url("main:/manager#controller")
+print(my_url) --> url: [main:/manager#controller]
+print(my_url.socket) --> 786443 (internal numeric value)
+print(my_url.path) --> hash: [/manager]
+print(my_url.fragment) --> hash: [controller]
+
+-- Construct URL from parameters:
+local my_url = msg.url("main", "/manager", "controller")
+print(my_url) --> url: [main:/manager#controller]
+
+-- Build from empty URL object:
+local my_url = msg.url()
+my_url.socket = "main" -- specify by valid name
+my_url.path = hash("/manager") -- specify as string or hash
+my_url.fragment = "controller" -- specify as string or hash
+
+-- Post to target specified by URL
+msg.post(my_url, "hello_manager!")
+```

--- a/docs/de/manuals/ads.md
+++ b/docs/de/manuals/ads.md
@@ -1,0 +1,62 @@
+---
+title: Werbung in Defold anzeigen
+brief: Verschiedene Arten von Werbung anzuzeigen, ist eine gängige Möglichkeit, Web- und Mobilspiele zu monetarisieren. Dieses Handbuch zeigt mehrere Möglichkeiten, dein Spiel mit Werbung zu monetarisieren.
+---
+
+# Werbung {#ads}
+
+Werbung ist zu einer sehr verbreiteten Möglichkeit geworden, Web- und Mobilspiele zu monetarisieren, und hat sich zu einer Milliarden-Dollar-Branche entwickelt. Als Entwickler wirst du danach bezahlt, wie viele Menschen die Werbung ansehen, die du in deinem Spiel zeigst. Meist gilt ganz einfach: Je mehr Zuschauer, desto mehr Geld. Aber auch andere Faktoren beeinflussen, wie viel du erhältst:
+
+* Die Qualität der Werbung - relevante Werbeanzeigen erhalten eher Aufmerksamkeit von deinen Spielern und regen sie eher zur Interaktion an.
+* Das Werbeformat - Banneranzeigen bringen in der Regel weniger ein, während Vollbildanzeigen, die von Anfang bis Ende angesehen werden, mehr einbringen.
+* Das Werbenetzwerk - der Betrag, den du erhältst, unterscheidet sich von Werbenetzwerk zu Werbenetzwerk.
+
+::: sidenote
+CPM = Cost per mille (Kosten pro tausend Aufrufe). Der Betrag, den ein Werbetreibender für tausend Aufrufe bezahlt. Der CPM unterscheidet sich je nach Werbenetzwerk und Werbeformat.
+:::
+
+## Formate {#formats}
+
+Es gibt viele verschiedene Werbeformate, die in Spielen verwendet werden können. Zu den gängigeren gehören Banneranzeigen, Interstitial-Anzeigen und Werbung gegen Belohnung:
+
+### Banneranzeigen {#banner-ads}
+
+Banneranzeigen basieren auf Text, Bildern oder Videos und bedecken einen relativ kleinen Teil des Bildschirms, normalerweise am oberen oder unteren Bildschirmrand. Banneranzeigen lassen sich sehr leicht implementieren und passen sehr gut zu Casual-Spielen, die auf einem einzigen Bildschirm stattfinden und bei denen sich leicht ein Bildschirmbereich für Werbung reservieren lässt. Banneranzeigen maximieren die Sichtbarkeit der Werbung, während die Nutzer dein Spiel ohne Unterbrechung spielen.
+
+### Interstitial-Anzeigen {#interstitial-ads}
+
+Interstitial-Anzeigen sind großflächige Vollbildanzeigen mit Animationen und manchmal auch interaktiven *Rich-Media*-Inhalten. Interstitial-Anzeigen werden üblicherweise zwischen Leveln oder Spielsitzungen eingeblendet, da dies eine natürliche Pause im Spielerlebnis ist. Interstitial-Anzeigen erzielen üblicherweise weniger Aufrufe als Banneranzeigen, aber die Kosten (CPM) sind deutlich höher als bei Banneranzeigen, was insgesamt zu erheblichen Werbeeinnahmen führt.
+
+### Werbung gegen Belohnung {#rewarded-ads}
+
+Werbung gegen Belohnung (auch als Incentivized Ads bekannt) ist optional und daher weniger aufdringlich als viele andere Werbeformen. Werbung gegen Belohnung besteht in der Regel aus Vollbildanzeigen wie Interstitial-Anzeigen. Der Nutzer kann sich dafür entscheiden, im Austausch für das Ansehen der Werbung eine Belohnung zu erhalten - beispielsweise *Beute*, Münzen, Leben, Zeit oder eine andere Spielwährung oder einen Vorteil im Spiel. Werbung gegen Belohnung hat in der Regel die höchsten Kosten (CPM), aber die Anzahl der Aufrufe hängt direkt davon ab, wie viele Nutzer sich dafür entscheiden. Werbung gegen Belohnung erzielt nur dann sehr gute Ergebnisse, wenn die Belohnungen wertvoll genug sind und zum richtigen Zeitpunkt angeboten werden.
+
+
+## Werbenetzwerke {#ad-networks}
+
+Das [Defold Asset Portal](/tags/stars/ads/) enthält mehrere Assets zur Integration von Werbeanbietern:
+
+* [AdMob](https://defold.com/assets/admob-defold/) - Zeige Werbung über das Netzwerk von Google AdMob an.
+* [AppLovin MAX](https://defold.com/extension-applovin/) - Zeige Werbung über die Werbevermittlung von AppLovin MAX an.
+* [Facebook Instant Games](https://defold.com/assets/facebookinstantgames/) - Zeige Werbung in deinem Facebook Instant Game an.
+* [LevelPlay](https://defold.com/extension-levelplay/) - Zeige Werbung über die Werbevermittlung von Unity LevelPlay an.
+* [Unity Ads](https://defold.com/assets/defvideoads/) - Zeige Werbung über das Netzwerk von Unity Ads an.
+
+
+# Werbung in dein Spiel integrieren {#how-to-integrate-ads-in-your-game}
+
+Wenn du dich für ein Werbenetzwerk entschieden hast, das du in dein Spiel integrieren möchtest, musst du die Installations- und Nutzungsanweisungen des jeweiligen *Assets* befolgen. Üblicherweise fügst du die Erweiterung zunächst als [Projektabhängigkeit](/manuals/libraries/#setting-up-library-dependencies) hinzu. Sobald du das Asset zu deinem Projekt hinzugefügt hast, kannst du mit der Integration fortfahren und die Funktionen des jeweiligen Assets aufrufen, um Werbung zu laden und anzuzeigen.
+
+
+# Werbung und In-App-Käufe kombinieren {#combining-ads-and-in-app-purchases}
+
+In Mobilspielen ist es recht üblich, einen [In-App-Kauf](/manuals/iap) anzubieten, mit dem sich Werbung dauerhaft entfernen lässt.
+
+
+## Mehr erfahren {#learn-more}
+
+Es gibt viele Online-Ressourcen, aus denen du lernen kannst, wie du deine Werbeeinnahmen optimierst:
+
+* Google AdMob [Mobilspiele mit Werbung monetarisieren](https://admob.google.com/home/resources/monetize-mobile-game-with-ads/)
+* Game Analytics [Beliebte Werbeformate und ihre Verwendung](https://gameanalytics.com/blog/popular-mobile-game-ad-formats.html)
+* deltaDNA [Werbeeinblendungen in Spielen: 10 Expertentipps](https://deltadna.com/blog/ad-serving-in-games-10-tips/)

--- a/docs/de/manuals/ai-agents.md
+++ b/docs/de/manuals/ai-agents.md
@@ -1,0 +1,149 @@
+---
+title: KI-Programmieragenten mit Defold verwenden
+brief: Dieses Handbuch erläutert, wie du modellunabhängige Programmieragenten mit den Automatisierungsschnittstellen von Defold verbindest und dabei Überprüfung, Berechtigungen und Sicherheit ausdrücklich regelst.
+---
+
+# KI-Programmieragenten mit Defold verwenden {#using-ai-coding-agents-with-defold}
+
+Programmieragenten, die große Sprachmodelle (Large Language Models, LLM) und multimodale Modelle nutzen, können Defold-Projekte untersuchen, ändern und überprüfen. Dazu rufen sie dieselben modellunabhängigen Schnittstellen auf, die auch Entwickler, lokale Skripte, IDE-Integrationen und CI nutzen. Du kannst einen Agenten einsetzen, wenn die Arbeit Untersuchungen und Anpassungen erfordert.
+
+Defold ist von keinem bestimmten Modellanbieter oder Agentenprotokoll abhängig. Defold-Projekte funktionieren gut mit Claude Code, Codex, Cursor oder jeder anderen Lösung. Eine Agentenumgebung benötigt nur die für die Aufgabe gewährten Fähigkeiten, etwa Projektdateien zu lesen, ausgewählte Befehle auszuführen, lokale HTTP-Operationen aufzurufen, JSON zu parsen oder Bilder zu untersuchen. Möglich wird dies durch die von Defold bereitgestellten Automatisierungsschnittstellen für den Editor und eine laufende Game-Engine-Instanz sowie durch die leicht zu parsenden, textbasierten Ressourcendateien der Defold-Projekte.
+
+## Wann ein KI-Agent nützlich ist {#when-an-ai-agent-is-useful}
+
+Ein Agent kann nützlich sein, wenn eine Aufgabe beispielsweise Folgendes erfordert:
+
+* relevante Ressourcen und Dokumentation finden;
+* aus möglichen Implementierungen auswählen;
+* mehrere zusammengehörige Dateien ändern;
+* Build- oder Testfehler interpretieren;
+* ein visuelles Ergebnis mit semantischen Abnahmekriterien vergleichen;
+* anhand gesammelter Nachweise einen begrenzten Reparaturversuch unternehmen.
+
+Agenten sind leistungsfähige Werkzeuge für nicht deterministische Entwicklungs-, Untersuchungs- und Testprozesse. Sie können dabei helfen, vielfältige Lösungen zu erstellen, und funktionieren sehr gut mit Defold.
+
+## Modellunabhängige Defold-Schnittstellen {#model-neutral-defold-interfaces}
+
+Defold bietet mehrere unterstützte Schnittstellen, mit denen die Aufgabe unter Verwendung eines beliebigen verfügbaren Modells ausgeführt werden kann:
+
+* Projektdateien und Shell-Werkzeuge ermöglichen direkte Untersuchungen und Textänderungen.
+* [Editor-Skripte](/manuals/editor-scripts) können projektspezifische Ressourcenoperationen und Werkzeuge bereitstellen.
+* Die [HTTP-API des Editors](/manuals/editor-http-api) stellt Editorbefehle, Build-Ergebnisse, Konsolenausgaben, Referenzsuche, Vorschauen, Editoreinstellungen und Routen von Editor-Skripten bereit.
+* Die [APIs für den Engine-Dienst und die Laufzeitautomatisierung](/manuals/engine-service) stellen den aktuellen Zustand der Debug-Engine, Eingaben, Bildschirmaufnahmen und von Erweiterungen definierte Operationen bereit.
+* [Bob](/manuals/bob) ermöglicht Builds über die Kommandozeile sowie Berichte, Archive und Bundles.
+
+Ein Modell, das nur über eine Chatoberfläche verfügbar ist, kann Codeänderungen vorschlagen, aber weder das lokale Projekt eigenständig untersuchen noch ein laufendes Ergebnis überprüfen. Die zusätzliche umgebende Integration bestimmt, was der Agent tatsächlich beobachten und tun kann.
+
+## Integrationsschichten {#integration-layers}
+
+Eine Integrationsschicht kann einen Agenten mit lokalen Defold-Operationen verbinden. Sie kann ein Shell-Wrapper, ein Kommandozeilenprogramm, eine IDE-Erweiterung, ein OpenAPI-Client, eine Teststeuerung oder ein Protokolladapter sein.
+
+Belasse Richtlinien und Zugangsdaten in dieser lokalen Schicht. Jede verändernde Operation sollte strukturierte Ergebnisse zurückgeben oder zu einem deterministischen Überprüfungsschritt führen.
+
+Ermittle für Editoroperationen die aktuelle Schnittstelle über `/openapi.json`, statt dem Agenten eine dauerhaft fest einprogrammierte Kopie einer API bereitzustellen. Prüfe bei Laufzeiterweiterungen den Betriebszustand, die API-Version und die unterstützten Funktionen.
+
+Es kann sinnvoll sein, Werkzeuge nach Berechtigungsstufe zu trennen:
+
+| Stufe        | Beispiele                                              |
+| ------------ | ----------------------------------------------------- |
+| Nur lesend   | Projektuntersuchung, OpenAPI, `/ref`, Konsole, Vorschau |
+| Überprüfung  | Kompilierung, Tests, HTML5-Builds, Bildvergleiche       |
+| Änderung     | Dateiänderungen, Ressourcentransaktionen               |
+| Privilegiert | `/eval`, externe Befehle, Änderungen an Abhängigkeiten |
+
+Wenn der Adapter von Engine und Editor getrennt bleibt, bleiben die unterstützten Defold-Schnittstellen unabhängig von einem Modellanbieter oder Agentenprotokoll. Ein Adapter kann ausschließlich Operationen bereitstellen, die für seine Umgebung geeignet sind. Die Richtlinien für Berechtigungen und Bestätigungen verbleiben bei der Anwendung, in der der Agent ausgeführt wird.
+
+### Model Context Protocol
+
+Das [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) ist ein optionaler Adapter zwischen einem Agenten und einer Integrationsschicht. Ein MCP-Server kann Defold-Operationen als Werkzeuge und ausgewählte Dokumentation als Ressourcen bereitstellen. 
+
+::: important
+Gewähre nicht jedem Modell uneingeschränkten Zugriff auf die Shell und `/eval`.
+:::
+
+Defold benötigt derzeit keinen MCP-Server, da die wesentlichen Automatisierungsfunktionen bereits über offene, universell einsetzbare Schnittstellen verfügbar sind. Der Editor stellt eine lokale HTTP-API mit einer OpenAPI-Spezifikation bereit. Moderne Agenten können diese Schnittstellen direkt aufrufen oder eigene Adapter erzeugen. 
+
+Ein offizieller MCP-Server würde daher überwiegend die vorhandene API-Funktionalität duplizieren und eine weitere Integrationsschicht schaffen, die Defold pflegen müsste. Langfristig ist es sinnvoller, die zugrunde liegenden HTTP- und Laufzeitautomatisierungs-APIs stabil, auffindbar und gut dokumentiert zu halten und zugleich der Community oder einzelnen Werkzeuganbietern zu ermöglichen, bei Bedarf schlanke MCP-Wrapper zu entwickeln.
+
+Stattdessen hat das Defold-Team eine offizielle [Automation Bridge-Erweiterung](https://github.com/defold/extension-automation-bridge) bereitgestellt, mit der sich ein laufendes Spiel über einen Dienst auf der Engine-Seite steuern lässt.
+
+### MCP-Integrationen der Community {#community-mcp-integrations}
+
+Zu den von der Community erstellten MCP-Integrationen gehören:
+
+* das [Defold-MCP-Projekt von Fulviuus](https://github.com/Fulviuus/defold-mcp);
+* das [Defold-MCP-Projekt von ChadAragorn](https://github.com/ChadAragorn/defold-mcp).
+
+Diese Projekte werden von der Defold Foundation weder entwickelt noch geprüft, gepflegt oder offiziell unterstützt. Untersuche vor der Installation einer Community-Integration ihren aktuellen Quellcode, ihre Abhängigkeiten, Berechtigungen, ihr Netzwerkverhalten und ihre Kompatibilität mit der verwendeten Defold-Version.
+
+## Projektanweisungen {#project-instructions}
+
+Verfügbare große Sprachmodelle, die für Arbeitsabläufe mit Agenten eingesetzt werden, erzielen im Allgemeinen mit guten Anweisungen bessere Ergebnisse. Daher werden Projekten häufig Markdown-Dateien für Agenten hinzugefügt, die deren gewünschtes Verhalten beschreiben, oder sogenannte Skills, also Anweisungsartefakte für Agenten. Für optimale Ergebnisse ist es sinnvoll, eigene Anweisungen für jedes Projekt gesondert zu entwerfen und zu schreiben. Gemeinsames Wissen und allgemeine Regeln lassen sich jedoch teilweise wiederverwenden.
+
+Viele Agenten suchen und lesen zunächst eine kanonische Datei wie `AGENTS.md`, die Folgendes beschreiben kann:
+
+* Projektstruktur und wichtige Einstiegspunkte;
+* Formatierungs- und Namenskonventionen;
+* Befehle für Builds, Tests und Validierung;
+* erforderliche Abschlussereignisse und Speicherorte von Artefakten;
+* Dateien oder Verzeichnisse, die nicht geändert werden dürfen;
+* Operationen, die eine Zustimmung erfordern;
+* Annahmen zur Plattform und bekannte Einschränkungen.
+
+Manche Lösungen nutzen separate Markdown-Dateien für bestimmte Aktionen oder sogenannte „Skills“.
+
+Ein Community-Beispiel für Defold-spezifische Anweisungen und Skills findest du [hier im Defold-Forum](https://forum.defold.com/t/agent-config-collection-of-agents-md-and-skills/82387).
+
+Das Defold-Team empfiehlt, Anweisungen in Dateien wie AGENTS.md und Skill-Definitionen kurz, prägnant, leicht überprüfbar und pflegbar zu halten und sie stets zu aktualisieren. Projektspezifische Anweisungen können in der Versionsverwaltung gespeichert werden. Dadurch bleiben Änderungen nachvollziehbar, und die Wirksamkeit der Arbeitsabläufe lässt sich mit der Zeit verbessern.
+
+Es lohnt sich auch, regelmäßig zu testen, wie die neuesten Modelle ohne diese Anweisungen arbeiten. Neuere Modelle benötigen oft keine Anleitung mehr, die zuvor unverzichtbar war. Veraltete Skills oder übermäßig detaillierte Vorgaben können die Leistung mitunter sogar verringern.
+
+Vermeide es, komplexe technische Skills zu erstellen, die langfristig einen erheblichen Pflegeaufwand erfordern. Konzentriere dich stattdessen auf Werkzeuge und Arbeitsabläufe, die unabhängig davon nützlich bleiben, wie stark sich die zugrunde liegenden Modelle verbessern.
+
+## Dokumentation finden {#documentation-discovery}
+
+Agenten erzielen mit genauer, aktueller Dokumentation die besten Ergebnisse. Nutze die folgenden Quellen für aktuelle Informationen:
+
+* `/openapi.json` beschreibt die aktuelle HTTP-API des Editors.
+* `/ref` durchsucht die API-Dokumentation des laufenden Editors, sofern diese Operation verfügbar ist.
+* Das [LLM-Dokumentationsverzeichnis](https://defold.com/llms.txt) verlinkt offizielle Handbücher, API-Namespaces und Beispiele.
+* Die [vollständige LLM-Dokumentation](https://defold.com/llms-full.txt) unterstützt die Offline-Suche und lokale Indizierung.
+
+Rufe nur die für die Aufgabe relevanten Seiten ab. Es wird empfohlen, das vollständige zusammengeführte Dokument ausschließlich für die Offline-Indizierung oder für [Retrieval-Augmented Generation (RAG)](https://en.wikipedia.org/wiki/Retrieval-augmented_generation), also die Generierung mit abgerufenen Zusatzinformationen, zu verwenden. Auch hier sollte die vollständige Datei normalerweise nicht in jede Modellanfrage aufgenommen werden, um Tokens zu sparen und den Kontext nicht mit unnötigen Informationen zu belasten.
+
+## Begrenzte Änderungs- und Überprüfungsschleifen {#bounded-change-and-verification-loops}
+
+Agenten sollten dieselbe [Schleife aus Untersuchen, Ändern, Überprüfen und Bewerten](/manuals/automation/#the-automation-loop) befolgen wie jede andere Automatisierung.
+
+Bevor Dateien geändert werden, ist es sinnvoll, die Abnahmekriterien festzulegen und optional auch:
+* die zulässigen Dateien und Operationen;
+* die Build- und Testbefehle;
+* erforderliche Protokolle, Berichte, Zustände oder Bilder;
+* ein Zeitlimit für jeden asynchronen Schritt;
+* eine maximale Anzahl von Reparaturversuchen.
+
+Ein Agent kann einen deterministischen CI-Fehler diagnostizieren und beheben, aber die CI-Phase selbst sollte ohne den Agenten reproduzierbar bleiben.
+
+Bewährte Vorgehensweisen für automatisiertes Testen und Überprüfen werden in [diesem Handbuch](/manuals/automated-testing) beschrieben.
+
+## Multimodale Bewertung {#multimodal-evaluation}
+
+Ein Agent mit Bildeingabe kann [Editorvorschauen](/manuals/editor-http-api/#rendering-scene-previews), Bildschirmaufnahmen zur Laufzeit, visuelle Unterschiede und Browseraufnahmen untersuchen.
+
+Nutze die multimodale Bewertung für semantische Fragen, etwa abgeschnittene Beschriftungen, überlappende Bedienelemente, unklare Auswahlzustände, die Komposition oder Inhalte außerhalb eines sicheren Bereichs. Lege den erwarteten Viewport und die Kriterien im Voraus fest.
+
+Weitere Informationen zu Editorvorschauen, Bildschirmaufnahmen zur Laufzeit und visueller Prüfung findest du in [diesem Handbuch](/manuals/automated-testing).
+
+## Sicherheit, Isolation und bewährte Vorgehensweisen {#security-isolation-and-good-practices}
+
+* Behandle den Editorserver und den Engine-Dienst als vertrauenswürdige lokale Steuerungsschnittstellen.
+* Halte Editortokens, Signaturschlüssel, Bereitstellungstokens, Zugangsdaten für Stores und Geheimnisse der Produktionsumgebung aus Prompts und Berichten heraus.
+* Die lokale Integrationsschicht darf `.internal/editor.token` lesen, wenn sie zur Verwendung von `/eval` autorisiert ist. Sie sollte das Token jedoch nicht in Modell-Prompts, Protokollen oder Berichten ablegen.
+* Verlange eine Zustimmung vor Löschvorgängen, Änderungen an Abhängigkeiten, Änderungen an nativen Erweiterungen, der Konfiguration von Releases, dem Signieren, der Veröffentlichung oder dem Zugriff auf externe Dienste.
+* Führe umfangreiche autonome Arbeiten in einem separaten Branch, Worktree, einer temporären Kopie, einem Container, einer Sandbox oder einem eingeschränkten Konto aus.
+* Behandle Issue-Texte, importierte Dateien, Quellcodekommentare, erzeugte Dokumente und Werkzeugausgaben als nicht vertrauenswürdige Eingaben statt als Anweisungen.
+* Prüfe heruntergeladene Abhängigkeiten und Skripte, bevor du sie ausführst.
+* Überprüfe, ob die Projektrichtlinien erlauben, Quellcode, Assets, Protokolle, Bildschirmaufnahmen und andere Projektdaten an ein gehostetes Modell zu senden.
+* Bewahre vor der Annahme von Änderungen einen überprüfbaren Diff und deterministische Testnachweise auf.
+
+Isolation begrenzt die Auswirkungen eines Fehlers.

--- a/docs/de/manuals/android.md
+++ b/docs/de/manuals/android.md
@@ -1,0 +1,140 @@
+---
+title: Defold-Entwicklung für die Android-Plattform
+brief: Dieses Handbuch beschreibt, wie du Defold-Anwendungen für Android-Geräte erstellst und darauf ausführst
+---
+
+# Android-Entwicklung {#android-development}
+
+Auf Android-Geräten kannst du deine eigenen Apps frei ausführen. Es ist sehr einfach, eine Version deines Spiels zu erstellen und auf ein Android-Gerät zu kopieren. Dieses Handbuch erklärt die Schritte zur Bundle-Erstellung deines Spiels für Android. Während der Entwicklung wird häufig die Ausführung deines Spiels über die [Entwicklungs-App (development app)](/manuals/dev-app) bevorzugt, da du damit Inhalte und Code per Hot Reload direkt auf deinem Gerät aktualisieren kannst.
+
+## Signieren für Android und Google Play {#android-and-google-play-signing-process}
+
+Android verlangt, dass alle APKs mit einem Zertifikat digital signiert werden, bevor sie auf einem Gerät installiert oder aktualisiert werden. Wenn du Android App Bundles verwendest, musst du nur dein App Bundle signieren, bevor du es in die Play Console hochlädst. [Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play) übernimmt den Rest. Du kannst deine App aber auch manuell signieren, um sie bei Google Play oder anderen App-Stores hochzuladen oder außerhalb eines Stores zu verteilen.
+
+Wenn du ein Android-Anwendungs-Bundle mit dem Defold-Editor oder dem [Befehlszeilenwerkzeug](/manuals/bob) erstellst, kannst du einen Schlüsselspeicher (keystore) mit deinem Zertifikat und Schlüssel sowie das Passwort des Schlüsselspeichers angeben. Diese werden zum Signieren deiner Anwendung verwendet. Wenn du diese Angaben weglässt, erzeugt Defold einen Debug-Schlüsselspeicher und verwendet ihn zum Signieren des Anwendungs-Bundles.
+
+::: important
+Du solltest deine Anwendung **niemals** bei Google Play hochladen, wenn sie mit einem Debug-Schlüsselspeicher signiert wurde. Verwende immer einen eigenen Schlüsselspeicher, den du selbst erstellt hast.
+:::
+
+## Einen Schlüsselspeicher erstellen {#creating-a-keystore}
+
+::: sidenote
+Defold verwendet einen Schlüsselspeicher für den Signierungsprozess unter Android. [Weitere Informationen findest du in diesem Forumsbeitrag](https://forum.defold.com/t/upcoming-change-to-the-android-build-pipeline/66084).
+:::
+
+Du kannst einen Schlüsselspeicher [mit Android Studio](https://developer.android.com/studio/publish/app-signing#generate-key) oder über ein Terminal bzw. die Eingabeaufforderung erstellen:
+
+```bash
+keytool -genkey -v -noprompt -dname "CN=John Smith, OU=Area 51, O=US Air Force, L=Unknown, ST=Nevada, C=US" -keystore mykeystore.keystore -storepass 5Up3r_53cR3t -alias myAlias -keyalg RSA -validity 9125
+```
+
+Dadurch wird eine Schlüsselspeicherdatei namens `mykeystore.keystore` erstellt, die einen Schlüssel und ein Zertifikat enthält. Der Zugriff auf Schlüssel und Zertifikat wird durch das Passwort `5Up3r_53cR3t` geschützt. Schlüssel und Zertifikat sind 25 Jahre (9125 Tage) gültig. Der erzeugte Schlüssel und das Zertifikat werden durch den Alias `myAlias` identifiziert.
+
+::: important
+Bewahre den Schlüsselspeicher und das zugehörige Passwort an einem sicheren Ort auf. Wenn du deine Anwendungen selbst signierst und bei Google Play hochlädst und der Schlüsselspeicher oder sein Passwort verloren geht, kannst du die Anwendung bei Google Play nicht mehr aktualisieren. Du kannst dies vermeiden, indem du Google Play App Signing verwendest und Google deine Anwendungen für dich signieren lässt.
+:::
+
+
+## Ein Android-Anwendungs-Bundle erstellen {#creating-an-android-application-bundle}
+
+Mit dem Editor kannst du einfach ein eigenständiges Anwendungs-Bundle für dein Spiel erstellen. Vor der Bundle-Erstellung kannst du in der [Projekteinstellungsdatei](/manuals/project-settings/#android) *game.project* festlegen, welche Symbole für die App verwendet werden sollen, den Versionscode einstellen usw.
+
+Wähle zum Erstellen eines Bundles im Menü <kbd>Project ▸ Bundle... ▸ Android Application...</kbd>.
+
+Wenn der Editor automatisch zufällige Debug-Zertifikate erstellen soll, lasse die Felder *Keystore* und *Keystore password* leer:
+
+![Android-Bundle signieren](images/android/sign_bundle.png)
+
+Wenn du dein Bundle mit einem bestimmten Schlüsselspeicher signieren möchtest, gib *Keystore* und *Keystore password* an. Für *Keystore* wird die Dateierweiterung `.keystore` erwartet, während das Passwort in einer Textdatei mit der Erweiterung `.txt` gespeichert sein muss. Du kannst außerdem ein *Key password* angeben, wenn der Schlüssel im Schlüsselspeicher ein anderes Passwort als der Schlüsselspeicher selbst verwendet:
+
+![Android-Bundle signieren](images/android/sign_bundle2.png)
+
+Defold unterstützt die Erstellung von APK- und AAB-Dateien. Wähle APK oder AAB aus der Auswahlliste *Bundle Format*.
+
+Klicke auf <kbd>Create Bundle</kbd>, sobald du die Einstellungen für das Anwendungs-Bundle konfiguriert hast. Anschließend wirst du aufgefordert, den Speicherort auf deinem Computer anzugeben, an dem das Bundle erstellt werden soll.
+
+![Android-Anwendungspaketdatei](images/android/apk_file.png)
+
+:[Build Variants](../shared/build-variants.md)
+
+### Ein Android-Anwendungs-Bundle installieren {#installing-an-android-application-bundle}
+
+#### Eine APK installieren {#installing-an-apk}
+
+Eine *`.apk`*-Datei kann mit dem Werkzeug `adb` auf dein Gerät oder über die [Google Play-Entwicklerkonsole](https://play.google.com/apps/publish/) zu Google Play kopiert werden.
+
+:[Android ADB](../shared/android-adb.md)
+
+```
+$ adb install Defold\ examples.apk
+4826 KB/s (18774344 bytes in 3.798s)
+  pkg: /data/local/tmp/my_app.apk
+Success
+```
+
+#### Eine APK mit dem Editor installieren {#installing-an-apk-using-editor}
+
+Du kannst eine *`.apk`*-Datei mit den Kontrollkästchen „Install on connected device“ und „Launch installed app“ im Bundle-Dialogfeld des Editors installieren und starten:
+
+![APK installieren und starten](images/android/install_and_launch.png)
+
+Für diese Funktion muss *ADB* installiert und *USB debugging* auf dem verbundenen Gerät aktiviert sein. Wenn der Editor den Installationsort des ADB-Befehlszeilenwerkzeugs nicht erkennen kann, musst du ihn in [Preferences](/manuals/editor-preferences/#tools) angeben.
+
+#### Eine AAB installieren {#installing-an-aab}
+
+Eine *.aab*-Datei kann über die [Google Play-Entwicklerkonsole](https://play.google.com/apps/publish/) zu Google Play hochgeladen werden. Mit dem [Android bundletool](https://developer.android.com/studio/command-line/bundletool) kannst du außerdem aus einer *.aab*-Datei eine *`.apk`*-Datei erzeugen, um sie lokal zu installieren.
+
+## Java-Code mit R8 verkleinern {#shrinking-java-code-with-r8}
+
+R8 reduziert die Größe von Java-Code durch Verkleinerung, Optimierung und Verschleierung.
+
+### R8 aktivieren {#enabling-r8}
+
+Wähle `/builtins/manifests/android/dmengine.keep` unter **Android ▸ R8 Keep Rules** in *game.project* aus. Dadurch werden die Standardregeln von Defold direkt verwendet:
+
+```ini
+[android]
+r8_keep_rules = /builtins/manifests/android/dmengine.keep
+```
+
+Stelle sicher, dass jede Erweiterung mit Java-Code eine `.keep`-Datei für die Klassen bereitstellt, die sie zur Laufzeit benötigt. Die Regeln der Erweiterungen werden beim Build mit den ausgewählten Projektregeln kombiniert. Teste nach dem Aktivieren von R8 einen Release-Build auf einem Gerät.
+
+Wenn du **R8 Keep Rules** leer lässt, wird D8 ohne Verkleinerung verwendet. Beim Aktivieren von R8 wird der Build-Dienst für native Erweiterungen verwendet, auch für ein Projekt ohne native Erweiterungen.
+
+### Regeln zu einer Erweiterung hinzufügen {#adding-rules-to-an-extension}
+
+Die Keep-Regeln einer Erweiterung gehören in ihr Verzeichnis `manifests/android`, neben `build.gradle`. Unter [R8-Keep-Regeln für Android-Erweiterungen](/manuals/extensions/#r8-keep-rules-for-android) erfährst du, wie du eine Datei hinzufügst und die Java-Klassen der Erweiterung erhältst.
+
+### Die Zuordnung verschleierter Namen aufbewahren {#keeping-the-obfuscation-mapping}
+
+Aktiviere **Generate debug symbols** im Android-Bundle-Dialogfeld oder übergib `--with-symbols` an Bob, um die Datei `mapping.txt` von R8 aufzubewahren, wenn der Build eine erzeugt. Beispielsweise aus dem Projektverzeichnis:
+
+```sh
+java -jar bob.jar --platform arm64-android --variant release \
+  --archive --with-symbols --bundle-output build/android \
+  resolve build bundle
+```
+
+Die Zuordnung wird als `<binary-name>.apk.symbols/mapping.txt` neben der erzeugten APK oder AAB gespeichert. Bei dem Projekttitel `My Game` erzeugt der obige Befehl beispielsweise `build/android/MyGame/MyGame.apk.symbols/mapping.txt`.
+
+Bewahre die Zuordnungsdatei zusammen mit genau der Release-Version auf, aus der sie stammt. Sie ordnet verschleierten Java-Namen wieder ihre ursprünglichen Namen zu, um Stacktraces auswerten zu können. Eine Zuordnung aus einem anderen Build kann falsche Ergebnisse liefern.
+
+## Berechtigungen {#permissions}
+
+Die Defold-Engine benötigt verschiedene Berechtigungen, damit alle Engine-Funktionen arbeiten können. Die Berechtigungen werden in der Datei `AndroidManifest.xml` definiert, die in der [Projekteinstellungsdatei](/manuals/project-settings/#android) *game.project* angegeben ist. Weitere Informationen zu Android-Berechtigungen findest du in der [offiziellen Dokumentation](https://developer.android.com/guide/topics/permissions/overview). Im Standardmanifest werden die folgenden Berechtigungen angefordert:
+
+### android.permission.INTERNET und android.permission.ACCESS_NETWORK_STATE (Schutzstufe: normal) {#androidpermissioninternet-and-androidpermissionaccess_network_state-protection-level-normal}
+Erlaubt Anwendungen, *Netzwerk-Sockets* zu öffnen und auf Informationen über Netzwerke zuzugreifen. Diese Berechtigungen werden für den Internetzugriff benötigt. ([Offizielle Android-Dokumentation](https://developer.android.com/reference/android/Manifest.permission#INTERNET)) und ([Offizielle Android-Dokumentation](https://developer.android.com/reference/android/Manifest.permission#ACCESS_NETWORK_STATE)).
+
+### android.permission.WAKE_LOCK (Schutzstufe: normal) {#androidpermissionwake_lock-protection-level-normal}
+Erlaubt die Verwendung von PowerManager-WakeLocks, um zu verhindern, dass der Prozessor in den Ruhezustand wechselt oder der Bildschirm gedimmt wird. Diese Berechtigung wird benötigt, um das Gerät beim Empfang einer Push-Benachrichtigung vorübergehend am Wechsel in den Ruhezustand zu hindern. ([Offizielle Android-Dokumentation](https://developer.android.com/reference/android/Manifest.permission#WAKE_LOCK))
+
+
+## AndroidX verwenden {#using-androidx}
+AndroidX ist eine wesentliche Verbesserung gegenüber der ursprünglichen Android Support Library, die nicht mehr gepflegt wird. AndroidX-Pakete ersetzen die Support Library vollständig, indem sie denselben Funktionsumfang und neue Bibliotheken bereitstellen. Die meisten Android-Erweiterungen im [Asset Portal](/assets) unterstützen AndroidX. Wenn du AndroidX nicht verwenden möchtest, kannst du es ausdrücklich zugunsten der alten Android Support Library deaktivieren, indem du `Use Android Support Lib` im [Anwendungsmanifest](https://defold.com/manuals/app-manifest/) aktivierst.
+
+![](images/android/enable_supportlibrary.png)
+
+## FAQ
+:[Android FAQ](../shared/android-faq.md)

--- a/docs/de/manuals/animation.md
+++ b/docs/de/manuals/animation.md
@@ -1,0 +1,17 @@
+---
+title: Handbuch zu Animationen in Defold
+brief: Dieses Handbuch beschreibt die Animationsunterstützung von Defold.
+---
+
+# Animation
+
+Defold bietet integrierte Unterstützung für viele Arten von Animationen, die du als Grafikquelle für Komponenten (components) verwenden kannst:
+
+* [Flipbook-Animation](/manuals/flipbook-animation) - Eine Folge von Einzelbildern nacheinander wiedergeben
+* [Modellanimation](/manuals/model-animation) - 3D-Animationen mit Skinning wiedergeben
+* [Eigenschaftsanimation](/manuals/property-animation) - Eigenschaften wie Position, Skalierung, Drehung und viele weitere animieren
+
+Weitere Animationsformate lassen sich durch Erweiterungen hinzufügen:
+
+* [Rive-Animation](/extension-rive) - Vektorbasierte 2D-Skelettanimationen wiedergeben
+* [Spine-Animation](/extension-spine) - Texturierte 2D-Skelettanimationen wiedergeben

--- a/docs/de/manuals/app-manifest.md
+++ b/docs/de/manuals/app-manifest.md
@@ -1,0 +1,166 @@
+---
+title: Anwendungsmanifest
+brief: Dieses Handbuch beschreibt, wie du mit dem Anwendungsmanifest Funktionen aus der Engine ausschließen kannst.
+---
+
+# Anwendungsmanifest {#app-manifest}
+
+Das Anwendungsmanifest (app manifest) steuert, welche Funktionen und Backends in die Engine eingebunden werden. Es wird empfohlen, ungenutzte Funktionen auszuschließen, da dadurch die fertige Binärdatei deines Spiels kleiner wird. Das Anwendungsmanifest enthält außerdem Optionen für den Build-Vorgang, etwa die mindestens unterstützten HTML5-Browserversionen und die Speichereinstellungen für WebAssembly.
+
+![](images/app_manifest/create-app-manifest.png)
+
+![](images/app_manifest/app-manifest.png)
+
+# Das Manifest anwenden {#applying-the-manifest}
+
+Weise das Manifest in `game.project` unter `Native Extensions` -> `App Manifest` zu.
+
+## Physics 2D
+
+Wähle aus, welche Box2D-Implementierung eingebunden werden soll:
+
+* **Box2D Version 3** - Bindet Box2D 3 ein. Diese Option muss ausdrücklich aktiviert werden und kann andere Simulationsergebnisse liefern als die bisherige Implementierung. Bei bestehenden Projekten musst du daher möglicherweise die Physikeinstellungen neu abstimmen.
+* **Box2D (Legacy Defold version)** - Bindet die bisherige Box2D-Implementierung von Defold ein. Dies ist die Standardeinstellung.
+* **None** - Schließt die 2D-Physik aus.
+
+Die Einstellungen des Box2D-Solvers sind versionsabhängig. Einzelheiten findest du in den [Box2D-Projekteinstellungen](/manuals/project-settings/#box2d).
+
+## Physics 3D
+
+Bindet die 3D-Physikimplementierung Bullet ein. Sie ist standardmäßig enthalten; deaktiviere diese Einstellung, um die 3D-Physik auszuschließen.
+
+## Rig + Model
+
+Steuere die Funktionalität von Rigs und Modellen (models), oder wähle None aus, um Modelle und Rigs vollständig auszuschließen. (Siehe die Dokumentation zu [`Model`](https://defold.com/manuals/model/#model-component)).
+
+
+## Exclude Record
+
+Schließt die Videoaufnahmefunktion aus der Engine aus (siehe die Dokumentation zur Nachricht [`start_record`](https://defold.com/ref/stable/sys/#start_record)).
+
+
+## Profiler
+
+Steuere, wann die Profiler-Funktionalität in die Engine eingebunden wird:
+
+* **Debug Only** - Bindet den Profiler nur in Debug-Builds ein. Dies ist die Standardeinstellung.
+* **None** - Schließt die Profiler-Funktionalität aus allen Build-Varianten aus.
+* **Always** - Bindet den Profiler sowohl in Debug- als auch in Release-Builds ein.
+
+Die Einstellung im Anwendungsmanifest steuert, ob der Profiler-Code in einen Build eingebunden wird. Die Einstellungen unter `profiler` in *game.project* steuern das Verhalten des Profilers zur Laufzeit. Wie du die verfügbaren Funktionen verwendest, erfährst du im [Profiling-Handbuch](/manuals/profiling/).
+
+
+## Sound
+
+Die Audioeinstellungen bestimmen, welches Audiosystem und welche Decoder in die Engine eingebunden werden.
+
+### Exclude Sound
+
+Schließt sämtliche Funktionen zur Audiowiedergabe aus der Engine aus.
+
+### Exclude Sound Decoder: WAV
+
+Schließt die Unterstützung für WAV-Audioressourcen aus.
+
+### Exclude Sound Decoder: OGG
+
+Schließt die Unterstützung für Ogg-Vorbis-Audioressourcen aus.
+
+### Include Sound Decoder: Opus
+
+Bindet die Unterstützung für Ogg-Opus-Audioressourcen ein. Der Opus-Decoder ist standardmäßig ausgeschlossen. Du musst diese Option daher aktivieren, bevor `.opus`-Ressourcen wiedergegeben werden können. Die unterstützten Formate findest du im [Audiohandbuch](/manuals/sound/).
+
+
+## Exclude Input
+
+Schließt die gesamte Eingabeverarbeitung aus der Engine aus.
+
+
+## Exclude GUI
+
+Entfernt GUI-Ressourcen, Komponenten (components) und die Lua-Unterstützung aus der Engine. Aktiviere diese Option nur, wenn das Projekt keine GUI-Szenen oder GUI-Skripte verwendet. Beschriftungskomponenten (label components) bleiben verfügbar. Diese Option ist standardmäßig deaktiviert.
+
+
+## Exclude Particle FX
+
+Entfernt Ressourcen und Komponenten für Partikeleffekte (particle effects) sowie das Lua-Modul `particlefx`. Dadurch entfällt auch die Unterstützung für Partikelknoten in GUI-Szenen; GUI-Szenen ohne Partikelknoten werden weiterhin unterstützt. Entferne Referenzen auf Partikeleffekte und Aufrufe ihrer APIs, bevor du diese Option aktivierst. Sie ist standardmäßig deaktiviert.
+
+
+## Exclude Tilemaps
+
+Entfernt Ressourcen und Komponenten für Kachelkarten (tile maps) sowie das Lua-Modul `tilemap`. Aktiviere diese Option nur, wenn das Projekt keine Kachelkartenkomponenten oder deren APIs verwendet. Kachelquellen, die von anderen Komponenten verwendet werden, bleiben verfügbar. Diese Option ist standardmäßig deaktiviert.
+
+
+## Exclude Live Update
+
+Schließt die [Live-Update-Funktionalität](/manuals/live-update) aus der Engine aus.
+
+
+## Exclude Image
+
+Schließt das Skriptmodul `image` aus der Engine aus ([Link](https://defold.com/ref/stable/image/)).
+
+
+## Exclude Types
+
+Schließt das Skriptmodul `types` aus der Engine aus ([Link](https://defold.com/ref/stable/types/)).
+
+
+## Exclude Basis Transcoder
+
+Schließt die [Bibliothek zur Texturkomprimierung](/manuals/texture-profiles) Basis Universal aus der Engine aus.
+
+
+## Use Android Support Lib
+
+Verwendet die veraltete und zur Ablösung vorgesehene Android Support Library anstelle von Android X. [Weitere Informationen](https://defold.com/manuals/android/#using-androidx).
+
+
+## Graphics
+
+Wähle für jede Plattform aus, welche Grafik-Backends eingebunden werden sollen. Eine kombinierte Auswahl bindet beide Backends ein, sodass auf das andere Backend zurückgegriffen werden kann, wenn das bevorzugte nicht verfügbar ist.
+
+| Feld | Plattformen | Auswahlmöglichkeiten | Standard |
+|---|---|---|---|
+| **Graphics** | Windows und Linux | OpenGL, Vulkan, OpenGL & Vulkan | OpenGL |
+| **Graphics (macOS)** | macOS | OpenGL, Metal, Vulkan, OpenGL & Metal, OpenGL & Vulkan | Vulkan |
+| **Graphics (iOS)** | iOS | OpenGL, Metal, Vulkan, OpenGL & Metal, OpenGL & Vulkan | OpenGL |
+| **Graphics (Android)** | Android | OpenGL+Vulkan, OpenGL, Vulkan | OpenGL+Vulkan |
+| **Graphics (HTML5)** | HTML5 | WebGL, WebGPU, WebGL & WebGPU | WebGL |
+
+Unter Linux ARM64 verwendet die Auswahl **OpenGL** das OpenGL-ES-Backend. Die kombinierte Standardeinstellung für Android bevorzugt Vulkan, sofern es verfügbar ist, und greift andernfalls auf OpenGL ES zurück.
+
+## Use full text layout system
+
+Wenn diese Option aktiviert ist (`true`), wird das vollständige Textlayoutsystem für die Textformung eingebunden, einschließlich der Unterstützung für Sprachen, die von rechts nach links geschrieben werden. Aktiviere diese Option zusammen mit `font.runtime_generation` in *game.project*, um SDF-Schriftarten zur Laufzeit aus TrueType- (`.ttf`) oder OpenType-Ressourcen (`.otf`) zu erzeugen. Die Erzeugung zur Laufzeit aus `.otf`-Ressourcen wird seit Defold 1.13.2 unterstützt. Weitere Informationen findest du im [Schriftartenhandbuch](/manuals/font/#enabling-runtime-fonts).
+
+
+## Use Rich Text
+
+Bindet die Verarbeitung von Rich-Text-Auszeichnungen und Stileffekte für Beschriftungen und GUI-Text ein. Diese Option ist standardmäßig aktiviert. Deaktiviere sie, um die Engine zu verkleinern, wenn das Projekt nur unformatierten Text benötigt. Beschriftungen und GUI-Text werden weiterhin unterstützt, aber Auszeichnungen werden als unformatierter Text gerendert, statt Formatierungen oder Effekte anzuwenden.
+
+
+## Mindestens unterstützte Browserversionen {#minimum-browser-versions}
+
+Die YAML-Felder **`minSafariVersion`**, **`minFirefoxVersion`** und **`minChromeVersion`** geben die mindestens unterstützten Browserversionen an, auf die Emscripten ausgerichtet ist. Die aktuellen Standardwerte und die mindestens unterstützten Versionen unterscheiden sich zwischen den Zielen ohne und mit Thread-Unterstützung:
+
+| Ziel | Safari | Firefox | Chrome |
+|---|---:|---:|---:|
+| `wasm-web` | `101000` | `40` | `45` |
+| `wasm_pthread-web` | `150000` | `79` | `75` |
+
+Gib abweichende Werte im Kontext des jeweiligen Ziels an. Für das Ziel mit Thread-Unterstützung gelten außerdem zusätzliche [Hosting-Anforderungen](/manuals/html5/#creating-html5-bundle). Siehe die Emscripten-Einstellungsreferenz für [`MIN_SAFARI_VERSION`](https://emscripten.org/docs/tools_reference/settings_reference.html#min-safari-version), [`MIN_FIREFOX_VERSION`](https://emscripten.org/docs/tools_reference/settings_reference.html#min-firefox-version) und [`MIN_CHROME_VERSION`](https://emscripten.org/docs/tools_reference/settings_reference.html#min-chrome-version).
+
+## Anfänglicher Speicher (HTML5) {#initial-memory-html5}
+YAML-Feldname: **`initialMemory`**
+Standardwert: **33554432**
+
+Die anfänglich für die Webanwendung zugewiesene Speichermenge in Bytes. Der Wert muss ein Vielfaches der WebAssembly-Seitengröße (64 KiB) sein. Siehe die Emscripten-Einstellung [`INITIAL_MEMORY`](https://emscripten.org/docs/tools_reference/settings_reference.html#initial-memory).
+
+Diese Option legt den Standardwert zur Kompilierungszeit fest. Der Wert von [`html5.heap_size`](/manuals/html5/#heap-size) in *game.project* überschreibt ihn zur Laufzeit.
+
+## Stack-Größe (HTML5) {#stack-size-html5}
+YAML-Feldname: **`stackSize`**
+Standardwert: **5242880**
+
+Die Größe des Anwendungs-Stacks in Bytes. Siehe die Emscripten-Einstellung [`STACK_SIZE`](https://emscripten.org/docs/tools_reference/settings_reference.html#stack-size).

--- a/docs/de/manuals/application-lifecycle.md
+++ b/docs/de/manuals/application-lifecycle.md
@@ -1,0 +1,240 @@
+---
+title: Handbuch zum Anwendungslebenszyklus in Defold
+brief: Dieses Handbuch beschreibt den Lebenszyklus von Defold-Spielen und -Anwendungen im Detail.
+---
+
+# Anwendungslebenszyklus {#application-lifecycle}
+
+Der Lebenszyklus einer Defold-Anwendung oder eines Defold-Spiels ist im Großen und Ganzen einfach. Die Engine durchläuft drei Ausführungsphasen: die Initialisierung, die Aktualisierungsschleife (in der Anwendungen und Spiele die meiste Zeit verbringen) und die Finalisierung.
+
+::: sidenote
+Dieses Handbuch bezieht sich auf Defold-Versionen ab 1.12.0. In Version 1.12.0 wurden Änderungen am Lebenszyklus und die neue Funktion `late_update()` eingeführt.
+:::
+
+![Übersicht des Lebenszyklus](images/application_lifecycle/application_lifecycle.png)
+
+In vielen Fällen genügt ein grundlegendes Verständnis der internen Abläufe von Defold. Es können jedoch Sonderfälle auftreten, in denen die genaue Reihenfolge, in der Defold seine Aufgaben ausführt, entscheidend ist. Dieses Dokument beschreibt, wie die Engine eine Anwendung vom Start bis zum Ende ausführt.
+
+Zu Beginn initialisiert die Anwendung alles, was für den Betrieb der Engine erforderlich ist. Sie lädt die als Hauptsammlung verwendete Sammlung (collection) und ruft [`init()`](/ref/go#init) für alle geladenen Komponenten (components) auf, die eine Lua-Funktion namens `init()` besitzen (Skriptkomponenten und GUI-Komponenten mit GUI-Skripten). So kannst du eigene Initialisierungsschritte ausführen.
+
+Die Anwendung tritt dann in die Aktualisierungsschleife ein, in der sie den größten Teil ihrer Lebensdauer verbringt. In jedem Frame werden Spielobjekte (game objects) und die darin enthaltenen Komponenten aktualisiert. Alle [`update()`](/ref/go#update)-Funktionen in Skripten und GUI-Skripten werden aufgerufen. Während der Aktualisierungsschleife werden Nachrichten an ihre Empfänger zugestellt, Klänge abgespielt und sämtliche Grafiken gerendert.
+
+Irgendwann endet der Lebenszyklus der Anwendung. Bevor die Anwendung beendet wird, verlässt die Engine die Aktualisierungsschleife und tritt in die Finalisierungsphase ein. Sie bereitet alle geladenen Spielobjekte auf das Löschen vor. Die [`final()`](/ref/go#final)-Funktionen aller Objektkomponenten werden aufgerufen, sodass du eigene Aufräumarbeiten ausführen kannst. Anschließend werden die Objekte gelöscht und die Hauptsammlung wird entladen.
+
+Die Schritte des Durchlaufs [„Nachrichten zustellen“](#dispatching-messages) werden der Übersichtlichkeit halber in einem eigenen Diagramm am Ende dieses Handbuchs gezeigt. In den Diagrammen sind sie mit einem kleinen Symbol für einen „Briefumschlag mit Pfeil“ 📩 gekennzeichnet.
+
+## Initialisierung {#initialization}
+
+Hier beginnt dein Spiel; dies ist der erste Schritt seiner Ausführung. Er lässt sich in 3 Phasen unterteilen:
+
+![Initialisierung](images/application_lifecycle/initialization.png)
+
+### Vorinitialisierung {#preinitialization}
+
+Während der Phase `Preinitialization` führt die Engine viele Schritte aus, bevor die Hauptsammlung, also die Startsammlung (bootstrap collection), geladen wird. Der Speicherprofiler, Sockets, Grafik, HID (Eingabegeräte), Audio, Physik und vieles mehr werden eingerichtet. Auch die Anwendungskonfiguration (*game.project*) wird geladen und eingerichtet.
+
+![Vorinitialisierung](images/application_lifecycle/pre_init.png)
+
+Der erste von dir steuerbare Einstiegspunkt ist am Ende der Engine-Initialisierung der Aufruf der Funktion `init()` des aktuellen Render-Skripts.
+
+Danach wird die Hauptsammlung geladen und initialisiert.
+
+### Initialisierung der Sammlung {#collection-init}
+
+Während der Phase `Collection Init` wenden alle Spielobjekte in der Sammlung ihre Transformationen auf ihre untergeordneten Objekte an: Verschiebung (Änderung der Position), Drehung und Skalierung. Anschließend werden alle vorhandenen `init()`-Funktionen der Komponenten aufgerufen.
+
+![Initialisierung der Sammlung](images/application_lifecycle/collection_init.png)
+
+::: sidenote
+Die Reihenfolge, in der die `init()`-Funktionen der Spielobjektkomponenten aufgerufen werden, ist nicht festgelegt. Du solltest nicht davon ausgehen, dass die Engine Objekte derselben Sammlung in einer bestimmten Reihenfolge initialisiert.
+:::
+
+### Phase nach der Aktualisierung während der Initialisierung {#post-update-in-initialization}
+
+Die Engine führt dann einen vollständigen `Post Update`-Durchlauf aus – denselben Durchlauf, der später nach jedem Schritt der `Update Loop` ausgeführt wird. Er erfolgt am Ende der Initialisierung, weil dein `init()`-Code neue Nachrichten senden, Fabriken (factories) zum dynamischen Erzeugen neuer Objekte anweisen, Objekte zum Löschen vormerken und andere Aktionen ausführen kann.
+
+![Phase nach der Aktualisierung](images/application_lifecycle/post_init.png)
+
+Dieser Durchlauf stellt Nachrichten zu, erzeugt die Spielobjekte über Fabriken tatsächlich und löscht Objekte. Beachte, dass der `Post Update`-Durchlauf eine Sequenz zum „Zustellen von Nachrichten“ enthält, die sowohl wartende Nachrichten zustellt als auch Nachrichten an Sammlungs-Proxys (collection proxies) verarbeitet. Alle daraus folgenden Aktualisierungen der Proxys (Aktivieren, Deaktivieren, Initialisieren, Finalisieren, Laden und Vormerken zum Entladen) werden während dieser Schritte ausgeführt.
+
+Es ist durchaus möglich, während `init()` einen [Sammlungs-Proxy](/manuals/collection-proxy) zu laden, sicherzustellen, dass alle darin enthaltenen Objekte initialisiert sind, und die Sammlung anschließend über den Proxy wieder zu entladen. All das kann geschehen, bevor die erste `update()`-Funktion einer Komponente aufgerufen wird, also bevor die Engine die Initialisierungsphase verlassen hat und in die Aktualisierungsschleife eingetreten ist:
+
+```lua
+function init(self)
+    print("init()")
+    msg.post("#collectionproxy", "load")
+end
+
+function update(self, dt)
+    -- The proxy collection is unloaded before this code is reached.
+    print("update()")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        print("proxy_loaded. Init, enable and then unload.")
+        msg.post("#collectionproxy", "init")
+        msg.post("#collectionproxy", "enable")
+        msg.post("#collectionproxy", "unload")
+        -- The proxy collection objects’ init() and final() functions
+        -- are called before we reach this object’s update()
+    end
+end
+```
+
+## Aktualisierungsschleife {#update-loop}
+
+Die `Update Loop` durchläuft einmal pro Frame eine bestimmte Sequenz. Diese Sequenz lässt sich in 5 Hauptphasen unterteilen:
+
+![Aktualisierungsschleife](images/application_lifecycle/update_loop.png)
+
+1. Eingabe (Verarbeitung und Behandlung)
+2. Aktualisierung (einschließlich der Aktualisierungen mit festem Zeitschritt, der regulären und späten Aktualisierungen sowie der Aktualisierungen der Engine-Komponenten)
+3. Aktualisierung des Renderings
+4. Phase nach der Aktualisierung (Entladen von Sammlungs-Proxys, dynamisches Erzeugen und Löschen von Spielobjekten)
+5. Rendern des Frames (die endgültige Grafik wird gerendert)
+
+### Eingabephase {#input-phase}
+
+Eingaben werden von verfügbaren Geräten gelesen, anhand der [Eingabebindungen (input bindings)](/manuals/input) zugeordnet und dann weitergeleitet. Jedes Spielobjekt, das den Eingabefokus erhalten hat, erhält Eingaben in den `on_input()`-Funktionen all seiner Komponenten. Bei einem Spielobjekt mit einer Skriptkomponente und einer GUI-Komponente mit GUI-Skript erhalten die `on_input()`-Funktionen beider Komponenten Eingaben – vorausgesetzt, sie sind definiert und haben den Eingabefokus erhalten.
+
+![Eingabephase](images/application_lifecycle/input_phase.png)
+
+Jedes Spielobjekt, das den Eingabefokus erhalten hat und Sammlungs-Proxy-Komponenten enthält, leitet Eingaben an die Komponenten innerhalb der vom Proxy geladenen Sammlung weiter. Dieser Vorgang setzt sich rekursiv über aktivierte Sammlungs-Proxys innerhalb aktivierter Sammlungs-Proxys fort.
+
+### Aktualisierungsphase {#update-phase}
+
+Die Phase `Update` ist Teil der `Update Loop`. Sie wird einmal für die Sammlung auf oberster Ebene gestartet und läuft dann rekursiv für jeden aktivierten Sammlungs-Proxy.
+
+Innerhalb einer Sammlung verarbeitet Defold Callbacks nach Komponententyp: Die Engine durchläuft alle Instanzen eines Komponententyps, der die entsprechende Phase implementiert, ruft den Lua-Callback für jede Instanz auf, stellt die Nachrichten zu und geht dann zum nächsten Komponententyp über.
+
+Die grundsätzliche Reihenfolge der Lua-Callback-Phasen von *Skriptkomponenten* ist:
+
+1. `fixed_update()` – wird 0..N Mal pro Frame aufgerufen (bei Verwendung eines festen Zeitschritts)
+2. `update()` – wird 1 Mal pro Frame aufgerufen
+3. `late_update()` – wird 1 Mal pro Frame aufgerufen
+
+![Aktualisierungsphase](images/application_lifecycle/update_phase.png)
+
+
+Jede Spielobjektkomponente in der Hauptsammlung wird durchlaufen. Wenn eine dieser Komponenten ein Skript mit einer Funktion `fixed_update()`/`update()`/`late_update()` besitzt, wird diese aufgerufen. Ist die Komponente ein Sammlungs-Proxy, wird jede Komponente in der vom Proxy geladenen Sammlung rekursiv mit allen Schritten der Phase `Update` aktualisiert.
+
+::: sidenote
+Die Reihenfolge, in der die `update()`-Funktionen der Spielobjektkomponenten aufgerufen werden, ist nicht festgelegt. Du solltest nicht davon ausgehen, dass die Engine Objekte derselben Sammlung in einer bestimmten Reihenfolge aktualisiert. Dasselbe gilt für `fixed_update()` und `late_update()` (seit 1.12.0).
+:::
+
+#### Physik {#physics}
+
+Bei Kollisionsobjektkomponenten werden Physiknachrichten (Kollisionen, Trigger, Antworten auf Strahlabfragen (raycasts) usw.) innerhalb des zugehörigen Spielobjekts an alle Komponenten zugestellt, die ein Skript mit der Funktion `on_message()` enthalten.
+
+Wenn für die Physiksimulation ein [fester Zeitschritt](/manuals/physics/#physics-updates) verwendet wird, kann außerdem die Funktion `fixed_update()` in allen Skriptkomponenten aufgerufen werden. Diese Funktion ist in physikbasierten Spielen nützlich, wenn du Physikobjekte in regelmäßigen Abständen verändern möchtest, um eine stabile Physiksimulation zu erzielen.
+
+#### Transformationen {#transforms}
+
+Vor **jeder** Aktualisierung eines Komponententyps werden bei Bedarf die Transformationen aktualisiert, also mehrmals während der `Update Loop`. Dabei werden alle Bewegungen, Drehungen und Skalierungen der Spielobjekte auf jede Spielobjektkomponente und alle Komponenten untergeordneter Spielobjekte angewendet.
+
+Am Ende der `Update Loop` werden die Transformationen bei Bedarf ein weiteres, abschließendes Mal aktualisiert.
+
+#### Aktualisierungsphase der Engine (ohne Aktualisierungen mit festem Zeitschritt) {#engine-update-phase-no-fixed-updates}
+
+Die folgenden Tabellen beschreiben die Aktualisierungsdurchläufe auf *Engine-Ebene*. Sie lassen die genaue interne Prioritätsreihenfolge der Komponenten bewusst aus (sie ist ein Implementierungsdetail der Engine), geben aber die für Skripte relevanten Zusicherungen zur Reihenfolge wieder:
+
+- `fixed_update()` wird vor `update()` ausgeführt
+- `late_update()` wird nach `update()` ausgeführt
+- gesendete Nachrichten werden zwischen den Aktualisierungen der Komponententypen sowie zwischen den Skript-Callback-Phasen zugestellt
+
+Wenn `Use Fixed Timestep` auf `false` gesetzt ist und/oder Fixed Update Frequency den Wert `0` hat, wird zu Beginn der Phase `dt` vorbereitet. Danach ist der Ablauf wie in der folgenden Tabelle dargestellt:
+
+:::sidenote
+Beachte, dass nach der Aktualisierung **jedes** Komponententyps alle Nachrichten zugestellt werden. Damit die folgende Tabelle übersichtlich bleibt, ist dies dort nicht eingezeichnet.
+:::
+
+| Schritt | Engine-Phase | Lua-Callback | Kommentar |
+|-|-|-|-|
+| 1 | **Aktualisierung** | `update()` | Wird einmal pro Frame für jeden Komponententyp, der die Aktualisierung implementiert, in der internen Prioritätsreihenfolge aufgerufen. Außerdem werden hier mit `go.animate()` gestartete Animationen von Spielobjekteigenschaften als eigener Komponententyp aktualisiert. **Physikkomponenten** werden hier aktualisiert. Für jeden aktivierten Sammlungs-Proxy wird die gesamte Phase `Update` rekursiv ab Schritt 1 aufgerufen. |
+| 2 | **Späte Aktualisierung** | `late_update()` | Wird einmal pro Frame für jeden Komponententyp, der die späte Aktualisierung implementiert, in der internen Prioritätsreihenfolge aufgerufen. |
+| 3 | **Transformationen** | | Am Ende wird bei Bedarf für jede Komponente eine zusätzliche abschließende Aktualisierung der Transformationen ausgeführt. |
+
+#### Aktualisierungsphase der Engine mit festem Zeitschritt {#engine-update-phase-with-fixed-timestep}
+
+Wenn `Use Fixed Timestep` auf `true` gesetzt ist und Fixed Update Frequency ungleich null ist, werden zu Beginn der Phase `dt` (Zeitdifferenz), `fixed_dt` und `num_fixed_steps` (`0..N`) vorbereitet. Letzteres gibt an, wie oft die Aktualisierung mit festem Zeitschritt aufgerufen wird. Die Anzahl wird anhand der Zeit seit der letzten Aktualisierung bestimmt, um eine feste Anzahl von Aktualisierungen sicherzustellen.
+
+:::sidenote
+Beachte, dass nach der Aktualisierung **jedes** Komponententyps alle Nachrichten zugestellt werden. Damit die folgende Tabelle übersichtlich bleibt, ist dies dort nicht eingezeichnet.
+:::
+
+Dann folgt die Schleife:
+
+| Schritt | Engine-Phase | Lua-Callback | Kommentar |
+|-|-|-|-|
+| 1 | **Aktualisierung mit festem Zeitschritt** | `fixed_update()` | Wird je nach Zeitverlauf `0..N` Mal pro Frame für jeden Komponententyp, der die Aktualisierung mit festem Zeitschritt implementiert, in der internen Prioritätsreihenfolge aufgerufen. Dies umfasst die Aktualisierungsschritte mit festem Zeitschritt der *Physikkomponenten*. |
+| 2 | **Aktualisierung** | `update()` | Wird einmal pro Frame für jeden Komponententyp, der die Aktualisierung implementiert, in der internen Prioritätsreihenfolge aufgerufen. Außerdem werden hier mit `go.animate()` gestartete Animationen von Spielobjekteigenschaften als eigener Komponententyp aktualisiert. Für jeden aktivierten Sammlungs-Proxy wird die Phase `Update` rekursiv ab Schritt 1 aufgerufen. |
+| 3 | **Späte Aktualisierung** | `late_update()` | Wird einmal pro Frame für jeden Komponententyp, der die späte Aktualisierung implementiert, in der internen Prioritätsreihenfolge aufgerufen. |
+| 4 | **Transformationen** | | Am Ende wird bei Bedarf für jede Komponente eine zusätzliche abschließende Aktualisierung der Transformationen ausgeführt. |
+
+Wenn du mehr darüber erfahren möchtest, wie Defold während der Aktualisierungsphase intern arbeitet, lohnt sich ein Blick direkt in den Code von [`gameobject.cpp`](https://github.com/defold/defold/blob/dev/engine/gameobject/src/gameobject/gameobject.cpp).
+
+### Aktualisierungsphase des Renderings {#render-update-phase}
+
+Der Block zur Aktualisierung des Renderings stellt zuerst alle Nachrichten zu, die an den Socket `@render` gesendet wurden (z. B. `set_view_projection`-Nachrichten von Kamerakomponenten, `set_clear_color`-Nachrichten usw.). Anschließend wird `update()` im Render-Skript aufgerufen.
+
+![Aktualisierungsphase des Renderings](images/application_lifecycle/render_update_phase.png)
+
+### Phase nach der Aktualisierung {#post-update-phase}
+
+Nach den Aktualisierungen wird eine Sequenz für die Phase nach der Aktualisierung ausgeführt. Sie entlädt Sammlungs-Proxys aus dem Speicher, die zum Entladen vorgemerkt sind (dies geschieht während der Sequenz zum „Zustellen von Nachrichten“). Für jedes zum Löschen vorgemerkte Spielobjekt werden alle `final()`-Funktionen seiner Komponenten aufgerufen, sofern welche vorhanden sind. Der Code in den `final()`-Funktionen sendet häufig neue Nachrichten an die Warteschlange, daher folgt danach der Durchlauf zum „Zustellen von Nachrichten“.
+
+![Phase nach der Aktualisierung](images/application_lifecycle/post_update_phase.png)
+
+Als Nächstes erzeugt jede Fabrikkomponente, die zum dynamischen Erzeugen eines Spielobjekts angewiesen wurde, dieses Spielobjekt. Zum Schluss werden die zum Löschen vorgemerkten Spielobjekte tatsächlich gelöscht.
+
+### Renderphase {#render-phase}
+
+Im letzten Schritt der Aktualisierungsschleife werden `@system`-Nachrichten zugestellt (`exit`- und `reboot`-Nachrichten, Umschalten des Profilers, Starten und Stoppen der Videoaufnahme usw.).
+
+![Renderphase](images/application_lifecycle/render_phase.png)
+
+Danach werden die Grafiken sowie gegebenenfalls die Darstellung des visuellen Profilers gerendert (siehe die [Debugging-Dokumentation](/manuals/debugging)). Nach dem Rendern der Grafiken erfolgt die Videoaufnahme.
+
+#### Bildrate und Zeitschritt der Sammlung {#frame-rate-and-collection-time-step}
+
+Die Anzahl der Frame-Aktualisierungen pro Sekunde (die der Anzahl der Durchläufe der Aktualisierungsschleife pro Sekunde entspricht) lässt sich in den Projekteinstellungen festlegen oder per Programm, indem eine `set_update_frequency`-Nachricht an den Socket `@system` gesendet wird. Außerdem kannst du den _Zeitschritt_ für Sammlungs-Proxys einzeln festlegen, indem du eine `set_time_step`-Nachricht an den jeweiligen Proxy sendest. Eine Änderung des Zeitschritts einer Sammlung beeinflusst die Bildrate nicht. Sie wirkt sich auf den Zeitschritt der Physikaktualisierung sowie auf die Variable `dt` aus, die an `update().` übergeben wird. Beachte auch, dass eine Änderung des Zeitschritts die Anzahl der Aufrufe von `update()` pro Frame nicht verändert – es ist immer genau ein Aufruf.
+
+(Weitere Informationen findest du im [Handbuch zu Sammlungs-Proxys](/manuals/collection-proxy) und unter [`set_time_step`](/ref/collectionproxy#set-time-step))
+
+#### Drosselung der Engine {#engine-throttling}
+
+Defold 1.12.0 führte eine API zum Drosseln der Engine ein, mit der sich Engine-Aktualisierungen und Rendering vollständig überspringen lassen, während Eingaben weiterhin erkannt werden. Jede Eingabe weckt die Engine wieder auf. Nach einer Wartezeit kann die Engine erneut in den gedrosselten Zustand wechseln.
+
+Weitere Informationen und Anwendungsbeispiele findest du in der API zu `sys.set_engine_throttle()`.
+
+## Finalisierung {#finalization}
+
+Wenn die Anwendung beendet wird, schließt sie zunächst die letzte Sequenz der Aktualisierungsschleife ab. Dabei werden alle Sammlungs-Proxys entladen: Alle Spielobjekte in jeder vom Proxy geladenen Sammlung werden finalisiert und gelöscht.
+
+Anschließend tritt die Engine in eine Finalisierungssequenz ein, die die Hauptsammlung und ihre Objekte behandelt:
+
+![Finalisierung](images/application_lifecycle/finalization.png)
+
+Zuerst werden die `final()`-Funktionen der Komponenten aufgerufen. Darauf folgt das Zustellen von Nachrichten. Schließlich werden alle Spielobjekte gelöscht und die Hauptsammlung wird entladen.
+
+Die Engine fährt dann im Hintergrund die Subsysteme herunter: Die Projektkonfiguration wird gelöscht, der Speicherprofiler wird beendet und so weiter.
+
+Die Anwendung ist jetzt vollständig beendet.
+
+## Nachrichten zustellen {#dispatching-messages}
+
+Das **Zustellen von Nachrichten** ist ein besonderer Durchlauf, der nach der Aktualisierung **jedes** Komponententyps ausgeführt wird, also beispielsweise nach der Aktualisierung von Sprites und Skripten, sowie nach jeder anderen Aktion, die Nachrichten senden kann. Dabei werden alle gesendeten Nachrichten zugestellt, die in einer Warteschlange gesammelt wurden. Diese Durchläufe sind in den Diagrammen mit kleinen Symbolen für einen „Briefumschlag mit Pfeil“ 📩 gekennzeichnet.
+
+![Nachrichten zustellen](images/application_lifecycle/dispatch_messages.png)
+
+Nachdem alle **benutzerdefinierten Nachrichten** durch Aufrufe von `on_message()` für die jeweiligen Komponenten zugestellt wurden, werden die speziellen Defold-Nachrichten für jeden Sammlungs-Proxy in der folgenden Reihenfolge verarbeitet (die auch im Diagramm dargestellt ist):
+
+1. `load`-Nachrichten – laden zum Laden vorgemerkte Sammlungs-Proxys und senden die Nachricht `proxy_loaded` zurück.
+2. `unload`-Nachrichten – entladen zum Entladen vorgemerkte Sammlungs-Proxys und senden die Nachricht `proxy_unloaded` zurück.
+3. `init`-Nachrichten – lösen die Phase `Collection Init` für alle zu initialisierenden Sammlungs-Proxys aus.
+4. `final`-Nachrichten – lösen `final()` für alle Komponenten des zur Finalisierung vorgemerkten Proxys aus.
+5. `enable`-Nachrichten – aktivieren den Sammlungs-Proxy, sodass die `Update Loop` im nächsten Frame für ihn ausgeführt wird; dabei wird implizit `init()` für jede Komponente der Sammlung ausgelöst.
+6. `disable`-Nachrichten – deaktivieren den Sammlungs-Proxy, sodass die `Update Loop` im nächsten Frame **nicht** für ihn ausgeführt wird; die Ausführung der `Update Loop` für ihn wird vollständig angehalten.
+
+Da der `on_message()`-Code jeder empfangenden Komponente weitere Nachrichten senden kann, stellt die Nachrichtenverarbeitung gesendete Nachrichten rekursiv weiter zu, bis die Nachrichtenwarteschlange leer ist. Die Anzahl der Durchläufe durch die Nachrichtenwarteschlange ist jedoch begrenzt. Weitere Informationen findest du unter [Nachrichtenketten](/manuals/message-passing).

--- a/docs/de/manuals/application-security.md
+++ b/docs/de/manuals/application-security.md
@@ -1,0 +1,108 @@
+---
+title: Handbuch zur Anwendungssicherheit
+brief: Dieses Handbuch behandelt verschiedene Bereiche im Zusammenhang mit sicheren Entwicklungspraktiken.
+---
+
+# Anwendungssicherheit {#application-security}
+
+Anwendungssicherheit ist ein breites Thema, das von sicheren Entwicklungspraktiken bis zum Schutz deiner Spielinhalte nach der Veröffentlichung reicht. Dieses Handbuch behandelt verschiedene Bereiche und ordnet sie im Zusammenhang mit der Nutzung der Defold-Engine, ihrer Werkzeuge und Dienste in die Anwendungssicherheit ein:
+
+* Schutz des geistigen Eigentums
+* Anti-Cheat-Lösungen
+* Sichere Netzwerkkommunikation
+* Verwendung von Drittanbietersoftware
+* Nutzung von Cloud-Build-Servern
+* Herunterladbare Inhalte
+
+
+## Dein geistiges Eigentum vor Diebstahl schützen {#securing-your-intellectual-property-from-theft}
+Die meisten Entwickler beschäftigt die Frage, wie sie ihre Werke vor Diebstahl schützen können. Urheberrecht, Patente und Marken können aus rechtlicher Sicht dazu dienen, die verschiedenen Aspekte des geistigen Eigentums an Videospielen zu schützen. Das Urheberrecht gibt seinem Inhaber das ausschließliche Recht, das kreative Werk zu verbreiten. Patente schützen Erfindungen, und Marken schützen Namen, Symbole und Logos.
+
+Es kann auch wünschenswert sein, technische Vorkehrungen zum Schutz der kreativen Arbeit an einem Spiel zu treffen. Dabei solltest du jedoch bedenken, dass sich Wege finden lassen, die Assets zu extrahieren, sobald das Spiel in den Händen der Spieler ist. Dies ist durch Reverse Engineering der Spielanwendung und ihrer Dateien möglich, aber auch mithilfe von Werkzeugen, die Texturen und Modelle extrahieren, wenn diese an die GPU gesendet werden oder andere Assets in den Arbeitsspeicher geladen werden.
+
+Aus diesem Grund vertreten wir grundsätzlich die Auffassung, dass Nutzer die Assets eines Spiels extrahieren können, wenn sie entschlossen genug dazu sind.
+
+Entwickler können eigene Schutzmaßnahmen hinzufügen, um das Extrahieren der Assets zu erschweren, __aber nicht unmöglich zu machen__. Dazu gehören in der Regel verschiedene Verfahren zur Verschlüsselung und Verschleierung, um Spiel-Assets zu schützen und zu verbergen.
+
+### Quellcode-Verschleierung {#source-code-obfuscation}
+Die Quellcode-Verschleierung ist ein automatisierter Vorgang, bei dem der Quellcode für Menschen absichtlich schwer verständlich gemacht wird, ohne die Ausgabe des Programms zu beeinflussen. Der Zweck besteht in der Regel darin, vor Diebstahl zu schützen, aber auch das Cheaten zu erschweren.
+
+In Defold lässt sich die Quellcode-Verschleierung entweder als vorbereitender Schritt vor dem Build oder als integrierter Bestandteil des Defold-Build-Vorgangs anwenden. Bei einer Verschleierung vor dem Build wird der Quellcode mit einem Werkzeug zur Verschleierung bearbeitet, bevor der Defold-Build-Vorgang startet.
+
+Die Verschleierung während des Builds wird hingegen mithilfe eines Lua-Builder-Plugins in den Build-Vorgang integriert. Ein Lua-Builder-Plugin nimmt den unverarbeiteten Quellcode als Eingabe entgegen und gibt eine verschleierte Version des Quellcodes aus. Ein Beispiel für die Verschleierung während des Builds zeigt die [Prometheus-Erweiterung](https://github.com/defold/extension-prometheus), die auf Prometheus basiert, einem auf GitHub verfügbaren Lua-Obfuskator. Unten findest du ein Beispiel dafür, wie Prometheus einen Codeausschnitt stark verschleiert (beachte, dass sich eine derart starke Verschleierung auf die Leistung des Lua-Codes zur Laufzeit auswirkt):
+
+Beispiel:
+
+```
+function init(self)
+ print("hello")
+ test.greet("Bob")
+end
+```
+
+Verschleierte Ausgabe:
+
+```
+local v={"+qdW","ZK0tEKf=";"XP/IX3+="}for o,J in ipairs({{1;3};{1,1},{2,3}})do while J[1]<J[2]do v[J[1]],v[J[2]],J[1],J[2]=v[J[2]],v[J[1]],J[1]+1,J[2]-1 end end local function J(o)return v[o+45816]end do local o={["/"]=9;["8"]=48;["9"]=1;q=38,o=62;V=33;y=43,d=61,B=50,L=54;v=2;["0"]=21,n=31;p=63;R=5;N=3;i=10;e=35;C=7;l=56;a=47,J=58;m=59;["2"]=36;z=11;M=12;Z=26;O=18;["5"]=20;s=8,["4"]=30,P=55;w=4;U=29;Q=28;r=24,h=41;G=45;c=19;W=34,k=57;T=14,t=44,S=0;f=60;F=42,E=27;u=40;X=25,j=17;["3"]=23,b=13;["1"]=53;Y=32,A=22,K=6,["+"]=16,["6"]=46;["7"]=51;I=37;D=52;H=15,x=49,g=39}local J=type local x=string.sub local d=v local l=string.len local W=string.char local L=table.insert local w=table.concat local h=math.floor for v=1,#d,1 do local X=d[v]if J(X)=="string"then local J=l(X)local H={}local S=1 local k=0 local K=0 while S<=J do local v=x(X,S,S)local d=o[v]if d then k=k+d*64^(3-K)K=K+1 if K==4 then K=0 local o=h(k/65536)local v=h((k%65536)/256)local J=k%256 L(H,W(o,v,J))k=0 end elseif v=="="then L(H,W(h(k/65536)))if S>=J or x(X,S+1,S+1)~="="then L(H,W(h((k%65536)/256)))end break end S=S+1 end d[v]=w(H)end end end local function o(o)test[J(-45815)](o)end function init(v)print(J(-45813))o(J(-45814))end
+```
+
+### Ressourcenverschlüsselung {#resource-encryption}
+Während des Defold-Build-Vorgangs werden die Spielressourcen verarbeitet und in Formate umgewandelt, die sich für die Verwendung durch die Defold-Engine zur Laufzeit eignen. Texturen werden in das Format Basis Universal kompiliert, Sammlungen (collections), Spielobjekte (game objects) und Komponenten (components) werden von einer menschenlesbaren Textdarstellung in ihre binären Entsprechungen umgewandelt, und der Lua-Quellcode wird verarbeitet und in Bytecode kompiliert. Andere Assets wie Audiodateien werden unverändert verwendet.
+
+Nach Abschluss dieses Vorgangs werden die Assets einzeln zum Spielarchiv hinzugefügt. Das Spielarchiv ist eine große Binärdatei, und die Position jeder Ressource innerhalb des Archivs wird in einer Archivindexdatei gespeichert. Das Format ist [hier](https://github.com/defold/defold/blob/dev/engine/docs/ARCHIVE_FORMAT.md) dokumentiert.
+
+Bevor Lua-Quelldateien zum Archiv hinzugefügt werden, werden sie optional auch verschlüsselt. Die in Defold standardmäßig bereitgestellte Verschlüsselung ist eine einfache Blockchiffre. Sie verhindert, dass Zeichenfolgen im Code sofort sichtbar sind, wenn das Spielarchiv mit einem Anzeigeprogramm für Binärdateien untersucht wird. Sie sollte nicht als kryptografisch sicher angesehen werden, da der Defold-Quellcode auf GitHub verfügbar ist und der Chiffrierschlüssel darin sichtbar ist.
+
+Du kannst eine eigene Verschlüsselung für Lua-Quelldateien hinzufügen, indem du ein Plugin zur Ressourcenverschlüsselung implementierst. Ein solches Plugin besteht aus einem Teil, der Ressourcen während des Build-Vorgangs verschlüsselt, und einem Teil, der Ressourcen zur Laufzeit entschlüsselt, wenn sie aus dem Spielarchiv gelesen werden. Ein grundlegendes Plugin zur Ressourcenverschlüsselung, das du als Ausgangspunkt für deine eigene Verschlüsselung verwenden kannst, ist [auf GitHub verfügbar](https://github.com/defold/extension-resource-encryption).
+
+
+### Projektkonfigurationswerte kodieren {#encoding-project-configuration-values}
+Die Datei *game.project* wird unverändert in dein Anwendungs-Bundle aufgenommen. Manchmal möchtest du öffentliche API-Zugriffsschlüssel oder ähnliche Werte speichern, die sensibel, aber möglicherweise nicht vertraulich sind. Um die Sicherheit solcher Werte zu erhöhen, kannst du sie in die Binärdatei der Anwendung aufnehmen, statt sie in *game.project* zu speichern. Sie bleiben dabei für Defold-API-Funktionen wie `sys.get_config_string()` und ähnliche Funktionen zugänglich. Dazu kannst du eine native Erweiterung (native extension) in deiner Datei *game.project* hinzufügen und das Makro `DM_DECLARE_CONFIGFILE_EXTENSION` verwenden, um eigene Überschreibungen für das Abrufen von Konfigurationswerten über die Defold-API-Funktionen bereitzustellen. Ein Beispielprojekt, das du als Ausgangspunkt verwenden kannst, ist [auf GitHub verfügbar](https://github.com/defold/example-configfile-extension/tree/master).
+
+
+## Dein Spiel vor Cheatern schützen {#securing-your-game-against-cheaters}
+Cheaten in Videospielen gibt es schon so lange wie die Spielebranche selbst. Früher wurden Cheat-Codes in beliebten Videospielzeitschriften veröffentlicht, und für die frühen Heimcomputer wurden spezielle Cheat-Module verkauft. Mit der Weiterentwicklung der Branche und der Spiele haben sich auch die Cheater und ihre Methoden weiterentwickelt. Zu den beliebtesten Cheat-Methoden für Spiele gehören:
+
+* Erneutes Verpacken von Spielinhalten, um eigene Logik einzuschleusen
+* Speed-Hacks, um ein Spiel schneller oder langsamer als normal laufen zu lassen
+* Automatisierung und visuelle Analyse für automatisches Zielen und Bots
+* Code- und Speicherinjektion, um Punktzahlen, Leben, Munition usw. zu verändern
+
+Der Schutz vor Cheatern ist schwierig und grenzt an das Unmögliche. Selbst Cloud-Gaming, bei dem Spiele auf entfernten Servern ausgeführt und direkt auf das Gerät eines Nutzers gestreamt werden, ist nicht vollständig vor Cheatern gefeit.
+
+Defold bietet in der Engine oder den Werkzeugen keine Anti-Cheat-Lösungen an und überlässt diese Arbeit einem der vielen Unternehmen, die auf Anti-Cheat-Lösungen für Spiele spezialisiert sind.
+
+
+## Deine Netzwerkkommunikation absichern {#securing-your-network-communication}
+Die Socket- und HTTP-Kommunikation in Defold unterstützt sichere Socket-Verbindungen. Es wird empfohlen, für jede Serverkommunikation sichere Verbindungen zu verwenden, um den Server zu authentifizieren und die Vertraulichkeit und Integrität aller ausgetauschten Daten während der Übertragung vom Client zum Server und umgekehrt zu schützen. Defold verwendet die beliebte und weitverbreitete Open-Source-Implementierung [Mbed TLS](https://github.com/Mbed-TLS/mbedtls) der Protokolle TLS und SSL. Mbed TLS wird von ARM und seinen Technologiepartnern entwickelt.
+
+### Validierung von SSL-Zertifikaten {#ssl-certificate-validation}
+Um Man-in-the-Middle-Angriffe auf deine Netzwerkkommunikation zu verhindern, kannst du die Zertifikatskette während des SSL-Handshakes beim Aushandeln einer Verbindung mit einem Server validieren. Dazu stellst du dem Netzwerk-Client in Defold eine Liste öffentlicher Schlüssel bereit. Weitere Informationen zum Absichern deiner Netzwerkkommunikation findest du im Abschnitt zur SSL-Überprüfung im [Netzwerkhandbuch](https://defold.com/manuals/networking/#secure-connections).
+
+
+## Drittanbietersoftware sicher verwenden {#securing-your-use-of-third-party-software}
+Obwohl du keine Bibliotheken oder nativen Erweiterungen von Drittanbietern benötigst, um ein Spiel zu erstellen, ist es unter Entwicklern sehr üblich geworden, Assets aus dem offiziellen [Asset Portal](https://defold.com/assets/) zu verwenden, um die Entwicklung zu beschleunigen. Das Asset Portal enthält eine große Auswahl an Assets, von Integrationen mit SDKs von Drittanbietern über Bildschirmmanager, UI-Bibliotheken und Kameras bis hin zu vielem mehr.
+
+Keines der Assets im Asset Portal wurde von der Defold Foundation überprüft. Wir übernehmen keine Verantwortung für Schäden an deinem Computersystem oder einem anderen Gerät oder für Datenverluste, die durch die Verwendung eines über das Asset Portal bezogenen Assets entstehen. Das Kleingedruckte findest du in unseren [Allgemeinen Geschäftsbedingungen](https://defold.com/terms-and-conditions/#3-no-warranties).
+
+Wir empfehlen dir, jedes Asset vor der Verwendung zu prüfen. Sobald du es als für dein Projekt geeignet beurteilt hast, solltest du einen Fork oder eine Kopie des Assets erstellen, damit es sich nicht unbemerkt ändert.
+
+
+## Cloud-Build-Server sicher nutzen {#securing-your-use-of-cloud-build-servers}
+Die Defold-Cloud-Build-Server (auch als Extender-Server bekannt) wurden entwickelt, um Entwicklern das Hinzufügen neuer Funktionen zur Defold-Engine zu ermöglichen, ohne die Engine selbst neu erstellen zu müssen. Wenn ein Defold-Projekt mit nativem Code zum ersten Mal erstellt wird, werden der native Code und alle zugehörigen Ressourcen an die Cloud-Build-Server gesendet. Dort wird eine angepasste Version der Defold-Engine erstellt und an den Entwickler zurückgesendet. Derselbe Vorgang kommt zum Einsatz, wenn ein Projekt mit einem benutzerdefinierten Anwendungsmanifest erstellt wird, um nicht verwendete Komponenten aus der Engine zu entfernen.
+
+Die Cloud-Build-Server werden bei AWS gehostet und nach bewährten Sicherheitspraktiken eingerichtet. Die Defold Foundation garantiert jedoch nicht, dass die Cloud-Build-Server deine Anforderungen erfüllen, frei von Mängeln, virenfrei, sicher oder fehlerfrei sind oder dass deine Nutzung der Server unterbrechungsfrei oder sicher ist. Das Kleingedruckte findest du in unseren [Allgemeinen Geschäftsbedingungen](https://defold.com/terms-and-conditions/#3-no-warranties).
+
+Wenn dir die Sicherheit und Verfügbarkeit der Build-Server Sorgen bereiten, empfehlen wir dir, eigene private Build-Server einzurichten. Eine Anleitung zum Einrichten deines eigenen Servers findest du in der [zentralen Readme-Datei](https://github.com/defold/extender) des Extender-Repositorys auf GitHub.
+
+
+## Deine herunterladbaren Inhalte absichern {#securing-your-downloadable-content}
+Mit dem Live-Update-System von Defold können Entwickler Inhalte aus dem Haupt-Bundle des Spiels ausschließen, um sie später herunterzuladen und zu verwenden. Ein typischer Anwendungsfall ist das Herunterladen zusätzlicher Level, Karten oder Welten, während der Spieler im Spiel voranschreitet.
+
+Wenn ausgeschlossene Inhalte heruntergeladen und für die Verwendung in einem Spiel vorbereitet werden, überprüft die Engine sie vor der Verwendung. Diese Überprüfung besteht aus mehreren Prüfungen:
+
+* Ist das Binärformat korrekt?
+* Werden die heruntergeladenen Inhalte von der aktuell laufenden Engine-Version unterstützt?
+* Sind die heruntergeladenen Inhalte vollständig, ohne dass Dateien fehlen?
+
+Weitere Informationen zu diesem Vorgang findest du im [Handbuch zu Live Update](https://defold.com/manuals/live-update/#content-verification).

--- a/docs/de/manuals/atlas.md
+++ b/docs/de/manuals/atlas.md
@@ -1,0 +1,228 @@
+---
+title: Atlas-Handbuch
+brief: Dieses Handbuch erklärt, wie Atlas-Ressourcen in Defold funktionieren.
+---
+
+# Atlas
+
+Einzelne Bilder werden häufig als Quelle für Sprites verwendet. Aus Leistungsgründen müssen Bilder jedoch zu größeren Bildsätzen zusammengefasst werden, die als Atlanten (atlases) bezeichnet werden. Das Zusammenfassen kleinerer Bilder zu Atlanten ist besonders auf Mobilgeräten wichtig, auf denen weniger Speicher und Rechenleistung zur Verfügung stehen als auf Desktoprechnern oder dedizierten Spielkonsolen.
+
+In Defold ist eine Atlas-Ressource eine Liste separater Bilddateien, die automatisch zu einem größeren Bild zusammengefasst werden.
+
+## Einen Atlas erstellen {#creating-an-atlas}
+
+Wähle <kbd>New... ▸ Atlas</kbd> im Kontextmenü des Browsers *Assets*. Gib der neuen Atlas-Datei einen Namen. Der Editor öffnet die Datei nun im Atlas-Editor. Die Atlas-Eigenschaften werden im Bereich
+*Properties* angezeigt, sodass du sie bearbeiten kannst (Einzelheiten findest du weiter unten).
+
+Du musst einem Atlas Bilder oder Animationen hinzufügen, bevor du ihn als Grafikquelle für Komponenten (components) von Spielobjekten (game objects) wie Sprites und Partikeleffektkomponenten (ParticleFX) verwenden kannst.
+
+Vergewissere dich, dass du deine Bilder zum Projekt hinzugefügt hast (ziehe die Bilddateien an die richtige Stelle im Browser *Assets* und lege sie dort ab)
+
+Einzelne Bilder hinzufügen
+
+: Ziehe Bilder aus dem Bereich *Asset* in die Editoransicht und lege sie dort ab.
+  
+  Führe alternativ einen <kbd>Rechtsklick</kbd> auf den obersten Atlas-Eintrag im Bereich *Outline* aus.
+
+  Wähle im eingeblendeten Kontextmenü <kbd>Add Images</kbd>, um einzelne Bilder hinzuzufügen.
+
+  Ein Dialogfeld öffnet sich, in dem du die Bilder suchen und auswählen kannst, die du dem Atlas hinzufügen möchtest. Beachte, dass du die Bilddateien filtern und mehrere Dateien gleichzeitig auswählen kannst.
+
+  ![Einen Atlas erstellen und Bilder hinzufügen](images/atlas/add.png)
+
+  Die hinzugefügten Bilder werden in *Outline* aufgelistet, und der vollständige Atlas ist in der mittleren Editoransicht zu sehen. Möglicherweise musst du <kbd>F</kbd> drücken (<kbd>View ▸ Frame Selection</kbd> im Menü), um die Ansicht auf die Auswahl auszurichten.
+
+  ![Hinzugefügte Bilder](images/atlas/single_images.png)
+
+Flipbook-Animationen hinzufügen
+: Führe einen <kbd>Rechtsklick</kbd> auf den obersten Atlas-Eintrag im Bereich *Outline* aus.
+
+  Wähle im eingeblendeten Kontextmenü <kbd>Add Animation Group</kbd>, um eine Flipbook-Animationsgruppe zu erstellen.
+
+  Dem Atlas wird eine neue, leere Animationsgruppe mit einem Standardnamen (`New Animation`) hinzugefügt.
+
+  Ziehe Bilder aus dem Bereich *Asset* in die Editoransicht und lege sie dort ab, um sie der aktuell ausgewählten Gruppe hinzuzufügen.
+  
+  Führe alternativ einen <kbd>Rechtsklick</kbd> auf die neue Gruppe aus und wähle im Kontextmenü <kbd>Add Images</kbd>.
+
+  Ein Dialogfeld öffnet sich, in dem du die Bilder suchen und auswählen kannst, die du der Animationsgruppe hinzufügen möchtest.
+
+  ![Einen Atlas erstellen und Bilder hinzufügen](images/atlas/add_animation.png)
+
+  Drücke bei ausgewählter Animationsgruppe <kbd>Space</kbd>, um eine Vorschau anzuzeigen, und <kbd>Ctrl/Cmd+T</kbd>, um die Vorschau zu schließen. Passe die *Properties* der Animation nach Bedarf an (siehe unten).
+
+  ![Animationsgruppe](images/atlas/animation_group.png)
+
+Du kannst die Bilder in Outline neu anordnen, indem du sie auswählst und <kbd>Alt + Up/down</kbd> drückst. Du kannst auch leicht Duplikate erstellen, indem du Bilder in Outline kopierst und einfügst (über das Menü <kbd>Edit</kbd>, das Kontextmenü per Rechtsklick oder Tastenkombinationen).
+
+## Atlas-Eigenschaften {#atlas-properties}
+
+Jede Atlas-Ressource hat eine Reihe von Eigenschaften. Diese werden im Bereich *Properties* angezeigt, wenn du den obersten Eintrag in der Ansicht *Outline* auswählst.
+
+Size
+: Zeigt die berechnete Gesamtgröße der resultierenden Texturressource an. Breite und Höhe werden auf die nächstgelegene Zweierpotenz gesetzt. Beachte, dass einige Formate quadratische Texturen erfordern, wenn du die Texturkomprimierung aktivierst. Nicht quadratische Texturen werden dann in der Größe angepasst und mit leerem Raum aufgefüllt, um sie quadratisch zu machen. Einzelheiten findest du im [Handbuch zu Texturprofilen](/manuals/texture-profiles/).
+
+Margin
+: Die Anzahl der Pixel, die zwischen den einzelnen Bildern hinzugefügt werden sollen.
+
+Inner Padding
+: Die Anzahl der leeren Pixel, mit denen jedes Bild rundherum aufgefüllt werden soll.
+
+Extrude Borders
+: Die Anzahl der Randpixel, die wiederholt um jedes Bild herum hinzugefügt werden sollen. Wenn der Fragment-Shader Pixel am Rand eines Bildes abtastet, können Pixel eines benachbarten Bildes (auf derselben Atlas-Textur) übergreifen (texture bleeding). Das Erweitern der Randpixel nach außen löst dieses Problem.
+
+Max Page Size
+: Die maximale Größe einer Seite in einem mehrseitigen Atlas. Damit kannst du einen Atlas in mehrere Seiten desselben Atlas aufteilen, um die Atlas-Größe zu begrenzen und trotzdem nur einen einzigen Zeichenaufruf (draw call) zu verwenden. Diese Funktion muss in Kombination mit Materialien verwendet werden, die mehrseitige Atlanten unterstützen und unter `/builtins/materials/*_paged_atlas.material` zu finden sind.
+
+![Mehrseitiger Atlas](images/atlas/multipage_atlas.png)
+
+Rename Patterns
+: Eine durch Kommas (´,´) getrennte Liste von Such- und Ersetzungsmustern, wobei jedes Muster die Form `search=replace` hat.
+Der ursprüngliche Name jedes Bildes (der Basisname der Datei) wird mithilfe dieser Muster umgewandelt. (Ein Muster wie `hat=cat,_normal=` benennt beispielsweise ein Bild namens `hat_normal` in `cat` um.) Das ist nützlich, um Animationen zwischen Atlanten einander zuzuordnen.
+
+Hier siehst du Beispiele für die verschiedenen Eigenschaftseinstellungen mit vier quadratischen Bildern der Größe 64 × 64, die einem Atlas hinzugefügt wurden. Beachte, wie die Atlas-Größe auf 256 × 256 springt, sobald die Bilder nicht mehr in 128 × 128 passen, wodurch viel Texturfläche verschwendet wird.
+
+![Atlas-Eigenschaften](images/atlas/atlas_properties.png)
+
+## Bildeigenschaften {#image-properties}
+
+Jedes Bild in einem Atlas hat eine Reihe von Eigenschaften:
+
+Id
+: Die ID des Bildes (schreibgeschützt).
+
+Size
+: Die Breite und Höhe des Bildes (schreibgeschützt).
+
+Pivot
+: Der Bezugspunkt (pivot) des Bildes (in Einheiten). Oben links ist (0,0) und unten rechts ist (1,1). Der Standardwert ist (0.5, 0.5). Der Bezugspunkt kann außerhalb des Bereichs von 0 bis 1 liegen. Der Bezugspunkt ist die Stelle, an der das Bild zentriert wird, wenn es beispielsweise in einem Sprite verwendet wird. Du kannst den Bezugspunkt ändern, indem du seinen Anfasser in der Editoransicht ziehst. Der Anfasser ist nur sichtbar, wenn ein einzelnes Bild ausgewählt ist. Du kannst das Einrasten aktivieren, indem du beim Ziehen <kbd>Shift</kbd> gedrückt hältst.
+
+Sprite Trim Mode
+: Legt fest, wie das Sprite gerendert wird. Standardmäßig wird das Sprite als Rechteck gerendert (Sprite Trim Mode ist auf Off gesetzt). Wenn das Sprite viele transparente Pixel enthält, kann es effizienter sein, das Sprite als nicht rechteckige Form mit 4 bis 8 Vertices zu rendern. Beachte, dass das Beschneiden von Sprites nicht zusammen mit Sprites mit Neun-Segment-Skalierung (9-slice) funktioniert.
+
+Image
+: Pfad zum Bild selbst.
+
+![Bildeigenschaften](images/atlas/image_properties.png)
+
+## Animationseigenschaften {#animation-properties}
+
+Zusätzlich zur Liste der Bilder, die zu einer Animationsgruppe gehören, steht eine Reihe von Eigenschaften zur Verfügung:
+
+Id
+: Der Name der Animation.
+
+Fps
+: Die Wiedergabegeschwindigkeit der Animation, angegeben in Bildern pro Sekunde (FPS).
+
+Flip horizontal
+: Spiegelt die Animation horizontal.
+
+Flip vertical
+: Spiegelt die Animation vertikal.
+
+Playback
+: Legt fest, wie die Animation abgespielt werden soll:
+
+  - `None` spielt die Animation überhaupt nicht ab; das erste Bild wird angezeigt.
+  - `Once Forward` spielt die Animation einmal vom ersten bis zum letzten Bild ab.
+  - `Once Backward` spielt die Animation einmal vom letzten bis zum ersten Bild ab.
+  - `Once Ping Pong` spielt die Animation einmal vom ersten bis zum letzten Bild und dann zurück zum ersten Bild ab.
+  - `Loop Forward` spielt die Animation wiederholt vom ersten bis zum letzten Bild ab.
+  - `Loop Backward` spielt die Animation wiederholt vom letzten bis zum ersten Bild ab.
+  - `Loop Ping Pong` spielt die Animation wiederholt vom ersten bis zum letzten Bild und dann zurück zum ersten Bild ab.
+
+## Texturen und Atlanten zur Laufzeit erstellen {#runtime-texture-and-atlas-creation}
+
+Du kannst eine Textur und einen Atlas zur Laufzeit erstellen.
+
+### Eine Texturressource zur Laufzeit erstellen {#creating-a-texture-resource-at-runtime}
+
+Verwende [`resource.create_texture(path, params)`](https://defold.com/ref/stable/resource/#resource.create_texture:path-table), um eine neue Texturressource zu erstellen:
+
+```lua
+  local params = {
+    width  = 128,
+    height = 128,
+    type   = graphics.TEXTURE_TYPE_2D,
+    format = graphics.TEXTURE_FORMAT_RGBA,
+  }
+  local my_texture_id = resource.create_texture("/my_custom_texture.texturec", params)
+```
+
+Nachdem die Textur erstellt wurde, kannst du [`resource.set_texture(path, params, buffer)`](https://defold.com/ref/stable/resource/#resource.set_texture:path-table-buffer) verwenden, um die Pixel der Textur festzulegen:
+
+```lua
+  local width = 128
+  local height = 128
+  local buf = buffer.create(width * height, { { name=hash("rgba"), type=buffer.VALUE_TYPE_UINT8, count=4 } } )
+  local stream = buffer.get_stream(buf, hash("rgba"))
+
+  for y=1, height do
+      for x=1, width do
+          local index = (y-1) * width * 4 + (x-1) * 4 + 1
+          stream[index + 0] = 0xff
+          stream[index + 1] = 0x80
+          stream[index + 2] = 0x10
+          stream[index + 3] = 0xFF
+      end
+  end
+
+  local params = { width=width, height=height, x=0, y=0, type=graphics.TEXTURE_TYPE_2D, format=graphics.TEXTURE_FORMAT_RGBA, num_mip_maps=1 }
+  resource.set_texture(my_texture_id, params, buf)
+```
+
+::: sidenote
+Mit `resource.set_texture()` kannst du auch einen Teilbereich der Textur aktualisieren, indem du eine Pufferbreite und -höhe verwendest, die kleiner als die volle Größe der Textur sind, und die Parameter x und y von `resource.set_texture()` änderst.
+:::
+
+Die Textur kann mit `go.set()` direkt auf einer [Modellkomponente](/manuals/model/) verwendet werden:
+
+```lua
+  go.set("#model", "texture0", my_texture_id)
+```
+
+### Einen Atlas zur Laufzeit erstellen {#creating-an-atlas-at-runtime}
+
+Wenn die Textur auf einer [Sprite-Komponente](/manuals/sprite/) verwendet werden soll, muss sie zunächst von einem Atlas verwendet werden. Verwende [`resource.create_atlas(path, params)`](https://defold.com/ref/stable/resource/#resource.create_atlas:path-table), um einen Atlas zu erstellen:
+
+```lua
+  local params = {
+    texture = texture_id,
+    animations = {
+      {
+        id          = "my_animation",
+        width       = width,
+        height      = height,
+        frames      = { 1 },
+      }
+    },
+    geometries = {
+      {
+        vertices  = {
+          0,     0,
+          0,     height,
+          width, height,
+          width, 0
+        },
+        uvs = {
+          0,     0,
+          0,     height,
+          width, height,
+          width, 0
+        },
+        indices = {0,1,2,0,2,3}
+      }
+    }
+  }
+  local my_atlas_id = resource.create_atlas("/my_atlas.texturesetc", params)
+
+  -- assign the atlas to the 'sprite' component on the same go
+  go.set("#sprite", "image", my_atlas_id)
+
+  -- play the "animation"
+  sprite.play_flipbook("#sprite", "my_animation")
+
+```
+
+Die Einträge in `frames` sind bei 1 beginnende Indizes in die Tabelle `geometries`. Eine Liste kann Geometrien wiederverwenden, neu anordnen oder überspringen; das lässt sich mit den veralteten, zur Ablösung vorgesehenen Intervallfeldern `frame_start` und `frame_end` nicht darstellen. `resource.get_atlas()` gibt `frames` zurück; verwende dieselbe Darstellung, wenn du Atlas-Daten an `resource.set_atlas()` oder `resource.create_atlas()` übergibst. Die Intervallfelder werden aus Kompatibilitätsgründen weiterhin von den Funktionen zum Festlegen und Erstellen akzeptiert, neuer Code sollte jedoch `frames` verwenden.

--- a/docs/de/manuals/automated-testing.md
+++ b/docs/de/manuals/automated-testing.md
@@ -1,0 +1,197 @@
+---
+title: Automatisiertes Testen und Überprüfen
+brief: Dieses Handbuch erklärt, wie du deterministische Defold-Tests lokal, in einem laufenden Spiel, in Browsern und in der kontinuierlichen Integration entwirfst, ausführst und ihre Ergebnisse protokollierst.
+---
+
+# Automatisiertes Testen und Überprüfen {#automated-testing-and-verification}
+
+Automatisiertes Testen überprüft Defold-Code und -Inhalte anhand ausdrücklicher, maschinenlesbarer Nachweise. Nutze dieses Handbuch, um Tests zu entwerfen, die gleichermaßen mit lokalen Skripten, Runnern für CI (kontinuierliche Integration) und Programmieragenten funktionieren. Es behandelt Modultests, laufende Sammlungen (collections), Browsertests, Laufzeitautomatisierung, visuelle Prüfungen und Builds ohne grafische Oberfläche (headless) und gibt nützliche Empfehlungen für die Praxis.
+
+## Überprüfungsebenen {#verification-levels}
+
+Sinnvoll aufgebaute Ebenen für automatisierte Tests folgen dem Modell der Testpyramide, das Tests in drei Hauptebenen unterteilt: Unit-Tests, Integrationstests und Ende-zu-Ende-Tests (E2E). In Defold kannst du Tests in gesonderte Sammlungen aufteilen, die beim Start geladen werden können. Üblicherweise ist es sinnvoll, mit der am engsten gefassten und schnellsten Prüfung zu beginnen, die das Problem erkennen kann, und dann bei Bedarf Laufzeit- oder Plattformtests hinzuzufügen.
+
+| Ebene | Geeignete Nachweise |
+| --- | --- |
+| Statische Validierung | Parser, Formatierungswerkzeug, Ressourcenvalidator oder Vergleich generierter Dateien |
+| Modultest | Assertion-Ergebnisse für wiederverwendbare Lua-Logik mit minimalen Engine-Abhängigkeiten |
+| Laufende Sammlung | Nachrichten, Komponenten (components), Eingabe, Physik, Lebenszyklus und Engine-Verhalten |
+| Laufzeitautomatisierung | Aktueller Szenenzustand, eingespeiste Eingabe, Anwendungszustand und Bildschirmaufnahmen zur Laufzeit |
+| HTML5-Browsertest | Eingabe auf der Zeichenfläche, Browserintegration, Verhalten des Ansichtsbereichs (viewport) und Web-Ausgabe |
+| Plattformtest | Verhalten und Rendering auf der tatsächlichen Zielplattform |
+| Build und Bundle | Beendigungsstatus von Bob, Build-Bericht, Archiv und Bundle-Artefakte |
+
+Eine erfolgreiche Kompilierung belegt, dass sich das Projekt erstellen lässt, aber nicht, dass sich das Gameplay korrekt verhält. Eine Bildschirmaufnahme belegt keine komplexen Übergänge, Animationen, Interaktionen oder Spielabläufe. Moderne multimodale Lösungen können damit jedoch untersuchen, wie ein einzelner Frame aussah und ob Shader und visuelles Layout korrekt sind. Bevorzuge für automatisierte Tests jedoch deterministische Assertions, wenn sich die Bedingung direkt ausdrücken lässt.
+
+## Wiederverwendbarer und testbarer Lua-Code {#reusable-and-testable-lua-code}
+
+Halte wiederverwendbare Logik in Lua-Modulen mit minimalen Engine-Abhängigkeiten. Reine Datentransformationen, Regeln, Zustandsautomaten und Berechnungen lassen sich dann testen, ohne eine vollständige Spielwelt aufzubauen.
+
+Trenne Code, der mit der Engine interagiert, von der Logik, die er aufruft. Ein Skript kann Nachrichten und Komponentenzustände in Aufrufe eines Moduls übersetzen, während Tests das Modul direkt mit kontrollierten Eingaben aufrufen.
+
+Weitere Einzelheiten findest du im [Handbuch zum Schreiben von Code](/manuals/writing-code).
+
+## Tests in einer laufenden Sammlung {#tests-in-a-running-collection}
+
+Verwende eine eigene Testsammlung, wenn das Verhalten von Spielobjekten (game objects), Komponenten, Nachrichten, Eingabe, Physik oder anderen Engine-Systemen abhängt.
+
+Jeder Test sollte:
+
+1. einen bekannten Zustand herstellen;
+2. ein einzelnes Verhalten ausführen;
+3. das erwartete Ergebnis mit Assertions prüfen und bewerten;
+4. erstellte Ressourcen bereinigen;
+5. eine strukturierte Ergebnisbeschreibung ausgeben.
+
+Bevorzuge isolierte Testsammlungen für Tests. Ein Projekt kann über eine vorübergehende Projekteinstellung in `game.project` eine Testsammlung als Startsammlung (bootstrap collection) auswählen:
+
+```ini
+[bootstrap]
+main_collection = /test/test.collectionc
+```
+
+Lasse eine vorübergehende Startsammlung für Tests nicht in der normalen Projektkonfiguration stehen. Bevorzuge in CI eine eigene Einstellungsdatei, die du an Bob übergibst. CI kann den Zustand des Repositorys nicht ändern; sie sollte nur bei Bedarf vorübergehende Änderungen vornehmen.
+
+Für komplexe Spiele kannst du kleine Sammlungen als „Entwicklungsräume“ mit vordefinierten Szenarien und einfachen geometrischen Entwürfen erstellen. Sie machen Mechaniken reproduzierbar und erleichtern die Entwicklung, weil du sie testen kannst, ohne durch dafür nicht relevante Spielzustände und Abschnitte navigieren zu müssen.
+
+### Testframeworks {#test-frameworks}
+
+Projekte können einen kleinen Testrunner implementieren oder eine [Testbibliothek aus der Community](https://defold.com/assets/?tag=testing) verwenden.
+
+Zum Beispiel ist [DefTest](https://defold.com/assets/deftest/) eine auf Telescope basierende Unit-Test-Bibliothek. Sie unterstützt Testsuites, Funktionen zur Testvorbereitung und -nachbereitung, Assertions, Namensfilter, Mocks für ausgewählte Defold-APIs und optional die Ermittlung der Codeabdeckung mit LuaCov. Tests können aus einer eigenen Startsammlung ausgeführt werden, auch in einem mit Bob erstellten Bundle ohne grafische Oberfläche.
+
+## Strukturierte Testergebnisse {#structured-test-results}
+
+Die Zusammenfassung eines Frameworks in der Konsole oder im Protokoll kann für Entwickler nützlich sein, doch eine unbeaufsichtigte automatische Steuerung benötigt weiterhin ein ausdrückliches Abschlussergebnis. Ergänze bei Bedarf einen kleinen Adapter um den Callback oder die Zusammenfassung des Frameworks, damit die Steuerung die Testergebnisse leicht verarbeiten kann.
+
+Eine einfache Ergebnisbeschreibung kann ein eindeutiges Präfix verwenden, gefolgt von jeweils einem JSON-Objekt pro physischer Konsolenzeile:
+
+```text
+TEST {"run":"8f13","event":"suite_start","tests":2}
+TEST {"run":"8f13","event":"case","name":"player_moves","status":"pass","duration_ms":3}
+TEST {"run":"8f13","event":"case","name":"player_stops","status":"pass","duration_ms":2}
+TEST {"run":"8f13","event":"suite_end","status":"pass","passed":2,"failed":0}
+```
+
+Ein Erfassungsprogramm sollte jede Zeile unabhängig verarbeiten, das Präfix `TEST` finden, das darauf folgende JSON parsen und nicht dazugehörige Engine-Ausgaben ignorieren.
+
+Gib eine eindeutige Lauf-ID an, damit Ausgaben eines alten oder gleichzeitig laufenden Prozesses den aktuellen Lauf nicht abschließen können. Jede Testsuite sollte genau ein eindeutiges Abschlussereignis ausgeben (etwa `Pass`, `Failure`, `Crash`, `Timeout` usw.).
+
+### Konsolenausgabe erfassen {#collecting-console-output}
+
+Wenn ein Spiel aus dem Editor heraus läuft, stellt es sowohl den aktuellen Konsolenverlauf als auch einen kontinuierlichen Datenstrom bereit. Schließe den Datenstrom nach einem passenden Abschlussereignis der Testsuite, dem Ende des Prozesses, einem Fehler oder dem Erreichen eines konfigurierten Zeitlimits und einer Zeilenbegrenzung.
+
+Weitere Informationen findest du im [Handbuch zur HTTP-API des Editors](/manuals/editor-http-api/#reading-console-output).
+
+### Gespeicherte Protokolle {#persisted-logs}
+
+Defold kann das Spielprotokoll auch speichern, wenn du `Write Log File` in `game.project` aktivierst. Siehe [Spiel- und Systemprotokolle](/manuals/debugging-game-and-system-logs/). Die Protokollierung in einer Datei ist nützlich für paketierte Anwendungen und zum Testen von Zielgeräten, auf denen die Editorkonsole nicht verfügbar ist.
+
+Das Projekt kann die integrierten Funktionen `print()` und `pprint()` oder beispielsweise eine andere [Protokollierungsbibliothek](https://defold.com/assets/?tag=logging) aus unserem Asset Portal verwenden.
+
+## Ein laufendes Spiel über eine Laufzeit-API testen {#testing-a-running-game-through-a-runtime-api}
+
+Eine API für Laufzeitautomatisierung kann eine laufende Debug-Engine untersuchen und steuern. Sie lässt sich verwenden, wenn Tests Objekte zur Laufzeit finden, Eingaben einspeisen, auf einen sichtbaren Zustand warten oder das gerenderte Ergebnis aufnehmen müssen.
+
+Weitere Einzelheiten findest du im [Handbuch zum Engine-Dienst](/manuals/engine-service/#automation-bridge-extension).
+
+Das folgende Beispiel verwendet die Struktur der Python-Hilfsfunktionen von [Automation Bridge](https://github.com/defold/extension-automation-bridge). Das Projekt muss eine kompatible Version der Debug-Erweiterung enthalten, ein Element mit der angegebenen Automatisierungs-ID zugänglich machen und den Anwendungszustand `screen` veröffentlichen:
+
+```python
+from automation_bridge import editor
+
+project = editor.open_project(".")
+game = project.build_and_run()
+
+try:
+    play = game.element(automation_id="play_button")
+    game.click(play)
+    game.wait_for_state("screen", "gameplay", timeout=5.0)
+    screenshot = game.screenshot()
+    print(screenshot.path)
+finally:
+    game.close_engine()
+```
+
+Von der Anwendung definierte Zustände und Automatisierungs-IDs verwenden die optionale, nur zum Debuggen verfügbare Lua-API von Automation Bridge, die das Projekt aktivieren und zugänglich machen muss. Eine feste Wartezeit ist anfällig für Unterschiede bei Rechnergeschwindigkeit und Frame-Timing; zeitlich begrenztes wiederholtes Abfragen eines definierten Zustands ist zuverlässiger.
+
+Automation Bridge ist eine Erweiterung und kein Bestandteil der Kern-Engine. In ihrer [Python-API-Referenz](https://github.com/defold/extension-automation-bridge/tree/master/automation_bridge/automation-bridge-python) findest du die für die installierte Version geltenden Informationen zu Selektoren, Wartevorgängen, Zustand, Ereignissen, Bildschirmaufnahmen und Diagnose.
+
+## Browsertests für HTML5 {#browser-tests-for-html5}
+
+Der Editor kann über seinen derzeitigen Befehl `build-html5` einen HTML5-Build erstellen und bereitstellen, wie im [Handbuch zur HTTP-API des Editors](/manuals/editor-http-api/#building-html5) beschrieben. Bob kann auch ohne den Editor ein HTML5-Bundle erstellen.
+
+Externe Werkzeuge zur Browserautomatisierung wie Playwright, Puppeteer, Selenium, WebdriverIO oder Cypress können:
+
+* auf die Defold-Zeichenfläche und die Bereitschaft der Anwendung warten;
+* Tastatur-, Maus- und emulierte Berührungseingaben senden;
+* die Größe des Ansichtsbereichs ändern;
+* Browserkonsolenausgaben und JavaScript-Fehler erfassen;
+* Bildschirmaufnahmen erstellen und Artefakte vergleichen.
+
+Eingaben, die an die Zeichenfläche gerichtet sind, werden über die normalen Eingabebindungen (input bindings) und `on_input()`-Callbacks des Projekts verarbeitet. Teste sowohl die Reaktion des Spiels als auch browserspezifische Integrationspunkte.
+
+Der zuverlässigste Ansatz besteht darin, eine ausdrückliche JavaScript-Testbrücke in der angepassten `index.html` bereitzustellen. Auf der Defold-Seite können HTML5-Builds mit `html5.run()` JavaScript ausführen, was die Kommunikation mit einer solchen Brücke auf der Browserseite ermöglicht. Verwende für Befehle, die von JavaScript zurück an Defold gelangen, eine eigene Brücke zwischen JavaScript und Engine.
+
+Begrenze die Ausführung von Browsertests. Unterscheide im Abschlussbericht zwischen einem Fehler beim Laden der Seite, einer fehlenden Zeichenfläche, einem JavaScript-Fehler, einer Zeitüberschreitung des Tests und einer fehlgeschlagenen Assertion im Spiel.
+
+## Editorvorschauen und Bildschirmaufnahmen zur Laufzeit für die visuelle Prüfung {#editor-previews-and-runtime-screenshots}
+
+Du kannst Bildschirmaufnahmen von Ressourcendateien in der standardmäßigen Szenenansicht des geöffneten Editors oder in einem Spiel zur Laufzeit erstellen.
+
+| Methode | Zweck |
+| --- | --- |
+| [Editorvorschau](/manuals/editor-http-api/#rendering-scene-previews) | Layout geladener Ressourcen, etwa eines Levels oder einer GUI, Atlaszusammenstellung, Prüfung von Kachelkarten (tile maps), statischer Szenenaufbau, Korrektheit von Editor-Rendering und Shadern oder Erstellung von Miniaturbildern für die Dokumentation |
+| [Bildschirmaufnahme zur Laufzeit](/manuals/engine-service) | Der gerenderte Zustand eines laufenden Builds in einem kontrollierten Szenario |
+
+Du kannst Bildvergleiche beispielsweise für Regressionstests verwenden. Speichere das Differenzbild und die Vergleichsmetriken, wenn eine Prüfung fehlschlägt.
+
+Ein multimodales Modell kann bei der visuellen Prüfung semantische Bedingungen bewerten, die sich ansonsten schwer ausdrücken lassen, etwa abgeschnittenen Text, überlappende Bedienelemente, unklare Auswahlzustände oder Inhalte außerhalb eines sicheren Bereichs. Es wird empfohlen, diese Bewertung als zusätzliches Signal mit ausdrücklichen Kriterien zu behandeln, jedoch nicht als Ersatz für deterministische Logikprüfungen oder Bildvergleiche.
+
+## Tests ohne grafische Oberfläche und CI {#headless-tests-and-ci}
+
+Verwende das Kommandozeilenwerkzeug Bob the builder für CI unabhängig vom Editor.
+
+Du kannst damit Abhängigkeiten auflösen, ein Spiel, ein Archiv oder ein eigenständiges Bundle erstellen und einen JSON-Bericht erzeugen:
+
+```sh
+mkdir -p build/reports
+
+java -jar bob.jar \
+  --root . \
+  --archive \
+  --build-report-json build/reports/build-report.json \
+  resolve build
+```
+
+Erstelle ein Test-Bundle ohne grafische Oberfläche mit eigenen Einstellungen:
+
+```sh
+java -jar bob.jar \
+  --root . \
+  --settings test/test.settings \
+  --platform x86_64-linux \
+  --variant headless \
+  --archive \
+  --bundle-output build/test-bundle \
+  resolve build bundle
+```
+
+Führe die resultierende ausführbare Datei mit einer für die Plattform geeigneten Prozesssteuerung aus. Erfasse ihren Beendigungsstatus und ihre Protokolle, erzwinge ein Zeitlimit und verlange das strukturierte Abschlussereignis der Testsuite.
+
+Das [Bob-Handbuch](/manuals/bob) beschreibt Plattformen, Einstellungsdateien, Bundles, Caches, native Erweiterungen und Build-Berichte.
+
+## Fehlerberichte und Artefakte {#failure-reports-and-artifacts}
+
+Gute Testergebnisse sollten genügend Nachweise aufbewahren, um einen Fehler nachzustellen und zu diagnostizieren:
+
+* Testname, Lauf-ID und Einzelheiten der Assertion;
+* verstrichene Zeit und klassifiziertes Ergebnis;
+* vollständiges Konsolen- oder Prozessprotokoll;
+* Defold-Version, Zielplattform und relevante Konfiguration;
+* Build-Bericht von Bob und Beendigungsstatus des Prozesses;
+* Laufzeitzustand oder Momentaufnahme der Szene, sofern verfügbar;
+* Bildschirmaufnahmen, Abweichungen von Referenzbildern, Aufzeichnungen oder Browser-Traces;
+* Pfade oder Links zu allen erzeugten Artefakten.
+
+Dasselbe Format sollte von einem Entwickler, einem lokalen Skript, einem CI-Dienst oder einem [KI-Programmieragenten](/manuals/ai-agents) genutzt werden können. So bleibt die Überprüfung deterministisch, auch wenn Diagnose oder Fehlerbehebung delegiert werden.

--- a/docs/de/manuals/automation.md
+++ b/docs/de/manuals/automation.md
@@ -1,0 +1,63 @@
+---
+title: Automatisierung in Defold
+brief: Dieses Handbuch stellt die Automatisierungsschnittstellen von Defold vor und erläutert, wie du zwischen Arbeitsabläufen für den Editor, die Laufzeit, die Kommandozeile, Tests und Agenten auswählst.
+---
+
+# Automatisierung in Defold {#automation-in-defold}
+
+Dieses Handbuch bietet einen Überblick und verlinkt auf die einzelnen Handbücher zu jedem Thema.
+
+Defold unterstützt Automatisierung auf mehreren Ebenen. Eine für die Aufgabe geeignete Schnittstelle auszuwählen, ist einer der wichtigsten Aspekte einer wirksamen Automatisierung. Die folgende Tabelle hilft dir, die einfachste Schnittstelle für eine bestimmte Aktion auszuwählen:
+
+| Ebene | Zweck |
+| --- | --- |
+| [Editor-Skripte](/manuals/editor-scripts) | Benutzerdefinierte Befehle und Arbeitsabläufe im Editor oder Integrationen, die Tests und Entwicklung beschleunigen, z. B. das Erstellen von Leveln und Assets |
+| [UI-Skripte für den Editor](/manuals/editor-scripts-ui/) | Benutzerdefinierte visuelle Werkzeuge, Popups, Konfiguratoren oder Benutzeroberflächen mithilfe von Editor-Skripten |
+| [HTTP-API des Editors](/manuals/editor-http-api) | Das geöffnete Spielprojekt im Defold-Editor über OpenAPI-Operationen, Projektressourcen, Builds, Editorbefehle, Vorschauen, Editoreinstellungen, Konsolenausgaben oder Editor-Skripte steuern: für benutzerdefinierte Operationen, externe Werkzeuge, IDE-Integrationen und Teststeuerungen |
+| [Bob CLI](/manuals/bob) | Einen Build eines Projekts erstellen, Datenarchive oder eigenständige Bundles über die Kommandozeile erstellen, Berichte, CI |
+| [Lebenszyklus-Hooks](/manuals/editor-http-api#lifecycle-hooks) | Validierung oder Generierung vor und nach Builds oder der Bundle-Erstellung im Editor |
+| [HTTP-Dienst der Engine](/manuals/engine-service) | Die laufende Defold-Game-Engine (`dmengine`) untersuchen, Entwicklungsdienste, Profiling, Laufzeitnachrichten oder durch Erweiterungen definierte Laufzeit-APIs zur Automatisierung nutzen sowie mit externen Werkzeugen Abfragen stellen und Befehle an einen laufenden Debug-Build senden |
+| [Automation Bridge](https://github.com/defold/extension-automation-bridge) | Offizielle Defold-Erweiterung, die zusätzliche Endpunkte zur Automatisierung der Engine zur Laufzeit bereitstellt |
+| [Automatisierte Tests](/manuals/automated-testing) | Spiellogik, Nachrichten, Komponenten (components), Eingabe, Physik und Engine-Verhalten testen, Szenen untersuchen, visuelle Rückmeldungen z. B. über die [Editorvorschau](/manuals/editor-http-api/#rendering-scene-previews), eingespeiste Eingaben, aktueller Anwendungszustand, [Ausführen von Testsammlungen (test collections)](/manuals/automated-testing/#tests-in-a-running-collection) |
+| Shell-Skripte oder Taskrunner | Generierung, Formatierung, Validierung und wiederholbare Aufgaben, gewöhnliche Dateioperationen |
+| Externe plattformspezifische Werkzeuge und Werkzeuge zur Automatisierung von Webbrowsern | Desktop-Testwerkzeuge, HTML5-Interaktionstests, Bildschirmaufnahmen, Webintegrationen |
+| Programmieragenten mit künstlicher Intelligenz (KI) und multimodale Modelle | Aufgaben, bei denen sich ein deterministischer Ansatz nur schwer oder gar nicht umsetzen lässt, semantische Analyse von Szenen, GUI-Layouts oder Bildschirmaufnahmen des laufenden Spiels |
+
+Die wichtigste Unterscheidung besteht zwischen dem Defold-Editor und einem laufenden Spiel. Sie sind getrennte Prozesse mit eigenen HTTP-Servern.
+
+## Deterministische Automatisierung oder KI-Agenten {#deterministic-automation-or-ai-agents}
+
+Bevorzuge eine deterministische Lösung, wenn die Abfolge der Operationen bereits bekannt ist, etwa bei einem Werkzeug zur Levelvalidierung, einem Formatierungswerkzeug, einem Build-Job oder einem Regressionstest. Dafür sollten normalerweise feste Eingaben, Ausgaben, Grenzen für Zeitüberschreitungen und Rückgabecodes des Prozesses definiert sein. Das eignet sich gut für automatisierte Hooks und Tests, die zuverlässig in CI ausgeführt werden können. Auch für die prozedurale Erstellung von Ressourcen für deine Projekte ist eine deterministische Lösung vorzuziehen, z. B. ein Werkzeug, das gltf-Objekte in Modelle mit einem bestimmten Material umwandelt oder ein Level etwa mit Bäumen bestückt. Solche Abläufe lassen sich für jedes Projekt leicht mit Editor-Skripten und einer Benutzeroberfläche erstellen. Lies mehr darüber im [Handbuch](/manuals/editor-scripts-ui).
+
+Ein Agent kann nützlich sein, wenn eine Aufgabe Untersuchungen oder multimodale Analysen erfordert, die z. B. auch visuelle Informationen einbeziehen: relevante Ressourcen finden, eine Implementierung auswählen, mehrere Dateien ändern, Fehler interpretieren und schrittweise auf festgelegte Abnahmekriterien hinarbeiten. Der Agent sollte dabei dennoch deterministische Schnittstellen aufrufen und dieselben Nachweise auswerten wie ein lokales Skript oder ein CI-Runner. Siehe das Handbuch zur [Verwendung von KI-Programmieragenten mit Defold](/manuals/ai-agents).
+
+## Die Automatisierungsschleife {#the-automation-loop}
+
+Ein zuverlässiger Automatisierungsprozess bildet eine geschlossene Schleife:
+
+1. Untersuchen - Projektdateien, die aktuelle Schnittstellenbeschreibung und relevante Dokumentation lesen.
+2. Ändern - Editortransaktionen, Editor-Skripte oder Datei- und Shell-Werkzeuge verwenden.
+3. Überprüfen - einen Build erstellen, gezielte Tests ausführen und Protokolle, Berichte, Zustandsdaten oder Bilder sammeln.
+4. Bewerten - die Nachweise mit den Abnahmekriterien vergleichen und dann abschließen oder einen erneuten Versuch starten.
+
+![Die Automatisierungsschleife aus Untersuchen, Ändern, Überprüfen und Bewerten](images/automation/automation_loop.png)
+
+Die Überprüfung sollte Nachweise aus der tatsächlichen Umgebung liefern. Geeignete Nachweise sind unter anderem:
+
+* ein erfolgreiches Build-Ergebnis;
+* eine ausdrücklich abgeschlossene Testsuite;
+* der erwartete Zustand des laufenden Spiels;
+* ein erzeugtes Bundle oder ein Build-Bericht;
+* ein deterministischer Bildvergleich;
+* eine Bildschirmaufnahme, die festgelegte visuelle Kriterien erfüllt.
+
+Lege das erwartete Ergebnis fest, bevor du Änderungen vornimmst. Definiere außerdem eine Grenze für Zeitüberschreitungen und eine maximale Anzahl an Reparaturversuchen. Ein unbeaufsichtigter Prozess sollte nicht unbegrenzt weiterlaufen, wenn er die Abnahmekriterien nicht erfüllen kann.
+
+## Nächste Schritte {#next-steps}
+
+Weitere Einzelheiten zu bestimmten Themen rund um Automatisierungsabläufe findest du in den folgenden Handbüchern:
+
+* [Aufgaben im Defold-Editor mit der HTTP-API automatisieren](/manuals/editor-http-api)
+* [Der Engine-Dienst und die HTTP-API zur Laufzeit](/manuals/engine-service)
+* [Automatisiertes Testen und Überprüfen](/manuals/automated-testing)
+* [KI-Programmieragenten mit Defold verwenden](/manuals/ai-agents)

--- a/docs/de/manuals/bob.md
+++ b/docs/de/manuals/bob.md
@@ -1,0 +1,242 @@
+---
+title: Handbuch zum Erstellen von Defold-Projekten
+brief: Bob ist ein Kommandozeilenwerkzeug zum Erstellen von Builds für Defold-Projekte. Dieses Handbuch erklärt, wie du das Werkzeug verwendest.
+---
+
+# Bob, der Baumeister {#bob-the-builder}
+
+Bob ist ein Kommandozeilenwerkzeug, mit dem du Builds von Defold-Projekten außerhalb des üblichen Arbeitsablaufs im Editor erstellen kannst.
+
+Bob kann Builds der Daten erstellen (entspricht dem Build-Schritt beim Auswählen des Editor-Menüeintrags <kbd>Project ▸ Build</kbd>), Datenarchive erzeugen und eigenständige, verteilbare Anwendungsbundles erstellen (entspricht den Optionen unter dem Editor-Menüeintrag <kbd>Project ▸ Bundle ▸ ...</kbd>)
+
+Bob wird als Java-_JAR_-Archiv bereitgestellt, das alles enthält, was für einen Build benötigt wird. Die neueste Version von *bob.jar* findest du auf der [GitHub-Seite mit den Releases](https://github.com/defold/defold/releases). Wähle ein Release aus und lade dann *bob/bob.jar* herunter. Zum Ausführen benötigst du OpenJDK 25.
+
+Kompatible Bezugsquellen für OpenJDK 25:
+* [OpenJDK 25 von Microsoft](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-25)
+* [OpenJDK 25 von der Adoptium Working Group](https://github.com/adoptium/temurin25-binaries/releases) / [Adoptium.net](https://adoptium.net/)
+
+Unter Windows benötigst du das Installationsprogramm für OpenJDK als `.msi`-Datei.
+
+## Verwendung {#usage}
+
+Du führst Bob in einer Shell oder über die Kommandozeile aus, indem du `java` (unter Windows `java.exe`) aufrufst und das Java-Archiv von Bob als Argument übergibst:
+
+```text
+$ java -jar bob.jar --help
+usage: bob [options] [commands]
+ -a,--archive                            Build archive
+ -ar,--architectures <arg>               Comma separated list of
+                                         architectures to include for the
+                                         platform
+    --archive-resource-padding <arg>     The alignment of the resources in
+                                         the game archive. Default is 4
+ -bf,--bundle-format <arg>               Which formats to create the
+                                         application bundle in. Comma
+                                         separated list. (Android: 'apk'
+                                         and 'aab')
+    --binary-output <arg>                Location where built engine
+                                         binary will be placed. Default is
+                                         "<build-output>/<platform>/"
+ -bo,--bundle-output <arg>               Bundle output directory
+ -br,--build-report <arg>                DEPRECATED! Use
+                                         --build-report-json instead
+ -brhtml,--build-report-html <arg>       Filepath where to save a build
+                                         report as HTML
+ -brjson,--build-report-json <arg>       Filepath where to save a build
+                                         report as JSON
+    --build-artifacts <arg>              If left out, will default to
+                                         build the engine. Choices:
+                                         'engine', 'plugins', 'library'.
+                                         Comma separated list
+    --build-input <arg>                  Project resource path to build
+                                         instead of game.project. May be
+                                         specified more than once. More
+                                         than one occurrence is allowed
+    --build-input-file <arg>             File containing project resource
+                                         paths to build instead of
+                                         game.project. May be specified
+                                         more than once. More than one
+                                         occurrence is allowed
+    --build-server <arg>                 The build server (when using
+                                         native extensions)
+    --build-server-header <arg>          Additional build server header to
+                                         set. More than one occurrence is
+                                         allowed
+ -ce,--certificate <arg>                 DEPRECATED! Use --keystore
+                                         instead
+ -d,--debug                              DEPRECATED! Use --variant=debug
+                                         instead
+    --debug-ne-upload                    Outputs the files sent to build
+                                         server as upload.zip
+    --debug-output-glsl <arg>            Force build GLSL shaders
+    --debug-output-hlsl <arg>            Force build HLSL shaders
+    --debug-output-msl <arg>             Force build Metal shaders
+    --debug-output-spirv <arg>           Force build SPIR-V shaders
+    --debug-output-wgsl <arg>            Force build WGSL shaders
+    --defoldsdk <arg>                    What version of the defold sdk
+                                         (sha1) to use
+ -e,--email <arg>                        User email
+ -ea,--exclude-archive                   Exclude resource archives from
+                                         application bundle. Use this to
+                                         create an empty Defold
+                                         application for use as a build
+                                         target
+    --exclude-build-folder <arg>         DEPRECATED! Use '.defignore' file
+                                         instead
+    --experimental-path-minification     Minimizes resource path names in
+                                         order to save bundle size.
+ -h,--help                               This help message
+ -i,--input <arg>                        DEPRECATED! Use --root instead
+    --identity <arg>                     Sign identity (iOS)
+ -kp,--key-pass <arg>                    Password of the deployment key if
+                                         different from the keystore
+                                         password (Android)
+ -ks,--keystore <arg>                    Deployment keystore used to sign
+                                         APKs (Android)
+ -ksa,--keystore-alias <arg>             The alias of the signing key+cert
+                                         you want to use (Android)
+ -ksp,--keystore-pass <arg>              Password of the deployment
+                                         keystore (Android)
+ -l,--liveupdate <arg>                   Yes if liveupdate content should
+                                         be published
+    --max-cpu-threads <arg>              Max count of threads that bob.jar
+                                         can use
+ -mp,--mobileprovisioning <arg>          mobileprovisioning profile (iOS)
+    --ne-build-dir <arg>                 Specify a folder with includes or
+                                         source, to build a specific
+                                         library. More than one occurrence
+                                         is allowed
+    --ne-output-name <arg>               Specify a library target name
+ -o,--output <arg>                       Output directory. Default is
+                                         "build/default"
+ -p,--platform <arg>                     Platform (when building and
+                                         bundling)
+ -pk,--private-key <arg>                 DEPRECATED! Use --keystore
+                                         instead
+ -r,--root <arg>                         Build root directory. Default is
+                                         current directory
+    --resource-cache-local <arg>         Path to local resource cache
+    --resource-cache-remote <arg>        URL to remote resource cache
+    --resource-cache-remote-pass <arg>   Password/token to authenticate
+                                         access to the remote resource
+                                         cache
+    --resource-cache-remote-user <arg>   Username to authenticate access
+                                         to the remote resource cache
+    --settings <arg>                     Path to a game project settings
+                                         file. The settings files are
+                                         applied left to right. More than
+                                         one occurrence is allowed
+    --strip-executable                   Strip the dmengine of debug
+                                         symbols (when bundling iOS or
+                                         Android)
+ -tc,--texture-compression               Use texture compression as
+                                         specified in texture profiles
+ -tp,--texture-profiles <arg>            DEPRECATED! Use
+                                         --texture-compression instead
+ -u,--auth <arg>                         User auth token
+    --use-async-build-server             DEPRECATED! Asynchronous build is
+                                         now the default
+    --use-lua-bytecode-delta             Use byte code delta compression
+                                         when building for multiple
+                                         architectures
+    --use-uncompressed-lua-source        Use uncompressed and unencrypted
+                                         Lua source code instead of byte
+                                         code
+    --use-vanilla-lua                    DEPRECATED! Use
+                                         --use-uncompressed-lua-source
+                                         instead
+ -v,--verbose                            Verbose output
+    --variant <arg>                      Specify debug, release or
+                                         headless version of dmengine
+                                         (when bundling)
+    --version                            Prints the version number to the
+                                         output
+    --with-sha1                          Generate (and verify) sha1
+                                         signatures from build artifacts
+                                         (when bunding for web)
+    --with-symbols                       Generate the symbol file (if
+                                         applicable)
+```
+
+`--texture-compression` ist ein Schalter ohne Wert. Gib ihn an, um die in den Texturprofilen (texture profiles) gewählte Komprimierung zu aktivieren; lasse ihn weg, um die Texturkomprimierung zu deaktivieren. Die ältere Form `--texture-compression=true` wird weiterhin akzeptiert. Die ältere Form `--texture-compression=false` wird ignoriert und erzeugt eine Warnung; lasse stattdessen den Schalter weg.
+
+Verfügbare Befehle:
+
+`clean`
+: Löscht die beim Build erstellten Dateien im Build-Verzeichnis.
+
+`distclean`
+: Löscht alle Dateien im Build-Verzeichnis.
+
+`build`
+: Erstellt einen Build für den Abhängigkeitsgraphen, der von den ausgewählten Ausgangspunkten für den Build aus erreichbar ist. Standardmäßig ist der Ausgangspunkt `game.project`; mit `--build-input` und `--build-input-file` kannst du alternative Ausgangspunkte angeben. Dateien werden nicht allein deshalb in den Build einbezogen, weil sie unterhalb des Projektstammverzeichnisses liegen. Wenn `game.project` ein Ausgangspunkt für den Build ist, füge `--archive` hinzu, um das Spieldatenarchiv im Build-Verzeichnis zu erstellen.
+
+`bundle`
+: Erstellt ein plattformspezifisches Anwendungsbundle. Die Bundle-Erstellung setzt voraus, dass ein erstelltes Archiv vorhanden ist (`build` mit der Option `--archive`) und eine Zielplattform angegeben wird (mit der Option `--platform`). Bob erstellt das Bundle im Ausgabeverzeichnis, sofern du mit der Option `--bundle-output` kein anderes Verzeichnis angibst. Das Bundle wird entsprechend der Einstellung für den Projektnamen in *game.project* benannt. Mit der Option `--variant` legst du fest, welcher Typ ausführbarer Datei bei der Bundle-Erstellung erzeugt wird. Zusammen mit der Option `--strip-executable` ersetzt sie die Option `--debug`. Wenn du `--variant` nicht angibst, erhältst du eine Release-Version der Engine (unter Android und iOS ohne Symbole). Wenn du `--variant` auf debug setzt und `--strip-executable` weglässt, erhältst du denselben Typ ausführbarer Datei wie früher mit `--debug`.
+
+`resolve`
+: Löst alle Abhängigkeiten von externen Bibliotheken auf.
+
+Verfügbare Plattformen und Architekturen:
+
+`x86_64-macos`
+: macOS mit 64 Bit
+
+`arm64-macos`
+: macOS Apple Silicon (ARM)
+
+`x86_64-win32`
+: Windows mit 64 Bit
+
+`x86-win32`
+: Windows mit 32 Bit
+
+`x86_64-linux`
+: Linux mit 64 Bit
+
+`arm64-linux`
+: Linux ARM64 für Raspberry Pi und Handheld-Geräte mit Linux.
+
+`arm64_sim-ios`
+: iOS Simulator auf Macs mit Apple Silicon. Simulator-Bundles verwenden weder eine Signierungsidentität noch ein Bereitstellungsprofil, daher werden `--identity` und `--mobileprovisioning` ignoriert.
+
+`arm64-ios`
+: iOS mit 64 Bit. Standardmäßig ist der Wert des Arguments `--architectures` auf `arm64-ios` gesetzt.
+
+`armv7-android`
+: Android mit den verfügbaren Architekturen `armv7-android` mit 32 Bit, `arm64-android` mit 64 Bit und `x86_64-android` mit 64 Bit. Standardmäßig ist der Wert des Arguments `--architectures` auf `armv7-android,arm64-android` gesetzt. Die Architektur `x86_64-android` ist optional (vor allem für Android-Emulatoren, ChromeOS und Windows Subsystem for Android nützlich) und muss ausdrücklich hinzugefügt werden.
+
+`wasm-web`
+: HTML5 mit den verfügbaren Architekturen `wasm-web` und `wasm_pthread-web`. Standardmäßig ist der Wert des Arguments `--architectures` auf `wasm-web` gesetzt.
+
+Standardmäßig sucht Bob im aktuellen Verzeichnis nach einem Projekt und erstellt einen Build der von `game.project` aus erreichbaren Ressourcen (resources) in *build/default*. Nicht referenzierte Ressourcen werden nicht kompiliert. Wenn dein Code zur Laufzeit Rohdateien über ihren Pfad lädt, binde sie über die [Projekteinstellung Custom Resources](/manuals/project-settings/#custom-resources) ein; andere Defold-Ressourcen benötigen eine Referenz, die von einem Ausgangspunkt für den Build aus erreichbar ist.
+
+```sh
+$ cd /Applications/Defold-beta/branches/14/4/main
+$ java -jar bob.jar
+100%
+$
+```
+
+Du kannst Befehle aneinanderreihen, um mehrere Aufgaben nacheinander in einem Durchgang auszuführen. Das folgende Beispiel löst Bibliotheksabhängigkeiten auf, leert das Build-Verzeichnis, erstellt die Archivdaten und erzeugt ein Bundle für eine macOS-Anwendung (mit dem Namen *My Game.app*):
+
+```sh
+$ java -jar bob.jar --archive --platform x86_64-macos resolve distclean build bundle
+100%
+$ ls -al build/default/
+total 70784
+drwxr-xr-x   13 sicher  staff       442  1 Dec 10:15 .
+drwxr-xr-x    3 sicher  staff       102  1 Dec 10:15 ..
+drwxr-xr-x    3 sicher  staff       102  1 Dec 10:15 My Game.app
+drwxr-xr-x    8 sicher  staff       272  1 Dec 10:15 builtins
+-rw-r--r--    1 sicher  staff    140459  1 Dec 10:15 digest_cache
+drwxr-xr-x    4 sicher  staff       136  1 Dec 10:15 fonts
+-rw-r--r--    1 sicher  staff  35956340  1 Dec 10:15 game.darc
+-rw-r--r--    1 sicher  staff       735  1 Dec 10:15 game.projectc
+drwxr-xr-x  223 sicher  staff      7582  1 Dec 10:15 graphics
+drwxr-xr-x    3 sicher  staff       102  1 Dec 10:15 input
+drwxr-xr-x   20 sicher  staff       680  1 Dec 10:15 logic
+drwxr-xr-x   27 sicher  staff       918  1 Dec 10:15 sound
+-rw-r--r--    1 sicher  staff    131926  1 Dec 10:15 state
+$
+```

--- a/docs/de/manuals/buffer.md
+++ b/docs/de/manuals/buffer.md
@@ -1,0 +1,33 @@
+---
+title: Handbuch zu Puffern
+brief: Dieses Handbuch erklärt, wie Pufferressourcen in Defold funktionieren.
+---
+
+# Puffer {#buffer}
+
+Die Pufferressource (Buffer resource) beschreibt einen oder mehrere Datenströme von Werten, beispielsweise Positionen oder Farben. Jeder Datenstrom enthält einen Namen, einen Datentyp, eine Anzahl sowie die Daten selbst. Beispiel:
+
+```
+[
+  {
+    "name": "position",
+    "type": "float32",
+    "count": 3,
+    "data": [
+      -1.0,
+      -1.0,
+      -1.0,
+      -1.0,
+      -1.0,
+      1.0,
+      ...
+    ]
+  }
+]
+```
+
+Das obige Beispiel beschreibt einen Datenstrom von Positionen in drei Dimensionen, dargestellt als 32-Bit-Gleitkommazahlen. Eine Pufferdatei verwendet das JSON-Format und die Dateierweiterung `.buffer`.
+
+Pufferressourcen werden üblicherweise mit externen Werkzeugen oder Skripten erstellt, beispielsweise beim Export aus Modellierungswerkzeugen wie Blender. 
+
+Du kannst eine Pufferressource als Eingabe für eine [Mesh-Komponente (mesh component)](/manuals/mesh) verwenden. Pufferressourcen können auch zur Laufzeit mit `buffer.create()` und [verwandten API-Funktionen](/ref/stable/buffer/#buffer.create:element_count-declaration) erstellt werden. 

--- a/docs/de/manuals/building-blocks.md
+++ b/docs/de/manuals/building-blocks.md
@@ -1,0 +1,116 @@
+---
+title: Die Bausteine von Defold
+brief: Dieses Handbuch erklärt im Detail, wie Spielobjekte, Komponenten und Sammlungen funktionieren.
+---
+
+#  Bausteine {#building-blocks}
+
+Der Aufbau von Defold beruht auf einigen Konzepten, die du gut verstehen solltest. Dieses Handbuch erklärt, woraus die Bausteine von Defold bestehen. Lies anschließend das [Handbuch zur Adressierung](/manuals/addressing) und das [Handbuch zur Nachrichtenübermittlung](/manuals/message-passing). Außerdem stehen dir direkt im Editor eine Reihe von [Tutorials](/tutorials/getting-started) zur Verfügung, die dir einen schnellen Einstieg ermöglichen.
+
+![Bausteine](images/building_blocks/building_blocks.png)
+
+Es gibt drei grundlegende Arten von Bausteinen, mit denen du ein Defold-Spiel aufbaust:
+
+Sammlung
+: Eine Sammlung (collection) ist eine Datei, mit der du dein Spiel strukturierst. In Sammlungen baust du Hierarchien aus Spielobjekten (game objects) und weiteren Sammlungen auf. Üblicherweise strukturierst du damit Spiellevels, Gegnergruppen oder Figuren, die aus mehreren Spielobjekten bestehen.
+
+Spielobjekt
+: Ein Spielobjekt ist ein Container mit einem Bezeichner (ID), einer Position, einer Drehung und einer Skalierung. Es dient dazu, Komponenten (components) aufzunehmen. Spielobjekte werden üblicherweise verwendet, um Spielfiguren, Geschosse, das Regelsystem des Spiels oder eine Funktion zum Laden von Levels zu erstellen.
+
+Komponente
+: Komponenten sind Einheiten, die du in Spielobjekte einfügst, um ihnen im Spiel eine visuelle, akustische und/oder logische Darstellung zu geben. Üblicherweise erstellst du damit Sprites für Figuren und Skriptdateien oder fügst Soundeffekte oder Partikeleffekte hinzu.
+
+## Sammlungen {#collections}
+
+Sammlungen sind Baumstrukturen, die Spielobjekte und weitere Sammlungen enthalten. Eine Sammlung wird immer in einer Datei gespeichert.
+
+Beim Start lädt die Defold-Engine eine einzelne _Startsammlung (bootstrap collection)_, die in der Einstellungsdatei *game.project* festgelegt ist. Die Startsammlung heißt häufig "main.collection", du kannst aber jeden beliebigen Namen verwenden.
+
+Eine Sammlung kann Spielobjekte und weitere Sammlungen enthalten, die als Referenz auf die Datei der jeweiligen Untersammlung eingebunden sind. Du kannst sie beliebig tief verschachteln. Hier siehst du eine Beispieldatei namens "main.collection". Sie enthält ein Spielobjekt (mit der ID "can") und eine Untersammlung (mit der ID "bean"). Die Untersammlung enthält wiederum zwei Spielobjekte: "bean" und "shield".
+
+![Sammlung](images/building_blocks/collection.png)
+
+Beachte, dass die Untersammlung mit der ID "bean" in einer eigenen Datei namens "/main/bean.collection" gespeichert ist und in "main.collection" lediglich referenziert wird:
+
+![Sammlung bean](images/building_blocks/bean_collection.png)
+
+Du kannst Sammlungen selbst nicht adressieren, da es zur Laufzeit keine Objekte gibt, die den Sammlungen "main" und "bean" entsprechen. Manchmal musst du jedoch den Bezeichner einer Sammlung als Teil des _Pfads_ zu einem Spielobjekt verwenden (Einzelheiten findest du im [Handbuch zur Adressierung](/manuals/addressing)):
+
+```lua
+-- file: can.script
+-- get position of the "bean" game object in the "bean" collection
+local pos = go.get_position("bean/bean")
+```
+
+Eine Sammlung wird einer anderen Sammlung immer als Referenz auf eine Sammlungsdatei hinzugefügt:
+
+Führe einen <kbd>Rechtsklick</kbd> auf die Sammlung in der Ansicht *Outline* aus und wähle <kbd>Add Collection File</kbd>.
+
+## Spielobjekte {#game-objects}
+
+Spielobjekte sind einfache Objekte, die während der Ausführung deines Spiels jeweils eine eigene Lebensdauer haben. Spielobjekte besitzen eine Position, eine Drehung und eine Skalierung, die du jeweils zur Laufzeit verändern und animieren kannst.
+
+```lua
+-- animate X position of "can" game object
+go.animate("can", "position.x", go.PLAYBACK_LOOP_PINGPONG, 100, go.EASING_LINEAR, 1.0)
+```
+
+Du kannst Spielobjekte leer verwenden, etwa als Positionsmarkierungen. Üblicherweise sind sie jedoch mit verschiedenen Komponenten wie Sprites, Audiokomponenten, Skripten, Modellen, Fabriken (factory) und weiteren ausgestattet. Spielobjekte werden entweder im Editor erstellt und in Sammlungsdateien platziert oder zur Laufzeit dynamisch durch _Fabrikkomponenten_ erzeugt.
+
+Spielobjekte werden entweder direkt in eine Sammlung eingefügt (in-place) oder einer Sammlung als Referenz auf eine Spielobjektdatei hinzugefügt:
+
+Führe einen <kbd>Rechtsklick</kbd> auf die Sammlung in der Ansicht *Outline* aus und wähle <kbd>Add Game Object</kbd> (direkt einfügen) oder <kbd>Add Game Object File</kbd> (als Dateireferenz einfügen).
+
+
+## Komponenten {#components}
+
+:[components](../shared/components.md)
+
+Eine Liste aller verfügbaren Komponententypen findest du in der [Komponentenübersicht](/manuals/components/).
+
+## Objekte direkt oder als Referenz hinzufügen {#objects-added-in-place-or-by-reference}
+
+Wenn du eine _Datei_ für eine Sammlung, ein Spielobjekt oder eine Komponente erstellst, legst du damit einen sogenannten Prototyp an (in anderen Engines auch als „Prefabs“ oder „Blueprints“ bekannt). Dadurch wird lediglich eine Datei zur Dateistruktur des Projekts hinzugefügt. Deinem laufenden Spiel wird nichts hinzugefügt. Um eine Instanz einer Sammlung, eines Spielobjekts oder einer Komponente auf Grundlage einer Prototypdatei hinzuzufügen, fügst du eine Instanz davon in eine deiner Sammlungsdateien ein.
+
+In der Ansicht Outline kannst du sehen, auf welcher Datei eine Objektinstanz beruht. Die Datei "main.collection" enthält drei Instanzen, die auf Dateien beruhen:
+
+1. Die Untersammlung "bean".
+2. Die Skriptkomponente "bean" im Spielobjekt "bean" in der Untersammlung "bean".
+3. Die Skriptkomponente "can" im Spielobjekt "can".
+
+![Instanz](images/building_blocks/instance.png)
+
+Der Vorteil von Prototypdateien wird deutlich, wenn du mehrere Instanzen eines Spielobjekts oder einer Sammlung hast und alle ändern möchtest:
+
+![Spielobjektinstanzen](images/building_blocks/go_instance.png)
+
+Wenn du die Prototypdatei änderst, wird jede Instanz, die diese Datei verwendet, sofort aktualisiert.
+
+![Prototyp eines Spielobjekts ändern](images/building_blocks/go_change_blueprint.png)
+
+Hier wird das Sprite-Bild der Prototypdatei geändert, und sofort werden alle Instanzen aktualisiert, die diese Datei verwenden:
+
+![Aktualisierte Spielobjektinstanzen](images/building_blocks/go_instance2.png)
+
+## Spielobjekte einem übergeordneten Spielobjekt zuordnen {#childing-game-objects}
+
+In einer Sammlungsdatei kannst du Hierarchien von Spielobjekten aufbauen, sodass ein oder mehrere Spielobjekte einem einzelnen übergeordneten Spielobjekt untergeordnet sind. Wenn du ein Spielobjekt auf ein anderes <kbd>ziehst</kbd> und dort <kbd>ablegst</kbd>, wird das gezogene Spielobjekt dem Zielobjekt untergeordnet:
+
+![Spielobjekte einem übergeordneten Spielobjekt zuordnen](images/building_blocks/childing.png)
+
+Eltern-Kind-Hierarchien von Objekten sind dynamische Beziehungen, die beeinflussen, wie Objekte auf Transformationen reagieren. Jede Transformation (Bewegung, Drehung oder Skalierung), die auf ein Objekt angewendet wird, wird wiederum auch auf dessen untergeordnete Objekte angewendet, sowohl im Editor als auch zur Laufzeit:
+
+![Transformation eines untergeordneten Objekts](images/building_blocks/child_transform.png)
+
+Umgekehrt erfolgen Verschiebungen eines untergeordneten Objekts im lokalen Koordinatensystem des übergeordneten Objekts. Im Editor kannst du wählen, ob du ein untergeordnetes Spielobjekt im lokalen Koordinatensystem oder im Weltkoordinatensystem bearbeitest. Wähle dazu <kbd>Edit ▸ World Space</kbd> (die Standardeinstellung) oder <kbd>Edit ▸ Local Space</kbd>.
+
+Du kannst das übergeordnete Objekt auch zur Laufzeit ändern, indem du eine `set_parent`-Nachricht an das Objekt sendest.
+
+```lua
+local parent = go.get_id("bean")
+msg.post("child_bean", "set_parent", { parent_id = parent })
+```
+
+::: important
+Ein häufiges Missverständnis ist, dass sich die Position eines Spielobjekts in der Sammlungshierarchie ändert, wenn es Teil einer Eltern-Kind-Hierarchie wird. Dabei handelt es sich jedoch um zwei sehr unterschiedliche Dinge. Eltern-Kind-Hierarchien verändern den Szenengraphen dynamisch, sodass Objekte visuell miteinander verbunden werden können. Die Adresse eines Spielobjekts wird ausschließlich durch seine Position in der Sammlungshierarchie bestimmt. Sie bleibt während der gesamten Lebensdauer des Objekts unverändert.
+:::

--- a/docs/de/manuals/bundling.md
+++ b/docs/de/manuals/bundling.md
@@ -1,0 +1,91 @@
+---
+title: Ein Anwendungs-Bundle erstellen
+brief: Dieses Handbuch beschreibt, wie du ein Anwendungs-Bundle erstellst.
+---
+
+# Ein Anwendungs-Bundle erstellen {#bundling-an-application}
+
+Während du deine Anwendung entwickelst, solltest du dir angewöhnen, das Spiel so oft wie möglich auf den Zielplattformen zu testen. So erkennst du Leistungsprobleme früh im Entwicklungsprozess, wenn sie sich noch wesentlich leichter beheben lassen. Es wird außerdem empfohlen, auf allen Zielplattformen zu testen, um Unterschiede etwa bei Shadern zu finden. Bei der Entwicklung für Mobilgeräte kannst du die [Entwicklungs-App für Mobilgeräte](/manuals/dev-app/) verwenden, um Inhalte an die App zu übertragen, statt jedes Mal ein vollständiges Bundle erstellen und die App deinstallieren und erneut installieren zu müssen.
+
+Du kannst direkt im Defold-Editor ein Anwendungs-Bundle für alle von Defold unterstützten Plattformen erstellen, ohne externe Werkzeuge zu benötigen. Mit unseren Kommandozeilenwerkzeugen kannst du Bundles auch über die Kommandozeile erstellen. Für die Erstellung eines Anwendungs-Bundles ist eine Netzwerkverbindung erforderlich, wenn dein Projekt eine oder mehrere [native Erweiterungen (native extensions)](/manuals/extensions) enthält.
+
+## Ein Bundle im Editor erstellen {#bundling-from-within-the-editor}
+
+Du erstellst ein Anwendungs-Bundle über die Option Bundle im Menü Project:
+
+![](images/bundling/bundle_menu.png)
+
+Wenn du eine der Menüoptionen auswählst, öffnet sich das Dialogfeld Bundle für die jeweilige Plattform.
+
+### Build-Berichte {#build-reports}
+
+Beim Erstellen eines Bundles für dein Spiel kannst du einen Build-Bericht erstellen lassen. Damit verschaffst du dir einen guten Überblick über die Größe aller Assets, die in deinem Spiel-Bundle enthalten sind. Aktiviere dazu beim Erstellen des Bundles einfach das Kontrollkästchen *Generate build report*.
+
+![Build-Bericht](images/profiling/build_report.png)
+
+Weitere Informationen zu Build-Berichten findest du im [Handbuch zum Profiling](/manuals/profiling/#build-reports).
+
+### Android
+
+Das Erstellen eines Android-Anwendungs-Bundles (.apk-Datei) wird im [Android-Handbuch](/manuals/android/#creating-an-android-application-bundle) beschrieben.
+
+### iOS
+
+Das Erstellen eines iOS-Anwendungs-Bundles (.ipa-Datei) wird im [iOS-Handbuch](/manuals/ios/#creating-an-ios-application-bundle) beschrieben.
+
+### macOS
+
+Das Erstellen eines macOS-Anwendungs-Bundles (.app-Datei) wird im [macOS-Handbuch](/manuals/macos) beschrieben.
+
+### Linux
+
+Das Erstellen eines Linux-Anwendungs-Bundles erfordert keine besondere Einrichtung und keine optionale plattformspezifische Konfiguration in der Datei *game.project* für die [Projekteinstellungen](/manuals/project-settings/).
+
+### Windows
+
+Das Erstellen eines Windows-Anwendungs-Bundles (.exe-Datei) wird im [Windows-Handbuch](/manuals/windows) beschrieben.
+
+### HTML5
+
+Das Erstellen eines HTML5-Anwendungs-Bundles sowie optionale Einrichtungsschritte werden im [HTML5-Handbuch](/manuals/html5/#creating-html5-bundle) beschrieben.
+
+#### Facebook Instant Games
+
+Du kannst eine spezielle Version eines HTML5-Anwendungs-Bundles für Facebook Instant Games erstellen. Dieser Vorgang wird im [Handbuch zu Facebook Instant Games](/manuals/instant-games/) beschrieben.
+
+## Ein Bundle über die Kommandozeile erstellen {#bundling-from-the-command-line}
+
+Der Editor verwendet unser Kommandozeilenwerkzeug [Bob](/manuals/bob/), um das Anwendungs-Bundle zu erstellen.
+
+Bei der täglichen Entwicklung deiner Anwendung erstellst du Builds und Bundles wahrscheinlich im Defold-Editor. Unter anderen Umständen möchtest du Anwendungs-Bundles möglicherweise automatisch erzeugen, etwa Builds für alle Zielplattformen in einem Durchlauf bei der Veröffentlichung einer neuen Version oder nächtliche Builds der neuesten Spielversion, vielleicht in einer CI-Umgebung. Mit dem [Kommandozeilenwerkzeug Bob](/manuals/bob/) kannst du Builds und Bundles einer Anwendung außerhalb des üblichen Arbeitsablaufs im Editor erstellen.
+
+## Der Aufbau eines Bundles {#the-bundle-layout}
+
+Der logische Aufbau eines Bundles sieht folgendermaßen aus:
+
+![](images/bundling/bundle_schematic_01.png)
+
+Ein Bundle wird in einem Ordner ausgegeben. Je nach Plattform kann dieser Ordner außerdem als ZIP-Archiv in einer `.apk` oder `.ipa` gespeichert werden.
+Der Inhalt des Ordners hängt von der Plattform ab.
+
+Neben den ausführbaren Dateien stellt unser Vorgang zur Bundle-Erstellung auch die für die Plattform erforderlichen Assets zusammen (z. B. die .xml-Ressourcendateien für Android).
+
+Mit der Einstellung [bundle_resources](https://defold.com/manuals/project-settings/#bundle-resources) kannst du Assets festlegen, die unverändert in das Bundle aufgenommen werden sollen.
+Das kannst du für jede Plattform einzeln steuern.
+
+Die Spiel-Assets befinden sich in der Datei `game.arcd` und werden einzeln mit LZ4 komprimiert.
+Mit der Einstellung [custom_resources](https://defold.com/manuals/project-settings/#custom-resources) kannst du Assets festlegen, die (komprimiert) in die Datei `game.arcd` aufgenommen werden sollen.
+Auf diese Assets kannst du mit der Funktion [`sys.load_resource()`](https://defold.com/ref/sys/#sys.load_resource) zugreifen.
+
+## Release- und Debug-Bundles {#release-vs-debug}
+
+Beim Erstellen eines Anwendungs-Bundles kannst du zwischen einem Debug- und einem Release-Bundle wählen. Die Unterschiede zwischen den beiden Bundles sind gering, du solltest sie jedoch beachten:
+
+* Release-Builds enthalten standardmäßig keinen [Profiler](/manuals/profiling). Setze **Profiler** auf **Always** im [Anwendungsmanifest](/manuals/app-manifest/#profiler), um die Profiler-Unterstützung sowohl in Debug- als auch in Release-Builds einzuschließen.
+* Release-Builds enthalten keine [Bildschirmaufnahmefunktion](/ref/stable/sys/#start_record)
+* Release-Builds zeigen weder die Ausgabe von Aufrufen von `print()` noch die Ausgabe nativer Erweiterungen an
+* Bei Release-Builds ist der Wert `is_debug` in `sys.get_engine_info()` auf `false` gesetzt
+* Release-Builds führen beim Aufruf von `tostring()` keine Rückwärtssuche für `hash`-Werte durch. In der Praxis bedeutet das, dass `tostring()` für einen Wert vom Typ `url` oder `hash` dessen numerische Darstellung statt der ursprünglichen Zeichenfolge zurückgibt (`'hash: [/camera_001]'` gegenüber `'hash: [11844936738040519888 (unknown)]'`)
+* Release-Builds können im Editor nicht als Ziel für [Hot Reload](/manuals/hot-reload) und ähnliche Funktionen ausgewählt werden
+
+

--- a/docs/de/manuals/caching-assets.md
+++ b/docs/de/manuals/caching-assets.md
@@ -1,0 +1,47 @@
+---
+title: Assets zwischenspeichern
+brief: Dieses Handbuch erklärt, wie du mit dem Asset-Cache Builds beschleunigst.
+---
+
+# Assets zwischenspeichern {#caching-assets}
+
+Builds von Spielen, die mit Defold erstellt wurden, dauern normalerweise nur wenige Sekunden. Mit der Größe eines Projekts wächst jedoch auch die Anzahl der Assets. Das Kompilieren von Schriftressourcen und das Komprimieren von Texturen kann in einem großen Projekt viel Zeit in Anspruch nehmen. Der Asset-Cache beschleunigt Builds, indem nur geänderte Assets neu erstellt werden. Für unveränderte Assets werden bereits kompilierte Assets aus dem Cache verwendet.
+
+Defold verwendet einen dreistufigen Cache:
+
+1. Projekt-Cache
+2. Lokaler Cache
+3. Entfernter Cache
+
+
+## Projekt-Cache {#project-cache}
+
+Defold speichert kompilierte Assets standardmäßig im Ordner `build/default` eines Defold-Projekts zwischen. Der Projekt-Cache beschleunigt nachfolgende Builds, da nur geänderte Assets neu kompiliert werden müssen, während unveränderte Assets aus dem Projekt-Cache verwendet werden. Dieser Cache ist immer aktiviert und wird sowohl vom Editor als auch von den Kommandozeilenwerkzeugen verwendet.
+
+Du kannst den Projekt-Cache manuell löschen, indem du die Dateien in `build/default` löschst oder den Befehl `clean` mit dem [Kommandozeilen-Build-Werkzeug Bob](/manuals/bob) ausführst.
+
+
+## Lokaler Cache {#local-cache}
+
+Der lokale Cache ist ein optionaler zweiter Cache, in dem kompilierte Assets an einem externen Speicherort auf demselben Computer oder auf einem Netzlaufwerk gespeichert werden. Dank dieses externen Speicherorts bleibt der Inhalt des Caches beim Bereinigen des Projekt-Caches erhalten. Er kann außerdem von mehreren Entwicklern, die am selben Projekt arbeiten, gemeinsam genutzt werden. Der Cache ist derzeit nur verfügbar, wenn du Builds mit den Kommandozeilenwerkzeugen erstellst. Du aktivierst ihn über die Option `resource-cache-local`:
+
+```sh
+java -jar bob.jar --resource-cache-local /Users/john.doe/defold_local_cache
+```
+
+Auf kompilierte Assets im lokalen Cache wird anhand einer berechneten Prüfsumme zugegriffen. Diese berücksichtigt die Version der Defold-Engine, die Namen und Inhalte der Quell-Assets sowie die Build-Optionen des Projekts. Dadurch wird sichergestellt, dass zwischengespeicherte Assets eindeutig sind und der Cache von mehreren Versionen von Defold gemeinsam genutzt werden kann.
+
+::: sidenote
+Dateien im lokalen Cache werden auf unbestimmte Zeit gespeichert. Für das manuelle Entfernen alter oder ungenutzter Dateien bist du selbst verantwortlich.
+:::
+
+
+## Entfernter Cache {#remote-cache}
+
+Der entfernte Cache ist ein optionaler dritter Cache, in dem kompilierte Assets auf einem Server gespeichert werden und auf den über HTTP-Anfragen zugegriffen wird. Der Cache ist derzeit nur verfügbar, wenn du Builds mit den Kommandozeilenwerkzeugen erstellst. Du aktivierst ihn über die Option `resource-cache-remote`:
+
+```sh
+java -jar bob.jar --resource-cache-remote http://192.168.0.100/
+```
+
+Wie beim lokalen Cache wird auf alle Assets im entfernten Cache anhand einer berechneten Prüfsumme zugegriffen. Der Zugriff auf zwischengespeicherte Assets erfolgt über die HTTP-Anfragemethoden GET, PUT und HEAD. Defold stellt den Server für den entfernten Cache nicht bereit. Du musst ihn selbst einrichten. Ein Beispiel für [einen einfachen Python-Server findest du hier](https://github.com/britzl/httpserver-python).

--- a/docs/de/manuals/camera.md
+++ b/docs/de/manuals/camera.md
@@ -1,0 +1,335 @@
+---
+title: Handbuch zur Kamerakomponente
+brief: Dieses Handbuch beschreibt die Funktionen der Kamerakomponente von Defold.
+---
+
+# Kameras {#cameras}
+
+Eine Kamera in Defold ist eine Komponente (component), die den Ansichtsbereich (viewport) und die Projektion der Spielwelt ändert. Die Kamerakomponente definiert eine grundlegende perspektivische oder orthografische Kamera, die dem Render-Skript eine Ansichts- und eine Projektionsmatrix bereitstellt.
+
+Eine perspektivische Kamera wird üblicherweise für 3D-Spiele verwendet. Dabei hängen die Ansicht der Kamera sowie die Größe und Perspektive der Objekte von einem Sichtpyramidenstumpf und dem Abstand und Blickwinkel der Kamera zu den Objekten im Spiel ab.
+
+Bei 2D-Spielen ist es oft erwünscht, die Szene mit einer orthografischen Projektion zu rendern. Das bedeutet, dass die Ansicht der Kamera nicht mehr durch einen Sichtpyramidenstumpf, sondern durch einen Quader bestimmt wird. Eine orthografische Projektion ist insofern unrealistisch, als sie die Größe der Objekte nicht abhängig von ihrer Entfernung verändert. Ein 1000 Einheiten entferntes Objekt wird in derselben Größe gerendert wie ein Objekt direkt vor der Kamera.
+
+![Projektionen](images/camera/projections.png)
+
+
+## Eine Kamera erstellen {#creating-a-camera}
+
+Um eine Kamera zu erstellen, klicke <kbd>mit der rechten Maustaste</kbd> auf ein Spielobjekt (game object) und wähle <kbd>Add Component ▸ Camera</kbd>. Alternativ kannst du in deiner Projekthierarchie eine Komponentendatei erstellen und sie dem Spielobjekt hinzufügen.
+
+![Kamerakomponente erstellen](images/camera/create.png)
+
+Die Kamerakomponente hat die folgenden Eigenschaften, die das *Sichtvolumen* der Kamera definieren:
+
+![Kameraeinstellungen](images/camera/settings.png)
+
+Id
+: Der Bezeichner der Komponente
+
+Aspect Ratio
+: (**Nur perspektivische Kamera**) - Das Verhältnis zwischen Breite und Höhe des Sichtvolumens. 1.0 bedeutet, dass du von einer quadratischen Ansicht ausgehst. 1.33 eignet sich für eine 4:3-Ansicht wie 1024 × 768. 1.78 eignet sich für eine 16:9-Ansicht. Diese Einstellung wird ignoriert, wenn *Auto Aspect Ratio* aktiviert ist.
+
+Fov
+: (**Nur perspektivische Kamera**) - Der *vertikale* Sichtwinkel der Kamera, angegeben im _Bogenmaß_. Je größer der Sichtwinkel, desto mehr sieht die Kamera.
+
+Near Z
+: Der Z-Wert der nahen Begrenzungsebene.
+
+Far Z
+: Der Z-Wert der fernen Begrenzungsebene.
+
+Auto Aspect Ratio
+: (**Nur perspektivische Kamera**) - Aktiviere diese Einstellung, damit die Kamera das Seitenverhältnis automatisch berechnet.
+
+Orthographic Projection
+: Aktiviere diese Einstellung, um die Kamera auf eine orthografische Projektion umzustellen (siehe unten).
+
+Orthographic Zoom
+: (**Nur orthografische Kamera**) - Ein von dir steuerbarer Zoom-Multiplikator (> 1 = vergrößern, < 1 = verkleinern). Im Modus `Fixed` ist er der effektive Zoom. In den Modi `Auto Fit` und `Auto Cover` wird er mit dem automatisch berechneten Zoom multipliziert. Dadurch kannst du zusätzlichen Zoom anwenden, ohne die automatische Größenanpassung zu deaktivieren.
+
+Orthographic Mode
+: (**Nur orthografische Kamera**) - Steuert, wie die orthografische Kamera den Zoom anhand der Fenstergröße und deiner Entwurfsauflösung (der Werte in `game.project` → `display.width/height`) bestimmt.
+  - `Fixed` (konstanter Zoom): Verwendet den aktuellen Wert von `Orthographic Zoom` unverändert.
+  - `Auto Fit` (einpassen): Berechnet den Zoom automatisch so, dass der gesamte Entwurfsbereich in das Fenster passt, und multipliziert ihn anschließend mit `Orthographic Zoom`. An den Seiten oder oben und unten können zusätzliche Inhalte sichtbar sein.
+  - `Auto Cover` (ausfüllen): Berechnet den Zoom automatisch so, dass der Entwurfsbereich das gesamte Fenster ausfüllt, und multipliziert ihn anschließend mit `Orthographic Zoom`. An den Seiten oder oben und unten können Inhalte abgeschnitten werden.
+  Nur verfügbar, wenn `Orthographic Projection` aktiviert ist.
+
+
+## Die Kamera verwenden {#using-the-camera}
+
+Alle Kameras werden innerhalb eines Frames automatisch aktiviert und aktualisiert. Das Lua-Modul `camera` ist in allen Skriptkontexten verfügbar. Seit Defold 1.8.1 musst du eine Kamera nicht mehr ausdrücklich aktivieren, indem du eine Nachricht vom Typ `acquire_camera_focus` an die Kamerakomponente sendest. Die alten Nachrichten zum Anfordern und Freigeben des Kamerafokus sind weiterhin verfügbar. Es wird jedoch empfohlen, stattdessen die Nachrichten `enable` und `disable` zu verwenden, wie bei jeder anderen Komponente, die du aktivieren oder deaktivieren möchtest:
+
+```lua
+msg.post("#camera", "disable")
+msg.post("#camera", "enable")
+```
+
+Mit `camera.get_cameras()` kannst du alle aktuell verfügbaren Kameras auflisten:
+
+```lua
+-- Note: The render calls are only available in a render script.
+--       The camera.get_cameras() function can be used anywhere,
+--       but render.set_camera can only be used in a render script.
+
+for k,v in pairs(camera.get_cameras()) do
+    -- the camera table contains the URLs of all cameras
+    render.set_camera(v)
+    -- do rendering here - anything rendered here that uses materials with
+    -- view and projection matrices specified, will use matrices from the camera.
+end
+-- to disable a camera, pass in nil (or no arguments at all) to render.set_camera.
+-- after this call, all render calls will use the view and projection matrices
+-- that are specified on the render context (render.set_view and render.set_projection)
+render.set_camera()
+```
+
+Das Skriptmodul `camera` bietet mehrere Funktionen, mit denen du die Kamera verändern kannst. Hier sind einige davon aufgeführt. Alle verfügbaren Funktionen findest du in der [API-Dokumentation](/ref/camera/)).
+
+```lua
+camera.get_aspect_ratio(camera) -- get aspect ratio
+camera.get_far_z(camera) -- get far z
+camera.get_fov(camera) -- get field of view
+camera.get_orthographic_mode(camera) -- get orthographic mode (one of camera.ORTHO_MODE_*)
+camera.get_orthographic_zoom(camera) -- get the user-controlled zoom multiplier
+camera.get_orthographic_auto_zoom(camera) -- get the automatically calculated zoom
+camera.set_aspect_ratio(camera, ratio) -- set aspect ratio
+camera.set_far_z(camera, far_z) -- set far z
+camera.set_near_z(camera, near_z) -- set near z
+camera.set_orthographic_mode(camera, camera.ORTHO_MODE_AUTO_FIT) -- set orthographic mode
+... And so forth
+```
+
+Eine Kamera wird durch eine URL identifiziert. Diese enthält den vollständigen Szenenpfad der Komponente, einschließlich der Sammlung (collection), des zugehörigen Spielobjekts und des Komponentenbezeichners. In diesem Beispiel verwendest du die URL `/go#camera`, um die Kamerakomponente innerhalb derselben Sammlung zu identifizieren, und `main:/go#camera`, wenn du aus einer anderen Sammlung oder aus dem Render-Skript auf die Kamera zugreifst.
+
+![Kamerakomponente erstellen](images/camera/create.png)
+
+```lua
+-- Accessing a camera from a script in the same collection:
+camera.get_fov("/go#camera")
+
+-- Accessing a camera from a script in a different collection:
+camera.get_fov("main:/go#camera")
+
+-- Accessing a camera from the render script:
+render.set_camera("main:/go#camera")
+```
+
+In jedem Frame sendet die Kamerakomponente, die aktuell den Kamerafokus hat, eine Nachricht vom Typ `set_view_projection` an den Socket `@render`:
+
+```lua
+-- builtins/render/default.render_script
+--
+function on_message(self, message_id, message)
+    if message_id == hash("set_view_projection") then
+        self.view = message.view                    -- [1]
+        self.projection = message.projection
+    end
+end
+```
+1. Die von der Kamerakomponente gesendete Nachricht enthält eine Ansichtsmatrix und eine Projektionsmatrix.
+
+Die Kamerakomponente stellt dem Render-Skript je nach Eigenschaft *Orthographic Projection* der Kamera eine perspektivische oder eine orthografische Projektionsmatrix bereit. Die Projektionsmatrix berücksichtigt außerdem die festgelegte nahe und ferne Begrenzungsebene, den Sichtwinkel und das Seitenverhältnis der Kamera.
+
+Die von der Kamera bereitgestellte Ansichtsmatrix definiert die Position und Ausrichtung der Kamera. Eine Kamera mit *Orthographic Projection* zentriert die Ansicht auf die Position des Spielobjekts, dem sie zugeordnet ist. Bei einer Kamera mit *Perspective Projection* befindet sich die untere linke Ecke der Ansicht an der Position des Spielobjekts, dem sie zugeordnet ist.
+
+
+### Render-Skript {#render-script}
+
+Wenn du das Standard-Render-Skript verwendest, legt Defold automatisch die zuletzt aktivierte Kamera als Kamera für das Rendering fest. Vor dieser Änderung musste ein Skript im Projekt ausdrücklich die Nachricht `use_camera_projection` an den Renderer senden, um ihm mitzuteilen, dass die Ansicht und Projektion der Kamerakomponenten verwendet werden sollen. Das ist nicht mehr erforderlich, bleibt aber aus Gründen der Abwärtskompatibilität weiterhin möglich.
+
+Alternativ kannst du in einem Render-Skript eine bestimmte Kamera festlegen, die für das Rendering verwendet werden soll. Das kann nützlich sein, wenn du genauer steuern musst, welche Kamera für das Rendering verwendet wird, beispielsweise in einem Mehrspielerspiel.
+
+```lua
+-- render.set_camera will automatically use the view and projection matrices
+-- for any rendering happening until render.set_camera() is called.
+render.set_camera("main:/my_go#camera")
+```
+
+Mit der Funktion `get_enabled` aus der [Kamera-API](https://defold.com/ref/alpha/camera/#camera.get_enabled:camera) kannst du prüfen, ob eine Kamera aktiv ist:
+
+```lua
+if camera.get_enabled("main:/my_go#camera") then
+    -- camera is enabled, use it for rendering!
+    render.set_camera("main:/my_go#camera")
+end
+```
+
+::: sidenote
+Um die Funktion `set_camera` zusammen mit dem Aussondern von Geometrie außerhalb des Sichtvolumens (Frustum Culling) zu verwenden, musst du dies als Option an die Funktion übergeben:
+`render.set_camera("main:/my_go#camera", {use_frustum = true})`
+:::
+
+### Die Kamera verschieben {#panning-the-camera}
+
+Du verschiebst die Kamera in der Spielwelt, indem du das Spielobjekt bewegst, dem die Kamerakomponente zugeordnet ist. Die Kamerakomponente sendet automatisch eine aktualisierte Ansichtsmatrix anhand der aktuellen Position der Kamera auf der x- und y-Achse.
+
+### Den Kamerazoom ändern {#zooming-the-camera}
+
+Bei einer perspektivischen Kamera kannst du die Ansicht vergrößern und verkleinern, indem du das Spielobjekt, dem die Kamera zugeordnet ist, entlang der z-Achse bewegst. Die Kamerakomponente sendet automatisch eine aktualisierte Ansichtsmatrix anhand der aktuellen z-Position der Kamera.
+
+Bei einer orthografischen Kamera kannst du die Ansicht vergrößern und verkleinern, indem du die Eigenschaft *Orthographic Zoom* der Kamera im Editor oder zur Laufzeit änderst:
+
+```lua
+-- In Fixed mode, this is the effective zoom.
+go.set("#camera", "orthographic_zoom", 2)
+```
+
+In den Modi `Auto Fit` und `Auto Cover` wird *Orthographic Zoom* zusätzlich auf den automatisch berechneten Zoom angewendet und nicht ignoriert. Setze beispielsweise im Editor *Orthographic Mode* auf `Auto Fit` und *Orthographic Zoom* auf `1.25`, um den Entwurfsbereich in das Fenster einzupassen und die Ansicht anschließend um weitere 25 % zu vergrößern. Die entsprechende Konfiguration zur Laufzeit lautet:
+
+```lua
+camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_AUTO_FIT)
+go.set("#camera", "orthographic_zoom", 1.25)
+
+local auto_zoom = camera.get_orthographic_auto_zoom("#camera")
+local zoom_multiplier = camera.get_orthographic_zoom("#camera")
+local effective_zoom = auto_zoom * zoom_multiplier
+```
+
+`camera.get_orthographic_auto_zoom()` gibt in den Modi `Auto Fit` und `Auto Cover` den Zoom zurück, der anhand der aktuellen Fenster- und Projektabmessungen berechnet wird. Im Modus `Fixed` gibt die Funktion `1.0` zurück. Derselbe Wert ist über die nur lesbare Komponenteneigenschaft `orthographic_auto_zoom` verfügbar:
+
+```lua
+local auto_zoom = go.get("#camera", "orthographic_auto_zoom")
+```
+
+Bei einer orthografischen Kamera kannst du außerdem über die Einstellung `Orthographic Mode` oder per Skript ändern, wie der Zoom bestimmt wird:
+
+```lua
+-- get current mode (one of camera.ORTHO_MODE_FIXED, _AUTO_FIT, _AUTO_COVER)
+local mode = camera.get_orthographic_mode("#camera")
+
+-- switch to auto-fit (contain) to always keep the full design area visible
+camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_AUTO_FIT)
+
+-- switch to auto-cover to ensure the design area covers the window
+camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_AUTO_COVER)
+
+-- switch to fixed mode to use orthographic_zoom without automatic sizing
+camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_FIXED)
+```
+
+### Adaptiver Zoom {#adaptive-zoom}
+
+Das Konzept hinter adaptivem Zoom besteht darin, den Zoomwert der Kamera anzupassen, wenn sich die Auflösung der Anzeige gegenüber der ursprünglich in *game.project* festgelegten Auflösung ändert.
+
+Zwei gängige Ansätze für adaptiven Zoom sind:
+
+1. Maximaler Zoom - Berechne einen Zoomwert, bei dem der von der ursprünglichen Auflösung in *game.project* abgedeckte Inhalt den Bildschirm ausfüllt und über dessen Grenzen hinausreicht. Dabei können Inhalte an den Seiten oder oben und unten verdeckt werden.
+2. Minimaler Zoom - Berechne einen Zoomwert, bei dem der von der ursprünglichen Auflösung in *game.project* abgedeckte Inhalt vollständig innerhalb der Bildschirmgrenzen liegt. Dabei können zusätzliche Inhalte an den Seiten oder oben und unten sichtbar werden.
+
+Beispiel:
+
+```lua
+local DISPLAY_WIDTH = sys.get_config_int("display.width")
+local DISPLAY_HEIGHT = sys.get_config_int("display.height")
+
+function init(self)
+    local initial_zoom = go.get("#camera", "orthographic_zoom")
+    local display_scale = window.get_display_scale()
+    window.set_listener(function(self, event, data)
+        if event == window.WINDOW_EVENT_RESIZED then
+            local window_width = data.width
+            local window_height = data.height
+            local design_width = DISPLAY_WIDTH / initial_zoom
+            local design_height = DISPLAY_HEIGHT / initial_zoom
+
+            -- max zoom: ensure that the initial design dimensions will fill and expand beyond the screen bounds
+            local zoom = math.max(window_width / design_width, window_height / design_height) / display_scale
+
+            -- min zoom: ensure that the initial design dimensions will shrink and be contained within the screen bounds
+            --local zoom = math.min(window_width / design_width, window_height / design_height) / display_scale
+            
+            go.set("#camera", "orthographic_zoom", zoom)
+        end
+    end)
+end
+```
+
+Ein vollständiges Beispiel für adaptiven Zoom findest du in [diesem Beispielprojekt](https://github.com/defold/sample-adaptive-zoom).
+
+Hinweis: Mit einer orthografischen Kamera kannst du jetzt ohne eigenen Code erreichen, dass der Entwurfsbereich eingepasst wird oder das Fenster ausfüllt. Setze dazu `Orthographic Mode` auf `Auto Fit` (einpassen) oder `Auto Cover` (ausfüllen). In diesen Modi wird der aus der Fenstergröße und der Entwurfsauflösung berechnete Zoom mit `Orthographic Zoom` multipliziert.
+
+
+### Einem Spielobjekt folgen {#following-a-game-object}
+
+Du kannst die Kamera einem Spielobjekt folgen lassen, indem du das Spielobjekt mit der Kamerakomponente dem zu verfolgenden Spielobjekt unterordnest:
+
+![Einem Spielobjekt folgen](images/camera/follow.png)
+
+Alternativ kannst du in jedem Frame die Position des Spielobjekts mit der Kamerakomponente aktualisieren, während sich das zu verfolgende Spielobjekt bewegt.
+
+### Zwischen Bildschirm- und Weltkoordinaten umrechnen {#converting-mouse-to-world-coordinates}
+
+Wenn eine Kamera verschoben, ihr Zoom verändert oder ihre Projektion geändert wurde, stimmen Eingabekoordinaten nicht mehr direkt mit Weltkoordinaten überein. Verwende die Umrechnungsfunktionen der Kamera mit `action.screen_x` und `action.screen_y`. Wenn du die optionale Kamera-URL weglässt, wird die zuletzt aktivierte Kamera verwendet.
+
+Bei einer orthografischen Kamera gibt [`camera.screen_xy_to_world()`](/ref/camera/#camera.screen_xy_to_world:x-y-[camera]) für ein Bildschirmpixel den Punkt auf der nahen Begrenzungsebene der Kamera im Weltkoordinatensystem zurück:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local world_position = camera.screen_xy_to_world(
+            action.screen_x, action.screen_y, "#camera")
+        go.set_position(world_position, "/marker")
+    end
+end
+```
+
+Bei einer perspektivischen Kamera nimmt [`camera.screen_to_world()`](/ref/camera/#camera.screen_to_world:pos-[camera]) einen `vector3` entgegen, dessen Z-Komponente die von der Kameraebene aus gemessene Ansichtstiefe in Welteinheiten angibt:
+
+```lua
+local depth = 10
+local world_position = camera.screen_to_world(
+    vmath.vector3(action.screen_x, action.screen_y, depth), "#camera")
+```
+
+[`camera.world_to_screen()`](/ref/camera/#camera.world_to_screen:world_pos-[camera]) führt die umgekehrte Umrechnung durch. Die Funktion gibt X und Y in Bildschirmpixeln sowie Z nach derselben Konvention für die Ansichtstiefe zurück. Ihr Ergebnis kann daher wieder an `camera.screen_to_world()` übergeben werden:
+
+```lua
+-- Update the cached world transform first if the object moved this frame.
+go.update_world_transform("/marker")
+local world_position = go.get_world_position("/marker")
+local screen_position = camera.world_to_screen(world_position, "#camera")
+```
+
+Auf der [Beispielseite](https://defold.com/examples/render/screen_to_world/) kannst du die Koordinatenumrechnung in Aktion sehen. Außerdem gibt es ein [Beispielprojekt](https://github.com/defold/sample-screen-to-world-coordinates/), das dieselben APIs zeigt.
+
+::: sidenote
+Die [in diesem Handbuch erwähnten Kameralösungen von Drittanbietern](/manuals/camera/#third-party-camera-solutions) bieten Funktionen für die Umrechnung in und aus Bildschirmkoordinaten.
+:::
+
+## Änderungen zur Laufzeit {#runtime-manipulation}
+Du kannst Kameras zur Laufzeit über verschiedene Nachrichten und Eigenschaften verändern (Hinweise zur Verwendung findest du in der [API-Dokumentation](/ref/camera/)).
+
+Eine Kamera hat verschiedene Eigenschaften, auf die du mit `go.get()` und `go.set()` zugreifen kannst:
+
+`fov`
+: Der Sichtwinkel der Kamera (`number`).
+
+`near_z`
+: Der nahe Z-Wert der Kamera (`number`).
+
+`far_z`
+: Der ferne Z-Wert der Kamera (`number`).
+
+`orthographic_zoom`
+: Der von dir steuerbare Zoom-Multiplikator der orthografischen Kamera. In den Modi `Auto Fit` und `Auto Cover` wird er mit `orthographic_auto_zoom` multipliziert. (`number`).
+
+`orthographic_auto_zoom`
+: Der berechnete orthografische Zoom für die Modi `Auto Fit` und `Auto Cover` oder `1.0` im Modus `Fixed`. NUR LESBAR. (`number`).
+
+`aspect_ratio`
+: Das Verhältnis zwischen Breite und Höhe des Sichtvolumens. Wird bei der Berechnung der Projektion einer perspektivischen Kamera verwendet. (`number`).
+
+`view`
+: Die berechnete Ansichtsmatrix der Kamera. NUR LESBAR. (`matrix4`).
+
+`projection`
+: Die berechnete Projektionsmatrix der Kamera. NUR LESBAR. (`matrix4`).
+
+
+## Kameralösungen von Drittanbietern {#third-party-camera-solutions}
+
+Es gibt Kameralösungen aus der Community, die gängige Funktionen wie Bildschirmwackeln, das Verfolgen von Spielobjekten, die Umrechnung von Bildschirm- in Weltkoordinaten und vieles mehr bereitstellen. Du kannst sie aus dem Defold Asset Portal herunterladen:
+
+- [Orthographic camera](https://defold.com/assets/orthographic/) (nur 2D) von Björn Ritzl.
+- [Defold Rendy](https://defold.com/assets/defold-rendy/) (2D und 3D) von Klayton Kowalski.

--- a/docs/de/manuals/collection-factory.md
+++ b/docs/de/manuals/collection-factory.md
@@ -1,0 +1,169 @@
+---
+title: Handbuch zu Sammlungsfabriken
+brief: Dieses Handbuch erklärt, wie du mit Sammlungsfabrikkomponenten Hierarchien von Spielobjekten dynamisch erzeugst.
+---
+
+# Sammlungsfabriken {#collection-factories}
+
+Die Sammlungsfabrik (collection factory) ist eine Komponente (component), mit der du Gruppen und Hierarchien von Spielobjekten (game objects), die in Sammlungsdateien gespeichert sind, in einem laufenden Spiel dynamisch erzeugst.
+
+Sammlungen (collections) bieten einen leistungsfähigen Mechanismus, um wiederverwendbare Vorlagen oder „Prefabs“ in Defold zu erstellen. Eine Übersicht über Sammlungen findest du in der [Dokumentation zu den Bausteinen](/manuals/building-blocks#collections). Sammlungen können im Editor platziert oder dynamisch in dein Spiel eingefügt werden.
+
+Mit einer Sammlungsfabrikkomponente kannst du die Inhalte einer Sammlungsdatei in einer Spielwelt dynamisch erzeugen. Das entspricht dem dynamischen Erzeugen aller Spielobjekte innerhalb der Sammlung durch eine Fabrik (factory) mit anschließendem Aufbau der Eltern-Kind-Hierarchie zwischen den Objekten. Ein typischer Anwendungsfall ist das dynamische Erzeugen von Gegnern, die aus mehreren Spielobjekten bestehen (zum Beispiel Gegner + Waffe).
+
+## Eine Sammlung dynamisch erzeugen {#spawning-a-collection}
+
+Angenommen, wir möchten ein Spielobjekt für eine Figur und ein separates Spielobjekt für einen Schild, das der Figur untergeordnet ist. Wir erstellen die Spielobjekthierarchie in einer Sammlungsdatei und speichern sie als `bean.collection`.
+
+::: sidenote
+Die Komponente *Sammlungs-Proxy (collection proxy)* wird verwendet, um auf Grundlage einer Sammlung eine neue Spielwelt einschließlich einer separaten Physikwelt zu erstellen. Auf die neue Welt wird über einen neuen Socket zugegriffen. Alle in der Sammlung enthaltenen Assets werden über den Proxy geladen, wenn du ihm eine Nachricht zum Starten des Ladevorgangs sendest. Dadurch sind Sammlungs-Proxys beispielsweise sehr nützlich, um in einem Spiel die Level zu wechseln. Neue Spielwelten bringen allerdings einen erheblichen Zusatzaufwand mit sich. Verwende sie daher nicht zum dynamischen Laden kleiner Inhalte. Weitere Informationen findest du in der [Dokumentation zu Sammlungs-Proxys](/manuals/collection-proxy).
+:::
+
+![Dynamisch zu erzeugende Sammlung](images/collection_factory/collection.png)
+
+Anschließend fügen wir einem Spielobjekt, das für das dynamische Erzeugen zuständig sein wird, eine *Collection factory* hinzu und legen `bean.collection` als *Prototype* der Komponente fest:
+
+![Sammlungsfabrik](images/collection_factory/factory.png)
+
+Um `bean` und den Schild dynamisch zu erzeugen, müssen wir jetzt nur noch die Funktion `collectionfactory.create()` aufrufen:
+
+```lua
+local bean_ids = collectionfactory.create("#bean_factory")
+```
+
+Die Funktion nimmt 5 Parameter entgegen:
+
+`url`
+: Der Bezeichner (ID) der Sammlungsfabrikkomponente, die die neue Gruppe von Spielobjekten dynamisch erzeugen soll.
+
+`[position]`
+: (optional) Die Position der dynamisch erzeugten Spielobjekte im Weltkoordinatensystem. Dies sollte ein `vector3` sein. Wenn du keine Position angibst, werden die Objekte an der Position der Sammlungsfabrikkomponente erzeugt.
+
+`[rotation]`
+: (optional) Die Drehung der neuen Spielobjekte im Weltkoordinatensystem. Dies sollte ein `quat` sein.
+
+`[properties]`
+: (optional) Eine Lua-Tabelle mit `id`-`table`-Paaren, die zur Initialisierung der dynamisch erzeugten Spielobjekte verwendet werden. Wie du diese Tabelle aufbaust, erfährst du weiter unten.
+
+`[scale]`
+: (optional) Die Skalierung der dynamisch erzeugten Spielobjekte. Die Skalierung kann als `number` (größer als 0) angegeben werden, die eine gleichmäßige Skalierung entlang aller Achsen festlegt. Du kannst auch einen `vector3` angeben, bei dem jede Vektorkomponente die Skalierung entlang der entsprechenden Achse festlegt.
+
+`collectionfactory.create()` gibt die Bezeichner der dynamisch erzeugten Spielobjekte als Tabelle zurück. Die Tabellenschlüssel ordnen den Hashwert der sammlungslokalen ID jedes Objekts dessen Laufzeit-ID zu:
+
+::: sidenote
+Die Eltern-Kind-Beziehung zwischen `bean` und `shield` wird in der zurückgegebenen Tabelle *nicht* abgebildet. Diese Beziehung besteht nur im Szenengraphen zur Laufzeit, also darin, wie Objekte gemeinsam transformiert werden. Die Zuordnung eines Objekts zu einem anderen übergeordneten Objekt ändert niemals seine ID.
+:::
+
+```lua
+local bean_ids = collectionfactory.create("#bean_factory")
+go.set_scale_xy(0.5, bean_ids[hash("/bean")])
+pprint(bean_ids)
+-- DEBUG:SCRIPT:
+-- {
+--   hash: [/shield] = hash: [/collection0/shield], -- <1>
+--   hash: [/bean] = hash: [/collection0/bean],
+-- }
+```
+1. Der ID wird ein Präfix `/collection[N]/` hinzugefügt, wobei `[N]` ein Zähler ist, um jede Instanz eindeutig zu identifizieren:
+
+## Eigenschaften {#properties}
+
+Wenn du eine Sammlung dynamisch erzeugst, kannst du jedem Spielobjekt Eigenschaftsparameter übergeben. Erstelle dazu eine Tabelle, deren Schlüssel Objekt-IDs und deren Werte Tabellen mit den festzulegenden Skripteigenschaften sind.
+
+```lua
+local props = {}
+props[hash("/bean")] = { shield = false }
+local ids = collectionfactory.create("#bean_factory", nil, nil, props)
+```
+
+Dabei gehen wir davon aus, dass das Spielobjekt `bean` in `bean.collection` die Eigenschaft `shield` definiert. [Das Handbuch zu Skripteigenschaften](/manuals/script-properties) enthält Informationen zu Skripteigenschaften.
+
+```lua
+-- bean/controller.script
+go.property("shield", true)
+
+function init(self)
+    if not self.shield then
+        go.delete("shield")
+    end     
+end
+```
+
+## Fabrikressourcen dynamisch laden {#dynamic-loading-of-factory-resources}
+
+Wenn du das Kontrollkästchen *Load Dynamically* in den Eigenschaften der Sammlungsfabrik aktivierst, verschiebt die Engine das Laden der mit der Fabrik verknüpften Ressourcen auf einen späteren Zeitpunkt.
+
+![Dynamisch laden](images/collection_factory/load_dynamically.png)
+
+Wenn das Kontrollkästchen deaktiviert ist, lädt die Engine die Ressourcen des Prototyps beim Laden der Sammlungsfabrikkomponente, sodass sie sofort zum dynamischen Erzeugen bereitstehen.
+
+Wenn das Kontrollkästchen aktiviert ist, hast du zwei Verwendungsmöglichkeiten:
+
+Synchrones Laden
+: Rufe [`collectionfactory.create()`](/ref/collectionfactory/#collectionfactory.create:url-[position]-[rotation]-[properties]-[scale]) auf, wenn du Objekte dynamisch erzeugen möchtest. Dadurch werden die Ressourcen synchron geladen, was zu einem kurzen Ruckler führen kann. Anschließend werden neue Instanzen dynamisch erzeugt.
+
+  ```lua
+  function init(self)
+      -- No factory resources are loaded when the collection factory’s
+      -- parent collection is loaded. Calling create without
+      -- having called load will create the resources synchronously.
+      self.go_ids = collectionfactory.create("#collectionfactory")
+  end
+
+  function final(self)  
+      -- Delete game objects. Will decref resources.
+      -- In this case resources are deleted since the collection
+      -- factory component holds no reference.
+      go.delete(self.go_ids)
+
+      -- Calling unload will do nothing since factory holds
+      -- no references
+      collectionfactory.unload("#factory")
+  end
+  ```
+
+Asynchrones Laden
+: Rufe [`collectionfactory.load()`](/ref/collectionfactory/#collectionfactory.load:[url]-[complete_function]) auf, um die Ressourcen ausdrücklich asynchron zu laden. Sobald die Ressourcen zum dynamischen Erzeugen bereitstehen, wird ein Callback aufgerufen.
+
+  ```lua
+  function load_complete(self, url, result)
+      -- Loading is complete, resources are ready to spawn
+      self.go_ids = collectionfactory.create(url)
+  end
+
+  function init(self)
+      -- No factory resources are loaded when the collection factory’s
+      -- parent collection is loaded. Calling load will load the resources.
+      collectionfactory.load("#factory", load_complete)
+  end
+
+  function final(self)
+      -- Delete game object. Will decref resources.
+      -- In this case resources aren’t deleted since the collection factory
+      -- component still holds a reference.
+      go.delete(self.go_ids)
+
+      -- Calling unload will decref resources held by the factory component,
+      -- resulting in resources being destroyed.
+      collectionfactory.unload("#factory")
+  end
+  ```
+
+
+## Dynamischer Prototyp {#dynamic-prototype}
+
+Du kannst ändern, welchen *Prototype* eine Sammlungsfabrik erzeugen kann, indem du das Kontrollkästchen *Dynamic Prototype* in den Eigenschaften der Sammlungsfabrik aktivierst.
+
+![Dynamischer Prototyp](images/collection_factory/dynamic_prototype.png)
+
+Wenn die Option *Dynamic Prototype* aktiviert ist, kann die Sammlungsfabrikkomponente ihren Prototyp mit der Funktion `collectionfactory.set_prototype()` ändern. Beispiel:
+
+```lua
+collectionfactory.unload("#factory") -- unload the previous resources
+collectionfactory.set_prototype("#factory", "/main/levels/level1.collectionc")
+local ids = collectionfactory.create("#factory")
+```
+
+::: important
+Wenn die Option *Dynamic Prototype* aktiviert ist, kann die Komponentenanzahl der Sammlung nicht optimiert werden. Die Sammlung, zu der die Komponente gehört, verwendet dann die Standardanzahlen für Komponenten aus der Datei *game.project*.
+:::

--- a/docs/de/manuals/collection-proxy.md
+++ b/docs/de/manuals/collection-proxy.md
@@ -1,0 +1,237 @@
+---
+title: Handbuch zu Sammlungs-Proxys
+brief: Dieses Handbuch erklärt, wie du dynamisch neue Spielwelten erstellst und zwischen ihnen wechselst.
+---
+
+# Sammlungs-Proxy {#collection-proxy}
+
+Ein Sammlungs-Proxy (collection proxy) ist eine Komponente (component) zum dynamischen Laden und Entladen neuer „Spielwelten“ anhand des Inhalts einer Sammlungsdatei. Du kannst damit den Wechsel zwischen Spiellevels und GUI-Bildschirmen, das Laden und Entladen erzählerischer „Szenen“ im Verlauf eines Levels, das Laden und Entladen von Minispielen und mehr umsetzen.
+
+Defold organisiert alle Spielobjekte (game objects) in Sammlungen (collections). Eine Sammlung kann Spielobjekte und andere Sammlungen (also Untersammlungen) enthalten. Mit Sammlungs-Proxys kannst du deine Inhalte in getrennte Sammlungen aufteilen und das Laden und Entladen dieser Sammlungen dann dynamisch durch Skripte verwalten.
+
+Sammlungs-Proxys unterscheiden sich von [Komponenten vom Typ Sammlungsfabrik (collection factory)](/manuals/collection-factory/). Eine Sammlungsfabrik instanziiert den Inhalt einer Sammlung in der aktuellen Spielwelt. Sammlungs-Proxys erstellen zur Laufzeit eine neue Spielwelt und haben deshalb andere Anwendungsfälle.
+
+## Eine Sammlungs-Proxy-Komponente erstellen {#creating-a-collection-proxy-component}
+
+1. Füge einem Spielobjekt eine Sammlungs-Proxy-Komponente hinzu, indem du einen <kbd>Rechtsklick</kbd> auf ein Spielobjekt ausführst und im Kontextmenü <kbd>Add Component ▸ Collection Proxy</kbd> auswählst.
+
+2. Setze die Eigenschaft *Collection* auf eine Sammlung, die du zu einem späteren Zeitpunkt dynamisch in die Laufzeitumgebung laden möchtest. Dies ist eine statische Abhängigkeit zur Build-Zeit: Die referenzierte Sammlung und ihre Abhängigkeiten werden kompiliert. Wenn *Exclude* nicht angekreuzt ist, werden sie in das Haupt-Bundle aufgenommen. Ist *Exclude* angekreuzt, können Ressourcen, die ausschließlich über ausgeschlossene Proxys referenziert werden, für Live Update aus dem Haupt-Bundle weggelassen werden. Außerdem kann der entladene Proxy zur Laufzeit auf eine andere kompilierte Sammlung umgeleitet werden, wie unten beschrieben.
+
+![Proxy-Komponente hinzufügen](images/collection-proxy/create_proxy.png)
+
+(Du kannst die Inhalte vom Build ausschließen und stattdessen per Code herunterladen, indem du das Kästchen *Exclude* ankreuzt und die [Funktion Live Update](/manuals/live-update/) verwendest.)
+
+## Startsammlung {#bootstrap}
+
+Beim Start lädt und instanziiert die Defold-Engine alle Spielobjekte aus einer *Startsammlung (bootstrap collection)* in der Laufzeitumgebung. Anschließend initialisiert und aktiviert sie die Spielobjekte und ihre Komponenten. Welche Startsammlung die Engine verwenden soll, wird in den [Projekteinstellungen](/manuals/project-settings/#main-collection) festgelegt. Üblicherweise wird diese Sammlungsdatei `main.collection` genannt.
+
+![Startsammlung](images/collection-proxy/bootstrap.png)
+
+Um die Spielobjekte und ihre Komponenten unterzubringen, weist die Engine den Speicher zu, der für die gesamte „Spielwelt“ benötigt wird, in der die Inhalte der Startsammlung instanziiert werden. Für Kollisionsobjekte und die Physiksimulation wird außerdem eine eigene Physikwelt erstellt.
+
+Da Skriptkomponenten alle Objekte im Spiel auch von außerhalb der Startwelt adressieren können müssen, erhält diese einen eindeutigen Namen: die Eigenschaft *Name*, die du in der Sammlungsdatei festlegst:
+
+![Startsammlung](images/collection-proxy/collection_id.png)
+
+Wenn die geladene Sammlung Sammlungs-Proxy-Komponenten enthält, werden die von ihnen referenzierten Sammlungen *nicht* automatisch geladen. Du musst das Laden dieser Ressourcen durch Skripte steuern.
+
+## Eine Sammlung laden {#loading-a-collection}
+
+Um eine Sammlung dynamisch über einen Proxy zu laden, sendest du aus einem Skript eine Nachricht namens `"load"` an die Proxy-Komponente:
+
+```lua
+-- Tell the proxy "myproxy" to start loading.
+msg.post("#myproxy", "load")
+```
+
+![Laden](images/collection-proxy/proxy_load.png)
+
+Die Proxy-Komponente weist die Engine an, Speicherplatz für eine neue Welt zuzuweisen. Außerdem wird eine eigene Physikwelt in der Laufzeitumgebung erstellt, und alle Spielobjekte in der Sammlung „`mylevel.collection`“ werden instanziiert.
+
+Die neue Welt erhält ihren Namen aus der Eigenschaft *Name* in der Sammlungsdatei; in diesem Beispiel ist sie auf „`mylevel`“ gesetzt. Der Name muss eindeutig sein. Wenn der in der Sammlungsdatei festgelegte *Name* bereits für eine geladene Welt verwendet wird, meldet die Engine einen Fehler aufgrund eines Namenskonflikts:
+
+```txt
+ERROR:GAMEOBJECT: The collection 'default' could not be created since there is already a socket with the same name.
+WARNING:RESOURCE: Unable to create resource: build/default/mylevel.collectionc
+ERROR:GAMESYS: The collection /mylevel.collectionc could not be loaded.
+```
+
+Wenn die Engine das Laden der Sammlung abgeschlossen hat, sendet die Sammlungs-Proxy-Komponente eine Nachricht namens `"proxy_loaded"` an das Skript zurück, das die Nachricht `"load"` gesendet hat. Als Reaktion auf diese Nachricht kann das Skript die Sammlung dann initialisieren und aktivieren:
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        -- New world is loaded. Init and enable it.
+        msg.post(sender, "init")
+        msg.post(sender, "enable")
+        ...
+    end
+end
+```
+
+`"load"`
+: Diese Nachricht weist die Sammlungs-Proxy-Komponente an, mit dem Laden ihrer Sammlung in eine neue Welt zu beginnen. Wenn der Proxy damit fertig ist, sendet er eine Nachricht namens `"proxy_loaded"` zurück.
+
+`"async_load"`
+: Diese Nachricht weist die Sammlungs-Proxy-Komponente an, ihre Sammlung im Hintergrund in eine neue Welt zu laden. Wenn der Proxy damit fertig ist, sendet er eine Nachricht namens `"proxy_loaded"` zurück.
+
+`"init"`
+: Diese Nachricht teilt der Sammlungs-Proxy-Komponente mit, dass alle instanziierten Spielobjekte und Komponenten initialisiert werden sollen. In dieser Phase werden alle `init()`-Funktionen der Skripte aufgerufen.
+
+`"enable"`
+: Diese Nachricht teilt der Sammlungs-Proxy-Komponente mit, dass alle Spielobjekte und Komponenten aktiviert werden sollen. Beispielsweise beginnen alle Sprite-Komponenten nach der Aktivierung mit dem Zeichnen.
+
+## Die Sammlung eines ausgeschlossenen Proxys ändern {#changing-an-excluded-proxys-collection}
+
+Mit [`collectionproxy.set_collection()`](/ref/collectionproxy/#collectionproxy.set_collection) kannst du einen ausgeschlossenen, entladenen Proxy auf eine kompilierte Sammlung umleiten. Das ist nach dem Einbinden eines Live-Update-Pakets nützlich. Beim Proxy muss *Exclude* angekreuzt sein, und er darf weder geladen sein noch gerade geladen werden. Der Pfad muss auf `.collectionc` enden. Die Sammlung und alle ihre Abhängigkeiten müssen dem Ressourcensystem zur Verfügung stehen, wenn der Proxy geladen wird.
+
+Prüfe den Rückgabewert, bevor du den Proxy lädst. Initialisiere und aktiviere die neue Welt erst nach dem Empfang von `proxy_loaded`:
+
+```lua
+local function load_mounted_level()
+    local ok, result = collectionproxy.set_collection(
+        "#level_proxy",
+        "/level_pack/level_3.collectionc"
+    )
+
+    if ok then
+        msg.post("#level_proxy", "load")
+    else
+        print("Unable to change proxy collection", result)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        msg.post(sender, "init")
+        msg.post(sender, "enable")
+    end
+end
+```
+
+Rufe `collectionproxy.set_collection("#level_proxy", nil)` auf, während der Proxy weder geladen ist noch gerade geladen wird, um die im Editor zugewiesene Sammlung wiederherzustellen. Informationen zum Herunterladen und Einbinden von Inhalten findest du im [Handbuch zur Skriptsteuerung von Live Update](/manuals/live-update-scripting/); die Fehlercodes `collectionproxy.RESULT_*` sind in der API-Referenz beschrieben.
+
+## Adressierung in der neuen Welt {#addressing-into-the-new-world}
+
+Der in den Eigenschaften der Sammlungsdatei festgelegte *Name* wird verwendet, um Spielobjekte und Komponenten in der geladenen Welt zu adressieren. Wenn du beispielsweise ein Ladeobjekt in der Startsammlung erstellst, musst du möglicherweise von jeder geladenen Sammlung aus mit ihm kommunizieren:
+
+```lua
+-- tell the loader to load the next level:
+msg.post("main:/loader#script", "load_level", { level_id = 2 })
+```
+
+![Laden](images/collection-proxy/message_passing.png)
+
+Wenn du vom Ladeobjekt aus mit einem Spielobjekt in der geladenen Sammlung kommunizieren musst, kannst du über die [vollständige URL des Objekts](/manuals/addressing/#urls) eine Nachricht senden:
+
+```lua
+msg.post("mylevel:/myobject", "hello")
+```
+
+::: important
+Es ist nicht möglich, von außerhalb einer geladenen Sammlung direkt auf Spielobjekte innerhalb dieser Sammlung zuzugreifen:
+
+```lua
+local position = go.get_position("mylevel:/myobject")
+-- loader.script:42: function called can only access instances within the same collection.
+```
+:::
+
+
+## Eine Welt entladen {#unloading-a-world}
+
+Um eine geladene Sammlung zu entladen, sendest du Nachrichten, die den umgekehrten Schritten des Ladevorgangs entsprechen:
+
+```lua
+-- unload the level
+msg.post("#myproxy", "disable")
+msg.post("#myproxy", "final")
+msg.post("#myproxy", "unload")
+```
+
+`"disable"`
+: Diese Nachricht weist die Sammlungs-Proxy-Komponente an, alle Spielobjekte und Komponenten in der Welt zu deaktivieren. In dieser Phase werden Sprites nicht mehr gerendert.
+
+`"final"`
+: Diese Nachricht weist die Sammlungs-Proxy-Komponente an, alle Spielobjekte und Komponenten in der Welt zu finalisieren. In dieser Phase werden die `final()`-Funktionen aller Skripte aufgerufen.
+
+`"unload"`
+: Diese Nachricht weist den Sammlungs-Proxy an, die Welt vollständig aus dem Speicher zu entfernen.
+
+Wenn du keine so feine Steuerung benötigst, kannst du die Nachricht `"unload"` direkt senden, ohne die Sammlung vorher zu deaktivieren und zu finalisieren. Der Proxy deaktiviert und finalisiert die Sammlung dann automatisch, bevor sie entladen wird.
+
+Wenn der Sammlungs-Proxy das Entladen der Sammlung abgeschlossen hat, sendet er eine Nachricht namens `"proxy_unloaded"` an das Skript zurück, das die Nachricht `"unload"` gesendet hat:
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_unloaded") then
+        -- Ok, the world is unloaded...
+        ...
+    end
+end
+```
+
+
+## Zeitschritt {#time-step}
+
+Die Aktualisierungen eines Sammlungs-Proxys können durch Ändern des _Zeitschritts_ skaliert werden. Das bedeutet, dass ein Proxy schneller oder langsamer aktualisiert werden kann, obwohl das Spiel mit konstanten 60 Bildern pro Sekunde (FPS) läuft. Das wirkt sich beispielsweise auf Folgendes aus:
+
+* Geschwindigkeit der Physiksimulation
+* Der Wert von `dt`, der an `update()` übergeben wird
+* [Eigenschaftsanimationen von Spielobjekten und GUI-Knoten](https://defold.com/manuals/animation/#property-animation-1)
+* [Flipbook-Animationen](https://defold.com/manuals/animation/#flip-book-animation)
+* [Simulationen von Partikeleffekten](https://defold.com/manuals/particlefx/)
+* Geschwindigkeit von Timern
+
+Du kannst außerdem den Aktualisierungsmodus festlegen. Damit steuerst du, ob die Skalierung diskret (was nur bei einem Skalierungsfaktor unter 1,0 sinnvoll ist) oder kontinuierlich erfolgt.
+
+Du steuerst den Skalierungsfaktor und den Skalierungsmodus, indem du dem Proxy eine Nachricht namens `set_time_step` sendest:
+
+```lua
+-- update loaded world at one-fifth-speed.
+msg.post("#myproxy", "set_time_step", {factor = 0.2, mode = 1}
+```
+
+Um zu sehen, was beim Ändern des Zeitschritts passiert, können wir ein Objekt mit dem folgenden Code in einer Skriptkomponente erstellen und es in die Sammlung aufnehmen, deren Zeitschritt wir verändern:
+
+```lua
+function update(self, dt)
+    print("update() with timestep (dt) " .. dt)
+end
+```
+
+Mit einem Zeitschritt von 0,2 erhalten wir folgendes Ergebnis in der Konsole:
+
+```txt
+INFO:ENGINE: Defold Engine 1.2.37 (6b3ae27)
+INFO:ENGINE: Loading data from: build/default
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0.016666667535901
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0.016666667535901
+```
+
+`update()` wird weiterhin 60 Mal pro Sekunde aufgerufen, aber der Wert von `dt` ändert sich. Wir sehen, dass nur 1/5 (0,2) der Aufrufe von `update()` einen Wert von 1/60 (entsprechend 60 FPS) für `dt` haben---bei den übrigen ist er null. Alle Physiksimulationen werden ebenfalls entsprechend diesem `dt` aktualisiert und schreiten nur in einem Fünftel der Frames voran.
+
+::: sidenote
+Du kannst die Zeitschrittfunktion der Sammlung verwenden, um dein Spiel zu pausieren, beispielsweise während ein Popup angezeigt wird oder wenn das Fenster den Fokus verloren hat. Verwende `msg.post("#myproxy", "set_time_step", {factor = 0, mode = 0})` zum Pausieren und `msg.post("#myproxy", "set_time_step", {factor = 1, mode = 1})` zum Fortsetzen.
+:::
+
+Weitere Einzelheiten findest du unter [`set_time_step`](/ref/collectionproxy#set_time_step).
+
+## Einschränkungen und häufige Probleme {#caveats-and-common-issues}
+
+Physik
+: Über Sammlungs-Proxys kannst du mehr als eine Sammlung auf oberster Ebene, also eine *Spielwelt*, in die Engine laden. Dabei musst du beachten, dass jede Sammlung auf oberster Ebene eine eigene Physikwelt ist. Physikalische Wechselwirkungen (Kollisionen, Trigger, Strahlabfragen (raycasts)) finden nur zwischen Objekten statt, die zur selben Welt gehören. Selbst wenn die Kollisionsobjekte zweier Welten optisch direkt übereinanderliegen, kann es daher keine physikalischen Wechselwirkungen zwischen ihnen geben.
+
+Speicher
+: Jede geladene Sammlung erstellt eine neue Spielwelt mit einem relativ hohen Speicherbedarf. Wenn du Dutzende von Sammlungen gleichzeitig über Proxys lädst, solltest du deinen Entwurf möglicherweise überdenken. Um viele Instanzen von Spielobjekthierarchien dynamisch zu erzeugen, eignen sich [Sammlungsfabriken](/manuals/collection-factory) besser.
+
+Eingabe
+: Wenn Objekte in deiner geladenen Sammlung Eingabeaktionen benötigen, musst du sicherstellen, dass das Spielobjekt, das den Sammlungs-Proxy enthält, den Eingabefokus anfordert. Wenn das Spielobjekt Eingabenachrichten empfängt, werden diese an die Komponenten dieses Objekts weitergegeben, also an die Sammlungs-Proxys. Die Eingabeaktionen werden über den Proxy an die geladene Sammlung gesendet.

--- a/docs/de/manuals/components.md
+++ b/docs/de/manuals/components.md
@@ -1,0 +1,108 @@
+---
+title: Komponenten von Spielobjekten
+brief: Dieses Handbuch gibt einen Überblick über die Komponenten und ihre Verwendung.
+---
+
+#  Komponenten {#components}
+
+:[components](../shared/components.md)
+
+## Komponententypen {#component-types}
+
+Defold unterstützt die folgenden Komponententypen:
+
+* [Sammlungsfabrik (collection factory)](/manuals/collection-factory) - Sammlungen (collections) dynamisch erzeugen
+* [Sammlungs-Proxy (collection proxy)](/manuals/collection-proxy) - Sammlungen laden und entladen
+* [Kollisionsobjekt (collision object)](/manuals/physics) - 2D- und 3D-Physik
+* [Kamera (camera)](/manuals/camera) - Den Ansichtsbereich (viewport) und die Projektion der Spielwelt ändern
+* [Fabrik (factory)](/manuals/factory) - Spielobjekte dynamisch erzeugen
+* [GUI](/manuals/gui) - Eine grafische Benutzeroberfläche rendern
+* [Beschriftung (label)](/manuals/label) - Einen Text rendern
+* [Licht (light)](/manuals/light) - Lichtdaten für Shader hinzufügen
+* [Mesh](/manuals/mesh) Ein 3D-Mesh anzeigen (mit Erstellung und Bearbeitung zur Laufzeit)
+* [Modell (model)](/manuals/model) Ein 3D-Modell anzeigen (mit optionalen Animationen)
+* [Partikeleffekt (Particle FX)](/manuals/particlefx) -  Partikel dynamisch erzeugen
+* [Skript (script)](/manuals/script) - Spiellogik hinzufügen
+* [Audiokomponente (sound)](/manuals/sound) - Audio oder Musik abspielen
+* [Sprite](/manuals/sprite) - Ein 2D-Bild anzeigen (mit optionaler Flipbook-Animation)
+* [Kachelkarte (tile map)](/manuals/tilemap) - Ein Raster aus Kacheln anzeigen
+
+Weitere Komponenten können durch Erweiterungen hinzugefügt werden:
+
+* [Rive-Modell](/extension-rive) - Eine Rive-Animation rendern
+* [Spine-Modell](/extension-spine) - Eine Spine-Animation rendern
+
+
+## Komponenten aktivieren und deaktivieren {#enabling-and-disabling-components}
+
+Die Komponenten eines Spielobjekts werden bei dessen Erstellung aktiviert. Wenn du eine Komponente deaktivieren möchtest, sende eine [`disable`](/ref/go/#disable)-Nachricht an die Komponente:
+
+```lua
+-- disable the component with id 'weapon' on the same game object as this script
+msg.post("#weapon", "disable")
+
+-- disable the component with id 'shield' on the 'enemy' game object
+msg.post("enemy#shield", "disable")
+
+-- disable all components on the current game object
+msg.post(".", "disable")
+
+-- disable all components on the 'enemy' game object
+msg.post("enemy", "disable")
+```
+
+Um eine Komponente wieder zu aktivieren, kannst du eine [`enable`](/ref/go/#enable)-Nachricht an die Komponente senden:
+
+```lua
+-- enable the component with id 'weapon'
+msg.post("#weapon", "enable")
+```
+
+## Komponenteneigenschaften {#component-properties}
+
+Die Komponententypen von Defold haben jeweils unterschiedliche Eigenschaften. Der Bereich [Properties](/manuals/editor/#the-editor-views) im Editor zeigt die Eigenschaften der Komponente an, die gerade im Bereich [Outline](/manuals/editor/#the-editor-views) ausgewählt ist. In den Handbüchern zu den einzelnen Komponententypen erfährst du mehr über die verfügbaren Komponenteneigenschaften.
+
+## Position, Drehung und Skalierung von Komponenten {#component-position-rotation-and-scale}
+
+Visuelle Komponenten haben normalerweise Eigenschaften für Position und Drehung und meist auch eine Eigenschaft für die Skalierung. Du kannst diese Eigenschaften im Editor ändern. In fast allen Fällen lassen sie sich jedoch nicht zur Laufzeit ändern (die einzige Ausnahme ist die Skalierung von Sprite- und Beschriftungskomponenten, die zur Laufzeit geändert werden kann).
+
+Wenn du die Position, Drehung oder Skalierung einer Komponente zur Laufzeit ändern musst, änderst du stattdessen die Position, Drehung oder Skalierung des Spielobjekts, zu dem die Komponente gehört. Das wirkt sich auch auf alle anderen Komponenten dieses Spielobjekts aus. Wenn du nur eine einzelne von mehreren Komponenten eines Spielobjekts verändern möchtest, wird empfohlen, diese Komponente in ein separates Spielobjekt zu verschieben. Füge dieses dann als untergeordnetes Spielobjekt dem Spielobjekt hinzu, zu dem die Komponente ursprünglich gehörte.
+
+## Zeichenreihenfolge von Komponenten {#component-draw-order}
+
+Die Zeichenreihenfolge visueller Komponenten hängt von zwei Dingen ab:
+
+### Prädikate im Render-Skript {#render-script-predicates}
+Jeder Komponente ist ein [Material](/manuals/material/) zugewiesen, und jedes Material hat ein oder mehrere Tags. Das Render-Skript definiert wiederum eine Reihe von Prädikaten, die jeweils einem oder mehreren Material-Tags entsprechen. Die [Prädikate werden nacheinander](/manuals/render/#render-predicates) in der Funktion *update()* des Render-Skripts gezeichnet. Dabei werden jeweils die Komponenten gezeichnet, die den im Prädikat definierten Tags entsprechen. Das standardmäßige Render-Skript zeichnet zuerst Sprites und Kachelkarten in einem Durchlauf, dann Partikeleffekte in einem weiteren Durchlauf, jeweils im Weltkoordinatensystem. Anschließend zeichnet das Render-Skript GUI-Komponenten in einem separaten Durchlauf im Bildschirmkoordinatensystem.
+
+### Z-Wert von Komponenten {#component-z-value}
+Alle Spielobjekte und Komponenten sind im 3D-Raum positioniert, wobei ihre Positionen als `vector3`-Objekte angegeben werden. Wenn du den grafischen Inhalt deines Spiels in 2D betrachtest, bestimmen der X- und der Y-Wert die Position eines Objekts entlang der Achsen für „Breite“ und „Höhe“. Die Z-Position bestimmt die Position entlang der „Tiefenachse“. Mit der Z-Position kannst du die Sichtbarkeit überlappender Objekte steuern: Ein Sprite mit einem Z-Wert von 1 erscheint vor einem Sprite an der Z-Position 0. Standardmäßig verwendet Defold ein Koordinatensystem, das Z-Werte zwischen -1 und 1 zulässt:
+
+![Modell](images/graphics/z-order.png)
+
+Die Komponenten, die einem [Render-Prädikat](/manuals/render/#render-predicates) entsprechen, werden gemeinsam gezeichnet. Ihre Zeichenreihenfolge hängt vom endgültigen Z-Wert der jeweiligen Komponente ab. Der endgültige Z-Wert einer Komponente ist die Summe der Z-Werte der Komponente selbst, des Spielobjekts, zu dem sie gehört, und aller übergeordneten Spielobjekte.
+
+::: sidenote
+Die Reihenfolge, in der mehrere GUI-Komponenten gezeichnet werden, wird **nicht** durch den Z-Wert der GUI-Komponenten bestimmt. Die Zeichenreihenfolge der GUI-Komponenten wird durch die Funktion [gui.set_render_order()](/ref/gui/#gui.set_render_order:order) gesteuert.
+:::
+
+Beispiel: Zwei Spielobjekte A und B. B ist A untergeordnet. B hat eine Sprite-Komponente.
+
+| Objekt   | Z-Wert  |
+|----------|---------|
+| A        | 2       |
+| B        | 1       |
+| B#sprite | 0.5     |
+
+![](images/graphics/component-hierarchy.png)
+
+Bei der obigen Hierarchie beträgt der endgültige Z-Wert der Sprite-Komponente von B: 2 + 1 + 0.5 = 3.5.
+
+::: important
+Wenn zwei Komponenten genau denselben Z-Wert haben, ist ihre Reihenfolge nicht definiert. Dadurch können die Komponenten abwechselnd voreinander erscheinen und flackern oder auf verschiedenen Plattformen in unterschiedlicher Reihenfolge gerendert werden.
+
+Das Render-Skript definiert eine nahe und eine ferne Begrenzungsebene für Z-Werte. Komponenten mit einem Z-Wert außerhalb dieses Bereichs werden nicht gerendert. Der Standardbereich reicht von -1 bis 1, [kann aber leicht geändert werden](/manuals/render/#default-view-projection). Die numerische Genauigkeit der Z-Werte ist bei einer nahen und fernen Grenze von -1 und 1 sehr hoch. Wenn du mit 3D-Assets arbeitest, musst du möglicherweise die nahe und ferne Grenze der Standardprojektion in einem eigenen Render-Skript ändern. Weitere Informationen findest du im [Rendering-Handbuch](/manuals/render/).
+:::
+
+
+:[Component max count optimizations](../shared/component-max-count-optimizations.md)

--- a/docs/de/manuals/compute.md
+++ b/docs/de/manuals/compute.md
@@ -1,0 +1,248 @@
+---
+title: Defold-Handbuch zu Compute-Programmen
+brief: Dieses Handbuch erklärt den Umgang mit Compute-Programmen, Shader-Konstanten und Samplern.
+---
+
+# Compute-Programme {#compute-programs}
+
+::: sidenote
+Die Unterstützung für Compute-Shader in Defold befindet sich derzeit in der *technischen Vorschau*.
+Das bedeutet, dass einige Funktionen fehlen und sich die API in Zukunft möglicherweise ändern kann.
+:::
+
+Compute-Shader (compute shaders) sind ein leistungsfähiges Werkzeug für allgemeine Berechnungen auf der GPU. Sie ermöglichen es dir, die parallele Rechenleistung der GPU für Aufgaben wie Physiksimulationen, Bildverarbeitung und mehr zu nutzen. Ein Compute-Shader arbeitet mit Daten, die in Puffern oder Texturen gespeichert sind, und führt Operationen parallel über viele GPU-Threads aus. Diese Parallelität macht Compute-Shader so leistungsfähig bei rechenintensiven Aufgaben.
+
+* Weitere Informationen zur Rendering-Pipeline findest du in der [Rendering-Dokumentation](/manuals/render).
+* Eine ausführliche Erklärung von Shader-Programmen findest du in der [Shader-Dokumentation](/manuals/shader).
+
+## Was kann ich mit Compute-Shadern machen? {#what-can-i-do-with-compute-shaders}
+
+Da Compute-Shader für allgemeine Berechnungen vorgesehen sind, gibt es praktisch keine Grenzen für ihre Einsatzmöglichkeiten. Hier sind einige Beispiele für typische Anwendungen von Compute-Shadern:
+
+Bildverarbeitung
+  - Bildfilterung: Weichzeichnung, Kantenerkennung, Schärfefilter und so weiter anwenden.
+  - Farbkorrektur: Den Farbraum eines Bildes anpassen.
+
+Physik
+  - Partikelsysteme: Eine große Anzahl von Partikeln für Effekte wie Rauch, Feuer und Strömungsdynamik simulieren.
+  - Physik verformbarer Körper: Verformbare Objekte wie Stoff und Gelee simulieren.
+  - Aussondern von Geometrie (Culling): Aussondern verdeckter Geometrie (Occlusion Culling), Aussondern von Geometrie außerhalb des Sichtvolumens (Frustum Culling)
+
+Prozedurale Erzeugung
+  - Gelände erzeugen: Detailliertes Gelände mithilfe von Rauschfunktionen erstellen.
+  - Vegetation und Blattwerk: Prozedural erzeugte Pflanzen und Bäume erstellen.
+
+Rendering-Effekte
+  - Globale Beleuchtung: Realistische Beleuchtung simulieren, indem die Ausbreitung von reflektiertem Licht in einer Szene angenähert wird.
+  - Voxelisierung: Ein 3D-Voxelraster aus Mesh-Daten erstellen.
+
+## Wie funktionieren Compute-Shader? {#how-does-compute-shaders-work}
+
+Grundsätzlich teilen Compute-Shader eine Aufgabe in viele kleinere Aufgaben auf, die gleichzeitig ausgeführt werden können. Dafür werden die Konzepte der `Arbeitsgruppen` (work groups) und `Aufrufe` (invocations) verwendet:
+
+Arbeitsgruppen
+: Der Compute-Shader arbeitet mit einem Raster aus `Arbeitsgruppen`. Jede Arbeitsgruppe enthält eine feste Anzahl von Aufrufen (oder Threads). Die Größe der Arbeitsgruppen und die Anzahl der Aufrufe werden im Shader-Code definiert.
+
+Aufrufe
+: Jeder Aufruf (oder Thread) führt das Compute-Shader-Programm aus. Aufrufe innerhalb einer Arbeitsgruppe können Daten über gemeinsam genutzten Speicher austauschen. Das ermöglicht eine effiziente Kommunikation und Synchronisierung zwischen ihnen.
+
+Die GPU führt den Compute-Shader aus, indem sie viele Aufrufe über mehrere Arbeitsgruppen hinweg parallel startet. Dadurch stellt sie erhebliche Rechenleistung für geeignete Aufgaben bereit.
+
+## Ein Compute-Programm erstellen {#creating-a-compute-program}
+
+Um ein Compute-Programm zu erstellen, führe einen <kbd>Rechtsklick</kbd> auf einen Zielordner im Browser *Assets* aus und wähle <kbd>New... ▸ Compute</kbd>. (Du kannst auch <kbd>File ▸ New...</kbd> im Menü und anschließend <kbd>Compute</kbd> wählen.) Gib der neuen Compute-Datei einen Namen und klicke auf <kbd>Ok</kbd>.
+
+![Compute-Datei](images/compute/compute_file.png)
+
+Die neue Compute-Datei wird im *Compute Editor* geöffnet.
+
+![Compute-Editor](images/compute/compute.png)
+
+Die Compute-Datei enthält die folgenden Informationen:
+
+Compute Program
+: Die zu verwendende Compute-Shader-Programmdatei (*`.cp`*). Der Shader arbeitet mit „abstrakten Arbeitselementen“. Das bedeutet, dass es keine feste Definition der Datentypen für Ein- und Ausgaben gibt. Du legst beim Programmieren fest, was der Compute-Shader erzeugen soll.
+
+Constants
+: Uniforms, die an das Compute-Shader-Programm übergeben werden. Eine Liste der verfügbaren Konstanten findest du weiter unten.
+
+Samplers
+: Du kannst optional bestimmte Sampler in der Materialdatei konfigurieren. Füge einen Sampler hinzu, gib ihm den im Shader-Programm verwendeten Namen und passe die Einstellungen für Texturadressierung und Filterung nach deinen Wünschen an.
+
+
+## Das Compute-Programm in Defold verwenden {#using-the-compute-program-in-defold}
+
+Im Gegensatz zu Materialien werden Compute-Programme keinen Komponenten (components) zugewiesen und sind nicht Teil des normalen Rendering-Ablaufs. Ein Compute-Programm muss in einem Render-Skript `gestartet` werden, um Arbeit auszuführen. Vor dem Start musst du jedoch sicherstellen, dass das Render-Skript eine Referenz auf das Compute-Programm besitzt. Derzeit kann ein Render-Skript nur auf das Compute-Programm zugreifen, wenn du es der Datei mit der Erweiterung .render hinzufügst, die die Referenz auf dein Render-Skript enthält:
+
+![Render-Datei mit Compute-Programm](images/compute/compute_render_file.png)
+
+Um das Compute-Programm zu verwenden, muss es zunächst an den Render-Kontext gebunden werden. Das geschieht auf die gleiche Weise wie bei Materialien:
+
+```lua
+render.set_compute("my_compute")
+-- Do compute work here, call render.set_compute() to unbind
+render.set_compute()
+```
+
+Die Compute-Konstanten werden beim Start des Programms automatisch angewendet. Es gibt jedoch keine Möglichkeit, Eingabe- oder Ausgaberessourcen (Texturen, Puffer und so weiter) über den Editor an ein Compute-Programm zu binden. Stattdessen musst du dies über Render-Skripte tun:
+
+```lua
+render.enable_texture("blur_render_target", "tex_blur")
+render.enable_texture(self.storage_texture, "tex_storage")
+```
+
+Um das Programm in dem von dir festgelegten Arbeitsraum auszuführen, musst du es starten:
+
+```lua
+render.dispatch_compute(128, 128, 1)
+-- dispatch_compute also accepts an options table as the last argument
+-- you can use this argument table to pass in render constants to the dispatch call
+local constants = render.constant_buffer()
+constants.tint = vmath.vector4(1, 1, 1, 1)
+render.dispatch_compute(32, 32, 32, {constants = constants})
+```
+
+### Daten aus Compute-Programmen schreiben {#writing-data-from-compute-programs}
+
+Derzeit lassen sich Ausgaben jeglicher Art aus einem Compute-Programm nur über `Speichertexturen` (storage textures) erzeugen. Eine Speichertextur ähnelt einer „normalen Textur“, bietet aber mehr Funktionen und Konfigurationsmöglichkeiten. Speichertexturen können, wie der Name nahelegt, als allgemeiner Puffer verwendet werden, aus dem du in einem Compute-Programm Daten lesen und in den du Daten schreiben kannst. Anschließend kannst du denselben Puffer zum Lesen an ein anderes Shader-Programm binden.
+
+Um eine Speichertextur in Defold zu erstellen, musst du eine reguläre `.script`-Datei verwenden. Render-Skripte bieten diese Funktion nicht, da dynamische Texturen über die `resource`-API erstellt werden müssen, die nur in regulären `.script`-Dateien verfügbar ist.
+
+```lua
+-- In a .script file:
+function init(self)
+    -- Create a texture resource like usual, but add the "storage" flag
+    -- so it can be used as the backing storage for compute programs
+    local t_backing = resource.create_texture("/my_backing_texture.texturec", {
+        type   = graphics.TEXTURE_TYPE_IMAGE_2D,
+        width  = 128,
+        height = 128,
+        format = graphics.TEXTURE_FORMAT_RGBA32F,
+        flags  = graphics.TEXTURE_USAGE_FLAG_STORAGE + graphics.TEXTURE_USAGE_FLAG_SAMPLE,
+    })
+
+    -- get the texture handle from the resource
+    local t_backing_handle = resource.get_texture_info(t_backing).handle
+
+    -- notify the renderer of the backing texture, so it can be bound with render.enable_texture
+    msg.post("@render:", "set_backing_texture", { handle = t_backing_handle })
+end
+```
+
+## Alles zusammenfügen {#putting-it-all-together}
+
+### Shader-Programm {#shader-program}
+
+```glsl
+// compute.cp
+#version 450
+
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+// specify the input resources
+uniform vec4 color;
+uniform sampler2D texture_in;
+
+// specify the output image
+layout(rgba32f) uniform image2D texture_out;
+
+void main()
+{
+    // This isn't a particularly interesting shader, but it demonstrates
+    // how to read from a texture and constant buffer and write to a storage texture
+
+    ivec2 tex_coord   = ivec2(gl_GlobalInvocationID.xy);
+    vec4 output_value = vec4(0.0, 0.0, 0.0, 1.0);
+    vec2 tex_coord_uv = vec2(float(tex_coord.x)/(gl_NumWorkGroups.x), float(tex_coord.y)/(gl_NumWorkGroups.y));
+    vec4 input_value = texture(texture_in, tex_coord_uv);
+    output_value.rgb = input_value.rgb * color.rgb;
+
+    // Write the output value to the storage texture
+    imageStore(texture_out, tex_coord, output_value);
+}
+```
+
+### Skriptkomponente {#script-component}
+```lua
+-- In a .script file
+
+-- Here we specify the input texture that we later will bind to the
+-- compute program. We can assign this texture to a model component,
+-- or enable it to the render context in the render script.
+go.property("texture_in", resource.texture())
+
+function init(self)
+    -- Create a texture resource like usual, but add the "storage" flag
+    -- so it can be used as the backing storage for compute programs
+    local t_backing = resource.create_texture("/my_backing_texture.texturec", {
+        type   = graphics.TEXTURE_TYPE_IMAGE_2D,
+        width  = 128,
+        height = 128,
+        format = graphics.TEXTURE_FORMAT_RGBA32F,
+        flags  = graphics.TEXTURE_USAGE_FLAG_STORAGE + graphics.TEXTURE_USAGE_FLAG_SAMPLE,
+    })
+
+    local textures = {
+        texture_in = resource.get_texture_info(self.texture_in).handle,
+        texture_out = resource.get_texture_info(t_backing).handle
+    }
+
+    -- notify the renderer of the input and output textures
+    msg.post("@render:", "set_backing_texture", textures)
+end
+```
+
+### Render-Skript {#render-script}
+```lua
+-- respond to the message "set_backing_texture"
+-- to set the backing texture for the compute program
+function on_message(self, message_id, message)
+    if message_id == hash("set_backing_texture") then
+        self.texture_in = message.texture_in
+        self.texture_out = message.texture_out
+    end
+end
+
+function update(self)
+    render.set_compute("compute")
+    -- We can bind textures to specific named constants
+    render.enable_texture(self.texture_in, "texture_in")
+    render.enable_texture(self.texture_out, "texture_out")
+    render.set_constant("color", vmath.vector4(0.5, 0.5, 0.5, 1.0))
+    -- Dispatch the compute program as many times as we have pixels.
+    -- This constitutes our "working group". The shader will be invoked
+    -- 128 x 128 x 1 times, or once per pixel.
+    render.dispatch_compute(128, 128, 1)
+    -- when we are done with the compute program, we need to unbind it
+    render.set_compute()
+end
+```
+
+## Kompatibilität {#compatibility}
+
+Defold unterstützt Compute-Shader derzeit mit den folgenden Grafikadaptern:
+
+- Vulkan
+- Metal (über MoltenVK)
+- OpenGL 4.3+
+- OpenGL ES 3.1+
+
+Verwende `graphics.get_adapter_info()`, um zu prüfen, ob der aktive Grafikadapter Compute-Shader unterstützt. Das Feld `features` enthält ein Array der Kontextfunktionskonstanten, die der Adapter unterstützt:
+
+```lua
+local function has_context_feature(feature)
+    local adapter_info = graphics.get_adapter_info()
+    for _, supported_feature in ipairs(adapter_info.features) do
+        if supported_feature == feature then
+            return true
+        end
+    end
+    return false
+end
+
+local compute_shaders_supported = has_context_feature(
+    graphics.CONTEXT_FEATURE_COMPUTE_SHADER
+)
+```
+
+Das Array enthält nur unterstützte Funktionen; es ist keine Tabelle, deren Schlüssel die Funktionskonstanten sind. Führe diese Prüfung immer vor der Verwendung von Compute-Shadern durch, wenn das Spiel mit verschiedenen Grafikadaptern oder auf Geräten mit unterschiedlicher Treiberunterstützung laufen kann. Die Unterstützung durch OpenGL und OpenGL ES hängt von der API-Version und dem Treiber ab. Vulkan und Metal über MoltenVK unterstützen Compute-Shader ab Version 1.0. Verwende ein [Anwendungsmanifest](/manuals/app-manifest), um Vulkan auf Plattformen auszuwählen, auf denen es noch nicht das standardmäßige Grafik-Backend ist.

--- a/docs/de/manuals/debugging-game-and-system-logs.md
+++ b/docs/de/manuals/debugging-game-and-system-logs.md
@@ -1,0 +1,111 @@
+---
+title: Debugging - Spiel- und Systemprotokolle
+brief: Dieses Handbuch erklärt, wie du Spiel- und Systemprotokolle liest.
+---
+
+# Spiel- und Systemprotokoll {#game-and-system-log}
+
+Das Spielprotokoll zeigt alle Ausgaben der Engine, nativer Erweiterungen (native extensions) und deiner Spiellogik an. Mit den Befehlen [print()](/ref/stable/base/#print:...) und [pprint()](/ref/stable/builtins/?q=pprint#pprint:v) kannst du aus deinen Skripten und Lua-Modulen Informationen im Spielprotokoll anzeigen. Mit den Funktionen im [Namensraum `dmLog`](/ref/stable/dmLog/) kannst du aus nativen Erweiterungen in das Spielprotokoll schreiben. Das Spielprotokoll kannst du im Editor, in einem Terminalfenster, mit plattformspezifischen Werkzeugen oder aus einer Protokolldatei lesen.
+
+Systemprotokolle werden vom Betriebssystem erzeugt und können zusätzliche Informationen liefern, die dir helfen, ein Problem einzugrenzen. Die Systemprotokolle können Stacktraces zu Abstürzen und Warnungen bei knappem Arbeitsspeicher enthalten.
+
+::: important
+Die Protokollierung in der Konsole bzw. auf dem Bildschirm zeigt nur in Debug-Builds Informationen an. In Release-Builds ist das Konsolenprotokoll leer. Du kannst die Dateiprotokollierung für Release-Builds jedoch aktivieren, indem du die Projekteinstellung „Write Log File“ auf „Always“ setzt. Einzelheiten findest du weiter unten.
+:::
+
+## Das Spielprotokoll im Editor lesen {#reading-the-game-log-from-the-editor}
+
+Wenn du dein Spiel lokal aus dem Editor oder über eine Verbindung zur [mobilen Entwicklungs-App](/manuals/dev-app) ausführst, werden alle Ausgaben im Konsolenbereich des Editors angezeigt:
+
+![Editor 2](images/editor/editor2_overview.png)
+
+## Das Spielprotokoll im Terminal lesen {#reading-the-game-log-from-the-terminal}
+
+Wenn du ein Defold-Spiel aus dem Terminal startest, wird das Protokoll direkt im Terminalfenster angezeigt. Unter Windows und Linux gibst du den Namen der ausführbaren Datei im Terminal ein, um das Spiel zu starten. Unter macOS musst du die Engine aus der .app-Datei heraus starten:
+
+```
+$ > ./mygame.app/Contents/MacOS/mygame
+```
+
+## Spiel- und Systemprotokolle mit plattformspezifischen Werkzeugen lesen {#reading-game-and-system-logs-using-platform-specific-tools}
+
+### HTML5
+
+Du kannst Protokolle mit den Entwicklerwerkzeugen lesen, die die meisten Browser bereitstellen.
+
+* [Chrome](https://developers.google.com/web/tools/chrome-devtools/console) - Menu > More Tools > Developer Tools
+* [Firefox](https://developer.mozilla.org/en-US/docs/Tools/Browser_Console) - Tools > Web Developer > Web Console
+* [Edge](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide/console)
+* [Safari](https://support.apple.com/guide/safari-developer/log-messages-with-the-console-dev4e7dedc90/mac) - Develop > Show JavaScript Console
+
+### Android
+
+Mit dem Werkzeug Android Debug Bridge (ADB) kannst du das Spiel- und Systemprotokoll anzeigen.
+
+:[Android ADB](../shared/android-adb.md)
+
+Verbinde nach der Installation und Einrichtung dein Gerät per USB, öffne ein Terminal und führe Folgendes aus:
+
+```txt
+$ cd <path_to_android_sdk>/platform-tools/
+$ adb logcat
+```
+
+Das Gerät gibt dann sämtliche Ausgaben einschließlich der Ausgaben des Spiels im aktuellen Terminal aus.
+
+Wenn du nur die Ausgaben der Defold-Anwendung sehen möchtest, verwende diesen Befehl:
+
+```txt
+$ cd <path_to_android_sdk>/platform-tools/
+$ adb logcat -s defold
+--------- beginning of /dev/log/system
+--------- beginning of /dev/log/main
+I/defold  ( 6210): INFO:ENGINE: Defold Engine 1.2.50 (8d1b912)
+I/defold  ( 6210): INFO:ENGINE: Loading data from:
+I/defold  ( 6210): INFO:ENGINE: Initialized sound device 'default'
+I/defold  ( 6210):
+D/defold  ( 6210): DEBUG:SCRIPT: Hello there, log!
+...
+```
+
+### iOS
+
+Unter iOS hast du mehrere Möglichkeiten, Spiel- und Systemprotokolle zu lesen:
+
+1. Du kannst das [Werkzeug Console](https://support.apple.com/guide/console/welcome/mac) verwenden, um das Spiel- und Systemprotokoll zu lesen.
+2. Du kannst den LLDB-Debugger mit einem Spiel verbinden, das auf einem Gerät läuft. Um ein Spiel zu debuggen, muss es mit einem „Apple Developer Provisioning Profile“ signiert sein, das das Gerät einschließt, auf dem du debuggen möchtest. Erstelle im Editor ein Bundle des Spiels und gib das Bereitstellungsprofil im Dialogfeld für die Bundle-Erstellung an (die Bundle-Erstellung für iOS ist nur unter macOS verfügbar).
+
+Um das Spiel zu starten und den Debugger damit zu verbinden, benötigst du ein Werkzeug namens [ios-deploy](https://github.com/phonegap/ios-deploy). Installiere und debugge dein Spiel, indem du Folgendes in einem Terminal ausführst:
+
+```txt
+$ ios-deploy --debug --bundle <path_to_game.app> # NOTE: not the .ipa file
+```
+
+Dadurch wird die App auf deinem Gerät installiert und gestartet, und ein LLDB-Debugger wird automatisch mit ihr verbunden. Wenn du LLDB noch nicht kennst, lies [Erste Schritte mit LLDB](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/gdb_to_lldb_transition_guide/document/lldb-basics.html).
+
+
+## Das Spielprotokoll aus der Protokolldatei lesen {#reading-the-game-log-from-the-log-file}
+
+Mit der Projekteinstellung „Write Log File“ in *game.project* steuerst du die Dateiprotokollierung:
+
+- „Never“: Keine Protokolldatei schreiben.
+- „Debug“: Nur für Debug-Builds eine Protokolldatei schreiben.
+- „Always“: Sowohl für Debug- als auch für Release-Builds eine Protokolldatei schreiben.
+
+Wenn die Dateiprotokollierung aktiviert ist, werden alle Spielausgaben in eine Datei namens „`log.txt`“ auf dem Datenträger geschrieben. So extrahierst du die Datei, wenn du das Spiel auf einem Gerät ausführst:
+
+iOS
+: Verbinde dein Gerät mit einem Computer, auf dem macOS und Xcode installiert sind.
+
+  Öffne Xcode und gehe zu <kbd>Window ▸ Devices and Simulators</kbd>.
+
+  Wähle dein Gerät in der Liste aus und wähle dann die entsprechende App in der Liste *Installed Apps* aus.
+
+  Klicke auf das Zahnradsymbol unter der Liste und wähle <kbd>Download Container...</kbd>.
+
+  ![Container herunterladen](images/debugging/download_container.png)
+
+  Sobald der Container extrahiert wurde, wird er im *Finder* angezeigt. Klicke mit der rechten Maustaste auf den Container und wähle <kbd>Show Package Content</kbd>. Suche die Datei „`log.txt`“, die sich in „`AppData/Documents/`“ befinden sollte.
+
+Android(
+: Ob du die Datei „`log.txt`“ extrahieren kannst, hängt von der Betriebssystemversion und dem Hersteller ab. Hier findest du eine kurze und einfache [Schritt-für-Schritt-Anleitung](https://stackoverflow.com/a/48077004/129360).

--- a/docs/de/manuals/debugging-game-logic.md
+++ b/docs/de/manuals/debugging-game-logic.md
@@ -1,0 +1,164 @@
+---
+title: Debugging in Defold
+brief: Dieses Handbuch erläutert die in Defold verfügbaren Debugging-Funktionen.
+---
+
+# Spiellogik debuggen {#debugging-game-logic}
+
+Defold enthält einen integrierten Lua-Debugger mit Möglichkeiten zur Untersuchung des Spielzustands. Zusammen mit den integrierten [Profiling-Werkzeugen](/manuals/profiling) ist er ein leistungsfähiges Werkzeug, mit dem du die Ursache von Fehlern in deiner Spiellogik finden oder Leistungsprobleme analysieren kannst.
+
+## Debugging mit Ausgaben und visuellen Hilfen {#print-and-visual-debugging}
+
+Die einfachste Möglichkeit, dein Spiel in Defold zu debuggen, ist [Debugging mit Ausgaben](http://en.wikipedia.org/wiki/Debugging#Techniques). Verwende `print()`- oder [`pprint()`](/ref/builtins#pprint)-Anweisungen, um Variablen zu beobachten oder den Ausführungsablauf sichtbar zu machen. Wenn sich ein Spielobjekt (game object) ohne Skript ungewöhnlich verhält, kannst du ihm ein Skript hinzufügen, das ausschließlich der Fehlersuche dient. Jede der Ausgabefunktionen schreibt in die Ansicht *Console* im Editor und in das [Spielprotokoll](/manuals/debugging-game-and-system-logs).
+
+Zusätzlich zu Ausgaben kann die Engine auch Debug-Text und gerade Linien auf dem Bildschirm zeichnen. Dazu sendest du Nachrichten an den Socket `@render`:
+
+```lua
+-- Draw value of "my_val" with debug text on the screen
+msg.post("@render:", "draw_text", { text = "My value: " .. my_val, position = vmath.vector3(200, 200, 0) })
+
+-- Draw colored text on the screen
+local color_green = vmath.vector4(0, 1, 0, 1)
+msg.post("@render:", "draw_debug_text", { text = "Custom color", position = vmath.vector3(200, 180, 0), color = color_green })
+
+-- Draw debug line between player and enemy on the screen
+local start_p = go.get_position("player")
+local end_p = go.get_position("enemy")
+local color_red = vmath.vector4(1, 0, 0, 1)
+msg.post("@render:", "draw_line", { start_point = start_p, end_point = end_p, color = color_red })
+```
+
+Die Nachrichten für das visuelle Debugging fügen der Rendering-Pipeline Daten hinzu, die als Teil der regulären Rendering-Pipeline gezeichnet werden.
+
+* `"draw_line"` fügt Daten hinzu, die mit der Funktion `render.draw_debug3d()` im Render-Skript gerendert werden.
+* `"draw_text"` wird mit der Schriftressource `/builtins/fonts/debug/always_on_top.font` gerendert, die das Material `/builtins/fonts/debug/always_on_top_font.material` verwendet.
+* `"draw_debug_text"` entspricht `"draw_text"`, wird aber in einer benutzerdefinierten Farbe gerendert.
+
+Beachte, dass du diese Daten wahrscheinlich in jedem Frame aktualisieren möchtest. Daher bietet es sich an, die Nachrichten in der Funktion `update()` zu senden.
+
+## Den Debugger starten {#running-the-debugger}
+
+Um den Debugger zu starten, wähle <kbd>Debug ▸ Start/Attach</kbd>. Dadurch wird entweder das Spiel mit verbundenem Debugger gestartet oder der Debugger mit einem bereits laufenden Spiel verbunden.
+
+![Übersicht](images/debugging/overview.png)
+
+Sobald der Debugger verbunden ist, kannst du die Ausführung des Spiels über die Debugger-Schaltflächen in der Konsole oder über das Menü <kbd>Debug</kbd> steuern:
+
+Break
+: ![Pausieren](images/debugging/pause.svg){width=60px .left}
+  Unterbrich die Ausführung des Spiels sofort. Das Spiel hält an der aktuellen Stelle an. Du kannst nun den Spielzustand untersuchen, das Spiel schrittweise ausführen oder es bis zum nächsten Haltepunkt weiterlaufen lassen. Die aktuelle Ausführungsstelle wird im Code-Editor markiert:
+
+  ![Skript](images/debugging/script.png)
+
+Continue
+: ![Fortsetzen](images/debugging/play.svg){width=60px .left}
+  Setze die Ausführung des Spiels fort. Der Spielcode läuft weiter, bis du entweder auf die Pause-Schaltfläche klickst oder die Ausführung einen von dir gesetzten Haltepunkt erreicht. Wenn die Ausführung an einem gesetzten Haltepunkt anhält, wird die Ausführungsstelle im Code-Editor über der Haltepunktmarkierung angezeigt:
+
+  ![Unterbrechung](images/debugging/break.png)
+
+Stop
+: ![Beenden](images/debugging/stop.svg){width=60px .left}
+  Beende den Debugger. Wenn du diese Schaltfläche drückst, wird der Debugger sofort beendet, vom Spiel getrennt und das laufende Spiel beendet.
+
+Step Over
+: ![Aufruf ohne Einsteigen ausführen](images/debugging/step_over.svg){width=60px .left}
+  Führe das Programm einen Schritt weiter aus. Wenn dabei eine weitere Lua-Funktion aufgerufen wird, _steigt die Ausführung nicht in diese Funktion ein_, sondern läuft weiter und hält in der nächsten Zeile unterhalb des Funktionsaufrufs an. Wenn du in diesem Beispiel „step over“ drückst, führt der Debugger den Code aus und hält an der `end`-Anweisung unterhalb der Zeile mit dem Aufruf der Funktion `nextspawn()` an:
+
+  ![Schritt](images/debugging/step.png)
+
+::: sidenote
+Eine Zeile Lua-Code entspricht nicht einem einzelnen Ausdruck. Beim schrittweisen Ausführen im Debugger wird jeweils ein Ausdruck weitergegangen. Das bedeutet, dass du derzeit die Schaltfläche für einen Schritt möglicherweise mehr als einmal drücken musst, um zur nächsten Zeile zu gelangen.
+:::
+
+Step Into
+: ![In einen Aufruf einsteigen](images/debugging/step_in.svg){width=60px .left}
+  Führe das Programm einen Schritt weiter aus. Wenn dabei eine weitere Lua-Funktion aufgerufen wird, _steigt die Ausführung in diese Funktion ein_. Der Funktionsaufruf fügt dem Aufrufstapel einen Eintrag hinzu. Du kannst jeden Eintrag in der Liste des Aufrufstapels anklicken, um die Eintrittsstelle und den Inhalt aller Variablen in dieser Closure anzuzeigen. Hier wurde in die Funktion `nextspawn()` eingestiegen:
+
+  ![In eine Funktion einsteigen](images/debugging/step_into.png)
+
+Step Out
+: ![Bis zum Rücksprung ausführen](images/debugging/step_out.svg){width=60px .left}
+  Setze die Ausführung fort, bis die aktuelle Funktion zurückkehrt. Wenn du bei der Ausführung in eine Funktion eingestiegen bist, setzt die Schaltfläche „step out“ die Ausführung fort, bis die Funktion zurückkehrt.
+
+Haltepunkte setzen und entfernen
+: Du kannst beliebig viele Haltepunkte in deinem Lua-Code setzen. Wenn das Spiel mit verbundenem Debugger läuft, hält es die Ausführung am nächsten erreichten Haltepunkt an und wartet auf weitere Eingaben von dir.
+
+  ![Haltepunkt hinzufügen](images/debugging/add_breakpoint.png)
+
+  Um einen Haltepunkt zu setzen oder zu entfernen, klicke im Code-Editor in die Spalte direkt rechts neben den Zeilennummern. Du kannst auch <kbd>Edit ▸ Toggle Breakpoint</kbd> im Menü wählen.
+
+Haltepunkte deaktivieren und aktivieren
+: Haltepunkte können vorübergehend deaktiviert werden, ohne sie zu entfernen. Wenn sie deaktiviert sind, werden sie während der Ausführung ignoriert, können aber jederzeit wieder aktiviert werden. Klicke mit der rechten Maustaste auf den Haltepunkt am Rand des Code-Editors und schalte dann das Kontrollkästchen `Enabled` um. Deaktivierte Haltepunkte werden unausgefüllt dargestellt, um anzuzeigen, dass sie inaktiv sind.
+
+  ![Haltepunkt deaktivieren](images/debugging/disable_breakpoint.png)
+
+Bedingte Haltepunkte setzen
+: Du kannst für deinen Haltepunkt eine Bedingung festlegen, die den Wert true ergeben muss, damit der Haltepunkt ausgelöst wird. Die Bedingung kann auf lokale Variablen zugreifen, die während der Codeausführung in dieser Zeile verfügbar sind.
+
+  ![Haltepunkt bearbeiten](images/debugging/edit_breakpoint.png)
+
+  Um die Bedingung des Haltepunkts zu bearbeiten, klicke im Code-Editor mit der rechten Maustaste in die Spalte direkt rechts neben den Zeilennummern oder wähle <kbd>Edit ▸ Edit Breakpoint</kbd> im Menü.
+
+Lua-Ausdrücke auswerten
+: Wenn der Debugger verbunden ist und das Spiel an einem Haltepunkt angehalten wurde, steht eine Lua-Laufzeitumgebung mit dem aktuellen Kontext zur Verfügung. Gib unten in der Konsole Lua-Ausdrücke ein und drücke <kbd>Enter</kbd>, um sie auszuwerten:
+
+  ![Konsole](images/debugging/console.png)
+
+  Derzeit ist es nicht möglich, Variablen über diese Auswertung zu ändern.
+
+Den Debugger trennen
+: Wähle <kbd>Debug ▸ Detach Debugger</kbd>, um den Debugger vom Spiel zu trennen. Das Spiel läuft sofort weiter.
+
+## Registerkarte Breakpoints {#breakpoints-tab}
+
+  ![Registerkarte Breakpoints](images/debugging/breakpoints_tab.png)
+
+  Wenn du mit mehreren Haltepunkten in verschiedenen Skripten arbeitest, bietet die Registerkarte Breakpoints eine zentrale Ansicht, in der du alle deine Haltepunkte an einem Ort verwalten kannst.
+
+##### Einzelne Haltepunkte steuern {#individual-breakpoint-controls}
+
+  Für die Arbeit mit einzelnen Haltepunkten:
+  - Klicke auf das rote Papierkorbsymbol, um einen Haltepunkt zu entfernen
+  - Doppelklicke auf die Zeile (außerhalb des Bedingungsbereichs), um in der Code View zu dieser Zeile zu springen
+  - Doppelklicke auf die Bedingungszelle oder klicke auf das Stiftsymbol, um bedingte Haltepunkte zu bearbeiten
+  - Klicke auf die Schaltfläche X zum Löschen, während du den Mauszeiger über eine Bedingungszelle hältst, um die Bedingung zu entfernen
+
+##### Mehrere Haltepunkte gleichzeitig bearbeiten {#batch-operations}
+
+  Wähle mehrere Haltepunkte mit Ctrl/Cmd+click oder Shift+click aus und klicke dann mit der rechten Maustaste, um Aktionen auf mehrere Haltepunkte anzuwenden. Du kannst die Bedingungen mehrerer Haltepunkte gleichzeitig bearbeiten, ihren Aktivierungszustand umschalten oder sie vollständig entfernen.
+
+  Mit den Schaltflächen der Werkzeugleiste kannst du alle Haltepunkte auf einmal aktivieren, deaktivieren oder umschalten. Das ist nützlich, wenn du dein Spiel ohne Unterbrechungen ausführen möchtest, aber die Positionen der Haltepunkte beibehalten willst. Du kannst auch alle entfernen, wenn du deine Debugging-Sitzung beendet hast.
+
+## Lua-Debug-Bibliothek {#lua-debug-library}
+
+Lua enthält eine Debug-Bibliothek, die in manchen Situationen nützlich ist, insbesondere wenn du das Innenleben deiner Lua-Umgebung untersuchen musst. Weitere Informationen findest du im [Kapitel zur Debug-Bibliothek im Lua-Handbuch](http://www.lua.org/pil/contents.html#23).
+
+## Checkliste zur Fehlersuche {#debugging-checklist}
+
+Wenn ein Fehler auftritt oder sich dein Spiel nicht wie erwartet verhält, hilft dir diese Checkliste zur Fehlersuche:
+
+1. Prüfe die Konsolenausgabe und stelle sicher, dass keine Laufzeitfehler auftreten.
+
+2. Füge deinem Code `print`-Anweisungen hinzu, um zu prüfen, ob der Code tatsächlich ausgeführt wird.
+
+3. Wenn er nicht ausgeführt wird, prüfe, ob du im Editor die für seine Ausführung erforderlichen Einstellungen vorgenommen hast. Ist das Skript dem richtigen Spielobjekt hinzugefügt? Hat dein Skript den Eingabefokus erhalten? Sind die Eingabeauslöser korrekt? Ist der Shader-Code dem Material hinzugefügt? Und so weiter.
+
+4. Wenn dein Code von den Werten von Variablen abhängt (beispielsweise in einer if-Anweisung), gib diese Werte entweder mit `print` dort aus, wo sie verwendet oder geprüft werden, oder untersuche sie mit dem Debugger.
+
+Manchmal kann die Fehlersuche schwierig und zeitaufwendig sein. Dann musst du deinen Code Stück für Stück durchgehen, alles prüfen, den fehlerhaften Code eingrenzen und Fehlerquellen ausschließen. Das gelingt am besten mit einer Methode namens „Teile und herrsche“:
+
+1. Ermittle, welche Hälfte (oder welcher kleinere Teil) des Codes den Fehler enthalten muss.
+2. Ermittle erneut, welche Hälfte dieser Hälfte den Fehler enthalten muss.
+3. Grenze den Code, der den Fehler verursachen muss, weiter ein, bis du ihn findest.
+
+Viel Erfolg bei der Fehlersuche!
+
+## Physikprobleme debuggen {#debugging-problems-with-physics}
+
+Wenn du Probleme mit der Physik hast und Kollisionen nicht wie erwartet funktionieren, empfiehlt es sich, das Physik-Debugging zu aktivieren. Aktiviere das Kontrollkästchen *Debug* im Abschnitt *Physics* der Datei *game.project*:
+
+![Einstellung für Physik-Debugging](images/debugging/physics_debug_setting.png)
+
+Wenn dieses Kontrollkästchen aktiviert ist, zeichnet Defold alle Kollisionsformen und Kontaktpunkte von Kollisionen:
+
+![Visualisierung für Physik-Debugging](images/debugging/physics_debug_visualisation.png)

--- a/docs/de/manuals/debugging-native-code-android.md
+++ b/docs/de/manuals/debugging-native-code-android.md
@@ -1,0 +1,86 @@
+---
+title: Debugging unter Android
+brief: Dieses Handbuch beschreibt, wie du einen Build mit Android Studio debuggst.
+---
+
+# Debugging unter Android {#debugging-on-android}
+
+Hier beschreiben wir, wie du einen Build mit [Android Studio](https://developer.android.com/studio/) debuggst, der offiziellen IDE für Googles Betriebssystem Android.
+
+
+## Android Studio
+
+* Bereite das Bundle vor, indem du die Option `android.debuggable` in *game.project* setzt
+
+	![android.debuggable](images/extensions/debugging/android/game_project_debuggable.png)
+
+* Erstelle im Debug-Modus ein Bundle der App in einem Ordner deiner Wahl.
+
+	![Android-Bundle erstellen](images/extensions/debugging/android/bundle_android.png)
+
+* Starte [Android Studio](https://developer.android.com/studio/)
+
+* Wähle `Profile or debug APK`
+
+	![APK debuggen](images/extensions/debugging/android/android_profile_or_debug.png)
+
+* Wähle das APK-Bundle, das du gerade erstellt hast
+
+	![APK auswählen](images/extensions/debugging/android/android_select_apk.png)
+
+* Wähle die Hauptdatei mit der Erweiterung `.so` und stelle sicher, dass sie Debug-Symbole enthält
+
+	![SO-Datei auswählen](images/extensions/debugging/android/android_missing_symbols.png)
+
+* Falls sie keine enthält, lade eine `.so`-Datei hoch, deren Debug-Symbole nicht entfernt wurden. (Die Größe beträgt etwa 20 MB)
+
+* Mit Pfadzuordnungen kannst du die einzelnen Pfade, unter denen die ausführbare Datei in der Cloud erstellt wurde, einem tatsächlichen Ordner auf deinem lokalen Laufwerk zuordnen.
+
+* Wähle die .so-Datei und füge dann eine Zuordnung zu deinem lokalen Laufwerk hinzu
+
+	![Pfadzuordnung 1](images/extensions/debugging/android/path_mappings_android.png)
+
+	![Pfadzuordnung 2](images/extensions/debugging/android/path_mappings_android2.png)
+
+* Wenn du Zugriff auf den Quellcode der Engine hast, füge auch dafür eine Pfadzuordnung hinzu.
+
+* Stelle sicher, dass du die Version auscheckst, die du gerade debuggst
+
+	defold$ git checkout 1.2.148
+
+* Klicke auf `Apply changes`
+
+* Du solltest den zugeordneten Quellcode jetzt in deinem Projekt sehen
+
+	![Quellcode](images/extensions/debugging/android/source_mappings_android.png)
+
+* Füge einen Haltepunkt hinzu
+
+	![Haltepunkt](images/extensions/debugging/android/breakpoint_android.png)
+
+* Wähle `Run` -> `Debug "Appname"` und rufe den Code auf, in dem du die Ausführung anhalten möchtest
+
+	![Haltepunkt](images/extensions/debugging/android/callstack_variables_android.png)
+
+* Du kannst jetzt schrittweise durch den Aufrufstapel gehen und die Variablen untersuchen
+
+
+## Hinweise {#notes}
+
+### Auftragsordner für native Erweiterungen {#native-extension-job-folder}
+
+Der Arbeitsablauf bei der Entwicklung nativer Erweiterungen (native extensions) ist derzeit etwas umständlich. Das liegt daran, dass der Name des Auftragsordners
+bei jedem Build zufällig gewählt wird, wodurch die Pfadzuordnung bei jedem Build ungültig wird.
+
+Für eine Debugging-Sitzung funktioniert dies jedoch problemlos.
+
+Die Pfadzuordnungen werden in der `.iml`-Datei des Android-Studio-Projekts gespeichert.
+
+Du kannst den Auftragsordner aus der ausführbaren Datei ermitteln
+
+```sh
+$ arm-linux-androideabi-readelf --string-dump=.debug_str build/armv7-android/libdmengine.so | grep /job
+```
+
+Der Auftragsordner hat einen Namen wie `job1298751322870374150`, jeweils mit einer zufälligen Zahl.
+

--- a/docs/de/manuals/debugging-native-code-ios.md
+++ b/docs/de/manuals/debugging-native-code-ios.md
@@ -1,0 +1,154 @@
+---
+title: Debugging unter iOS/macOS
+brief: Dieses Handbuch beschreibt, wie du einen Build mit Xcode debuggst.
+---
+
+# Debugging unter iOS/macOS {#debugging-on-iosmacos}
+
+Hier beschreiben wir, wie du einen Build mit [Xcode](https://developer.apple.com/xcode/), Apples bevorzugter IDE zur Entwicklung für macOS und iOS, debuggst.
+
+## Xcode
+
+* Erstelle mit bob und der Option `--with-symbols` ein Bundle der App ([weitere Informationen](/manuals/debugging-native-code/#symbolicate-a-callstack)):
+
+```sh
+$ cd myproject
+$ wget http://d.defold.com/archive/<sha1>/bob/bob.jar
+$ java -jar bob.jar --platform armv7-darwin build --with-symbols --variant debug --archive bundle -bo build/ios -mp <app>.mobileprovision --identity "iPhone Developer: Your Name (ID)"
+```
+
+* Installiere die App mit `Xcode`, `iTunes` oder [ios-deploy](https://github.com/ios-control/ios-deploy)
+
+```sh
+$ ios-deploy -b <AppName>.ipa
+```
+
+* Besorge dir den Ordner `.dSYM` (also die Debug-Symbole)
+
+	* Wenn die App keine nativen Erweiterungen (native extensions) verwendet, kannst du die Datei `.dSYM` von [d.defold.com](http://d.defold.com) herunterladen
+
+	* Wenn du eine native Erweiterung verwendest, wird der Ordner `.dSYM` beim Erstellen eines Builds mit [bob.jar](https://www.defold.com/manuals/bob/) erzeugt. Dafür ist nur ein Build erforderlich (keine Archivierung oder Bundle-Erstellung):
+
+```sh
+$ cd myproject
+$ unzip .internal/cache/arm64-ios/build.zip
+$ mv dmengine.dSYM <AppName>.dSYM
+$ mv <AppName>.dSYM/Contents/Resources/DWARF/dmengine <AppName>.dSYM/Contents/Resources/DWARF/<AppName>
+```
+
+### Projekt erstellen {#create-project}
+
+Um richtig debuggen zu können, benötigen wir ein Projekt, in dem der Quellcode zugeordnet ist.
+Wir verwenden dieses Projekt nur zum Debuggen, nicht zum Erstellen von Builds.
+
+* Erstelle ein neues Xcode-Projekt und wähle die Vorlage `Game`
+
+	![Projektvorlage](images/extensions/debugging/ios/project_template.png)
+
+* Wähle einen Namen (z. B. `debug`) und die Standardeinstellungen
+
+* Wähle einen Ordner, in dem das Projekt gespeichert werden soll
+
+* Füge deinen Code zur App hinzu
+
+	![Dateien hinzufügen](images/extensions/debugging/ios/add_files.png)
+
+* Stelle sicher, dass „Copy items if needed“ deaktiviert ist.
+
+	![Quellcode hinzufügen](images/extensions/debugging/ios/add_source.png)
+
+* So sieht das Endergebnis aus
+
+	![Hinzugefügter Quellcode](images/extensions/debugging/ios/added_source.png)
+
+
+* Deaktiviere den Schritt `Build`
+
+	![Schema bearbeiten](images/extensions/debugging/ios/edit_scheme.png)
+
+	![Build-Schritt deaktivieren](images/extensions/debugging/ios/disable_build.png)
+
+* Stelle die Version von `Deployment target` so ein, dass sie nun höher als die iOS-Version deines Geräts ist
+
+	![Bereitstellungsversion](images/extensions/debugging/ios/deployment_version.png)
+
+* Wähle das Zielgerät
+
+	![Gerät auswählen](images/extensions/debugging/ios/select_device.png)
+
+
+### Den Debugger starten {#launch-the-debugger}
+
+Du hast mehrere Möglichkeiten, eine App zu debuggen
+
+1. Wähle entweder `Debug` -> `Attach to process...` und wähle dort die App aus
+
+2. Oder wähle `Attach to process by PID or Process name`
+
+	![Gerät auswählen](images/extensions/debugging/ios/attach_to_process_name.png)
+
+3. Starte die App auf dem Gerät
+
+4. Füge unter `Edit Scheme` den Ordner <AppName>.app als ausführbare Datei hinzu
+
+### Debug-Symbole {#debug-symbols}
+
+**Um lldb zu verwenden, muss die Ausführung angehalten sein**
+
+* Füge den Pfad zu `.dSYM` in lldb hinzu
+
+```
+(lldb) add-dsym <PathTo.dSYM>
+```
+
+	![Debug-Symbole hinzufügen](images/extensions/debugging/ios/add_dsym.png)
+
+* Prüfe, ob `lldb` die Symbole erfolgreich eingelesen hat
+
+```
+(lldb) image list <AppName>
+```
+
+### Pfadzuordnungen {#path-mappings}
+
+* Füge den Quellcode der Engine hinzu (passe die Pfade an deine Bedürfnisse an)
+
+```
+(lldb) settings set target.source-map /Users/builder/ci/builds/engine-ios-64-master/build /Users/mathiaswesterdahl/work/defold
+(lldb) settings append target.source-map /private/var/folders/m5/bcw7ykhd6vq9lwjzq1mkp8j00000gn/T/job4836347589046353012/upload/videoplayer/src /Users/mathiaswesterdahl/work/projects/extension-videoplayer-native/videoplayer/src
+```
+
+* Du kannst den Job-Ordner aus der ausführbaren Datei ermitteln. Der Job-Ordner heißt `job1298751322870374150`, wobei die Zahl jedes Mal zufällig gewählt wird.
+
+```sh
+$ dsymutil -dump-debug-map <executable> 2>&1 >/dev/null | grep /job
+
+```
+
+* Prüfe die Quellcodezuordnungen
+
+```
+(lldb) settings show target.source-map
+```
+
+Mit folgendem Befehl kannst du prüfen, aus welcher Quelldatei ein Symbol stammt
+
+```
+(lldb) image lookup -va <SymbolName>
+```
+
+### Haltepunkte {#breakpoints}
+
+* Öffne eine Datei in der Projektansicht und setze einen Haltepunkt
+
+	![Haltepunkt](images/extensions/debugging/ios/breakpoint.png)
+
+## Hinweise {#notes}
+
+### UUID der Binärdatei prüfen {#check-uuid-of-binary}
+
+Damit der Debugger den Ordner `.dSYM` akzeptiert, muss dessen UUID mit der UUID der ausführbaren Datei übereinstimmen, die du debuggst. Du kannst die UUID wie folgt prüfen:
+
+```sh
+$ dwarfdump -u <PathToBinary>
+```

--- a/docs/de/manuals/debugging-native-code.md
+++ b/docs/de/manuals/debugging-native-code.md
@@ -1,0 +1,161 @@
+---
+title: Nativen Code in Defold debuggen
+brief: Dieses Handbuch erklärt, wie du nativen Code in Defold debuggst.
+---
+
+# Nativen Code debuggen {#debugging-native-code}
+
+Defold ist gut getestet und sollte unter normalen Umständen nur sehr selten abstürzen. Es lässt sich jedoch nicht garantieren, dass es niemals abstürzt, insbesondere wenn dein Spiel native Erweiterungen (native extensions) verwendet. Wenn du Probleme mit Abstürzen oder nativem Code hast, der sich nicht wie erwartet verhält, gibt es verschiedene Vorgehensweisen:
+
+* Einen Debugger verwenden, um den Code schrittweise auszuführen
+* Debugging mit Protokollausgaben verwenden
+* Ein Absturzprotokoll analysieren
+* Einen Aufrufstapel symbolisieren
+
+
+## Einen Debugger verwenden {#use-a-debugger}
+
+Am häufigsten wird der Code mit einem `Debugger` ausgeführt. Damit kannst du den Code schrittweise ausführen und `Haltepunkte` setzen. Bei einem Absturz hält der Debugger die Ausführung an.
+
+Für jede Plattform gibt es mehrere Debugger.
+
+* Visual studio - Windows
+* VSCode - Windows, macOS, Linux
+* Android Studio - Windows, macOS, Linux
+* Xcode - macOS
+* WinDBG - Windows
+* lldb / gdb - macOS, Linux, (Windows)
+* ios-deploy - macOS
+
+Jedes Werkzeug kann bestimmte Plattformen debuggen:
+
+* Visual studio - Windows + Plattformen, die gdbserver unterstützen (z. B. Linux/Android)
+* VSCode - Windows, macOS (lldb), Linux (lldb/gdb) + Plattformen, die gdbserver unterstützen
+* Xcode -  macOS, iOS ([mehr erfahren](/manuals/debugging-native-code-ios))
+* Android Studio - Android ([mehr erfahren](/manuals/debugging-native-code-android))
+* WinDBG - Windows
+* lldb/gdb - macOS, Linux, (iOS)
+* ios-deploy - iOS (über lldb)
+
+
+## Debugging mit Protokollausgaben verwenden {#use-print-debugging}
+
+Die einfachste Möglichkeit, deinen nativen Code zu debuggen, ist [Debugging mit Protokollausgaben](http://en.wikipedia.org/wiki/Debugging#Techniques). Verwende die Funktionen im [Namensraum `dmLog`](/ref/stable/dmLog/), um Variablen zu beobachten oder den Ausführungsfluss sichtbar zu machen. Alle Protokollfunktionen geben Meldungen in der Ansicht *Console* im Editor und im [Spielprotokoll](/manuals/debugging-game-and-system-logs) aus.
+
+
+## Ein Absturzprotokoll analysieren {#analyze-a-crash-log}
+
+Die Defold-Engine speichert bei einem schweren Absturz eine Datei namens `_crash`. Die Absturzdatei enthält Informationen über das System sowie über den Absturz. Die [Ausgabe des Spielprotokolls](/manuals/debugging-game-and-system-logs) gibt an, wo sich die Absturzdatei befindet (dies hängt vom Betriebssystem, dem Gerät und der Anwendung ab).
+
+Du kannst das [crash-Modul](https://www.defold.com/ref/crash/) verwenden, um diese Datei in der nächsten Sitzung zu lesen. Es wird empfohlen, die Datei zu lesen, die Informationen zusammenzutragen, sie auf der Konsole auszugeben und an einen [Analysedienst](/tags/stars/analytics/) zu senden, der das Sammeln von Absturzprotokollen unterstützt.
+
+::: important
+Unter Windows wird außerdem eine Datei namens `_crash.dmp` erzeugt. Diese Datei ist beim Debuggen eines Absturzes hilfreich.
+:::
+
+### Das Absturzprotokoll von einem Gerät abrufen {#getting-the-crash-log-from-a-device}
+
+Wenn ein Absturz auf einem Mobilgerät auftritt, kannst du die Absturzdatei auf deinen eigenen Computer herunterladen und lokal auswerten.
+
+#### Android
+
+Wenn die App [debuggbar](/manuals/project-settings/#android) ist, kannst du das Absturzprotokoll mit dem [Werkzeug Android Debug Bridge (ADB)](https://developer.android.com/studio/command-line/adb.html) und dem Befehl `adb shell` abrufen:
+
+```
+$ adb shell "run-as com.defold.example sh -c 'cat /data/data/com.defold.example/files/_crash'" > ./_crash
+```
+
+#### iOS
+
+In iTunes kannst du den Container einer App anzeigen/herunterladen.
+
+Im Fenster `Xcode -> Devices` kannst du auch die Absturzprotokolle auswählen
+
+
+## Einen Aufrufstapel symbolisieren {#symbolicate-a-callstack}
+
+Wenn du einen Aufrufstapel (call stack) aus einer Datei namens `_crash` oder einer [Protokolldatei](/manuals/debugging-game-and-system-logs) erhältst, kannst du ihn symbolisieren. Dabei wird jede Adresse im Aufrufstapel in einen Dateinamen und eine Zeilennummer umgewandelt, was dabei hilft, die eigentliche Ursache zu finden.
+
+Es ist wichtig, dass du die zum Aufrufstapel passende Engine verwendest. Andernfalls wirst du bei der Fehlersuche sehr wahrscheinlich an der falschen Stelle suchen! Verwende die Option [`--with-symbols`](https://www.defold.com/manuals/bob/), wenn du mit [bob](https://www.defold.com/manuals/bob/) ein Bundle erstellst, oder aktiviere im Dialogfeld zur Bundle-Erstellung im Editor das Kontrollkästchen „Generate debug symbols“:
+
+* iOS - Der Ordner `dmengine.dSYM.zip` in `build/arm64-ios` enthält die Debug-Symbole für iOS-Builds.
+* macOS - Der Ordner `dmengine.dSYM.zip` in `build/x86_64-macos` enthält die Debug-Symbole für macOS-Builds.
+* Android - Der Ausgabeordner des Bundles `projecttitle.apk.symbols/lib/` enthält die Debug-Symbole für die Zielarchitekturen.
+* Linux - Die ausführbare Datei enthält die Debug-Symbole.
+* Windows - Die Datei `dmengine.pdb` in `build/x86_64-win32` enthält die Debug-Symbole für Windows-Builds.
+* HTML5 - Das Verzeichnis `<project_name>_symbols` neben dem HTML5-Bundle enthält `<project_name>_wasm.js.symbols` und, wenn die Architektur `wasm_pthread-web` ausgewählt ist, `<project_name>_pthread_wasm.js.symbols`.
+
+::: important
+Es ist sehr wichtig, dass du die Debug-Symbole für jede öffentliche Veröffentlichung deines Spiels an einem geeigneten Ort speicherst und weißt, zu welcher Veröffentlichung sie gehören. Ohne die Debug-Symbole kannst du keine Abstürze in nativem Code debuggen! Außerdem solltest du eine `unstripped`-Version der Engine aufbewahren. Damit lässt sich der Aufrufstapel bestmöglich symbolisieren.
+:::
+
+
+### Symbole auf Google Play hochladen {#uploading-symbols-to-google-play}
+Du kannst [die Debug-Symbole auf Google Play hochladen](https://developer.android.com/studio/build/shrink-code#android_gradle_plugin_version_40_or_earlier_and_other_build_systems), damit alle in Google Play protokollierten Abstürze symbolisierte Aufrufstapel anzeigen. Packe den Inhalt des Ausgabeordners des Bundles `projecttitle.apk.symbols/lib/` in ein ZIP-Archiv. Der Ordner enthält einen oder mehrere Unterordner mit Architekturnamen wie `arm64-v8a`, `armeabi-v7a` und `x86_64`.
+
+
+### Einen Android-Aufrufstapel symbolisieren {#symbolicate-an-android-callstack}
+
+1. Hole die Engine aus deinem Build-Ordner
+
+```sh
+	$ ls <project>/build/<platform>/[lib]dmengine[.exe|.so]
+```
+
+2. Entpacke sie in einen Ordner:
+
+```sh
+	$ unzip dmengine.apk -d dmengine_1_2_105
+```
+
+3. Ermittle die Adresse im Aufrufstapel
+
+	In einem nicht symbolisierten Aufrufstapel könnte sie beispielsweise so aussehen
+
+	`#00 pc 00257224 libmy_game_name.so`
+
+	Dabei ist *`00257224`* die Adresse
+
+4. Löse die Adresse auf
+
+```sh
+    $ arm-linux-androideabi-addr2line -C -f -e dmengine_1_2_105/lib/armeabi-v7a/libdmengine.so _address_
+```
+
+Hinweis: Wenn du einen Stacktrace aus den [Android-Protokollen](/manuals/debugging-game-and-system-logs) erhältst, kannst du ihn möglicherweise mit [ndk-stack](https://developer.android.com/ndk/guides/ndk-stack.html) symbolisieren
+
+### Einen iOS-Aufrufstapel symbolisieren {#symbolicate-an-ios-callstack}
+
+1. Wenn du native Erweiterungen verwendest, kann der Server dir die Symbole (.dSYM) bereitstellen (übergib `--with-symbols` an bob.jar)
+
+```sh
+	$ unzip <project>/build/arm64-darwin/build.zip
+	# it will produce a Contents/Resources/DWARF/dmengine
+```
+
+2. Wenn du keine nativen Erweiterungen verwendest, lade die Standardsymbole herunter:
+
+```sh
+	$ wget http://d.defold.com/archive/<sha1>/engine/arm64-darwin/dmengine.dSYM
+```
+
+3. Symbolisiere mit der Ladeadresse
+
+	Aus irgendeinem Grund funktioniert es nicht, nur die Adresse aus dem Aufrufstapel anzugeben (d. h. mit der Ladeadresse 0x0)
+
+```sh
+		$ atos -arch arm64 -o Contents/Resources/DWARF/dmengine 0x1492c4
+```
+
+	# Neither does specifying the load address directly
+
+```sh
+		$ atos -arch arm64 -o MyApp.dSYM/Contents/Resources/DWARF/MyApp -l0x100000000 0x1492c4
+```
+
+	Es funktioniert, wenn du die Ladeadresse zur Adresse addierst:
+
+```sh
+		$ atos -arch arm64 -o MyApp.dSYM/Contents/Resources/DWARF/MyApp 0x1001492c4
+		dmCrash::OnCrash(int) (in MyApp) (backtrace_execinfo.cpp:27)
+```

--- a/docs/de/manuals/debugging.md
+++ b/docs/de/manuals/debugging.md
@@ -1,0 +1,11 @@
+---
+title: Debugging in Defold
+brief: Dieses Handbuch erklärt die Debugging-Funktionen von Defold.
+---
+
+# Debugging
+
+Defold enthält einen integrierten Lua-Debugger mit einer Inspektionsfunktion. Zusammen mit den integrierten [Profiling-Werkzeugen](/manuals/profiling) ist er ein leistungsfähiges Werkzeug, das dir helfen kann, die Ursache von Fehlern in deiner Spiellogik zu finden oder Leistungsprobleme zu analysieren. Defold stellt außerdem Absturzprotokolle für die seltenen Fälle bereit, in denen die Engine selbst abstürzt.
+
+* Erfahre mehr über das [Debuggen deiner Spiellogik](/manuals/debugging-game-logic).
+* Erfahre mehr über das [Debuggen von nativem Code](/manuals/debugging-native-code).

--- a/docs/de/manuals/design.md
+++ b/docs/de/manuals/design.md
@@ -1,0 +1,24 @@
+---
+title: Das Design von Defold
+brief: Die Philosophie hinter dem Design von Defold
+---
+
+# Das Design von Defold {#the-design-of-defold}
+
+Defold wurde mit den folgenden Zielen entwickelt:
+
+- Eine vollständige, professionelle und sofort einsatzbereite Produktionsplattform für Spieleentwicklungsteams zu sein.
+- Einfach und klar zu sein und eindeutige Lösungen für häufige Probleme bei der Architektur und den Arbeitsabläufen in der Spieleentwicklung bereitzustellen.
+- Eine blitzschnelle Entwicklungsplattform zu sein, die sich ideal für die iterative Spieleentwicklung eignet.
+- Zur Laufzeit eine hohe Leistung zu bieten.
+- Wirklich plattformübergreifend zu sein.
+
+Editor und Engine sind sorgfältig darauf ausgelegt, diese Ziele zu erreichen. Einige Designentscheidungen des Defold-Teams unterscheiden sich möglicherweise von dem, was du gewohnt bist, wenn du Erfahrung mit anderen Plattformen hast, zum Beispiel:
+
+- Defold erfordert eine statische Deklaration des Ressourcenbaums (resource tree) und aller Namen. Das erfordert anfangs etwas Aufwand von dir, hilft dem Entwicklungsprozess aber auf lange Sicht enorm.
+- Das Defold-Team empfiehlt die Nachrichtenübermittlung (message passing) zwischen einfachen, gekapselten Einheiten.
+- Es gibt keine objektorientierte Vererbung.
+- Die APIs von Defold sind asynchron.
+- Die Rendering-Pipeline wird durch Code gesteuert und ist vollständig anpassbar.
+- Alle Ressourcendateien von Defold liegen in einfachen Klartextformaten vor, die für Zusammenführungen mit Git sowie für den Import und die Verarbeitung mit externen Werkzeugen optimal strukturiert sind.
+- Ressourcen können geändert und per Hot Reload in ein laufendes Spiel geladen werden, was extrem schnelle Iterationen und Experimente ermöglicht.

--- a/docs/de/manuals/dev-app.md
+++ b/docs/de/manuals/dev-app.md
@@ -1,0 +1,67 @@
+---
+title: Die Entwicklungs-App auf einem Gerät ausführen
+brief: Dieses Handbuch erklärt, wie du die Entwicklungs-App auf deinem Gerät installierst, um iterativ auf dem Gerät zu entwickeln.
+---
+
+# Die mobile Entwicklungs-App {#the-mobile-development-app}
+
+Mit der Entwicklungs-App (development app) kannst du Inhalte über WLAN auf dein Gerät übertragen. Das verkürzt die Zeit zwischen Entwicklungsdurchläufen erheblich, da du nicht jedes Mal ein Bundle erstellen und installieren musst, wenn du deine Änderungen testen möchtest. Installiere die Entwicklungs-App auf deinen Geräten, starte die App und wähle dann im Editor das Gerät als Build-Ziel aus.
+
+## Eine Entwicklungs-App installieren {#installing-a-development-app}
+
+Jede iOS- oder Android-Anwendung, deren Bundle im Modus Debug erstellt wurde, kann als Entwicklungs-App dienen. Dies ist auch die empfohlene Lösung, da die Entwicklungs-App dann die richtigen Projekteinstellungen hat und dieselben [nativen Erweiterungen (native extensions)](/manuals/extensions/) wie das Projekt verwendet, an dem du arbeitest. 
+
+Du kannst aus deinem Projekt ein Bundle der Variante Debug ohne Inhalte erstellen. Verwende diese Option, um eine Version deiner Anwendung mit nativen Erweiterungen zu erstellen, die für die in diesem Handbuch beschriebene iterative Entwicklung geeignet ist.
+
+![Bundle ohne Inhalte](images/dev-app/contentless-bundle.png)
+
+### Unter iOS installieren {#installing-on-ios}
+
+Folge den [Anweisungen im iOS-Handbuch](/manuals/ios/#creating-an-ios-application-bundle), um ein Bundle für iOS zu erstellen. Achte darauf, Debug als Variante auszuwählen!
+
+### Unter Android installieren {#installing-on-android}
+
+Folge den [Anweisungen im Android-Handbuch](https://defold.com/manuals/android/#creating-an-android-application-bundle), um ein Bundle für Android zu erstellen.
+
+## Dein Spiel starten {#launching-your-game}
+
+Um dein Spiel auf deinem Gerät zu starten, müssen sich die Entwicklungs-App und der Editor über dasselbe WLAN-Netzwerk oder über USB verbinden können (siehe unten).
+
+1. Stelle sicher, dass der Editor gestartet ist und läuft.
+2. Starte die Entwicklungs-App auf dem Gerät.
+3. Wähle dein Gerät im Editor unter <kbd>Project ▸ Targets</kbd> aus.
+4. Wähle <kbd>Project ▸ Build</kbd>, um das Spiel auszuführen. Es kann eine Weile dauern, bis das Spiel startet, da die Spielinhalte über das Netzwerk auf das Gerät übertragen werden.
+5. Während das Spiel läuft, kannst du wie gewohnt [Hot Reload](/manuals/hot-reload/) verwenden.
+
+### Unter Windows über USB mit einem iOS-Gerät verbinden {#connecting-to-an-ios-device-using-usb-on-windows}
+
+Wenn du unter Windows über USB eine Verbindung zu einer Entwicklungs-App auf einem iOS-Gerät herstellen möchtest, musst du zunächst [iTunes installieren](https://www.apple.com/lae/itunes/download/). Nach der Installation von iTunes musst du außerdem auf deinem iOS-Gerät im Menü Settings [Personal Hotspot aktivieren](https://support.apple.com/en-us/HT204023). Wenn die Meldung "Trust This Computer?" erscheint, tippe auf Trust. Das Gerät sollte nun unter <kbd>Project ▸ Targets</kbd> erscheinen, wenn die Entwicklungs-App läuft.
+
+### Unter Linux über USB mit einem iOS-Gerät verbinden {#connecting-to-an-ios-device-using-usb-on-linux}
+
+Unter Linux musst du auf deinem Gerät im Menü Settings die Option Personal Hotspot aktivieren, wenn du es über USB verbindest. Wenn die Meldung "Trust This Computer?" erscheint, tippe auf Trust. Das Gerät sollte nun unter <kbd>Project ▸ Targets</kbd> erscheinen, wenn die Entwicklungs-App läuft.
+
+### Unter macOS über USB mit einem iOS-Gerät verbinden {#connecting-to-an-ios-device-using-usb-on-macos}
+
+Bei neueren iOS-Versionen öffnet das Gerät automatisch eine neue Ethernet-Schnittstelle zwischen dem Gerät und dem Computer, wenn du es unter macOS über USB verbindest. Das Gerät sollte unter <kbd>Project ▸ Targets</kbd> erscheinen, wenn die Entwicklungs-App läuft.
+
+Bei älteren iOS-Versionen musst du auf deinem Gerät im Menü Settings die Option Personal Hotspot aktivieren, wenn du es unter macOS über USB verbindest. Wenn die Meldung "Trust This Computer?" erscheint, tippe auf Trust. Das Gerät sollte nun unter <kbd>Project ▸ Targets</kbd> erscheinen, wenn die Entwicklungs-App läuft.
+
+### Unter macOS über USB mit einem Android-Gerät verbinden {#connecting-to-an-android-device-using-usb-on-macos}
+
+Unter macOS kannst du über USB eine Verbindung zu einer laufenden Entwicklungs-App auf einem Android-Gerät herstellen, wenn auf dem Gerät USB Tethering Mode aktiviert ist. Unter macOS musst du einen Treiber eines Drittanbieters wie [HoRNDIS](https://joshuawise.com/horndis#available_versions) installieren. Nach der Installation von HoRNDIS musst du dessen Ausführung außerdem in den Einstellungen unter Security & Privacy erlauben. Sobald USB Tethering aktiviert ist, erscheint das Gerät unter <kbd>Project ▸ Targets</kbd>, wenn die Entwicklungs-App läuft.
+
+### Unter Windows oder Linux über USB mit einem Android-Gerät verbinden {#connecting-to-an-android-device-using-usb-on-windows-or-linux}
+
+Unter Windows und Linux kannst du über USB eine Verbindung zu einer laufenden Entwicklungs-App auf einem Android-Gerät herstellen, wenn auf dem Gerät USB Tethering Mode aktiviert ist. Sobald USB Tethering aktiviert ist, erscheint das Gerät unter <kbd>Project ▸ Targets</kbd>, wenn die Entwicklungs-App läuft.
+
+## Fehlerbehebung {#troubleshooting}
+
+Unable to download application
+: Stelle sicher, dass die UDID deines Geräts im Bereitstellungsprofil enthalten ist, das zum Signieren der App verwendet wurde.
+
+Dein Gerät erscheint nicht im Menü Targets
+: Stelle sicher, dass dein Gerät mit demselben WLAN-Netzwerk wie dein Computer verbunden ist. Stelle sicher, dass der Build der Entwicklungs-App im Modus Debug erstellt wurde.
+
+Das Spiel startet nicht und meldet, dass die Versionen nicht übereinstimmen
+: Dies passiert, wenn du den Editor auf die neueste Version aktualisiert hast. Du musst einen Build einer neuen Version erstellen und diese installieren.

--- a/docs/de/manuals/editor-http-api.md
+++ b/docs/de/manuals/editor-http-api.md
@@ -1,0 +1,508 @@
+---
+title: Den Defold-Editor mit HTTP automatisieren
+brief: Dieses Handbuch erklärt, wie externe Werkzeuge die lokale HTTP-API eines im Defold-Editor geöffneten Projekts ermitteln und nutzen können.
+---
+
+# Den Defold-Editor automatisieren {#automating-the-defold-editor}
+
+Der Defold-Editor startet einen speziellen Server für automatisierte Aktionen. Die HTTP-API steuert das geöffnete Projekt. Nutze sie für Editorbefehle, Builds, Projektressourcen, Vorschauen, Editoreinstellungen, Konsolenausgaben, die Suche in der Dokumentation oder Integrationen mit Editor-Skripten. Um stattdessen das laufende Spiel zu untersuchen oder zu steuern, verwende den [Engine-Dienst oder eine Automatisierungs-API für die Laufzeit](/manuals/engine-service).
+
+::: important
+Die HTTP-API des Editors ist experimentell und kann sich zwischen Defold-Versionen ändern. Das vom laufenden Editor erzeugte Dokument `/openapi.json` ist die maßgebliche Quelle für die verfügbaren Operationen und Schemas.
+:::
+
+## Den Editor aus einem externen Werkzeug starten {#starting-the-editor-from-an-external-tool}
+
+Ein externes Werkzeug benötigt die ausführbare Datei des Editors und den absoluten Pfad zur Datei `game.project` des Projekts.
+
+Installierte Defold-Versionen lassen sich über `installations.json` ermitteln, wie im [Editorhandbuch](/manuals/editor/#editor-installation-metadata) beschrieben. Das Feld `launcherPath` enthält die ausführbare Datei, die gestartet werden soll. Übergib den Pfad zu `game.project` als erstes positionsabhängiges Argument, um dieses Projekt direkt zu öffnen.
+
+Das optionale Argument `--port` oder `-p` legt den Port des Editorservers fest. Wenn du es weglässt, wählt Defold einen verfügbaren Port. Das ist in der Regel vorzuziehen, wenn mehrere Projekte geöffnet sein können.
+
+```sh
+# Linux
+/path/to/Defold/Defold --port 8181 /absolute/path/to/project/game.project
+```
+
+```sh
+# macOS
+/path/to/Defold.app/Contents/MacOS/Defold --port 8181 /absolute/path/to/project/game.project
+```
+
+```powershell
+# Windows
+C:\path\to\Defold\Defold.exe --port 8181 C:\absolute\path\to\project\game.project
+```
+
+Der Editor ist eine grafische Desktopanwendung. Starte ihn in einer interaktiven Benutzersitzung mit Zugriff auf die Anzeige. Verwende [Bob](/manuals/bob), wenn keine grafische Sitzung verfügbar ist, etwa in einer CI-Umgebung ohne grafische Oberfläche, oder um eigenständige Bundles zu erstellen. Ein geöffneter Editor unterstützt über `/command/compile` auch die Automatisierung einer reinen Kompilierung.
+
+Warte nach dem Start des Editors, bis das Projekt geöffnet wurde und `.internal/editor.port` vorhanden ist. Frage anschließend `/openapi.json` wiederholt ab, bis ein gültiges Dokument zurückgegeben wird. Gehe nicht davon aus, dass das Projekt bereits bereit ist, sobald der Prozess erstellt wurde.
+
+## Den Editorserver ermitteln {#locating-the-editor-server}
+
+Der Editor startet einen lokalen HTTP-Server, solange ein Projekt geöffnet ist. Wähle <kbd>Help ▸ Open Editor Server</kbd>, um dessen Startseite im Standardbrowser zu öffnen:
+
+![Die Startseite des lokalen Editorservers](images/automation/editor_server.png)
+
+Der gewählte Port wird im Projekt in diese Datei geschrieben:
+
+```text
+.internal/editor.port
+```
+
+Die Beispiele und Befehle in diesem Handbuch beziehen sich ab hier auf diese Shell-Variablen:
+
+```sh
+PORT="$(cat .internal/editor.port)"
+BASE_URL="http://127.0.0.1:$PORT"
+```
+
+Die Portdatei gehört zur aktuellen Editorsitzung. Lies sie nach einem Neustart des Editors erneut ein.
+
+::: important
+Der Editorserver ist eine vertrauenswürdige lokale Steuerschnittstelle. Mache ihn nicht über eine öffentliche Adresse, eine Portweiterleitung oder einen nicht vertrauenswürdigen Tunnel zugänglich.
+:::
+
+## Operationen über OpenAPI ermitteln {#discovering-operations-through-openapi}
+
+Die einzigen Defold-spezifischen Informationen, die ein externes Werkzeug zu Beginn benötigen sollte, sind der Editorport und das OpenAPI-Dokument:
+
+```sh
+curl -sS "http://127.0.0.1:$(cat .internal/editor.port)/openapi.json"
+```
+
+Das zurückgegebene OpenAPI-3.0.3-Dokument beschreibt die Operationen, die von der laufenden Editorversion unterstützt werden, einschließlich Pfaden, Methoden, Parametern, Befehlsnamen, Anfrageformaten, Antworten, Statuscodes und Authentifizierungsanforderungen.
+
+Liste die dokumentierten Pfade auf:
+
+```sh
+curl -sS "$BASE_URL/openapi.json" |
+  jq -r '.paths | keys[]'
+```
+
+Liste die dokumentierten Pfade der Editorbefehle auf:
+
+```sh
+curl -sS "$BASE_URL/openapi.json" |
+  jq -r '.paths | keys[] | select(startswith("/command/"))'
+```
+
+In Defold 1.13.2 und neuer hat jeder Befehl einen eigenen Pfad im OpenAPI-Dokument. Frühere Versionen beschreiben Befehle über einen Pfad `/command/{command}` und eine Aufzählung von Befehlsnamen.
+
+Eine Integration, die Versionsunterschiede berücksichtigt, sollte jede benötigte Operation überprüfen und Anfragen anhand des zurückgegebenen Schemas konfigurieren. Wir raten davon ab, eine vermeintlich vollständige Kopie der Endpunkt- oder Befehlsnamen zu pflegen, da diese veralten kann.
+
+Im Projekt definierte Routen erscheinen ebenfalls in `/openapi.json`, wenn ihre Editor-Skripte eine OpenAPI-Operationsbeschreibung bereitstellen.
+
+## Editorbefehle ausführen {#executing-editor-commands}
+
+Rufe Editorbefehle auf, indem du eine `POST`-Anfrage an den dokumentierten Pfad des Befehls sendest, zum Beispiel:
+
+```text
+POST /command/compile
+POST /command/run
+```
+
+So kompilierst du das Projekt, ohne es auszuführen:
+
+```sh
+curl -sS \
+  -X POST \
+  "$BASE_URL/command/compile" |
+  jq
+```
+
+So kompilierst du das Projekt und führst es aus:
+
+```sh
+curl -sS \
+  -X POST \
+  "$BASE_URL/command/run" |
+  jq
+```
+
+Diese Pipelines zeigen den Antwortinhalt an. Prüfe in Automatisierungsskripten zusätzlich den HTTP-Status und `success` nach dem Muster in [Builds für HTML5 erstellen](#building-html5).
+
+::: sidenote
+Seit Defold 1.13.2 ist `/command/build` ein veralteter und zur Ablösung vorgesehener Kompatibilitätsalias für `/command/run` und wird nicht in OpenAPI aufgeführt. Verwende `/command/run` in neuen Integrationen.
+:::
+
+Eine erfolgreiche Kompilierung gibt den HTTP-Status `200` mit einem strukturierten Ergebnis zurück:
+
+```json
+{
+  "success": true,
+  "issues": []
+}
+```
+
+Ein fehlgeschlagener Build gibt den HTTP-Status `422` mit Problemmeldungen wie diesen zurück:
+
+```json
+{
+  "success": false,
+  "issues": [
+    {
+      "message": "Example compiler message",
+      "severity": "error",
+      "resource": "/main/player.script",
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 4
+        },
+        "end": {
+          "line": 12,
+          "character": 17
+        }
+      }
+    }
+  ]
+}
+```
+
+Die verfügbaren Felder hängen vom Fehler ab. Verwende den Ressourcenpfad und den Quelltextbereich, wenn sie vorhanden sind, behandle aber auch Probleme, die nur eine Meldung enthalten.
+
+Zu den häufig nützlichen Befehlen gehören, sofern der laufende Editor sie aufführt:
+
+`compile`
+: Kompiliert das Projekt, ohne es auszuführen.
+
+`run`
+: Kompiliert das Projekt und führt es aus.
+
+`clean-build`
+: Leert den Build-Cache, kompiliert anschließend das Projekt und führt es aus. Verwende dies nur, wenn sich ein gewöhnlicher Build inkonsistent verhält oder Änderungen offenbar nicht berücksichtigt.
+
+`build-html5`
+: Erstellt einen Build des Projekts für HTML5 und stellt die Ausgabe über den Editorserver bereit.
+
+`fetch-libraries`
+: Lädt Projektabhängigkeiten herunter und lädt sie neu.
+
+`hot-reload`
+: Lädt geänderte Ressourcen in ein laufendes Spiel nach.
+
+`reload-extensions`
+: Lädt Editor-Skripte neu.
+
+`debugger-start`, `debugger-stop` und die Befehle zur schrittweisen Ausführung im Debugger
+: Steuern eine Debugsitzung und das laufende Projekt.
+
+Die genauen Namen und die Verfügbarkeit hängen von der Editorversion und dem aktuellen Zustand des Editors ab; ermittle sie über `/openapi.json`.
+
+Befehle, die mit Projektressourcen arbeiten, synchronisieren externe Dateiänderungen vor der Ausführung.
+
+### Befehlsantworten und asynchrone Vorgänge {#command-responses-and-asynchronous-work}
+
+Die Antworten hängen vom jeweiligen Befehl ab. In Defold 1.13.2 und neuer warten `compile`, `run`, `clean-build`, `build-html5`, `debugger-start` und `hot-reload` auf den Abschluss des Befehls und geben ein strukturiertes Ergebnis mit `success` und `issues` zurück, wie oben gezeigt. Ein erfolgreiches Ergebnis gibt HTTP `200` zurück; ein Build- oder Validierungsfehler gibt `422` zurück.
+
+Andere Befehle können weiterhin `202` zurückgeben, zum Beispiel `debugger-break`. Untersuche die Operation im aktuellen OpenAPI-Schema und behandle den tatsächlichen HTTP-Antwortstatus:
+
+| Status | Bedeutung |
+| --- | --- |
+| `200` | Der Befehl wurde abgeschlossen und hat ein Ergebnis zurückgegeben |
+| `202` | Der Befehl wurde angenommen und wird asynchron fortgesetzt |
+| `403` | Der Befehl ist im aktuellen Zustand des Editors nicht aktiv |
+| `404` | Der Befehl ist nicht verfügbar |
+| `422` | Der Build oder die Validierung ist fehlgeschlagen |
+| `500` | Ein interner Editorfehler ist aufgetreten |
+
+Eine HTTP-Antwort mit `202` ist kein Nachweis dafür, dass das angeforderte Ergebnis vorhanden ist. Warte auf die relevante Ausgabe, Ressource, Konsolenmarkierung oder bereitgestellte URL und setze eine Zeitbegrenzung durch.
+
+### Builds für HTML5 erstellen {#building-html5}
+
+Wenn das aktuelle OpenAPI-Dokument `/command/build-html5` aufführt, rufe den Befehl über diesen Pfad auf. Erfasse in einem Shell-Skript den HTTP-Status getrennt vom Antwortinhalt und brich bei einer fehlgeschlagenen Anfrage oder einem fehlgeschlagenen Build ab:
+
+```sh
+build_response_file="$(mktemp)" || exit 1
+if ! build_http_status="$(curl -sS \
+  -X POST \
+  -o "$build_response_file" \
+  -w '%{http_code}' \
+  "$BASE_URL/command/build-html5")"; then
+  cat "$build_response_file"
+  rm -f "$build_response_file"
+  exit 1
+fi
+
+cat "$build_response_file"
+if [ "$build_http_status" != "200" ] ||
+   ! jq -e '.success == true' "$build_response_file" > /dev/null; then
+  rm -f "$build_response_file"
+  exit 1
+fi
+rm -f "$build_response_file"
+```
+
+In Defold 1.13.2 und neuer wartet diese Anfrage auf den Abschluss des Builds und gibt ein strukturiertes Ergebnis zurück. Das Beispiel gibt den Antwortinhalt einschließlich etwaiger Build-Probleme aus und fährt nur bei HTTP `200` mit `success: true` fort. Nach einem erfolgreichen Build öffnet der Editor das Spiel in einem Browser und stellt es unter folgender Adresse bereit:
+
+```text
+http://127.0.0.1:<editor-port>/html5/
+```
+
+Ein abgeschlossener Build bedeutet nicht, dass das Spiel im Browser vollständig geladen wurde. Warte darauf, dass die Zeichenfläche und die Anwendung bereit sind, bevor du Eingaben sendest oder den Spielablauf prüfst. Weitere Einzelheiten findest du unter [Browsertests für HTML5](/manuals/automated-testing/#browser-tests-for-html5).
+
+## Die API-Dokumentation durchsuchen {#searching-api-documentation}
+
+Sofern in `/openapi.json` vorhanden, durchsucht die Operation `/ref` die API-Dokumentation, die mit der laufenden Editorversion ausgeliefert wird. Sie liefert Namen und Signaturen, die zu dieser Version passen.
+
+Um beispielsweise nach einer Funktion zu suchen, verwende:
+
+```sh
+curl -sS \
+  --get \
+  --data-urlencode "q=go.animate" \
+  "$BASE_URL/ref" |
+  jq
+```
+
+Filtere nach Umgebung und Sprache:
+
+```sh
+curl -sS \
+  --get \
+  --data-urlencode "environment=runtime" \
+  --data-urlencode "language=Lua" \
+  --data-urlencode "q=collision message|raycast" \
+  "$BASE_URL/ref" |
+  jq
+```
+
+Die Suchparameter sind:
+
+`environment`
+: `editor`, `runtime` oder durch Kommas getrennte Werte.
+
+`language`
+: `Lua`, `C`, `C++` oder durch Kommas getrennte Werte.
+
+`q`
+: Ein Ausdruck ohne Unterscheidung zwischen Groß- und Kleinschreibung. Leerraum steht für UND, während `|` für ODER steht.
+
+Es gibt außerdem zusammengefasste Dokumentationsressourcen: Der [Dokumentationsindex für große Sprachmodelle (Large Language Models, LLM)](https://defold.com/llms.txt) verlinkt auf offizielle Handbücher, API-Namespaces und Beispiele. Die [vollständige LLM-Dokumentation](https://defold.com/llms-full.txt) enthält die gesamte Dokumentation, um die Offline-Suche und lokale Indizierung zu unterstützen.
+
+KI-Agenten sollten jedoch gezielte Suchanfragen bevorzugen, statt eine vollständige Referenz abzurufen, wenn nur eine einzelne API oder Nachricht benötigt wird. So sparen sie Tokens und erhalten einen besser vorbereiteten, übersichtlichen Kontext für die jeweilige Aufgabe.
+
+## Konsolenausgaben lesen {#reading-console-output}
+
+Lies die Editorkonsole als JSON:
+
+```sh
+curl -sS "$BASE_URL/console" | jq
+```
+
+Die Antwort enthält Konsolentext in `lines` und semantische Bereiche in `regions`, darunter Fehler, Auswertungsergebnisse und Ressourcenreferenzen.
+
+Um die Konsolenausgabe fortlaufend zu verfolgen, verwende:
+
+```sh
+curl -N "$BASE_URL/console/stream"
+```
+
+Der Datenstrom enthält die vorhandenen Konsolenzeilen und bleibt anschließend für neue Ausgaben offen. Schließe ihn, nachdem du eine Abschlussmarkierung oder einen Fehler empfangen, die Beendigung des Prozesses erkannt oder eine Zeit- oder Zeilenbegrenzung erreicht hast.
+
+Informationen zur Abgrenzung von Testergebnissen und zur Klassifizierung von Fehlern findest du unter [Automatisiertes Testen und Überprüfen](/manuals/automated-testing/#structured-test-results).
+
+## Szenenvorschauen rendern {#rendering-scene-previews}
+
+Der Defold-Editor kann seit Version 1.13.1 über den Befehl `/preview/{path}` eine „Bildschirmaufnahme“ einer unterstützten Szenenressource als PNG rendern:
+
+```sh
+mkdir -p build/automation
+
+curl -sS \
+  "$BASE_URL/preview/main/main.collection?width=1280&height=720" \
+  --output build/automation/main-preview.png
+```
+
+Dies rendert die Hauptsammlung (main collection) aus dem geöffneten Vorlagenprojekt Basic 3D in einer standardmäßigen Ausgangsansicht:
+
+![Eine vom Editor gerenderte Vorschau der Hauptsammlung](images/automation/main-preview.png)
+
+Du kannst damit Vorschauen von Ressourcen rendern, die den visuellen Szeneneditor verwenden. Beispielsweise lässt sich eine Modellkomponente (model component) auf dieselbe Weise rendern, um ihr Aussehen oder etwa die korrekte Funktionsweise eines Shaders zu überprüfen:
+
+```sh
+curl -sS \
+  "$BASE_URL/preview/assets/models/cube.model?width=1280&height=720" \
+  --output build/automation/cube-preview.png
+```
+
+![Eine vom Editor gerenderte Vorschau des Würfelmodells](images/automation/cube-preview.png)
+
+Der Pfad nach `/preview/` enthält keinen führenden Schrägstrich. Die optionalen Abmessungen entsprechen standardmäßig der Anzeigegröße des Projekts und müssen zwischen `1` und `4096` liegen.
+
+| Status | Bedeutung |
+| --- | --- |
+| `200` | Die Vorschau wurde gerendert |
+| `400` | Die Abmessungen sind ungültig |
+| `404` | Die Ressource wurde nicht gefunden |
+| `422` | Die Ressource ist nicht geladen oder unterstützt keine Szenenvorschauen |
+
+Vorschauen können für die visuelle Analyse des Projekts sehr nützlich sein: zum Prüfen von Level-Layouts, GUI-Layouts, Shader- und Beleuchtungseinstellungen sowie visuellen Regressionen oder zum Erstellen von Vorschaubildern für die Dokumentation.
+
+::: important
+Eine Editorvorschau ist keine Bildschirmaufnahme des laufenden Spiels. Sie überprüft weder dynamisch erstellte Objekte noch Nachbearbeitung zur Laufzeit oder plattformspezifisches Rendering. Verwende eine [Bildschirmaufnahme zur Laufzeit](/manuals/automated-testing/#editor-previews-and-runtime-screenshots), wenn diese Elemente benötigt werden.
+:::
+
+## Lua im Editor ausführen {#executing-editor-lua}
+
+Die authentifizierte Operation `POST /eval` führt Lua in der Erweiterungsumgebung des Editors aus. Das Bearer-Token für die jeweilige Sitzung wird hier gespeichert:
+
+```text
+.internal/editor.token
+```
+
+Lies das Token ein und führe Code aus:
+
+```sh
+TOKEN="$(cat .internal/editor.token)"
+
+curl -sS \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: text/plain" \
+  --data-binary 'print(editor.version) return editor.platform' \
+  "$BASE_URL/eval"
+```
+
+Ausgaben und Rückgabewerte werden als Text zurückgegeben. Typische Antworten sind:
+
+| Status | Bedeutung |
+| --- | --- |
+| `200` | Der Code wurde ausgeführt |
+| `401` | Das Bearer-Token fehlt oder ist ungültig |
+| `422` | Der Lua-Code konnte nicht geparst oder ausgeführt werden |
+| `503` | Die Erweiterungsumgebung des Editors ist nicht bereit |
+
+Ein Client darf nach `503` einen erneuten Versuch unternehmen, sollte jedoch die Anzahl der Versuche begrenzen. Korrigiere den Code, bevor du eine Anfrage wiederholst, die `422` zurückgegeben hat.
+
+Ausgewerteter Code kann die [Editor-API](https://defold.com/ref/editor-lua/) und die Skriptumgebung des Editors nutzen. Er kann keine Laufzeit-APIs des Spiels wie `go.*` verwenden, um ein laufendes Spiel zu verändern. Verwende für den Spielablauf einen Laufzeittest, Debugger, Browsertest oder eine [Automatisierungs-API für die Laufzeit](/manuals/engine-service/#automation-bridge-extension).
+
+### Ressourcen und Dateien ändern {#modifying-resources-and-files}
+
+Viele Defold-Quellressourcen verwenden Textformate und lassen sich mit jedem Textbearbeitungswerkzeug ändern. Bevorzuge Editortransaktionen, um strukturierte Ressourcen eines Defold-Projekts zu ändern.
+
+| Änderung | Bevorzugte Methode |
+| --- | --- |
+| Lua, Shader, JSON oder ein anderes bekanntes Textformat | Direkte Dateiänderung |
+| Nicht gespeicherter Text in einer geöffneten Editorregisterkarte | `editor.get()` und `editor.transact()` |
+| Sammlung, Spielobjekt (game object), GUI, Atlas oder eine andere strukturierte Ressource | Editortransaktion |
+| Wiederholt erzeugte Inhalte | Eigenständiger Generator |
+| Wiederholbarer Projektvorgang | Editorbefehl oder benutzerdefinierter HTTP-Endpunkt |
+| Transformation ausschließlich für CI | Eigenständiges Skript, das vor Bob ausgeführt wird |
+
+Untersuche eine Ressource, bevor du sie änderst:
+
+```sh
+curl -sS \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: text/plain" \
+  --data-binary '
+    local path = "/game.project"
+    pprint(editor.properties(path))
+    return editor.get(path, "path")
+  ' \
+  "$BASE_URL/eval"
+```
+
+Prüfe `editor.can_get()`, `editor.can_set()` und die anderen Funktionen `editor.can_*()`, bevor du eine Transaktion durchführst.
+
+Verwende `editor.execute()` in Editor-Lua, um einen Formatierer, Validator oder Generator auszuführen:
+
+```lua
+local output = editor.execute(
+  "python3",
+  "scripts/generate_levels.py",
+  {
+    out = "capture"
+  }
+)
+
+print(output)
+```
+
+Wenn der Befehl keine Projektressourcen ändert, setze `reload_resources = false`, um unnötiges Neuladen zu vermeiden.
+
+::: important
+Ändere keine Dateien in `.internal/` und keine generierten Inhalte in `build/`.
+:::
+
+## Editoreinstellungen {#preferences}
+
+Editoreinstellungen lassen sich über den in OpenAPI dokumentierten Pfad lesen und schreiben, derzeit `/prefs/{path}`.
+
+Du kannst beispielsweise die konfigurierte Schriftgröße für Code auslesen:
+
+```sh
+curl -sS "$BASE_URL/prefs/code/font/size" | jq
+```
+
+Oder sie beispielsweise auf 16 setzen:
+
+```sh
+curl -sS \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --data '16' \
+  "$BASE_URL/prefs/code/font/size"
+```
+
+Der Editor validiert den Wert anhand seines Einstellungsschemas. Ein ungültiger Pfad oder Wert gibt HTTP `400` zurück.
+
+Editoreinstellungen sind dauerhafte benutzerspezifische oder projektbezogene benutzerspezifische Einstellungen und keine in `game.project` gespeicherte Projektkonfiguration. Wenn eine Automatisierung eine Editoreinstellung vorübergehend ändern muss, speichere den vorherigen Wert und stelle ihn anschließend wieder her.
+
+## Im Projekt definierte Routen {#project-defined-routes}
+
+Editor-Skripte können mit [`get_http_server_routes()`](/manuals/editor-scripts/#http-server) zusätzliche Routen definieren. Eine optionale OpenAPI-Operationstabelle macht eine Route über dasselbe Dokument `/openapi.json` wie die integrierten Operationen zugänglich.
+
+Im Projekt definierte Routen können Inhaltserzeugung, Validierung, Berichte, Lokalisierungsprüfungen, Ressourcenanalysen, projektspezifische Tests oder eine kleinere Schnittstelle für eine IDE oder ein externes Steuerprogramm bereitstellen.
+
+Eine gute Route sollte genau eine klar benannte Operation ausführen, ihre Eingabe validieren, ein strukturiertes Ergebnis zurückgeben, nach Möglichkeit idempotent sein und aufwendige Arbeiten begrenzen.
+
+Im Projekt definierte Routen werden nicht automatisch durch das Token für `/eval` geschützt. Ergänze projektspezifische Authentifizierung und Sicherheitsprüfungen, wenn eine Route sensible Operationen ausführt.
+
+## Lebenszyklus-Hooks {#lifecycle-hooks}
+
+Hooks sind Funktionen, die vor und nach Builds, vor und nach der Bundle-Erstellung sowie beim Start oder bei der Beendigung eines Spielprozesses ausgeführt werden können. Ein Projekt kann eine Datei `hooks.editor_script` in seinem Stammverzeichnis enthalten. Nur die Hook-Datei im Stammverzeichnis empfängt diese Ereignisse, sodass das Projekt einen zentralen Ort hat, um ihre Reihenfolge festzulegen.
+
+```lua
+local M = {}
+
+local function validate_project()
+  print(editor.execute(
+    "python3",
+    "scripts/validate_project.py",
+    {
+      out = "capture",
+      reload_resources = false
+    }
+  ))
+end
+
+function M.on_build_started(opts)
+  validate_project()
+end
+
+function M.on_build_finished(opts)
+  print("Build successful:", opts.success)
+end
+
+return M
+```
+
+Ein von `on_build_started()` ausgelöster Fehler bricht den Build im Editor ab. Lebenszyklus-Hooks werden nur im Editor ausgeführt; lege gemeinsam genutzte Validierungs- und Generierungslogik in eigenständigen Skripten ab, die auch aus CI heraus aufgerufen werden können.
+
+## Sicherheit und Kompatibilität {#security-and-compatibility}
+
+Behandle den gesamten Editorserver als vertrauenswürdige lokale Schnittstelle:
+
+* Mache den Zugriff auf den Port nicht öffentlich zugänglich.
+* Schütze `.internal/editor.token`; es autorisiert `/eval` für die aktuelle Sitzung.
+* Gewähre externen Stellen keinen uneingeschränkten Zugriff auf `/eval`.
+* Bewahre das Token in der lokalen Integrationsschicht auf, nicht in Prompts, Berichten oder Protokollen.
+* Denke daran, dass im Projekt definierte Routen die Authentifizierung von `/eval` nicht übernehmen.
+* Verwende eine aktuelle `/openapi.json`.
+* Begrenze die Wartezeiten für asynchrone automatisierte Befehle und für den Start des Editors.
+
+## Engine-Server
+
+Der Editorserver gehört zum Editorprozess. Ein laufendes Spiel hat einen anderen Port und andere Aufgaben, die im [Handbuch zum Engine-Dienst und zur Laufzeit-HTTP-API](/manuals/engine-service) beschrieben werden.

--- a/docs/de/manuals/editor-preferences.md
+++ b/docs/de/manuals/editor-preferences.md
@@ -1,0 +1,127 @@
+---
+title: Editoreinstellungen
+brief: Du kannst die Einstellungen des Editors im Fenster Preferences ändern.
+---
+
+# Editoreinstellungen {#editor-preferences}
+
+Du kannst die Einstellungen des Editors im Fenster Preferences ändern. Du öffnest das Einstellungsfenster über das Menü <kbd>File -> Preferences</kbd>.
+
+## General
+
+![](images/editor/preferences_general.png)
+
+Load External Changes on App Focus
+: Aktiviert die Suche nach externen Änderungen, wenn der Editor den Fokus erhält.
+
+Open Bundle Target Folder
+: Aktiviert das Öffnen des Bundle-Zielordners nach Abschluss der Bundle-Erstellung.
+
+Enable Texture Compression
+: Aktiviert die [Texturkomprimierung](/manuals/texture-profiles) für alle Builds, die im Editor erstellt werden.
+
+Escape Quits Game
+: Beendet einen laufenden Build deines Spiels mit der Taste <kbd>Esc</kbd>.
+
+Track Active Tab in Asset Browser
+: Die Datei, die in der ausgewählten Registerkarte des Bereichs *Editor* bearbeitet wird, wird im Asset Browser (auch als Bereich *Asset* bekannt) ausgewählt.
+
+Lint Code on Build
+: Aktiviert die [statische Codeprüfung](/manuals/writing-code/#linting-configuration) beim Erstellen eines Builds des Projekts. Diese Option ist standardmäßig aktiviert, kann aber deaktiviert werden, wenn die statische Codeprüfung in einem großen Projekt zu viel Zeit beansprucht.
+
+Engine Arguments
+: Argumente, die an die ausführbare Datei dmengine übergeben werden, wenn der Editor einen Build erstellt und startet.
+ Verwende ein Argument pro Zeile. Zum Beispiel:
+ ```
+--config=bootstrap.main_collection=/my dir/1.collectionc
+--verbose
+--graphics-adapter=vulkan
+```
+
+
+## Code
+
+![](images/editor/preferences_code.png)
+
+Custom Editor
+: Absoluter Pfad zu einem externen Editor. Unter macOS sollte dies der Pfad zur ausführbaren Datei innerhalb der .app sein (z. B. `/Applications/Atom.app/Contents/MacOS/Atom`).
+
+Open File
+: Das Muster, mit dem der benutzerdefinierte Editor angibt, welche Datei geöffnet werden soll. Das Muster `{file}` wird durch den Namen der zu öffnenden Datei ersetzt.
+
+Open File at Line
+: Das Muster, mit dem der benutzerdefinierte Editor angibt, welche Datei an welcher Zeilennummer geöffnet werden soll. Das Muster `{file}` wird durch den Namen der zu öffnenden Datei ersetzt und `{line}` durch die Zeilennummer.
+
+Code editor font
+: Name einer auf dem System installierten Schriftart, die im Code-Editor verwendet werden soll.
+
+Zoom on Scroll
+: Legt fest, ob sich die Schriftgröße beim Scrollen im Code-Editor ändert, während die Taste Cmd/Ctrl gedrückt gehalten wird.
+
+Auto-insert closing parens
+: Fügt beim Bearbeiten von Code automatisch passende schließende Zeichen ein. Diese Option ist standardmäßig aktiviert.
+
+Format on save
+: Führt beim Speichern die Formatierung des Sprachservers für geänderte, geöffnete Codedateien aus. Standardmäßig deaktiviert. Der Sprachserver muss die Formatierung unterstützen; wie du ein Dokument oder eine Auswahl manuell formatierst, erfährst du unter [Code formatieren](/manuals/writing-code/#formatting-code).
+
+
+### Skriptdateien in Visual Studio Code öffnen {#open-script-files-in-visual-studio-code}
+
+![](images/editor/preferences_vscode.png)
+
+Um Skriptdateien aus dem Defold-Editor direkt in Visual Studio Code zu öffnen, musst du die folgenden Einstellungen vornehmen und dabei den Pfad zur ausführbaren Datei angeben:
+
+- MacOS: `/Applications/Visual Studio Code.app/Contents/MacOS/Electron`
+- Linux: `/usr/bin/code`
+- Windows: `C:\Program Files\Microsoft VS Code\Code.exe`
+
+ Lege diese Parameter fest, um bestimmte Dateien und Zeilen zu öffnen:
+
+- Open File: `. {file}`
+- Open File at Line: `. -g {file}:{line}`
+
+Das Zeichen `.` ist hier erforderlich, um den gesamten Arbeitsbereich zu öffnen und nicht nur eine einzelne Datei.
+
+
+## Extensions
+
+![](images/editor/preferences_extensions.png)
+
+Build Server
+: URL des Build-Servers, der beim Erstellen eines Builds eines Projekts mit [nativen Erweiterungen (native extensions)](/manuals/extensions) verwendet wird. Du kannst der URL einen Benutzernamen und ein Zugriffstoken hinzufügen, um dich beim Zugriff auf den Build-Server zu authentifizieren. Verwende die folgende Schreibweise, um den Benutzernamen und das Zugriffstoken anzugeben: `username:token@build.defold.com`. Ein authentifizierter Zugriff ist für Nintendo Switch-Builds erforderlich sowie dann, wenn du eine eigene Build-Server-Instanz mit aktivierter Authentifizierung betreibst (weitere Informationen findest du in der [Dokumentation des Build-Servers](https://github.com/defold/extender/blob/dev/README_SECURITY.md)). Benutzername und Passwort können auch über die Systemumgebungsvariablen `DM_EXTENDER_USERNAME` und `DM_EXTENDER_PASSWORD` festgelegt werden.
+
+Build Server Username
+: Benutzername für die Authentifizierung.
+
+Build Server Password
+: Passwort für die Authentifizierung; wird verschlüsselt in der Einstellungsdatei gespeichert.
+
+Build Server Headers
+: Zusätzliche Header für den Build-Server beim Erstellen nativer Erweiterungen. Sie sind wichtig für die Verwendung des Dienstes CloudFlare oder ähnlicher Dienste mit extender.
+
+## Tools
+
+![](images/editor/preferences_tools.png)
+
+ADB path
+: Pfad zum auf diesem System installierten Befehlszeilenwerkzeug [ADB](https://developer.android.com/tools/adb). Wenn ADB auf deinem System installiert ist, verwendet der Defold-Editor es, um als Bundle erstellte Android-APKs auf einem angeschlossenen Android-Gerät zu installieren und auszuführen. Standardmäßig prüft der Editor, ob ADB an bekannten Speicherorten installiert ist. Du musst den Pfad daher nur angeben, wenn du ADB an einem benutzerdefinierten Speicherort installiert hast.
+
+ios-deploy path
+: Pfad zu den auf diesem System installierten Befehlszeilenwerkzeugen [ios-deploy](https://github.com/ios-control/ios-deploy) (nur für macOS relevant). Ähnlich wie beim ADB-Pfad verwendet der Defold-Editor dieses Werkzeug, um als Bundle erstellte iOS-Anwendungen auf einem angeschlossenen iPhone zu installieren und auszuführen. Standardmäßig prüft der Editor, ob ios-deploy an bekannten Speicherorten installiert ist. Du musst den Pfad daher nur angeben, wenn du eine benutzerdefinierte Installation von ios-deploy verwendest.
+
+## Keymap
+
+![](images/editor/preferences_keymap.png)
+
+Du kannst die Tastenkombinationen und die Maussteuerung des Editors auf der Registerkarte Keymap konfigurieren. Um einen Befehl zu ändern, doppelklicke darauf, drücke <kbd>Enter</kbd> oder <kbd>Space</kbd> oder verwende das Kontextmenü der Zeile.
+
+Tastenkombinationen werden in der Spalte *Shortcuts* angezeigt. Maussteuerungen erscheinen in derselben Liste mit einer Kennzeichnung:
+
+- <kbd>MB</kbd> steht für eine Maustastenbelegung, optional in Kombination mit <kbd>Shift</kbd>, <kbd>Ctrl</kbd>/<kbd>Control</kbd> oder <kbd>Alt</kbd>.
+- <kbd>MM</kbd> steht für eine Modifikatortaste, die bei einer Mausaktion verwendet wird.
+
+Einige Maussteuerungen verwenden die Standardbelegungen von Scene 2D Camera mit, sodass eine Zeile bereits eine Belegung anzeigen kann, bevor du sie anpasst. Diese Belegungen werden üblicherweise in einer dunkleren Farbe dargestellt. Wenn du für diese Zeile eine eigene Belegung festlegst, verwendet Defold stattdessen deine Belegung. Verwende *Reset to Defaults*, um deine Änderung zu entfernen und zum integrierten oder geerbten Verhalten zurückzukehren.
+
+Warnungen werden orange angezeigt. Bewege den Mauszeiger über eine Warnung, um Details zu sehen. Warnungen bedeuten üblicherweise:
+- Die Tastenkombination kann Text eingeben und Textfelder beeinträchtigen.
+- Dieselbe Tastenkombination oder Mausbelegung wird bereits von einem anderen Befehl verwendet.

--- a/docs/de/manuals/editor-scripts-ui.md
+++ b/docs/de/manuals/editor-scripts-ui.md
@@ -1,0 +1,415 @@
+---
+title: "Editor-Skripte: Benutzeroberfläche"
+brief: Dieses Handbuch erklärt, wie du mit Lua UI-Elemente im Editor erstellst
+---
+
+# Editor-Skripte und Benutzeroberflächen {#editor-scripts-and-ui}
+
+Dieses Handbuch erklärt, wie du mit in Lua geschriebenen Editor-Skripten interaktive Dialogfelder erstellst und Ressourcen im Editor öffnest. Einen Einstieg in Editor-Skripte findest du im [Handbuch zu Editor-Skripten](/manuals/editor-scripts). Die vollständige API-Referenz des Editors findest du [hier](/ref/stable/editor-lua/).
+
+## Hallo Welt {#hello-world}
+
+Alle Funktionen für Benutzeroberflächen befinden sich im Modul `editor.ui`. Hier ist zum Einstieg das einfachste Beispiel für ein Editor-Skript mit einer benutzerdefinierten Benutzeroberfläche:
+```lua
+local M = {}
+
+function M.get_commands()
+    return {
+        {
+            label = "Do with confirmation",
+            locations = {"View"},
+            run = function()
+                local result = editor.ui.show_dialog(editor.ui.dialog({
+                    title = "Perform action?",
+                    buttons = {
+                        editor.ui.dialog_button({
+                            text = "Cancel",
+                            cancel = true,
+                            result = false
+                        }),
+                        editor.ui.dialog_button({
+                            text = "Perform",
+                            default = true,
+                            result = true
+                        })
+                    }
+                }))
+                print('Perform action:', result)
+            end
+        }
+    }
+end
+
+return M
+
+```
+
+Dieser Codeausschnitt definiert einen Befehl **View → Do with confirmation**. Wenn du ihn ausführst, siehst du das folgende Dialogfeld:
+
+![Hallo-Welt-Dialogfeld](images/editor_scripts/perform_action_dialog.png)
+
+Nachdem du <kbd>Enter</kbd> drückst (oder auf die Schaltfläche `Perform` klickst), siehst du schließlich die folgende Zeile in der Editorkonsole:
+```
+Perform action:	true
+```
+
+## Ressourcen öffnen {#opening-resources}
+
+Rufe `editor.ui.open_resource()` in der Funktion `run` eines Befehls auf, um eine Projektressource zu öffnen. Der Pfad beginnt mit `/`. Wenn du die Ansicht weglässt, wird die primäre Ansicht der Ressource ausgewählt:
+
+```lua
+editor.ui.open_resource("/main/main.script")
+```
+
+Die Ansichten `code` und `text` akzeptieren als drittes Argument eine Cursorposition oder eine Auswahl. Zeilen- und Spaltennummern beginnen bei `1`; eine fehlende Spaltenangabe hat den Standardwert `1`. Gib die Ansicht an, wenn du diese Argumente übergibst:
+
+```lua
+editor.ui.open_resource("/main/main.script", "code", { line = 10 })
+editor.ui.open_resource("/main/main.script", "code", { line = 10, column = 5 })
+```
+
+Um einen Bereich auszuwählen, gib stattdessen die Cursorpositionen `from` und `to` an:
+
+```lua
+editor.ui.open_resource("/main/main.script", "code", {
+    from = { line = 10, column = 1 },
+    to = { line = 12, column = 1 }
+})
+```
+
+Die konfigurierte Ressourcenansicht kann im Editor oder in einer externen Anwendung geöffnet werden. Die integrierten Ansichten Code und Text unterstützen die Argumente für Cursorposition und Auswahl. Die unterstützten Ansichtsnamen findest du unter [`editor.ui.open_resource()`](/ref/beta/editor/#editor.ui.open_resource:resource_path-view-args).
+
+## Grundbegriffe {#basic-concepts}
+
+### Komponenten {#components}
+
+Der Editor bietet verschiedene UI-**Komponenten** (components), die du kombinieren kannst, um die gewünschte Benutzeroberfläche zu erstellen. Konventionsgemäß werden alle Komponenten mit einer einzigen Tabelle namens **props** konfiguriert. Die Komponenten selbst sind keine Tabellen, sondern **unveränderliche userdata-Werte**, die der Editor zum Erstellen der Benutzeroberfläche verwendet.
+
+### Props
+
+**Props** sind Tabellen, die Eingaben für Komponenten definieren. Props sollten als unveränderlich behandelt werden: Wenn du die Props-Tabelle direkt änderst, wird die Komponente nicht erneut gerendert. Verwendest du jedoch eine andere Tabelle, wird sie erneut gerendert. Die Benutzeroberfläche wird aktualisiert, wenn die Komponenteninstanz eine Props-Tabelle erhält, die bei einem flachen Vergleich mit der vorherigen Tabelle nicht übereinstimmt.
+
+### Ausrichtung {#alignment}
+
+Wenn der Komponente ein Bereich in der Benutzeroberfläche zugewiesen wird, nimmt sie den gesamten Platz ein. Das bedeutet jedoch nicht, dass der sichtbare Teil der Komponente gestreckt wird. Stattdessen nimmt der sichtbare Teil den benötigten Platz ein und wird dann innerhalb des zugewiesenen Bereichs ausgerichtet. Daher definieren die meisten integrierten Komponenten eine Eigenschaft `alignment`.
+
+Betrachte beispielsweise diese Beschriftungskomponente:
+```lua
+editor.ui.label({
+    text = "Hello",
+    alignment = editor.ui.ALIGNMENT.RIGHT
+})
+```
+Der sichtbare Teil ist der Text `Hello`, der innerhalb des zugewiesenen Komponentenbereichs ausgerichtet wird:
+
+![Ausrichtung](images/editor_scripts/alignment.png)
+
+## Integrierte Komponenten {#built-in-components}
+
+Der Editor definiert verschiedene integrierte Komponenten, die du zum Erstellen der Benutzeroberfläche kombinieren kannst. Komponenten lassen sich grob in 3 Kategorien einteilen: Layout, Datendarstellung und Eingabe.
+
+### Layoutkomponenten {#layout-components}
+
+Layoutkomponenten dienen dazu, andere Komponenten nebeneinander anzuordnen. Die wichtigsten Layoutkomponenten sind **`horizontal`**, **`vertical`** und **`grid`**. Diese Komponenten definieren außerdem Eigenschaften wie **padding** und **spacing**. Dabei bezeichnet padding den leeren Raum vom Rand des zugewiesenen Bereichs bis zum Inhalt und spacing den leeren Raum zwischen untergeordneten Komponenten:
+
+![Innenabstand und Abstand zwischen Komponenten](images/editor_scripts/padding_and_spacing.png)
+
+Der Editor definiert die Konstanten `small`, `medium` und `large` für Innenabstände und Abstände zwischen Komponenten. Bei Abständen zwischen Komponenten ist `small` für den Abstand zwischen verschiedenen Unterelementen eines einzelnen UI-Elements vorgesehen, `medium` für den Abstand zwischen einzelnen UI-Elementen und `large` für den Abstand zwischen Elementgruppen. Der Standardabstand ist `medium`. Ein Innenabstand von `large` bezeichnet den Abstand vom Fensterrand zum Inhalt, `medium` den Abstand von den Rändern eines größeren UI-Elements und `small` den Abstand von den Rändern kleiner UI-Elemente wie Kontextmenüs und Tooltips (noch nicht implementiert).
+
+Ein **`horizontal`**-Container ordnet seine untergeordneten Komponenten horizontal hintereinander an und passt die Höhe jeder Komponente immer so an, dass sie den verfügbaren Platz ausfüllt. Standardmäßig bleibt die Breite jeder untergeordneten Komponente minimal. Du kannst sie jedoch so viel Platz wie möglich einnehmen lassen, indem du ihre Eigenschaft `grow` auf `true` setzt.
+
+Ein **`vertical`**-Container ähnelt einem horizontalen Container, allerdings mit vertauschten Achsen.
+
+Schließlich ist **`grid`** eine Containerkomponente, die ihre untergeordneten Komponenten in einem 2D-Raster wie in einer Tabelle anordnet. Die Einstellung `grow` gilt in einem Raster für Zeilen oder Spalten und wird daher in der Konfigurationstabelle der Spalte statt an einer untergeordneten Komponente festgelegt. Außerdem kannst du untergeordnete Komponenten in einem Raster mit den Eigenschaften `row_span` und `column_span` so konfigurieren, dass sie sich über mehrere Zeilen oder Spalten erstrecken. Raster eignen sich zum Erstellen von Formularen mit mehreren Eingabefeldern:
+```lua
+editor.ui.grid({
+    padding = editor.ui.PADDING.LARGE, -- add padding around dialog edges
+    columns = {{}, {grow = true}}, -- make 2nd column grow
+    children = {
+        {
+            editor.ui.label({ 
+                text = "Level Name",
+                alignment = editor.ui.ALIGNMENT.RIGHT
+            }),
+            editor.ui.string_field({})
+        },
+        {
+            editor.ui.label({ 
+                text = "Author",
+                alignment = editor.ui.ALIGNMENT.RIGHT
+            }),
+            editor.ui.string_field({})
+        }
+    }
+})
+```
+Der obige Code erzeugt das folgende Dialogformular:
+
+![Dialogfeld für ein neues Level](images/editor_scripts/new_level_dialog.png)
+
+### Komponenten zur Datendarstellung {#data-presentation-components}
+
+Der Editor definiert die folgenden Komponenten zur Datendarstellung:
+
+- **`label`** — eine Textbeschriftung, die für die Verwendung mit Formulareingaben vorgesehen ist.
+- **`icon`** — ein Symbol; derzeit kann es nur eine kleine Auswahl vordefinierter Symbole darstellen, das Defold-Team plant aber, künftig weitere Symbole zuzulassen.
+- **`image`** — ein Bild, das über einen mit `/` beginnenden Projektressourcenpfad oder über eine externe URL geladen wird. Die optionalen Eigenschaften `width` und `height` passen das Bild unter Beibehaltung seines Seitenverhältnisses in die angegebenen Abmessungen ein.
+- **`heading`** — ein Textelement zur Darstellung einer Überschrift, beispielsweise in einem Formular oder Dialogfeld. Der Aufzählungstyp `editor.ui.HEADING_STYLE` definiert verschiedene Überschriftenstile, darunter die HTML-Überschriften `H1`-`H6` sowie die editorspezifischen Stile `DIALOG` und `FORM`.
+- **`paragraph`** — ein Textelement zur Darstellung eines Textabsatzes. Der Hauptunterschied zu `label` besteht darin, dass ein Absatz den Zeilenumbruch unterstützt: Ist der zugewiesene Bereich horizontal zu klein, wird der Text umgebrochen und möglicherweise mit `"..."` gekürzt, wenn er nicht in die Ansicht passt.
+
+Eine Benutzeroberfläche kann beispielsweise sowohl ein Projektbild als auch ein Bild aus dem Web anzeigen:
+
+```lua
+editor.ui.vertical({
+    children = {
+        editor.ui.image({
+            image = "/builtins/assets/images/logo/logo_256.png",
+            width = 64,
+            height = 64
+        }),
+        editor.ui.image({
+            image = "https://defold.com/images/assets/monarch-hero.jpg"
+        })
+    }
+})
+```
+
+### Eingabekomponenten {#input-components}
+
+Eingabekomponenten ermöglichen dir, mit der Benutzeroberfläche zu interagieren. Alle Eingabekomponenten unterstützen die Eigenschaft `enabled`, die steuert, ob die Interaktion aktiviert ist, und definieren verschiedene Callback-Eigenschaften, die das Editor-Skript bei einer Interaktion benachrichtigen.
+
+Wenn du eine statische Benutzeroberfläche erstellst, genügt es, Callbacks zu definieren, die lediglich lokale Variablen ändern. Für dynamische Benutzeroberflächen und komplexere Interaktionen siehe [Reaktivität](#reactivity).
+
+Du kannst beispielsweise folgendermaßen ein einfaches statisches Dialogfeld für eine neue Datei erstellen:
+```lua
+-- initial file name, will be replaced by the dialog
+local file_name = ""
+local create_file = editor.ui.show_dialog(editor.ui.dialog({
+    title = "Create New File",
+    content = editor.ui.horizontal({
+        padding = editor.ui.PADDING.LARGE,
+        spacing = editor.ui.SPACING.MEDIUM,
+        children = {
+            editor.ui.label({
+                text = "New File Name",
+                alignment = editor.ui.ALIGNMENT.CENTER
+            }),
+            editor.ui.string_field({
+                grow = true,
+                text = file_name,
+                -- Typing callback:
+                on_value_changed = function(new_text)
+                    file_name = new_text
+                end
+            })
+        }
+    }),
+    buttons = {
+        editor.ui.dialog_button({ text = "Cancel", cancel = true, result = false }),
+        editor.ui.dialog_button({ text = "Create File", default = true, result = true })
+    }
+}))
+if create_file then
+    print("create", file_name)
+end
+```
+Hier ist eine Liste der integrierten Eingabekomponenten:
+- **`string_field`**, **`integer_field`** und **`number_field`** sind Varianten eines einzeiligen Textfelds, mit denen du Zeichenfolgen, ganze Zahlen und Zahlen bearbeiten kannst.
+- **`select_box`** dient dazu, über eine Auswahlliste eine Option aus einem vordefinierten Array von Optionen auszuwählen.
+- **`check_box`** ist ein boolesches Eingabefeld mit einem Callback `on_value_changed`
+- **`button`** mit einem Callback `on_press`, der beim Drücken der Schaltfläche aufgerufen wird.
+- **`external_file_field`** ist eine Komponente zum Auswählen eines Dateipfads auf dem Computer. Sie besteht aus einem Textfeld und einer Schaltfläche, die ein Dialogfeld zur Dateiauswahl öffnet.
+- **`resource_field`** ist eine Komponente zum Auswählen einer Ressource im Projekt.
+
+Bei allen Komponenten außer Schaltflächen kannst du eine Eigenschaft `issue` festlegen, die ein Problem im Zusammenhang mit der Komponente anzeigt (entweder `editor.ui.ISSUE_SEVERITY.ERROR` oder `editor.ui.ISSUE_SEVERITY.WARNING`), zum Beispiel:
+```lua
+issue = {severity = editor.ui.ISSUE_SEVERITY.WARNING, message = "This value is deprecated"}
+```
+Wenn ein Problem angegeben ist, ändert sich das Erscheinungsbild der Eingabekomponente, und ein Tooltip mit der Problemmeldung wird hinzugefügt.
+
+Hier siehst du eine Demonstration aller Eingaben mit ihren Varianten für Problemmeldungen:
+
+![Eingaben](images/editor_scripts/inputs_demo.png)
+
+### Komponenten für Dialogfelder {#dialog-related-components}
+
+Um ein Dialogfeld anzuzeigen, musst du die Funktion `editor.ui.show_dialog` verwenden. Sie erwartet eine Komponente **`dialog`**, die die Grundstruktur von Defold-Dialogfeldern definiert: `title`, `header`, `content` und `buttons`. Die Dialogkomponente hat eine Besonderheit: Du kannst sie nicht als untergeordnete Komponente einer anderen Komponente verwenden, weil sie ein Fenster und kein UI-Element darstellt. `header` und `content` sind jedoch gewöhnliche Komponenten.
+
+Dialogschaltflächen sind ebenfalls besonders: Sie werden mit der Komponente **`dialog_button`** erstellt. Anders als gewöhnliche Schaltflächen haben Dialogschaltflächen keinen Callback `on_pressed`. Stattdessen definieren sie eine Eigenschaft `result` mit einem Wert, den die Funktion `editor.ui.show_dialog` zurückgibt, wenn das Dialogfeld geschlossen wird. Dialogschaltflächen definieren außerdem die booleschen Eigenschaften `cancel` und `default`: Eine Schaltfläche mit der Eigenschaft `cancel` wird ausgelöst, wenn du <kbd>Escape</kbd> drückst oder das Dialogfeld mit der Schließen-Schaltfläche des Betriebssystems schließt. Die Schaltfläche `default` wird ausgelöst, wenn du <kbd>Enter</kbd> drückst. Bei einer Dialogschaltfläche können die Eigenschaften `cancel` und `default` gleichzeitig auf `true` gesetzt sein.
+
+### Hilfskomponenten {#utility-components}
+
+Zusätzlich definiert der Editor einige Hilfskomponenten: 
+- **`separator`** ist eine dünne Linie zum Trennen von Inhaltsblöcken
+- **`scroll`** ist eine Wrapper-Komponente, die Bildlaufleisten anzeigt, wenn die umschlossene Komponente nicht in den zugewiesenen Bereich passt
+
+## Reaktivität {#reactivity}
+
+Da Komponenten **unveränderliche userdata-Werte** sind, kannst du sie nach ihrer Erstellung nicht mehr ändern. Wie lässt sich die Benutzeroberfläche dann im Laufe der Zeit ändern? Die Antwort: **reaktive Komponenten**. 
+
+::: sidenote
+Die Benutzeroberflächen für Editor-Skripte orientieren sich an der Bibliothek [React](https://react.dev/). Daher sind Kenntnisse über reaktive Benutzeroberflächen und React-Hooks hilfreich. 
+:::
+
+Vereinfacht ausgedrückt ist eine reaktive Komponente eine Komponente mit einer Lua-Funktion, die Daten (Props) empfängt und eine Ansicht (eine andere Komponente) zurückgibt. Die Funktion einer reaktiven Komponente kann **Hooks** verwenden: spezielle Funktionen im Modul `editor.ui`, die deinen Komponenten reaktive Funktionen hinzufügen. Konventionsgemäß beginnen die Namen aller Hooks mit `use_`.
+
+Verwende die Funktion `editor.ui.component()`, um eine reaktive Komponente zu erstellen. 
+
+Sehen wir uns dieses Beispiel an: ein Dialogfeld für eine neue Datei, das die Erstellung einer Datei nur erlaubt, wenn der eingegebene Dateiname nicht leer ist:
+
+```lua
+-- 1. dialog is a reactive component
+local dialog = editor.ui.component(function(props)
+    -- 2. the component defines a local state (file name) that defaults to empty string
+    local name, set_name = editor.ui.use_state("")
+
+    return editor.ui.dialog({ 
+        title = props.title,
+        content = editor.ui.vertical({
+            padding = editor.ui.PADDING.LARGE,
+            children = { 
+                editor.ui.string_field({ 
+                    value = name,
+                    -- 3. typing + Enter updates the local state
+                    on_value_changed = set_name 
+                }) 
+            }
+        }),
+        buttons = {
+            editor.ui.dialog_button({ 
+                text = "Cancel", 
+                cancel = true 
+            }),
+            editor.ui.dialog_button({ 
+                text = "Create File",
+                -- 4. creation is enabled when the name exists
+                enabled = name ~= "",
+                default = true,
+                -- 5. result is the name
+                result = name
+            })
+        }
+    })
+end)
+
+-- 6. show_dialog will either return non-empty file name or nil on cancel
+local file_name = editor.ui.show_dialog(dialog({ title = "New File Name" }))
+if file_name then 
+    print("create " .. file_name)
+else
+    print("cancelled")
+end
+```
+
+Wenn du einen Menübefehl ausführst, der diesen Code ausführt, zeigt der Editor ein Dialogfeld mit der anfangs deaktivierten Schaltfläche `"Create File"` an. Wenn du jedoch einen Namen eingibst und <kbd>Enter</kbd> drückst, wird sie aktiviert:
+
+![Dialogfeld für eine neue Datei](images/editor_scripts/reactive_new_file_dialog.png)
+
+Wie funktioniert das? Beim allerersten Rendern erstellt der Hook `use_state` einen mit der Komponente verknüpften lokalen Zustand und gibt ihn zusammen mit einer Setter-Funktion für den Zustand zurück. Wenn die Setter-Funktion aufgerufen wird, plant sie ein erneutes Rendern der Komponente ein. Bei nachfolgenden Renderdurchläufen wird die Komponentenfunktion erneut aufgerufen, und `use_state` gibt den aktualisierten Zustand zurück. Die neue Ansichtskomponente, die die Komponentenfunktion zurückgibt, wird dann mit der alten verglichen, und die Benutzeroberfläche wird dort aktualisiert, wo Änderungen erkannt wurden.
+
+Dieser reaktive Ansatz vereinfacht das Erstellen interaktiver Benutzeroberflächen und ihre Synchronisierung erheblich: Statt bei einer Benutzereingabe alle betroffenen UI-Komponenten ausdrücklich zu aktualisieren, definierst du die Ansicht als reine Funktion der Eingabe (Props und lokaler Zustand). Der Editor übernimmt alle Aktualisierungen selbst.
+
+### Regeln für Reaktivität {#rules-of-reactivity}
+
+Damit reaktive Funktionskomponenten funktionieren, erwartet der Editor, dass sie die folgenden Regeln einhalten:
+
+1. Komponentenfunktionen müssen rein sein. Es gibt keine Garantie dafür, wann oder wie oft eine Komponentenfunktion aufgerufen wird. Alle Seiteneffekte sollten außerhalb des Renderns stattfinden, beispielsweise in Callbacks
+2. Props und lokaler Zustand müssen unveränderlich sein. Verändere Props nicht. Wenn dein lokaler Zustand eine Tabelle ist, ändere sie nicht direkt, sondern erstelle eine neue Tabelle und übergib sie an die Setter-Funktion, wenn sich der Zustand ändern muss.
+3. Komponentenfunktionen müssen bei jedem Aufruf dieselben Hooks in derselben Reihenfolge aufrufen. Rufe Hooks nicht innerhalb von Schleifen, in bedingten Blöcken, nach vorzeitigen Rückgaben usw. auf. Es hat sich bewährt, Hooks am Anfang der Komponentenfunktion vor jedem anderen Code aufzurufen.
+4. Rufe Hooks nur aus Komponentenfunktionen heraus auf. Hooks arbeiten im Kontext einer reaktiven Komponente. Daher dürfen sie nur in der Komponentenfunktion aufgerufen werden (oder in einer anderen Funktion, die direkt von der Komponentenfunktion aufgerufen wird).
+
+### Hooks
+
+::: sidenote
+Wenn du mit [React](https://react.dev/) vertraut bist, wirst du feststellen, dass Hooks im Editor hinsichtlich ihrer Abhängigkeiten eine etwas andere Semantik haben.
+:::
+
+Der Editor definiert 2 Hooks: **`use_memo`** und **`use_state`**.
+
+### **`use_state`**
+
+Du kannst lokalen Zustand auf 2 Arten erstellen: mit einem Standardwert oder mit einer Initialisierungsfunktion:
+```lua
+-- default value
+local enabled, set_enabled = editor.ui.use_state(true)
+-- initializer function + args
+local id, set_id = editor.ui.use_state(string.lower, props.name)
+```
+Ebenso kannst du die Setter-Funktion mit einem neuen Wert oder mit einer Aktualisierungsfunktion aufrufen:
+```lua
+-- updater function
+local function increment_by(n, by)
+    return n + by
+end
+
+local counter = editor.ui.component(function(props)
+    local count, set_count = editor.ui.use_state(0)
+    
+    return editor.ui.horizontal({
+        spacing = editor.ui.SPACING.SMALL,
+        children = {
+            editor.ui.label({
+                text = tostring(count),
+                alignment = editor.ui.ALIGNMENT.LEFT,
+                grow = true
+            }),
+            editor.ui.text_button({
+                text = "+1",
+                on_pressed = function() set_count(increment_by, 1) end
+            }),
+            editor.ui.text_button({
+                text = "+5",
+                on_pressed = function() set_count(increment_by, 5) end
+            })
+        }
+    })
+end)
+```
+
+Schließlich kann der Zustand **zurückgesetzt** werden. Der Zustand wird zurückgesetzt, wenn sich eines der Argumente von `editor.ui.use_state()` ändert; dies wird mit `==` geprüft. Deshalb darfst du keine Tabellenliterale oder als Literal definierten Initialisierungsfunktionen als Argumente an den Hook `use_state` übergeben: Dadurch wird der Zustand bei jedem erneuten Rendern zurückgesetzt. Zur Veranschaulichung:
+```lua
+-- ❌ BAD: literal table initializer causes state reset on every re-render
+local user, set_user = editor.ui.use_state({ first_name = props.first_name, last_name = props.last_name})
+
+-- ✅ GOOD: use initializer function outside of component function to create table state
+local function create_user(first_name, last_name) 
+    return { first_name = first_name, last_name = last_name}
+end
+-- ...later, in component function:
+local user, set_user = editor.ui.use_state(create_user, props.first_name, props.last_name)
+
+
+-- ❌ BAD: literal initializer function causes state reset on every re-render
+local id, set_id = editor.ui.use_state(function() return string.lower(props.name) end)
+
+-- ✅ GOOD: use referenced initializer function to create the state
+local id, set_id = editor.ui.use_state(string.lower, props.name)
+```
+
+### **`use_memo`**
+
+Du kannst den Hook `use_memo` verwenden, um die Leistung zu verbessern. Häufig werden in den Renderfunktionen Berechnungen ausgeführt, beispielsweise um zu prüfen, ob die Benutzereingabe gültig ist. Der Hook `use_memo` eignet sich für Fälle, in denen die Prüfung, ob sich die Argumente der Berechnungsfunktion geändert haben, weniger Aufwand verursacht als der Aufruf der Berechnungsfunktion. Der Hook ruft die Berechnungsfunktion beim ersten Rendern auf und verwendet den berechneten Wert bei nachfolgenden Renderdurchläufen erneut, wenn alle Argumente von `use_memo` unverändert sind:
+```lua
+-- validation function outside of component function
+local function validate_password(password)
+    if #password < 8 then
+        return false, "Password must be at least 8 characters long."
+    elseif not password:match("%l") then
+        return false, "Password must include at least one lowercase letter."
+    elseif not password:match("%u") then
+        return false, "Password must include at least one uppercase letter."
+    elseif not password:match("%d") then
+        return false, "Password must include at least one number."
+    else
+        return true, "Password is valid."
+    end
+end
+
+-- ...later, in component function
+local username, set_username = editor.ui.use_state('')
+local password, set_password = editor.ui.use_state('')
+local valid, message = editor.ui.use_memo(validate_password, password)
+```
+In diesem Beispiel wird die Kennwortvalidierung bei jeder Kennwortänderung ausgeführt (beispielsweise beim Tippen in ein Kennwortfeld), aber nicht, wenn der Benutzername geändert wird.
+
+Ein weiterer Anwendungsfall für `use_memo` ist das Erstellen von Callbacks, die anschließend in Eingabekomponenten verwendet werden, oder die Verwendung einer lokal erstellten Funktion als Eigenschaftswert einer anderen Komponente. Dies verhindert unnötiges erneutes Rendern.

--- a/docs/de/manuals/editor-scripts.md
+++ b/docs/de/manuals/editor-scripts.md
@@ -1,0 +1,797 @@
+---
+title: Editor-Skripte
+brief: Dieses Handbuch erklärt, wie du den Editor mit Lua erweiterst
+---
+
+# Editor-Skripte {#editor-scripts}
+
+Du kannst eigene Menüeinträge und Lebenszyklus-Hooks (lifecycle hooks) für den Editor erstellen, indem du Lua-Dateien mit der speziellen Erweiterung `.editor_script` verwendest. Mit diesem System kannst du den Editor anpassen und deinen Arbeitsablauf bei der Entwicklung verbessern.
+
+## Laufzeitumgebung für Editor-Skripte {#editor-script-runtime}
+
+Editor-Skripte (editor scripts) laufen innerhalb des Editors in einer Lua-VM, die von der Java-VM emuliert wird. Alle Skripte teilen sich eine einzige Umgebung und können daher miteinander interagieren. Du kannst Lua-Module mit `require` laden, genau wie in `.script`-Dateien. Im Editor läuft jedoch eine andere Lua-Version, daher solltest du sicherstellen, dass dein gemeinsam verwendeter Code kompatibel ist. Der Editor verwendet Lua in Version 5.2.x, genauer gesagt die Laufzeitumgebung [luaj](https://github.com/luaj/luaj), die derzeit die einzige praktikable Lösung zum Ausführen von Lua auf der JVM ist. Darüber hinaus gelten einige Einschränkungen:
+- Es gibt kein `debug`-Paket;
+- es gibt kein `os.execute`, aber mit `editor.execute()` stellen wir eine ähnliche Funktion bereit;
+- es gibt weder `os.tmpname` noch `io.tmpfile` — derzeit können Editor-Skripte nur auf Dateien innerhalb des Projektverzeichnisses zugreifen;
+- derzeit gibt es kein `os.rename`, wir möchten es jedoch hinzufügen;
+- es gibt weder `os.exit` noch `os.setlocale`.
+- Einige länger laufende Funktionen dürfen nicht in Kontexten verwendet werden, in denen der Editor eine sofortige Antwort vom Skript benötigt. Weitere Informationen findest du unter [Ausführungsmodi](#execution-modes).
+
+Alle in Editor-Skripten definierten Editor-Erweiterungen werden geladen, wenn du ein Projekt öffnest. Wenn du Bibliotheken abrufst, werden die Erweiterungen neu geladen, da Bibliotheken, von denen dein Projekt abhängt, neue Editor-Skripte enthalten können. Bei diesem Neuladen werden Änderungen an deinen eigenen Editor-Skripten nicht übernommen, da du sie möglicherweise gerade bearbeitest. Um auch diese neu zu laden, solltest du den Befehl **Project → Reload Editor Scripts** ausführen.
+
+## Aufbau einer `.editor_script`-Datei {#anatomy-of-editor_script}
+
+Jedes Editor-Skript sollte ein Modul zurückgeben, zum Beispiel so:
+```lua
+local M = {}
+
+function M.get_commands()
+  -- TODO - define editor commands
+end
+
+function M.get_language_servers()
+  -- TODO - define language servers
+end
+
+function M.get_prefs_schema()
+  -- TODO - define preferences
+end
+
+return M
+```
+Der Editor sammelt dann alle im Projekt und in den Bibliotheken definierten Editor-Skripte, lädt sie in eine einzige Lua-VM und ruft sie bei Bedarf auf (mehr dazu in den Abschnitten [Befehle](#commands) und [Lebenszyklus-Hooks](#lifecycle-hooks)).
+
+## Editor-API
+
+Über das Paket `editor`, das die folgende API definiert, kannst du mit dem Editor interagieren:
+- `editor.platform` — eine Zeichenfolge, entweder `"x86_64-win32"` für Windows, `"x86_64-macos"` für macOS oder `"x86_64-linux"` für Linux.
+- `editor.version` — eine Zeichenfolge mit dem Versionsnamen von Defold, z. B. `"1.4.8"`
+- `editor.engine_sha1` — eine Zeichenfolge mit dem SHA1-Wert der Defold-Engine
+- `editor.editor_sha1` — eine Zeichenfolge mit dem SHA1-Wert des Defold-Editors
+- `editor.get(node_id, property)` — einen Wert eines Knotens innerhalb des Editors abrufen. Knoten im Editor sind verschiedene Entitäten, etwa eine Skriptdatei oder eine Datei für eine Sammlung (collection), ein Spielobjekt (game object) innerhalb einer Sammlung, eine als Ressource geladene JSON-Datei usw. `node_id` ist ein userdata-Wert, den der Editor an das Editor-Skript übergibt. Alternativ kannst du statt der Knoten-ID einen Ressourcenpfad übergeben, zum Beispiel `"/main/game.script"`. `property` ist eine Zeichenfolge. Derzeit werden folgende Eigenschaften unterstützt:
+  - `"path"` — Dateipfad relativ zum Projektordner für *Ressourcen* — Entitäten, die als Dateien oder Verzeichnisse existieren. Beispiel für einen Rückgabewert: `"/main/game.script"`
+  - `"children"` — Liste der Ressourcenpfade untergeordneter Elemente für Verzeichnisressourcen
+  - `"parent"` — übergeordneter Editorknoten eines Knotens in Outline, der einen übergeordneten Knoten hat
+  - `"text"` — Textinhalt einer als Text bearbeitbaren Ressource (etwa Skriptdateien oder JSON). Beispiel für einen Rückgabewert: `"function init(self)\nend"`. Beachte, dass dies nicht dem Lesen einer Datei mit `io.open()` entspricht: Du kannst eine Datei bearbeiten, ohne sie zu speichern, und diese Änderungen sind nur über den Zugriff auf die Eigenschaft `"text"` verfügbar.
+  - für Atlanten: `images` (Liste der Editorknoten für Bilder im Atlas) und `animations` (Liste der Animationsknoten)
+  - für Atlasanimationen: `images` (wie `images` im Atlas)
+  - für eine Kachelkarte (tile map): `layers` (Liste der Editorknoten für Ebenen in der Kachelkarte)
+  - für Kachelkartenebenen: `tiles` (ein unbegrenztes 2D-Raster aus Kacheln), weitere Informationen findest du unter `tilemap.tiles.*`
+  - für Partikeleffekte: `emitters` (Liste der Editorknoten für Emitter) und `modifiers` (Liste der Editorknoten für Modifikatoren)
+  - für Emitter von Partikeleffekten: `modifiers` (Liste der Editorknoten für Modifikatoren)
+  - für Kollisionsobjekte: `shapes` (Liste der Editorknoten für Kollisionsformen)
+  - für GUI-Dateien: Knotenlisten wie `layers`, `fonts`, `materials`, `textures`, `particlefxs`, `nodes` und `layouts`
+  - einige Eigenschaften, die in der Ansicht Properties angezeigt werden, wenn du etwas in der Ansicht Outline ausgewählt hast. Folgende Typen von Outline-Eigenschaften werden unterstützt:
+    - `strings`
+    - `booleans`
+    - `numbers`
+    - `vec2`/`vec3`/`vec4`
+    - `resources`
+    - `curves`
+    Beachte, dass einige dieser Eigenschaften schreibgeschützt sein können und andere je nach Kontext möglicherweise nicht verfügbar sind. Deshalb solltest du vor dem Lesen `editor.can_get` und vor dem Setzen durch den Editor `editor.can_set` verwenden. Bewege den Mauszeiger über den Eigenschaftsnamen in der Ansicht Properties, um einen Tooltip mit Informationen dazu anzuzeigen, wie diese Eigenschaft in Editor-Skripten heißt. Du kannst Ressourceneigenschaften auf `nil` setzen, indem du den Wert `""` übergibst.
+- `editor.properties(node_id)` — eine sortierte, kontextabhängige Liste der Eigenschaftsnamen zurückgeben, die von einem Knoten gelesen werden können, zum Beispiel `pprint(editor.properties("/game.project"))`. Verwende die Funktionen `editor.can_*`, um zu prüfen, ob eine aufgelistete Eigenschaft auch geändert oder zurückgesetzt werden kann, ob sich ihr Elemente hinzufügen lassen oder ob deren Reihenfolge geändert werden kann.
+- `editor.can_get(node_id, property)` — prüfen, ob du diese Eigenschaft abrufen kannst, sodass `editor.get()` keinen Fehler auslöst.
+- `editor.can_set(node_id, property)` — prüfen, ob ein Transaktionsschritt mit `editor.tx.set()` für diese Eigenschaft keinen Fehler auslöst.
+- `editor.create_directory(resource_path)` — ein Verzeichnis erstellen, falls es nicht existiert, einschließlich aller fehlenden übergeordneten Verzeichnisse.
+- `editor.create_resources(resources)` — 1 oder mehr Ressourcen erstellen, entweder aus Vorlagen oder mit eigenen Inhalten
+- `editor.delete_directory(resource_path)` — ein Verzeichnis löschen, falls es existiert, einschließlich aller vorhandenen Unterverzeichnisse und Dateien.
+- `editor.execute(cmd, [...args], [options])` — einen Shell-Befehl ausführen und optional seine Ausgabe erfassen.
+- `editor.save()` — alle ungespeicherten Änderungen auf dem Datenträger speichern.
+- `editor.transact(txs)` — den Zustand des Editors im Arbeitsspeicher mit 1 oder mehr Transaktionsschritten ändern, die mit den Funktionen `editor.tx.*` erstellt wurden.
+- `editor.ui.*` — verschiedene Funktionen für die Benutzeroberfläche, siehe [UI-Handbuch](/manuals/editor-scripts-ui).
+- `editor.prefs.*` — Funktionen für den Zugriff auf Editoreinstellungen, siehe [Editoreinstellungen](#preferences).
+
+Die vollständige Editor-API-Referenz findest du [hier](/ref/stable/editor/).
+
+## Befehle {#commands}
+
+Wenn ein Editor-Skriptmodul `get_commands()` definiert, wird diese Funktion beim Neuladen der Erweiterungen aufgerufen. Die zurückgegebenen Befehle können abhängig von ihren `locations` in den Menüs der Menüleiste und in den Kontextmenüs von Assets, Outline, Scene und Code erscheinen. Beispiel:
+
+```lua
+local M = {}
+
+function M.get_commands()
+  return {
+    {
+      label = "Remove Comments",
+      locations = {"Edit", "Assets"},
+      query = {
+        selection = {type = "resource", cardinality = "one"}
+      },
+      active = function(opts)
+        local path = editor.get(opts.selection, "path")
+        return ends_with(path, ".lua") or ends_with(path, ".script")
+      end,
+      run = function(opts)
+        local text = editor.get(opts.selection, "text")
+        editor.transact({
+          editor.tx.set(opts.selection, "text", strip_comments(text))
+        })
+      end
+    },
+    {
+      label = "Minify JSON",
+      locations = {"Assets"},
+      query = {
+        selection = {type = "resource", cardinality = "one"}
+      },
+      active = function(opts)
+        return ends_with(editor.get(opts.selection, "path"), ".json")
+      end,
+      run = function(opts)
+        local path = editor.get(opts.selection, "path")
+        editor.execute("./scripts/minify-json.sh", path:sub(2))
+      end
+    }
+  }
+end
+
+return M
+```
+Der Editor erwartet, dass `get_commands()` ein Array von Tabellen zurückgibt, die jeweils einen eigenen Befehl beschreiben. Eine Befehlsbeschreibung besteht aus:
+
+- `label` (erforderlich) — Text eines Menüeintrags, der angezeigt wird
+- `locations` (erforderlich) — ein Array, das angibt, wo dieser Befehl verfügbar sein soll. Unterstützte Werte sind `"Edit"`, `"View"`, `"Project"`, `"Debug"` und `"Help"` für die entsprechenden Menüs der Menüleiste; `"Bundle"` für das Untermenü **Project → Bundle**; sowie `"Assets"`, `"Outline"`, `"Scene"` und `"Code"` für die entsprechenden Kontextmenüs.
+- `query` — eine Möglichkeit für den Befehl, relevante Informationen beim Editor abzufragen und festzulegen, mit welchen Daten er arbeitet. Zu jedem Schlüssel in der Tabelle `query` gibt es einen entsprechenden Schlüssel in der Tabelle `opts`, die die Callbacks `active` und `run` als Argument erhalten. Unterstützte Schlüssel:
+  - `selection` bedeutet, dass dieser Befehl gültig ist, wenn etwas ausgewählt ist, und dass er auf dieser Auswahl arbeitet.
+    - `type` ist der Typ der ausgewählten Knoten, für die der Befehl relevant ist. Derzeit sind diese Typen zulässig:
+      - `"resource"` — in Assets und Outline ist eine Ressource das ausgewählte Element, zu dem eine Datei gehört. In der Menüleiste (Edit oder View) ist eine Ressource die aktuell geöffnete Datei;
+      - `"outline"` — etwas, das in Outline angezeigt werden kann. In Outline ist es ein ausgewähltes Element, in der Menüleiste die aktuell geöffnete Datei;
+      - `"scene"` — etwas, das in Scene gerendert werden kann.
+    - `cardinality` legt fest, wie viele Elemente ausgewählt sein sollen. Bei `"one"` ist die an den Befehls-Callback übergebene Auswahl eine einzelne Knoten-ID. Bei `"many"` ist sie ein Array mit einer oder mehreren Knoten-IDs.
+  - `active_view` bedeutet, dass dieser Befehl gültig ist, wenn die aktive Editoransicht dem angeforderten Typ entspricht. Die aktive Ansicht wird dem Befehls-Callback als `opts.active_view` übergeben.
+    - `type` ist der Typ der aktiven Ansicht, für den der Befehl relevant ist, entweder `"code"`, `"scene"`, `"html"` oder `"form"`.
+    - Die aktive Ansicht unterstützt die Eigenschaften `"type"`, `"resource"` und `"dirty"`. Verwende `editor.get(view, "resource")`, um die in der Ansicht angezeigte Ressource abzurufen, und `editor.get(view, "dirty")`, um zu prüfen, ob sie ungespeicherte Änderungen enthält.
+  - `argument` — Befehlsargument. Derzeit erhalten nur Befehle am Ort `"Bundle"` ein Argument. Es ist `true`, wenn der Bundle-Befehl ausdrücklich ausgewählt wird, und `false`, wenn das Bundle erneut erstellt wird.
+- `id` - eine Zeichenfolge als Bezeichner des Befehls, die z. B. zum Speichern des zuletzt verwendeten Bundle-Befehls in `prefs` dient
+- `active` - ein Callback, der prüft, ob der Befehl aktiv ist, und einen booleschen Wert zurückgeben soll. Wenn `locations` die Werte `"Assets"`, `"Scene"` oder `"Outline"` enthält, wird `active` beim Anzeigen des Kontextmenüs aufgerufen. Wenn locations die Werte `"Edit"` oder `"View"` enthält, wird active bei jeder Interaktion aufgerufen, etwa beim Tippen auf der Tastatur oder beim Klicken mit der Maus. Stelle daher sicher, dass `active` relativ schnell ist.
+- `run` - ein Callback, der ausgeführt wird, wenn du den Menüeintrag auswählst.
+
+### Den Zustand des Editors im Arbeitsspeicher mit Befehlen ändern {#use-commands-to-change-the-in-memory-editor-state}
+
+Im Handler `run` kannst du den Zustand des Editors im Arbeitsspeicher abfragen und ändern. Für Abfragen verwendest du die Funktion `editor.get()`, mit der du den Editor nach dem aktuellen Zustand von Dateien und der Auswahl fragen kannst (wenn du `query = {selection = ...}` verwendest). Du kannst die Eigenschaft `"text"` von Ressourcen abrufen, die als Text bearbeitbar sind, sowie einige Eigenschaften aus der Ansicht Properties. Bewege den Mauszeiger über den Eigenschaftsnamen, um einen Tooltip mit Informationen dazu anzuzeigen, wie diese Eigenschaft in Editor-Skripten heißt. Den Editorzustand änderst du mit `editor.transact()`. Dabei fasst du 1 oder mehr Änderungen in einem einzigen Schritt zusammen, der rückgängig gemacht werden kann. Wenn du zum Beispiel die Transformation eines Spielobjekts zurücksetzen möchtest, könntest du einen Befehl wie diesen schreiben:
+```lua
+{
+  label = "Reset transform",
+  locations = {"Outline"},
+  query = {selection = {type = "outline", cardinality = "one"}},
+  active = function(opts)
+    local node = opts.selection
+    return editor.can_set(node, "position") 
+       and editor.can_set(node, "rotation") 
+       and editor.can_set(node, "scale")
+  end,
+  run = function(opts)
+    local node = opts.selection
+    editor.transact({
+      editor.tx.set(node, "position", {0, 0, 0}),
+      editor.tx.set(node, "rotation", {0, 0, 0}),
+      editor.tx.set(node, "scale", {1, 1, 1})
+    })
+  end
+}
+```
+
+### Befehle mit der aktiven Editoransicht verwenden {#use-commands-with-the-active-editor-view}
+
+Befehle in Menüs wie `"View"` können die aktuell aktive Editoransicht abfragen. Das ist nützlich, wenn ein Befehl mit der Datei oder Szene arbeiten soll, die du gerade ansiehst:
+
+```lua
+editor.command({
+  label = "Print Active View",
+  locations = {"View"},
+  query = {active_view = {type = "code"}},
+  run = function(opts)
+    local view = opts.active_view
+    local resource = editor.get(view, "resource")
+    print(editor.get(view, "type"))
+    print(editor.get(resource, "path"))
+    print(editor.get(view, "dirty"))
+  end
+})
+```
+
+#### Atlanten bearbeiten {#editing-atlases}
+
+Du kannst nicht nur Eigenschaften eines Atlas lesen und schreiben, sondern auch seine Bilder und Animationen lesen und ändern. Ein Atlas definiert die Knotenlisteneigenschaften `images` und `animations`, und Animationen definieren die Knotenlisteneigenschaft `images`. Mit diesen Eigenschaften kannst du die Transaktionsschritte `editor.tx.add`, `editor.tx.remove` und `editor.tx.clear` verwenden.
+
+Um beispielsweise ein Bild zu einem Atlas hinzuzufügen, führe den folgenden Code im Handler `run` des Befehls aus:
+```lua
+editor.transact({
+    editor.tx.add("/main.atlas", "images", {image="/assets/hero.png"})
+})
+```
+Um die Menge aller Bilder in einem Atlas zu ermitteln, führe den folgenden Code aus:
+```lua
+local all_images = {} ---@type table<string, true>
+-- first, collect all "bare" images
+local image_nodes = editor.get("/main.atlas", "images")
+for i = 1, #image_nodes do
+    all_images[editor.get(image_nodes[i], "image")] = true
+end
+-- second, collect all images used in animations
+local animation_nodes = editor.get("/main.atlas", "animations")
+for i = 1, #animation_nodes do
+    local animation_image_nodes = editor.get(animation_nodes[i], "images")
+    for j = 1, #animation_image_nodes do
+        all_images[editor.get(animation_image_nodes[j], "image")] = true
+    end
+end
+pprint(all_images)
+-- {
+--     ["/assets/hero.png"] = true,
+--     ["/assets/enemy.png"] = true,
+-- }}
+```
+So ersetzt du alle Animationen in einem Atlas:
+```lua
+editor.transact({
+    editor.tx.clear("/main.atlas", "animations"),
+    editor.tx.add("/main.atlas", "animations", {
+        id = "hero_run",
+        images = {
+            {image = "/assets/hero_run_1.png"},
+            {image = "/assets/hero_run_2.png"},
+            {image = "/assets/hero_run_3.png"},
+            {image = "/assets/hero_run_4.png"}
+        }
+    })
+})
+```
+
+#### Kachelquellen bearbeiten {#editing-tilesources}
+
+Zusätzlich zu den Outline-Eigenschaften definiert eine Kachelquelle (tile source) die folgenden Eigenschaften:
+- `animations` - eine Liste der Animationsknoten der Kachelquelle
+- `collision_groups` - eine Liste der Kollisionsgruppenknoten der Kachelquelle
+- `tile_collision_groups` - eine Tabelle mit den Zuordnungen von Kollisionsgruppen zu Kacheln in der Kachelquelle
+
+So kannst du zum Beispiel eine Kachelquelle einrichten:
+```lua
+local tilesource = "/game/world.tilesource"
+editor.transact({
+    editor.tx.add(tilesource, "animations", {id = "idle", start_tile = 1, end_tile = 1}),
+    editor.tx.add(tilesource, "animations", {id = "walk", start_tile = 2, end_tile = 6, fps = 10}),
+    editor.tx.add(tilesource, "collision_groups", {id = "player"}),
+    editor.tx.add(tilesource, "collision_groups", {id = "obstacle"}),
+    editor.tx.set(tilesource, "tile_collision_groups", {
+        [1] = "player",
+        [7] = "obstacle",
+        [8] = "obstacle"
+    })
+})
+```
+
+#### Kachelkarten bearbeiten {#editing-tilemaps}
+
+Kachelkarten definieren die Eigenschaft `layers`, eine Knotenliste der Kachelkartenebenen. Jede Ebene definiert außerdem die Eigenschaft `tiles`, die ein unbegrenztes 2D-Raster mit den Kacheln dieser Ebene enthält. Dies unterscheidet sich von der Engine: Das Kachelraster ist unbegrenzt und Kacheln können überall hinzugefügt werden, auch an negativen Koordinaten. Zum Bearbeiten von Kacheln definiert die Editor-Skript-API das Modul `tilemap.tiles` mit den folgenden Funktionen:
+- `tilemap.tiles.new()`, um eine neue Datenstruktur zu erstellen, die ein unbegrenztes 2D-Kachelraster enthält (im Editor ist die Kachelkarte im Gegensatz zur Engine unbegrenzt und Koordinaten dürfen negativ sein)
+- `tilemap.tiles.get_tile(tiles, x, y)`, um den Kachelindex an einer bestimmten Koordinate abzurufen
+- `tilemap.tiles.get_info(tiles, x, y)`, um vollständige Kachelinformationen an einer bestimmten Koordinate abzurufen (die Datenstruktur entspricht der Funktion `tilemap.get_tile_info` der Engine)
+- `tilemap.tiles.iterator(tiles)`, um einen Iterator über alle Kacheln in der Kachelkarte zu erstellen
+- `tilemap.tiles.clear(tiles)`, um alle Kacheln aus der Kachelkarte zu entfernen
+- `tilemap.tiles.set(tiles, x, y, tile_or_info)`, um eine Kachel an einer bestimmten Koordinate zu setzen
+- `tilemap.tiles.remove(tiles, x, y)`, um eine Kachel an einer bestimmten Koordinate zu entfernen
+
+So kannst du zum Beispiel den Inhalt der gesamten Kachelkarte ausgeben:
+```lua
+local layers = editor.get("/level.tilemap", "layers")
+for i = 1, #layers do
+    local layer = layers[i]
+    local id = editor.get(layer, "id")
+    local tiles = editor.get(layer, "tiles")
+    print("layer " .. id .. ": {")
+    for x, y, tile in tilemap.tiles.iterator(tiles) do
+        print("  [" .. x .. ", " .. y .. "] = " .. tile)
+    end
+    print("}")
+end
+```
+
+Dieses Beispiel zeigt, wie du einer Kachelkarte eine Ebene mit Kacheln hinzufügst:
+```lua
+local tiles = tilemap.tiles.new()
+tilemap.tiles.set(tiles, 1, 1, 2)
+editor.transact({
+    editor.tx.add("/level.tilemap", "layers", {
+        id = "new_layer",
+        tiles = tiles
+    })
+})
+```
+
+#### Partikeleffekte bearbeiten {#editing-particlefx}
+
+Du kannst Partikeleffekte mit den Eigenschaften `modifiers` und `emitters` bearbeiten. So fügst du zum Beispiel einen kreisförmigen Emitter mit einem Beschleunigungsmodifikator hinzu:
+```lua
+editor.transact({
+    editor.tx.add("/fire.particlefx", "emitters", {
+        type = "emitter-type-circle",
+        modifiers = {
+          {type = "modifier-type-acceleration"}
+        }
+    })
+})
+```
+Viele Eigenschaften von Partikeleffekten sind Kurven oder Kurven mit Streuung (d. h. eine Kurve + ein Wert für zufällige Abweichungen). Kurven werden als Tabelle mit einer nicht leeren Liste von `points` dargestellt, wobei jeder Punkt eine Tabelle mit den folgenden Eigenschaften ist:
+- `x` - die x-Koordinate des Punktes; sie sollte bei 0 beginnen und bei 1 enden
+- `y` - der Wert des Punktes
+- `tx` (0 bis 1) und `ty` (-1 bis 1) - Tangenten des Punktes. Bei einem Winkel von 80 Grad sollte `tx` zum Beispiel `math.cos(math.rad(80))` und `ty` entsprechend `math.sin(math.rad(80))` sein.
+Kurven mit Streuung haben zusätzlich die numerische Eigenschaft `spread`. 
+
+So könnte beispielsweise das Setzen einer Alphakurve über die Partikellebensdauer für einen bereits vorhandenen Emitter aussehen:
+```lua
+local emitter = editor.get("/fire.particlefx", "emitters")[1]
+editor.transact({
+    editor.tx.set(emitter, "particle_key_alpha", { points = {
+        {x = 0,   y = 0, tx = 0.1, ty = 1}, -- start at 0, go up quickly
+        {x = 0.2, y = 1, tx = 1,   ty = 0}, -- reach 1 at 20% of a lifetime
+        {x = 1,   y = 0, tx = 1,   ty = 0}  -- slowly go down to 0
+    }})
+})
+```
+Natürlich kannst du den Schlüssel `particle_key_alpha` auch in einer Tabelle verwenden, wenn du einen Emitter erstellst. Außerdem kannst du stattdessen eine einzelne Zahl verwenden, um eine „statische“ Kurve darzustellen.
+
+#### Kollisionsobjekte bearbeiten {#editing-collision-objects}
+
+Zusätzlich zu den standardmäßigen Outline-Eigenschaften definieren Kollisionsobjekte die Knotenlisteneigenschaft `shapes`. So fügst du neue Kollisionsformen hinzu:
+```lua
+editor.transact({
+    editor.tx.add("/hero.collisionobject", "shapes", {
+        type = "shape-type-box" -- or "shape-type-sphere", "shape-type-capsule"
+    })
+})
+```
+Die Eigenschaft `type` einer Form ist beim Erstellen erforderlich und kann nach dem Hinzufügen der Form nicht mehr geändert werden. Es gibt 3 Formtypen:
+- `shape-type-box` - Quaderform mit der Eigenschaft `dimensions`
+- `shape-type-sphere` - Kugelform mit der Eigenschaft `diameter`
+- `shape-type-capsule` - Kapselform mit den Eigenschaften `diameter` und `height`
+
+#### GUI-Dateien bearbeiten {#editing-gui-files}
+
+Zusätzlich zu den Outline-Eigenschaften definieren GUI-Dateien mehrere Eigenschaften für Knotenlisten:
+
+- `layers` — Liste der Editorknoten für Ebenen (Reihenfolge änderbar)
+- `fonts` — Liste der Editorknoten für Schriftarten
+- `materials` — Liste der Editorknoten für Materialien
+- `textures` — Liste der Editorknoten für Texturen
+- `particlefxs` — Liste der Editorknoten für Partikeleffekte
+- `nodes` — Liste der Editorknoten für GUI-Knoten
+- `layouts` — Liste der Editorknoten für GUI-Layouts
+
+Du kannst GUI-Ebenen über die Editoreigenschaft `layers` bearbeiten, zum Beispiel:
+```lua
+editor.transact({
+    editor.tx.add("/main.gui", "layers", {name = "foreground"}),
+    editor.tx.add("/main.gui", "layers", {name = "background"})
+})
+```
+Außerdem kannst du die Reihenfolge der Ebenen ändern:
+```lua
+local fg, bg = table.unpack(editor.get("/main.gui", "layers"))
+editor.transact({
+    editor.tx.reorder("/main.gui", "layers", {bg, fg})
+})
+```
+Ebenso bearbeitest du Schriftarten, Materialien, Texturen und Partikeleffekte mit den Eigenschaften `fonts`, `materials`, `textures` und `particlefxs`:
+```lua
+editor.transact({
+    editor.tx.add("/main.gui", "fonts", {font = "/main.font"}),
+    editor.tx.add("/main.gui", "materials", {name = "shine", material = "/shine.material"}),
+    editor.tx.add("/main.gui", "particlefxs", {particlefx = "/confetti.particlefx"}),
+    editor.tx.add("/main.gui", "textures", {texture = "/ui.atlas"})
+})
+```
+Diese Eigenschaften unterstützen keine Änderung der Reihenfolge.
+
+Schließlich kannst du GUI-Knoten mit der Listeneigenschaft `nodes` bearbeiten, zum Beispiel:
+```lua
+editor.transact({
+    editor.tx.add("/main.gui", "nodes", {
+        type = "gui-node-type-box",
+        position = {20, 20, 20}
+    }),
+    editor.tx.add("/main.gui", "nodes", {
+        type = "gui-node-type-template",
+        template = "/button.gui"
+    }),
+})
+```
+Die integrierten Knotentypen sind:
+- `gui-node-type-box`
+- `gui-node-type-particlefx`
+- `gui-node-type-pie`
+- `gui-node-type-template`
+- `gui-node-type-text`
+
+Wenn du die Spine-Erweiterung verwendest, kannst du auch den Knotentyp `gui-node-type-spine` verwenden.
+
+Wenn die GUI-Datei Layouts definiert, kannst du die Werte aus den Layouts mit der Syntax `layout:property` abrufen und setzen, zum Beispiel:
+```lua
+local node = editor.get("/main.gui", "nodes")[1]
+
+-- GET:
+local position = editor.get(node, "position")
+pprint(position) -- {20, 20, 20}
+local landscape_position = editor.get(node, "Landscape:position")
+pprint(landscape_position) -- {20, 20, 20}
+
+-- SET:
+editor.transact({
+    editor.tx.set(node, "Landscape:position", {30, 30, 30})
+})
+pprint(editor.get(node, "Landscape:position")) -- {30, 30, 30}
+```
+
+Gesetzte Layout-Eigenschaften kannst du mit `editor.tx.reset` auf ihre Standardwerte zurücksetzen:
+```lua
+print(editor.can_reset(node, "Landscape:position")) -- true
+editor.transact({
+    editor.tx.reset(node, "Landscape:position")
+})
+```
+Knotenbäume von Vorlagen können gelesen, aber nicht bearbeitet werden — du kannst nur die Knoteneigenschaften im Knotenbaum der Vorlage setzen:
+```lua
+local template = editor.get("/main.gui", "nodes")[2]
+print(editor.can_add(template, "nodes")) -- false
+local node_in_template = editor.get(template, "nodes")[1]
+editor.transact({
+    editor.tx.set(node_in_template, "text", "Button text")
+})
+print(editor.can_reset(node_in_template, "text")) -- true (overrides a value in the template)
+```
+
+#### Spielobjekte bearbeiten {#editing-game-objects}
+
+Mit Editor-Skripten kannst du die Komponenten (components) einer Spielobjektdatei bearbeiten. Es gibt 2 Arten von Komponenten: referenzierte und eingebettete. Referenzierte Komponenten verwenden den Typ `component-reference` und dienen als Referenzen auf andere Ressourcen. Dabei lassen sich nur die in Skripten definierten Spielobjekteigenschaften überschreiben. Eingebettete Komponenten verwenden Typen wie `sprite`, `label` usw. und erlauben es, alle im Komponententyp definierten Eigenschaften zu bearbeiten sowie untergeordnete Komponenten wie Formen von Kollisionsobjekten hinzuzufügen. Mit folgendem Code kannst du zum Beispiel ein Spielobjekt einrichten:
+```lua
+editor.transact({
+    editor.tx.add("/npc.go", "components", {
+        type = "sprite",
+        id = "view"
+    }),
+    editor.tx.add("/npc.go", "components", {
+        type = "collisionobject",
+        id = "collision",
+        shapes = {
+            {
+                type = "shape-type-box",
+                dimensions = {32, 32, 32}
+            }
+        }
+    }),
+    editor.tx.add("/npc.go", "components", {
+        type = "component-reference",
+        path = "/npc.script",
+        id = "controller",
+        __hp = 100 -- set a go property defined in the script
+    })
+})
+```
+
+#### Sammlungen bearbeiten {#editing-collections}
+Mit Editor-Skripten kannst du Sammlungen bearbeiten. Du kannst Spielobjekte (eingebettet oder referenziert) und Sammlungen (referenziert) hinzufügen. Zum Beispiel:
+```lua
+local coll = "/char.collection"
+editor.transact({
+    editor.tx.add(coll, "children", {
+        -- embbedded game object
+        type = "go",
+        id = "root",
+        children = {
+            {
+                -- referenced game object
+                type = "go-reference",
+                path = "/char-view.go",
+                id = "view"
+            },
+            {
+                -- referenced collection
+                type = "collection-reference",
+                path = "/body-attachments.collection",
+                id = "attachments"
+            }
+        },
+        -- embedded gos can also have components
+        components = {
+            {
+                type = "collisionobject",
+                id = "collision",
+                shapes = {
+                    {type = "shape-type-box", dimensions = {2.5, 2.5, 2.5}}
+                }
+            },
+            {
+                type = "component-reference",
+                id = "controller",
+                path = "/char.script",
+                __hp = 100 -- set a go property defined in the script
+            }
+        }
+    })
+})
+```
+
+Wie im Editor können referenzierte Sammlungen nur auf der obersten Ebene der bearbeiteten Sammlung hinzugefügt werden. Spielobjekte können nur eingebetteten oder referenzierten Spielobjekten hinzugefügt werden, nicht aber referenzierten Sammlungen oder Spielobjekten innerhalb dieser referenzierten Sammlungen.
+
+### Shell-Befehle verwenden {#use-shell-commands}
+
+Im Handler `run` kannst du in Dateien schreiben (mit dem Modul `io`) und Shell-Befehle ausführen (mit dem Befehl `editor.execute()`). Beim Ausführen eines Shell-Befehls kannst du dessen Ausgabe als Zeichenfolge erfassen und anschließend im Code verwenden. Wenn du zum Beispiel einen Befehl zur Formatierung von JSON erstellen möchtest, der das global installierte [`jq`](https://jqlang.github.io/jq/) über die Shell aufruft, kannst du folgenden Befehl schreiben:
+```lua
+{
+  label = "Format JSON",
+  locations = {"Assets"},
+  query = {selection = {type = "resource", cardinality = "one"}},
+  action = function(opts)
+    local path = editor.get(opts.selection, "path")
+    return path:match(".json$") ~= nil
+  end,
+  run = function(opts)
+    local text = editor.get(opts.selection, "text")
+    local new_text = editor.execute("jq", "-n", "--argjson", "data", text, "$data", {
+      reload_resources = false, -- don't reload resources since jq does not touch disk
+      out = "capture" -- return text output instead of nothing
+    })
+    editor.transact({ editor.tx.set(opts.selection, "text", new_text) })
+  end
+}
+```
+Da dieser Befehl das Shell-Programm nur lesend aufruft (und dem Editor dies mit `reload_resources = false` mitteilt), hat er den Vorteil, dass sich diese Aktion rückgängig machen lässt.
+
+::: sidenote
+Zur Verteilung deines Editor-Skripts als Bibliothek möchtest du möglicherweise das Binärprogramm für die Editorplattformen innerhalb der Abhängigkeit mitliefern. Unter [Editor-Skripte in Bibliotheken](#editor-scripts-in-libraries) findest du weitere Informationen dazu.
+:::
+
+## Lebenszyklus-Hooks {#lifecycle-hooks}
+
+Eine Editor-Skriptdatei wird besonders behandelt: `hooks.editor_script` im Stammverzeichnis deines Projekts, im selben Verzeichnis wie *game.project*. Ausschließlich dieses Editor-Skript empfängt Lebenszyklusereignisse vom Editor. Beispiel für eine solche Datei:
+```lua
+local M = {}
+
+function M.on_build_started(opts)
+  local file = io.open("assets/build.json", "w")
+  file:write('{"build_time": "' .. os.date() .. '"}')
+  file:close()
+end
+
+return M
+```
+Wir haben uns entschieden, Lebenszyklus-Hooks auf eine einzige Editor-Skriptdatei zu beschränken, weil die Reihenfolge der Build-Hooks wichtiger ist als die Frage, wie leicht sich ein weiterer Build-Schritt hinzufügen lässt. Befehle sind voneinander unabhängig, daher ist ihre Reihenfolge im Menü nicht wirklich wichtig; letztlich wird ein bestimmter, ausgewählter Befehl ausgeführt. Wenn Build-Hooks in verschiedenen Editor-Skripten definiert werden könnten, entstünde ein Problem: In welcher Reihenfolge werden die Hooks ausgeführt? Wahrscheinlich möchtest du Prüfsummen für Inhalte erst nach deren Komprimierung erstellen ... Eine einzelne Datei, die die Reihenfolge der Build-Schritte festlegt, indem sie die Funktion jedes Schritts ausdrücklich aufruft, löst dieses Problem.
+
+Verfügbare Lebenszyklus-Hooks, die `/hooks.editor_script` definieren kann:
+- `on_build_started(opts)` — wird ausgeführt, wenn mit den Optionen Project Build oder Debug Start ein Build des Spiels erstellt wird, um es lokal oder auf einem entfernten Ziel auszuführen. Deine Änderungen erscheinen im erstellten Spiel. Wenn dieser Hook einen Fehler auslöst, wird der Build abgebrochen. `opts` ist eine Tabelle mit folgenden Schlüsseln:
+  - `platform` — eine Zeichenfolge im Format `%arch%-%os%`, die die Zielplattform des Builds beschreibt; derzeit immer derselbe Wert wie in `editor.platform`.
+- `on_build_finished(opts)` — wird ausgeführt, wenn der Build abgeschlossen ist, unabhängig davon, ob er erfolgreich war oder fehlgeschlagen ist. `opts` ist eine Tabelle mit folgenden Schlüsseln:
+  - `platform` — wie in `on_build_started`
+  - `success` — gibt an, ob der Build erfolgreich ist, entweder `true` oder `false`
+- `on_bundle_started(opts)` — wird ausgeführt, wenn du ein Bundle erstellst oder mit Build HTML5 eine HTML5-Version eines Spiels erstellst. Wie bei `on_build_started` erscheinen die durch diesen Hook ausgelösten Änderungen im Bundle, und Fehler brechen die Bundle-Erstellung ab. `opts` enthält folgende Schlüssel:
+  - `output_directory` — ein Dateipfad zu einem Verzeichnis mit der Bundle-Ausgabe. **Project ▸ Build HTML5** verwendet einen eigenen Artefaktbaum, zum Beispiel `"/path/to/project/build/default_html5/__htmlLaunchDir"`, getrennt von der normalen Build-Ausgabe unter `build/default`.
+  - `platform` — die Plattform, für die das Bundle des Spiels erstellt wird. Eine Liste möglicher Plattformwerte findest du im [Bob-Handbuch](/manuals/bob).
+  - `variant` — die Bundle-Variante, entweder `"debug"`, `"release"` oder `"headless"`
+- `on_bundle_finished(opts)` — wird ausgeführt, wenn die Bundle-Erstellung abgeschlossen ist, unabhängig davon, ob sie erfolgreich war. `opts` ist eine Tabelle mit denselben Daten wie `opts` in `on_bundle_started`, ergänzt um den Schlüssel `success`, der angibt, ob der Build erfolgreich ist.
+- `on_target_launched(opts)` — wird ausgeführt, nachdem du ein Spiel gestartet hast und es erfolgreich angelaufen ist. `opts` enthält den Schlüssel `url`, der auf den gestarteten Engine-Dienst verweist, zum Beispiel `"http://127.0.0.1:35405"`
+- `on_target_terminated(opts)` — wird ausgeführt, wenn das gestartete Spiel geschlossen wird, und erhält dieselben opts wie `on_target_launched`
+
+Beachte, dass Lebenszyklus-Hooks derzeit nur im Editor verfügbar sind. Bob führt sie bei der Bundle-Erstellung über die Kommandozeile nicht aus.
+
+## Sprachserver {#language-servers}
+
+Der Editor unterstützt einen Teil des [Language Server Protocol](https://microsoft.github.io/language-server-protocol/): Diagnosemeldungen (statische Codeprüfungen), Vervollständigungen, Informationen beim Bewegen des Mauszeigers über Symbole, Dokumentsymbole im Bereich Structure, das Springen zur Definition, das Suchen von Referenzen, das Umbenennen von Symbolen sowie die Formatierung von Dokumenten und Bereichen. Bewege den Mauszeiger über ein Symbol, um Informationen des Sprachservers zu sehen. Wenn sich der Cursor auf einem Symbol befindet, kannst du es mit <kbd>F2</kbd> umbenennen, mit <kbd>F12</kbd> zu seiner Definition springen oder mit <kbd>Shift+F12</kbd> Referenzen suchen. Diese Aktionen sind auch im Menü <kbd>Edit</kbd> verfügbar. Informationen zum Formatierungsbefehl und zur Einstellung für das Formatieren beim Speichern findest du unter [Code formatieren](/manuals/writing-code/#formatting-code).
+
+Der mitgelieferte Lua-Sprachserver enthält Defold-Typannotationen für die Laufzeit-API und die Editor-Skript-API. In `.editor_script`-Dateien erkennen die Vervollständigung und die Diagnosefunktionen die Funktionen `editor.*` sowie deren Argument- und Rückgabetypen. Siehe [Codevervollständigung](/manuals/writing-code/#code-completion).
+
+Um einen zusätzlichen Sprachserver zu registrieren, definiere die Funktion `get_language_servers` deines Editor-Skripts wie folgt:
+
+```lua
+function M.get_language_servers()
+  local command = 'build/plugins/my-ext/plugins/bin/' .. editor.platform .. '/lua-lsp'
+  if editor.platform == 'x86_64-win32' then
+    command = command .. '.exe'
+  end
+  return {
+    {
+      languages = {'lua'},
+      watched_files = {
+        { pattern = '**/.luacheckrc' }
+      },
+      command = {command, '--stdio'}
+    }
+  }
+end
+```
+Der Editor startet den Sprachserver mit dem angegebenen `command` und verwendet zur Kommunikation die Standardeingabe und Standardausgabe des Serverprozesses.
+
+Die Tabelle zur Definition des Sprachservers kann Folgendes angeben:
+- `languages` (erforderlich) — eine Liste der Sprachen, für die der Server zuständig ist, wie [hier](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers) definiert (Dateierweiterungen funktionieren ebenfalls);
+- `command` (erforderlich) - ein Array mit dem Befehl und seinen Argumenten
+- `watched_files` - ein Array von Tabellen mit `pattern`-Schlüsseln (ein Glob-Muster), die die Serverbenachrichtigung [über geänderte überwachte Dateien](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles) auslösen.
+
+## HTTP-Server
+
+Jede laufende Instanz des Editors betreibt einen HTTP-Server. Du kannst diesen Server mit Editor-Skripten erweitern. Um den HTTP-Server des Editors zu erweitern, musst du die Editor-Skriptfunktion `get_http_server_routes` hinzufügen — sie sollte die zusätzlichen Routen zurückgeben:
+```lua
+print("My route: " .. http.server.url .. "/my-extension")
+
+function M.get_http_server_routes()
+  return {
+    http.server.route("/my-extension", "GET", function(request)
+      return http.server.response(200, "Hello world!")
+    end)
+  }
+end
+```
+Nach dem Neuladen der Editor-Skripte siehst du in der Konsole folgende Ausgabe: `My route: http://0.0.0.0:12345/my-extension`. Wenn du diesen Link im Browser öffnest, siehst du deine Nachricht `"Hello world!"`.
+
+Das Eingabeargument `request` ist eine einfache Lua-Tabelle mit Informationen zur Anfrage. Sie enthält Schlüssel wie `path` (URL-Pfadsegment, das mit `/` beginnt), `method` für die Anfragemethode (z. B. `"GET"`), `headers` (eine Tabelle mit Headernamen in Kleinbuchstaben) sowie optional `query` (die Abfragezeichenfolge) und `body` (wenn die Route definiert, wie der Anfrageinhalt zu interpretieren ist). Wenn du zum Beispiel eine Route erstellen möchtest, die JSON als Anfrageinhalt akzeptiert, definierst du sie mit dem Konverterparameter `"json"`:
+```lua
+http.server.route("/my-extension/echo-request", "POST", "json", function(request)
+  return http.server.json_response(request)
+end)
+```
+Du kannst diesen Endpunkt mit `curl` und `jq` über die Kommandozeile testen:
+```sh
+curl 'http://0.0.0.0:12345/my-extension/echo-request?q=1' -X POST --data '{"input": "json"}' | jq
+{
+  "path": "/my-extension/echo-request",
+  "method": "POST",
+  "query": "q=1",
+  "headers": {
+    "host": "0.0.0.0:12345",
+    "content-type": "application/x-www-form-urlencoded",
+    "accept": "*/*",
+    "user-agent": "curl/8.7.1",
+    "content-length": "17"
+  },
+  "body": {
+    "input": "json"
+  }
+}
+```
+Der Routenpfad unterstützt Muster, deren Werte aus dem Anfragepfad extrahiert und der Handlerfunktion als Teil der Anfrage übergeben werden können, zum Beispiel:
+```lua
+http.server.route("/my-extension/setting/{category}.{key}", function(request)
+  return http.server.response(200, tostring(editor.get("/game.project", request.category .. "." .. request.key)))
+end)
+```
+Wenn du nun zum Beispiel `http://0.0.0.0:12345/my-extension/setting/project.title` öffnest, siehst du den Titel deines Spiels aus der Datei `/game.project`.
+
+Neben einem Muster für ein einzelnes Pfadsegment kannst du mit der Syntax `{*name}` auch den restlichen URL-Pfad erfassen. Hier ist beispielsweise ein einfacher Dateiserver-Endpunkt, der Dateien aus dem Stammverzeichnis des Projekts bereitstellt:
+```lua
+http.server.route("/my-extension/files/{*file}", function(request)
+  local attrs = editor.external_file_attributes(request.file)
+  if attrs.is_file then
+    return http.server.external_file_response(request.file)
+  else
+    return 404
+  end
+end)
+```
+Wenn du nun zum Beispiel `http://0.0.0.0:12345/my-extension/files/main/main.collection` im Browser öffnest, wird der Inhalt der Datei `main/main.collection` angezeigt.
+
+## Editor-Skripte in Bibliotheken {#editor-scripts-in-libraries}
+
+Du kannst Bibliotheken mit Befehlen veröffentlichen, damit andere sie verwenden können; der Editor erkennt diese Befehle automatisch. Hooks können dagegen nicht automatisch erkannt werden, da sie in einer Datei im Stammordner eines Projekts definiert werden müssen, während Bibliotheken nur Unterordner bereitstellen. Dadurch hast du mehr Kontrolle über den Build-Vorgang: Du kannst Lebenszyklus-Hooks weiterhin als einfache Funktionen in `.lua`-Dateien erstellen, sodass die Nutzer deiner Bibliothek sie in ihrer `/hooks.editor_script` laden und verwenden können.
+
+Beachte außerdem, dass Abhängigkeiten zwar in der Ansicht Assets angezeigt werden, aber nicht als Dateien existieren (sie sind Einträge in einem ZIP-Archiv). Du kannst den Editor veranlassen, bestimmte Dateien aus den Abhängigkeiten in den Ordner `build/plugins/` zu extrahieren. Dazu musst du in deinem Bibliotheksordner eine Datei `ext.manifest` erstellen und dann den Ordner `plugins/bin/${platform}` im selben Ordner anlegen, in dem sich die Datei `ext.manifest` befindet. Dateien aus diesem Ordner werden automatisch in den Ordner `/build/plugins/${extension-path}/plugins/bin/${platform}` extrahiert, sodass deine Editor-Skripte auf sie verweisen können.
+
+## Editoreinstellungen {#preferences}
+
+Editor-Skripte können Editoreinstellungen definieren und verwenden — dauerhaft auf deinem Computer gespeicherte Daten, die nicht in die Versionsverwaltung übernommen werden. Diese Einstellungen haben drei wesentliche Merkmale:
+- typisiert: Jede Einstellung hat eine Schemadefinition mit dem Datentyp und weiteren Metadaten wie dem Standardwert
+- mit Gültigkeitsbereich: Einstellungen gelten entweder pro Projekt oder pro Nutzer
+- verschachtelt: Jeder Einstellungsschlüssel ist eine durch Punkte getrennte Zeichenfolge. Das erste Pfadsegment identifiziert ein Editor-Skript, die übrigen Segmente identifizieren Gruppen und einzelne Einstellungen darin
+
+Alle Einstellungen müssen durch die Definition ihres Schemas registriert werden:
+```lua
+function M.get_prefs_schema()
+  return {
+    ["my_json_formatter.jq_path"] = editor.prefs.schema.string(),
+    ["my_json_formatter.indent.size"] = editor.prefs.schema.integer({default = 2, scope = editor.prefs.SCOPE.PROJECT}),
+    ["my_json_formatter.indent.type"] = editor.prefs.schema.enum({values = {"spaces", "tabs"}, scope = editor.prefs.SCOPE.PROJECT}),
+  }
+end
+```
+Nachdem ein solches Editor-Skript neu geladen wurde, registriert der Editor dieses Schema. Anschließend kann das Editor-Skript die Einstellungen abrufen und setzen, zum Beispiel:
+```lua
+-- Get a specific preference
+editor.prefs.get("my_json_formatter.indent.type")
+-- Returns: "spaces"
+
+-- Get an entire preference group
+editor.prefs.get("my_json_formatter")
+-- Returns:
+-- {
+--   jq_path = "",
+--   indent = {
+--     size = 2,
+--     type = "spaces"
+--   }
+-- }
+
+-- Set multiple nested preferences at once
+editor.prefs.set("my_json_formatter.indent", {
+    type = "tabs",
+    size = 1
+})
+```
+
+## Ausführungsmodi {#execution-modes}
+
+Die Laufzeitumgebung für Editor-Skripte verwendet 2 Ausführungsmodi, die für Editor-Skripte weitgehend transparent sind: **sofortige Ausführung (immediate)** und **länger laufende Ausführung (long-running)**. 
+
+Die **sofortige Ausführung** wird verwendet, wenn der Editor so schnell wie möglich eine Antwort vom Skript benötigt. Beispielsweise werden die `active`-Callbacks von Menübefehlen in diesem Modus ausgeführt, da diese Prüfungen im UI-Thread des Editors als Reaktion auf die Interaktion mit dem Editor stattfinden und die Benutzeroberfläche innerhalb desselben Frames aktualisieren sollen. 
+
+Die **länger laufende Ausführung** wird verwendet, wenn der Editor keine sofortige Antwort vom Skript benötigt. Beispielsweise werden die `run`-Callbacks von Menübefehlen im Modus für **länger laufende Ausführung** ausgeführt, sodass das Skript mehr Zeit für seine Arbeit in Anspruch nehmen kann.
+
+Einige Funktionen, die Editor-Skripte verwenden können, benötigen möglicherweise viel Ausführungszeit. Beispielsweise kann `editor.execute("git", "status", {reload_resources=false, out="capture"})` bei ausreichend großen Projekten bis zu einer Sekunde dauern. Damit der Editor reaktionsfähig bleibt und seine Leistung beibehält, sind potenziell zeitaufwendige Funktionen in Kontexten nicht erlaubt, in denen der Editor eine sofortige Antwort benötigt. Der Versuch, eine solche Funktion in einem Kontext mit sofortiger Ausführung zu verwenden, führt zu einem Fehler: `Cannot use long-running editor function in immediate context`. Um diesen Fehler zu beheben, vermeide solche Funktionen in Kontexten mit sofortiger Ausführung.
+
+Die folgenden Funktionen gelten als länger laufend und können nicht im Modus für sofortige Ausführung verwendet werden:
+- `editor.create_directory()`, `editor.create_resources()`, `editor.delete_directory()`, `editor.save()`, `os.remove()` und `file:write()`: Diese Funktionen ändern Dateien auf dem Datenträger. Dadurch synchronisiert der Editor seinen Ressourcenbaum im Arbeitsspeicher mit dem Zustand auf dem Datenträger, was bei großen Projekten Sekunden dauern kann.
+- `editor.execute()`: Die Ausführung von Shell-Befehlen kann unvorhersehbar lange dauern.
+- `editor.transact()`: Große Transaktionen an Knoten, auf die viele Referenzen verweisen, können Hunderte von Millisekunden dauern, was für eine reaktionsfähige Benutzeroberfläche zu langsam ist.
+
+Die folgenden Kontexte für die Codeausführung verwenden den Modus für sofortige Ausführung:
+- `active`-Callbacks von Menübefehlen: Der Editor benötigt innerhalb desselben UI-Frames eine Antwort vom Skript.
+- Code auf der obersten Ebene von Editor-Skripten: Wir erwarten, dass das Neuladen von Editor-Skripten keine Seiteneffekte hat.
+
+## Aktionen {#actions}
+
+::: sidenote
+Früher interagierte der Editor blockierend mit der Lua-VM. Daher galt die strikte Anforderung, dass Editor-Skripte nicht blockieren dürfen, da einige Interaktionen vom UI-Thread des Editors aus erfolgen müssen. Aus diesem Grund gab es beispielsweise weder `editor.execute()` noch `editor.transact()`. Das Ausführen von Skripten und das Ändern des Editorzustands wurden stattdessen durch die Rückgabe eines Arrays von „Aktionen“ aus Hooks und den Handlern `run` von Befehlen ausgelöst.
+
+Jetzt interagiert der Editor ohne Blockierung mit der Lua-VM, sodass diese Aktionen nicht mehr benötigt werden: Funktionen wie `editor.execute()` sind bequemer, kürzer und leistungsfähiger. Die Aktionen sind jetzt **VERALTET UND ZUR ABLÖSUNG VORGESEHEN**, wir planen jedoch nicht, sie zu entfernen.
+:::
+
+Editor-Skripte können aus der Funktion `run` eines Befehls oder aus den Hook-Funktionen von `/hooks.editor_script` ein Array von Aktionen zurückgeben. Der Editor führt diese Aktionen anschließend aus.
+
+Eine Aktion ist eine Tabelle, die beschreibt, was der Editor tun soll. Jede Aktion hat einen Schlüssel `action`. Es gibt 2 Arten von Aktionen: solche, die rückgängig gemacht werden können, und solche, die nicht rückgängig gemacht werden können.
+
+### Aktionen, die rückgängig gemacht werden können {#undoable-actions}
+
+::: sidenote
+Verwende vorzugsweise `editor.transact()`.
+:::
+
+Eine solche Aktion kann nach ihrer Ausführung rückgängig gemacht werden. Wenn ein Befehl mehrere solche Aktionen zurückgibt, werden sie gemeinsam ausgeführt und gemeinsam rückgängig gemacht. Du solltest nach Möglichkeit Aktionen verwenden, die rückgängig gemacht werden können. Ihr Nachteil ist, dass ihre Möglichkeiten stärker eingeschränkt sind.
+
+Verfügbare Aktionen, die rückgängig gemacht werden können:
+- `"set"` — eine Eigenschaft eines Knotens im Editor auf einen Wert setzen. Beispiel:
+  ```lua
+  {
+    action = "set",
+    node_id = opts.selection,
+    property = "text",
+    value = "current time is " .. os.date()
+  }
+  ```
+  Die Aktion `"set"` benötigt diese Schlüssel:
+  - `node_id` — ein userdata-Wert mit der Knoten-ID. Alternativ kannst du hier statt der vom Editor erhaltenen Knoten-ID einen Ressourcenpfad verwenden, zum Beispiel `"/main/game.script"`;
+  - `property` — die zu setzende Eigenschaft eines Knotens, z. B. `"text"`;
+  - `value` — der neue Wert der Eigenschaft. Für die Eigenschaft `"text"` sollte er eine Zeichenfolge sein.
+
+### Aktionen, die nicht rückgängig gemacht werden können {#non-undoable-actions}
+
+::: sidenote
+Verwende vorzugsweise `editor.execute()`.
+:::
+
+Eine solche Aktion löscht den Verlauf für das Rückgängigmachen. Wenn du sie rückgängig machen möchtest, musst du daher andere Mittel verwenden, etwa die Versionsverwaltung.
+
+Verfügbare Aktionen, die nicht rückgängig gemacht werden können:
+- `"shell"` — ein Shell-Skript ausführen. Beispiel:
+  ```lua
+  {
+    action = "shell",
+    command = {
+      "./scripts/minify-json.sh",
+      editor.get(opts.selection, "path"):sub(2) -- trim leading "/"
+    }
+  }
+  ```
+  Die Aktion `"shell"` benötigt den Schlüssel `command`, ein Array mit dem Befehl und seinen Argumenten.
+
+### Aktionen und Seiteneffekte kombinieren {#mixing-actions-and-side-effects}
+
+Du kannst Aktionen kombinieren, die rückgängig gemacht werden können, und solche, die es nicht können. Die Aktionen werden nacheinander ausgeführt. Je nach Reihenfolge verlierst du daher die Möglichkeit, Teile dieses Befehls rückgängig zu machen.
+
+Anstatt Aktionen aus Funktionen zurückzugeben, die sie erwarten, kannst du Dateien mit `io.open()` direkt lesen und schreiben. Dies löst ein Neuladen der Ressourcen aus, das den Verlauf für das Rückgängigmachen löscht.

--- a/docs/de/manuals/editor-styling.md
+++ b/docs/de/manuals/editor-styling.md
@@ -1,0 +1,129 @@
+---
+title: Gestaltung des Editors
+brief: Mit einem benutzerdefinierten Stylesheet kannst du die Farben, die Typografie und andere visuelle Aspekte des Editors ändern.
+---
+
+# Gestaltung des Editors {#editor-styling}
+
+Mit einem benutzerdefinierten Stylesheet kannst du die Farben, die Typografie und andere visuelle Aspekte des Editors ändern:
+
+* Erstelle in deinem Benutzerverzeichnis einen Ordner namens `.defold`.
+  * Unter Windows `C:\Users\**Your Username**\.defold`
+  * Unter macOS `/Users/**Your Username**/.defold`
+  * Unter Linux `~/.defold`
+* Erstelle eine Datei namens `editor.css` im Ordner `.defold`
+
+Beim Start lädt der Editor dein benutzerdefiniertes Stylesheet und wendet es zusätzlich zum Standardstil an. Der Editor verwendet JavaFX für die Benutzeroberfläche. Die Stylesheets sind nahezu identisch mit den CSS-Dateien, mit denen ein Browser Stilattribute auf die Elemente einer Webseite anwendet. Die Standard-Stylesheets des Editors kannst du [auf GitHub einsehen](https://github.com/defold/defold/tree/editor-dev/editor/styling/stylesheets/base).
+
+## Farben ändern {#changing-color}
+
+Die Standardfarben sind in [`_palette.scss`](https://github.com/defold/defold/blob/editor-dev/editor/styling/stylesheets/base/_palette.scss) definiert und sehen so aus:
+
+```
+* {
+	// Background
+	-df-background-darker:    derive(#212428, -10%);
+	-df-background-dark:      derive(#212428, -5%);
+	-df-background:           #212428;
+	-df-background-light:     derive(#212428, 10%);
+	-df-background-lighter:   derive(#212428, 20%);
+
+	// Component
+	-df-component-darker:     derive(#464c55, -20%);
+	-df-component-dark:       derive(#464c55, -10%);
+	-df-component:            #464c55;
+	-df-component-light:      derive(#464c55, 10%);
+	-df-component-lighter:    derive(#464c55, 20%);
+
+	// Text & icons
+	-df-text-dark:            derive(#b4bac1, -10%);
+	-df-text:                 #b4bac1;
+	-df-text-selected:        derive(#b4bac1, 20%);
+
+  and so on...
+```
+
+Das grundlegende Erscheinungsbild ist in drei Farbgruppen unterteilt (mit dunkleren und helleren Varianten):
+
+* Hintergrundfarbe - Hintergrundfarbe in Bereichen, Fenstern und Dialogfeldern
+* Farbe der Bedienelemente - Schaltflächen, Schieber von Bildlaufleisten, Umrandungen von Textfeldern
+* Textfarbe - Text und Symbole
+
+Wenn du beispielsweise Folgendes zu deinem benutzerdefinierten Stylesheet `editor.css` im Ordner `.defold` in deinem Benutzerverzeichnis hinzufügst:
+
+```
+* {
+	-df-background-darker:    derive(#0a0a42, -10%);
+	-df-background-dark:      derive(#0a0a42, -5%);
+	-df-background:           #0a0a42;
+	-df-background-light:     derive(#0a0a42, 10%);
+	-df-background-lighter:   derive(#0a0a42, 20%);
+}
+```
+
+Dann sieht dein Editor so aus:
+
+![](images/editor/editor-styling-color.png)
+
+
+## Schriftarten ändern {#changing-fonts}
+
+Der Editor verwendet zwei Schriftarten: `Dejavu Sans Mono` für Code und Text mit fester Zeichenbreite (Fehlermeldungen) sowie `Source Sans Pro` für den Rest der Benutzeroberfläche. Die Schriftartdefinitionen befinden sich hauptsächlich in [`_typography.scss`](https://github.com/defold/defold/blob/editor-dev/editor/styling/stylesheets/base/_typography.scss) und sehen so aus:
+
+```
+@font-face {
+  src: url("SourceSansPro-Light.ttf");
+}
+
+@font-face {
+  src: url("DejaVuSansMono.ttf");
+}
+
+$default-font-mono: 'Dejavu Sans Mono';
+$default-font: 'Source Sans Pro';
+$default-font-bold: 'Source Sans Pro Semibold';
+$default-font-italic: 'Source Sans Pro Italic';
+$default-font-light: 'Source Sans Pro Light';
+
+.root {
+    -fx-font-size: 13px;
+    -fx-font-family: $default-font;
+}
+
+Text.strong {
+  -fx-font-family: $default-font-bold;
+}
+
+and so on...
+```
+
+Die Hauptschriftart ist in einem Wurzelelement definiert. Dadurch lässt sich die Schriftart an den meisten Stellen recht leicht ersetzen. Füge Folgendes zu deiner `editor.css` hinzu:
+
+```
+@import url('https://fonts.googleapis.com/css2?family=Architects+Daughter&display=swap');
+
+.root {
+    -fx-font-family: "Architects Daughter";
+}
+```
+
+Dann sieht dein Editor so aus:
+
+![](images/editor/editor-styling-fonts.png)
+
+Du kannst auch eine lokale Schriftart anstelle einer Webschriftart verwenden:
+
+```
+@font-face {
+  font-family: 'Comic Sans MS';
+  src: local("cs.ttf");
+}
+
+.root {
+  -fx-font-family: 'Comic Sans MS';
+}
+```
+
+::: sidenote
+Die Schriftart des Code-Editors wird separat unter Preferences in den Editoreinstellungen festgelegt!
+:::

--- a/docs/de/manuals/editor-templates.md
+++ b/docs/de/manuals/editor-templates.md
@@ -1,0 +1,46 @@
+---
+title: Editor-Vorlagen
+brief: Du kannst dem Fenster New Project eigene Projektvorlagen hinzufügen.
+---
+
+# Editor-Vorlagen {#editor-templates}
+
+Du kannst dem Fenster New Project eigene Projektvorlagen hinzufügen:
+
+![eigene Projektvorlagen](images/editor/custom_project_templates.png)
+
+Um eine oder mehrere neue Registerkarten mit eigenen Projektvorlagen hinzuzufügen, musst du eine Datei `welcome.edn` im Ordner `.defold` in deinem Benutzerverzeichnis anlegen:
+
+* Erstelle einen Ordner namens `.defold` in deinem Benutzerverzeichnis.
+  * Unter Windows `C:\Users\**Your Username**\.defold`
+  * Unter macOS `/Users/**Your Username**/.defold`
+  * Unter Linux `~/.defold`
+* Erstelle eine Datei `welcome.edn` im Ordner `.defold`
+
+Die Datei `welcome.edn` verwendet das Format Extensible Data Notation. Beispiel:
+
+```
+{:new-project
+  {:categories [
+    {:label "My Templates"
+     :templates [
+          {:name "My project"
+           :description "My template with everything set up the way I want it."
+           :image "empty.svg"
+           :zip-url "https://github.com/britzl/template-project/archive/master.zip"
+           :skip-root? true},
+          {:name "My other project"
+           :description "My other template with everything set up the way I want it."
+           :image "empty.svg"
+           :zip-url "https://github.com/britzl/template-other-project/archive/master.zip"
+           :skip-root? true}]
+    }]
+  }
+}
+```
+
+Dadurch wird die Liste der Vorlagen erstellt, die du im Screenshot oben siehst.
+
+::: sidenote
+Du kannst nur die Vorlagenbilder verwenden, die [mit dem Editor geliefert werden](https://github.com/defold/defold/tree/dev/editor/resources/welcome/images).
+:::

--- a/docs/de/manuals/editor.md
+++ b/docs/de/manuals/editor.md
@@ -1,0 +1,291 @@
+---
+title: Überblick über den Editor
+brief: Dieses Handbuch gibt einen Überblick über das Aussehen und die Funktionsweise des Defold-Editors und erklärt, wie du darin navigierst.
+---
+
+# Überblick über den Editor {#editor-overview}
+
+Mit dem Editor kannst du alle Dateien und Ordner in deinem Spielprojekt effizient durchsuchen und bearbeiten. Beim Bearbeiten einer Datei öffnet sich ein geeigneter Editor, und alle relevanten Informationen zur Datei werden in eigenen Ansichten angezeigt.
+
+## Den Editor starten {#starting-the-editor}
+
+Wenn du den Defold-Editor startest, erscheint ein Bildschirm zum Auswählen und Erstellen von Projekten. Wähle per Klick aus, was du tun möchtest:
+
+MY PROJECTS
+: Hier findest du deine zuletzt geöffneten Projekte, damit du schnell auf sie zugreifen kannst. Dies ist die Standardansicht des Startbildschirms.
+
+  Wenn du noch keine Projekte geöffnet hast (oder alle entfernt hast), werden zwei Schaltflächen angezeigt. Du kannst auf `Open From Disk…` klicken, um ein Projekt mit dem Dateibrowser des Betriebssystems zu suchen und zu öffnen, oder auf die Schaltfläche `Create New Project` klicken, um zur Registerkarte `TEMPLATES` zu wechseln.
+
+  ![Meine Projekte](images/editor/start_no_projects.png)
+
+
+  Wenn du bereits Projekte geöffnet hast, erscheint eine Liste deiner Projekte, wie in der folgenden Abbildung:
+
+  ![Meine Projekte](images/editor/start_my_projects.png)
+
+TEMPLATES
+: Enthält leere oder nahezu leere Basisprojekte für den schnellen Einstieg in ein neues Defold-Projekt für bestimmte Plattformen oder mit bestimmten Erweiterungen.
+
+
+TUTORIALS
+: Enthält Projekte mit angeleiteten Tutorials zum Lernen, Ausprobieren und Verändern, wenn du einem Tutorial folgen möchtest.
+
+
+SAMPLES
+: Enthält Projekte, die bestimmte Anwendungsfälle veranschaulichen.
+
+  ![Neues Projekt](images/editor/start_templates.png)
+
+Wenn du ein neues Projekt erstellst, wird es auf deinem lokalen Laufwerk gespeichert. Alle Änderungen, die du vornimmst, werden lokal gespeichert.
+
+Mehr über die verschiedenen Möglichkeiten erfährst du im [Handbuch zur Projekteinrichtung](https://www.defold.com/manuals/project-setup/).
+
+## Sprache des Editors {#editor-language}
+
+Unten links auf dem Startbildschirm findest du eine Sprachauswahl. Wähle eine der derzeit verfügbaren Übersetzungen aus. Diese Einstellung findest du auch im Editor unter `File ▸ Preferences ▸ General ▸ Editor Language`.
+
+![Sprachen](images/editor/languages.png)
+
+## Die Bereiche des Editors {#the-editor-views}
+
+Der Defold-Editor ist in mehrere Bereiche oder Ansichten unterteilt, die jeweils bestimmte Informationen anzeigen.
+
+![Editor 2](images/editor/editor_overview.png)
+
+### 1. Bereich Assets {#1-assets-pane}
+Listet alle Dateien und Ordner deines Projekts in einer Baumstruktur auf, die der Struktur auf deinem Laufwerk entspricht. Navigiere durch Klicken und Scrollen in der Liste. Alle dateibezogenen Vorgänge lassen sich in dieser Ansicht ausführen:
+
+   - Mit einem <kbd>Klick mit der linken Maustaste</kbd> wählst du eine Datei oder einen Ordner aus. Wenn du dabei <kbd>⇧ Shift</kbd> gedrückt hältst, kannst du die Auswahl erweitern. Wenn du <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> gedrückt hältst, kannst du angeklickte Elemente auswählen oder aus der Auswahl entfernen.
+   - Mit einem <kbd>Doppelklick</kbd> auf eine Datei öffnest du sie in einem Editor für den jeweiligen Dateityp.
+   - Durch <kbd>Ziehen und Ablegen</kbd> kannst du Dateien von anderen Orten auf deinem Laufwerk zum Projekt hinzufügen oder Dateien und Ordner an andere Stellen im Projekt verschieben.
+   - Mit einem <kbd>Klick mit der rechten Maustaste</kbd> öffnest du ein _Kontextmenü_, in dem du neue Dateien oder Ordner erstellen, sie umbenennen oder löschen, Dateiabhängigkeiten nachverfolgen und weitere Aktionen ausführen kannst.
+
+Dateien und Ordner, die du über den Bereich *Assets* löschst, werden in den Papierkorb des Betriebssystems verschoben, sofern die Plattform dies unterstützt. Wenn das Verschieben in den Papierkorb nicht unterstützt wird oder fehlschlägt, löscht der Editor sie dauerhaft.
+
+### 2. Bereich Scene Editor {#the-scene-editor}
+
+Ein Doppelklick auf eine Datei für eine Sammlung (collection), ein Spielobjekt (game object) oder eine visuelle Komponente (component) öffnet den *Scene Editor*, den visuellen Editor zum Erstellen und Bearbeiten von Szenen. Skriptdateien und andere nicht visuelle Ressourcen werden in ihren jeweils eigenen Editoren geöffnet.
+
+![Scene Editor](images/editor/2d_scene.png)
+
+Zu den zentralen Funktionen des Szeneneditors gehören:
+
+- [Navigation in 2D- und 3D-Szenen](/manuals/scene-editing/#2d-and-3d-scene-orientation) mit orthografischen und perspektivischen Kameramodi
+- [Transformationswerkzeuge](/manuals/scene-editing/#manipulating-objects) zum Verschieben, Drehen und Skalieren von Objekten
+- [Freier Kameramodus (Free Camera Mode)](/manuals/scene-editing/#free-camera-mode) für die 3D-Navigation aus der Ich-Perspektive
+- [Rastereinstellungen](/manuals/scene-editing/#grid-settings) mit konfigurierbarer Größe, Ebene und Darstellung
+- [Sichtbarkeitsfilter](/manuals/scene-editing/#visibility-filters) zum Ein- und Ausblenden von Komponententypen und Hilfslinien
+
+Mehr dazu erfährst du im [Handbuch zum Szeneneditor](/manuals/scene-editing/).
+
+### 3. Bereich Outline {#3-outline-pane}
+
+Diese Ansicht zeigt den Inhalt der aktuell bearbeiteten Datei in einer hierarchischen Baumstruktur. Outline spiegelt die Editoransicht wider und ermöglicht dir, Aktionen an deinen Elementen auszuführen:
+
+   - Mit einem <kbd>Klick mit der linken Maustaste</kbd> wählst du ein Element aus. Wenn du dabei <kbd>⇧ Shift</kbd> gedrückt hältst, kannst du die Auswahl erweitern. Wenn du <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> gedrückt hältst, kannst du angeklickte Elemente auswählen oder aus der Auswahl entfernen.
+   - Durch <kbd>Ziehen und Ablegen</kbd> verschiebst du Elemente. Lege ein Spielobjekt auf einem anderen Spielobjekt in einer Sammlung ab, um eine Eltern-Kind-Beziehung herzustellen.
+   - Mit einem <kbd>Klick mit der rechten Maustaste</kbd> öffnest du ein _Kontextmenü_, in dem du Elemente hinzufügen, ausgewählte Elemente löschen und weitere Aktionen ausführen kannst.
+
+Du kannst die Sichtbarkeit von Spielobjekten und visuellen Komponenten umschalten, indem du auf das kleine Augensymbol `👁` rechts neben einem Element in der Liste klickst.
+
+![Outline](images/editor/outline.png)
+
+### 4. Bereich Properties {#4-properties-pane}
+
+Diese Ansicht zeigt die Eigenschaften des aktuell ausgewählten Elements an, beispielsweise Id, URL, Position, Rotation, Scale und/oder andere komponentenspezifische Eigenschaften sowie benutzerdefinierte Eigenschaften für Skripte.
+
+Du kannst auch den Auf-Ab-Pfeil `↕` <kbd>ziehen</kbd> und die Maus bewegen, um den Wert der jeweiligen numerischen Eigenschaft zu ändern.
+
+![Properties](images/editor/properties.png)
+
+### 5. Bereich Tools {#5-tools-pane}
+
+Diese Ansicht enthält mehrere Registerkarten.
+
+Registerkarte *Console*: zeigt alle Fehler-, Warn- und Informationsausgaben der Engine sowie die Ausgaben an, die du während der Ausführung deines Spiels gezielt erzeugst,
+
+*Build Errors*: zeigt Fehler aus dem Build-Vorgang an,
+
+*Search Results*: zeigt die Ergebnisse der Suche (<kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd>) im gesamten Projekt an, wenn du auf `Keep Results` klickst
+
+*Curve Editor*: wird beim Bearbeiten von Kurven im [Partikeleditor](/manuals/particlefx/) verwendet.
+
+Der Bereich Tools dient außerdem zur Bedienung des integrierten Debuggers. Mehr dazu erfährst du im [Handbuch zur Fehlersuche](/manuals/debugging/).
+
+### 6. Bereich Changed Files {#6-changed-files-pane}
+
+Wenn dein Projekt Git verwendet, listet diese Ansicht Dateien auf, die gegenüber dem aktuellen Commit (`HEAD`) lokal geändert, hinzugefügt, umbenannt oder gelöscht wurden. Verwende einen externen Git-Client oder die Kommandozeile, um das Projekt mit einem entfernten Repository zu synchronisieren. Mehr dazu erfährst du im [Handbuch zur Versionsverwaltung](/manuals/version-control/). Einige dateibezogene Vorgänge lassen sich in dieser Ansicht ausführen:
+
+   - Mit einem <kbd>Klick mit der linken Maustaste</kbd> wählst du eine Datei aus. Wenn du dabei <kbd>⇧ Shift</kbd> gedrückt hältst, kannst du die Auswahl erweitern. Wenn du <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> gedrückt hältst, kannst du angeklickte Elemente auswählen oder aus der Auswahl entfernen. Wenn eine einzelne geänderte Datei ausgewählt ist, kannst du auf `Diff` klicken, um die Unterschiede anzuzeigen. Mit `Revert` kannst du die Änderungen in allen ausgewählten Dateien rückgängig machen.
+   - Mit einem <kbd>Doppelklick mit der linken Maustaste</kbd> auf eine Datei öffnest du eine Ansicht der Datei. Der Editor öffnet die Datei in einem geeigneten Editor, genau wie in der Ansicht Assets.
+   - Mit einem <kbd>Klick mit der rechten Maustaste</kbd> auf eine Datei öffnest du ein Popup-Menü, in dem du eine Ansicht der Unterschiede öffnen, alle Änderungen an der Datei rückgängig machen, die Datei im Dateisystem finden und weitere Aktionen ausführen kannst.
+
+### Menüleiste {#menu-bar}
+
+Oben in der Editoransicht oder auf dem Mac in der Systemleiste findest du die Menüleiste mit 6 Menüs: `File`, `Edit`, `View`, `Project`, `Debug`, `Help`. Ihre Funktionen werden in den Handbüchern erläutert.
+
+### Statusleiste {#status-bar}
+
+In der unteren Leiste des Editors findest du einen schmalen Bereich, in dem der Status angezeigt wird, zum Beispiel:
+- Wenn ein neues Update verfügbar ist, erscheint die anklickbare Schaltfläche `Update Available`. Lies dazu weiter unten in diesem Handbuch den Abschnitt zum Aktualisieren des Editors.
+- Beim Erstellen eines Builds oder Bundles wird dort der Fortschritt angezeigt.
+
+## Größe und Sichtbarkeit der Bereiche {#panes-size-and-visibility}
+
+Du kannst die Größe der Bereiche im Editor anpassen, indem du die Trennlinien zwischen den 6 oben beschriebenen Bereichen <kbd>ziehst</kbd>.
+
+Du kannst die Sichtbarkeit der Bereiche im Editor über die Optionen im Menü `View` oder die angegebenen Tastenkombinationen umschalten:
+- `Toggle Assets Pane` (<kbd>F6</kbd>) schaltet die Sichtbarkeit der Bereiche Assets und Changed Files um
+- `Toggle Changed Files` schaltet nur die Sichtbarkeit des Bereichs Changed Files um
+- `Toggle Tools Pane` (<kbd>F7</kbd>) schaltet die Sichtbarkeit des Bereichs Tools um
+- `Toggle Properties Pane` (<kbd>F8</kbd>) schaltet die Sichtbarkeit der Bereiche Outline und Properties um
+
+![Sichtbarkeit der Bereiche](images/editor/editor_panes.png)
+
+Im Menü `View` kannst du auch andere Einstellungen für die Sichtbarkeit umschalten oder ändern, etwa Grid, Guides oder Camera. Du kannst die Ansicht an die Auswahl anpassen (`Frame Selection` oder die Taste <kbd>F</kbd>) und zwischen der standardmäßigen 2D- und 3D-Ansicht wechseln (`Realign Camera` oder die Taste <kbd>.</kbd>). Viele dieser Funktionen sind auch über die Werkzeugleiste oder Tastenkombinationen zugänglich.
+
+## Registerkarten {#tabs}
+
+Wenn du mehrere Dateien geöffnet hast, erscheint oben in der Editoransicht eine eigene Registerkarte für jede Datei. Registerkarten innerhalb eines Bereichs lassen sich verschieben: Durch <kbd>Ziehen und Ablegen</kbd> kannst du ihre Positionen innerhalb der Registerkartenleiste vertauschen. Außerdem kannst du:
+
+- mit einem <kbd>Klick mit der rechten Maustaste</kbd> auf eine Registerkarte ein _Kontextmenü_ öffnen,
+- auf `Close` (<kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> + <kbd>W</kbd>) klicken, um eine einzelne Registerkarte zu schließen,
+- auf `Close Others` klicken, um alle Registerkarten außer der ausgewählten zu schließen,
+- auf `Close All` (<kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> + <kbd>Shift</kbd>+<kbd>W</kbd>) klicken, um alle Registerkarten im aktiven Bereich zu schließen,
+- `➝| Open As` auswählen, um einen anderen Editor als den Standardeditor oder das zugeordnete externe Werkzeug zu verwenden, das unter `File ▸ Preferences ▸ Code ▸ Custom Editor` festgelegt ist. Mehr dazu erfährst du im [Handbuch zu den Editoreinstellungen](/manuals/editor-preferences).
+
+![Registerkarten](images/editor/tabs_custom.png)
+
+## Nebeneinander bearbeiten {#side-by-side-editing}
+
+Du kannst 2 Editoransichten nebeneinander öffnen.
+
+- Öffne mit einem <kbd>Klick mit der rechten Maustaste</kbd> das Menü der Registerkarte des Editors, den du verschieben möchtest, und wähle `Move to Other Tab Pane` aus.
+
+![2 Bereiche](images/editor/2-panes.png)
+
+Du kannst im Registerkartenmenü auch `Swap with Other Tab Pane` verwenden, um die jeweilige Registerkarte zwischen den Bereichen zu verschieben, oder die Bereiche mit `Join Tab Panes` zu einem einzigen Bereich zusammenführen.
+
+## Neue Projektdateien erstellen {#creating-new-project-files}
+
+Um neue Ressourcendateien zu erstellen, wähle entweder `File ▸ New…` und dann den Dateityp im Menü aus oder verwende das Kontextmenü:
+
+Öffne mit einem <kbd>Klick mit der rechten Maustaste</kbd> das Kontextmenü am Zielort im Browser `Assets` und wähle dann `New… ▸ [file type]`:
+
+![Datei erstellen](images/editor/create_file.png)
+
+Gib unter *Name* einen passenden Namen für die neue Datei ein und ändere bei Bedarf *Location*. Der vollständige Dateiname einschließlich der Dateierweiterung wird im Dialogfeld unter *Preview* angezeigt:
+
+![Dateinamen festlegen](images/editor/create_file_name.png)
+
+## Vorlagen {#templates}
+
+Du kannst für jedes Projekt eigene Vorlagen festlegen. Erstelle dazu einen neuen Ordner namens `templates` im Stammverzeichnis des Projekts und füge neue Dateien namens `default.*` mit den gewünschten Erweiterungen hinzu, beispielsweise `/templates/default.gui` oder `/templates/default.script`. Wenn in diesen Dateien das Token `{{NAME}}` verwendet wird, wird es außerdem durch den im Fenster zur Dateierstellung angegebenen Dateinamen ersetzt.
+
+Wenn für einen Dateityp eine Vorlage verfügbar ist, wird jede neu erstellte Datei dieses Typs mit dem Inhalt der entsprechenden Datei aus `templates` initialisiert.
+
+
+![Vorlagen](images/editor/templates.png)
+
+## Dateien in dein Projekt importieren {#importing-files-to-your-project}
+
+Um Asset-Dateien (Bilder, Audiodateien, Modelle usw.) zu deinem Projekt hinzuzufügen, ziehe sie einfach an die richtige Stelle im Browser *Assets* und lege sie dort ab. Dadurch werden _Kopien_ der Dateien am ausgewählten Ort in der Dateistruktur des Projekts erstellt. Mehr dazu erfährst du in unserem [Handbuch zum Importieren von Assets](/manuals/importing-assets/).
+
+![Dateien importieren](images/editor/import.png)
+
+## Den Editor aktualisieren {#updating-the-editor}
+
+Der Editor sucht automatisch nach Updates, wenn eine Internetverbindung besteht. Wenn ein Update gefunden wird, erscheint der blaue anklickbare Link `Update Available` unten links auf dem Bildschirm zur Projektauswahl oder unten rechts im Editorfenster.
+
+![Update über die Projektauswahl](images/editor/update_start.png)
+![Update über den Editor](images/editor/update_available.png)
+
+Klicke auf den Link `Update Available`, um das Update herunterzuladen und zu installieren. Ein Bestätigungsfenster mit Informationen erscheint. Klicke auf `Download Update`, um fortzufahren.
+
+![Popup zum Aktualisieren des Editors](images/editor/update.png)
+
+Den Downloadfortschritt siehst du in der unteren Statusleiste:
+
+![Downloadfortschritt](images/editor/download_status.png)
+
+Nach dem Herunterladen des Updates ändert sich der blaue Link zu `Restart to Update`. Klicke darauf, um den Editor neu zu starten und die aktualisierte Version zu öffnen.
+
+![Zum Aktualisieren neu starten](images/editor/restart_to_update.png)
+
+## Editoreinstellungen {#preferences}
+
+Du kannst die Einstellungen des Editors im Fenster `Preferences` ändern. Klicke zum Öffnen auf `File ▸ Preferences…` oder verwende die Tastenkombination <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> + <kbd>,</kbd>
+
+Weitere Einzelheiten findest du im [Handbuch zu den Editoreinstellungen](/manuals/editor-preferences)
+
+![Editoreinstellungen](images/editor/preferences.png)
+
+## Editorprotokolle {#editor-logs}
+Wenn ein Problem mit dem Editor auftritt und du es melden musst (`Help  ▸ Report Issue`), ist es sinnvoll, Protokolldateien des Editors beizufügen. Klicke auf `Help ▸ Show Logs`, um den Speicherort der Protokolle im Dateibrowser deines Betriebssystems zu öffnen.
+
+Mehr dazu erfährst du im [Handbuch zur Hilfesuche](/manuals/getting-help/#getting-help).
+
+![Protokolle anzeigen](images/editor/show_logs.png)
+
+Die Protokolldateien des Editors findest du hier:
+
+  * Windows: `C:\Users\ **Your Username** \AppData\Local\Defold`
+  * macOS: `/Users/ **Your Username** /Library/Application Support/` oder `~/Library/Application Support/Defold`
+  * Linux: `$XDG_STATE_HOME/Defold` oder `~/.local/state/Defold`
+
+Du kannst auch während der Ausführung des Editors auf seine Protokolle zugreifen, wenn du ihn über ein Terminal oder eine Eingabeaufforderung startest. Verwende zum Starten des Editors den Befehl:
+
+```shell
+# Linux:
+$ ./path/to/Defold/Defold
+
+# macOS:
+$ > ./path/to/Defold.app/Contents/MacOS/Defold
+```
+
+## Editorserver {#editor-server}
+
+Wenn der Editor ein Projekt öffnet, startet er einen Webserver auf einem zufälligen Port. Über den Server können andere Anwendungen mit dem Editor interagieren. Der Port wird in die Datei `.internal/editor.port` geschrieben.
+
+Der Server stellt unter `http://localhost:$(cat .internal/editor.port)/openapi.json` eine OpenAPI-Spezifikation bereit. Dies ist ein nützlicher minimaler Ausgangspunkt für Arbeitsabläufe mit Agenten.
+
+Außerdem unterstützt die ausführbare Datei des Editors die Kommandozeilenoption `--port` (oder `-p`), mit der sich der Port beim Start angeben lässt, zum Beispiel:
+```shell
+# Windows
+.\path\to\Defold\Defold.exe --port 8181
+
+# Linux:
+./path/to/Defold/Defold --port 8181
+
+# macOS:
+./path/to/Defold/Defold.app/Contents/MacOS/Defold --port 8181
+```
+
+## Metadaten zur Editorinstallation {#editor-installation-metadata}
+
+Beim Start schreibt der Editor Informationen über das Startprogramm und die Installationspfade an einen festgelegten Speicherort. IDE-Integrationen von Drittanbietern und andere Werkzeuge können damit installierte Defold-Editoren finden:
+
+| Betriebssystem | Speicherort |
+|---------|----------|
+| macOS   | `~/Library/Application Support/Defold/installations.json` |
+| Linux   | `${XDG_STATE_HOME:-~/.local/state}/Defold/installations.json` |
+| Windows | `%LOCALAPPDATA%\Defold\installations.json` |
+
+Die Datei enthält ein JSON-Array mit einem Objekt pro bekannter Installation:
+
+```json
+[
+  {
+    "launcherPath": "/Applications/Defold.app/Contents/MacOS/Defold",
+    "installPath": "/Applications/Defold.app",
+    "lastLaunchedAt": "2026-07-06T12:34:56.789Z"
+  }
+]
+```
+
+## Gestaltung des Editors {#editor-styling}
+
+Du kannst das Aussehen des Editors durch eigene Stile anpassen. Mehr dazu erfährst du im [Handbuch zur Gestaltung des Editors](/manuals/editor-styling).
+
+## FAQ
+:[Editor FAQ](../shared/editor-faq.md)

--- a/docs/de/manuals/engine-service.md
+++ b/docs/de/manuals/engine-service.md
@@ -1,0 +1,125 @@
+---
+title: Der Engine-Dienst und die HTTP-APIs zur Laufzeit
+brief: Dieses Handbuch erklärt den HTTP-Dienst für die Entwicklung in einer laufenden Defold-Debug-Engine und wie Laufzeiterweiterungen oder externe Werkzeuge ihn nutzen können.
+---
+
+# Der Engine-Dienst und die HTTP-APIs zur Laufzeit {#the-engine-service-and-runtime-http-apis}
+
+Wenn du ein Projekt im Debug-Modus ausführst, wird ein Prozess für eine bestimmte Laufzeitinstanz der Engine erstellt. Er enthält dein Spiel und einen speziellen Engine-Dienst (engine service), über den Entwicklungs- und Profiling-Infrastruktur, Laufzeitlogik und Nachrichten, der Engine-Zustand sowie Erweiterungen zugänglich sind.
+
+Der Engine-Dienst ist ein HTTP-Dienst für die Entwicklung, der zu einer laufenden Debug-Engine (`dmengine`) gehört.
+
+Er ist vom [Editorserver](/manuals/editor-http-api) getrennt, der zum Defold-Editor gehört und das geöffnete Projekt steuert.
+
+Die beiden Dienste verwenden unterschiedliche Ports. Ein Werkzeug, das sich mit dem Editorport verbindet, kann dort keine Routen von Laufzeiterweiterungen aufrufen. Umgekehrt kann ein Werkzeug, das sich mit dem Engine-Dienst verbindet, keine Editoroperationen aufrufen.
+
+Der Engine-Dienst ist Teil der Infrastruktur für Debugging, Entwicklung und Profiling. Release-Instanzen der Engine erstellen diesen Dienst nicht.
+
+## Verfügbarkeit und Ermitteln des Ports {#availability-and-port-discovery}
+
+Wenn der Editor eine Debug-Engine startet, fordert er einen dynamisch zugewiesenen Dienstport an. Die Engine meldet den gewählten Port in `Console` (`und bei einem Start über eine CLI auch in ihrem Protokoll):
+
+![Portinformationen des Engine-Dienstes in einem Defold-Debug-Build](images/automation/engine-service.png)
+
+```text
+INFO:ENGINE: Engine service started on port <port>
+```
+
+Die Zeile erscheint in der Editorkonsole, wenn das Spiel aus dem Editor gestartet wurde. Eine einfache lokale Steuerung kann diese Zeile auswerten. Bei einer wiederverwendbaren Integration sollte jedoch der Editor oder dessen Wrapper die Engine-Instanz und den registrierten Port nachverfolgen. So wird vermieden, dass ein alter Port mit einem neu gestarteten oder wiederverwendeten Prozess verwechselt wird.
+
+Auf unterstützten Plattformen gibt die Engine Entwicklungsziele außerdem über die Diensterkennung bekannt. Dieser Mechanismus wird hauptsächlich von Defold-Werkzeugen verwendet und sollte nicht durch einen dauerhaft fest einprogrammierten Port ersetzt werden.
+
+Der Server ist unter localhost (`127.0.0.1`) am jeweiligen Port erreichbar:
+
+![Zugriff auf den Engine-Server](images/automation/engine-server.png)
+
+## Integrierte Endpunkte {#built-in-endpoints}
+
+Die aktuelle Debug-Engine registriert eine kleine Anzahl von Kernrouten.
+
+| Endpunkt | Zweck |
+| --- | --- |
+| `GET /ping` | Prüfen, ob der Engine-Dienst antwortet |
+| `GET /info` | Engine-Version, Plattform, Build-Kennung und Informationen zum Protokolldienst lesen |
+| `GET /state` | Den von Defold-Werkzeugen verwendeten Verbindungszustand für die Entwicklung lesen |
+| `POST /post/<socket>/<message-type>` | Eine Protobuf-codierte Defold-Nachricht an einen benannten Engine-Socket senden |
+
+Zum Beispiel:
+
+```sh
+curl -sS "$ENGINE_URL/ping"
+curl -sS "$ENGINE_URL/info" | jq
+curl -sS "$ENGINE_URL/state" | jq
+```
+
+Die Route `/post` wird für Entwicklungsvorgänge wie Hot Reload, Neustart, Größenänderung und Prozesssteuerung verwendet. Ihr Anfrageinhalt ist eine binäre Protobuf-Nachricht des in der Route genannten Typs; sie ist keine API für JSON-Nachrichten. Die Protobuf-Nachricht darf in serialisierter Form nicht größer als 1024 Bytes sein, andernfalls wird `400 Too large message` zurückgegeben.
+
+Diese Routen gehören zur Entwicklungsinfrastruktur. In der Engine-Implementierung gibt es außerdem weitere Routen für den Profiler und die Untersuchung von Ressourcen.
+
+## Von Erweiterungen definierte Laufzeitrouten {#extension-defined-runtime-routes}
+
+In Debug-Builds kann das SDK für native Erweiterungen (native extensions) Zugriff auf den Webserver der Engine bereitstellen. Eine Erweiterung kann auf diesem Server ein Routenpräfix registrieren und Operationen verfügbar machen, die von Laufzeitdaten abhängen.
+
+Das ist für Entwicklungswerkzeuge nützlich, da eine Erweiterung den vorhandenen Engine-Dienst mitbenutzen kann, ohne einen weiteren HTTP-Server zu öffnen.
+
+Eine von einer Erweiterung definierte API zur Laufzeitautomatisierung sollte:
+
+* ein eigenes, versioniertes Routenpräfix verwenden;
+* unterstützte Funktionen offenlegen;
+* strukturierte Fehlerinformationen zurückgeben;
+* nicht verfügbare Plattform- oder Engine-Funktionen ausdrücklich behandeln;
+* Operationen auf lokale Entwicklung und Tests beschränken;
+* dokumentieren, ob sie aus Release-Builds ausgeschlossen wird.
+
+## Die Erweiterung Automation Bridge {#automation-bridge-extension}
+
+Die offizielle Defold-Erweiterung [Automation Bridge](https://github.com/defold/extension-automation-bridge) ist eine native Erweiterung, die ausschließlich in Debug-Builds verfügbar ist und auf dem Engine-Dienst aufbaut. Sie registriert eine versionierte API zur Laufzeitautomatisierung unter:
+
+```text
+http://127.0.0.1:<engine-service-port>/automation-bridge/v1
+```
+
+Ihre Laufzeit-API bietet Funktionen wie das Untersuchen von Szenen und Knoten (nodes), Eingaben, Bildschirminformationen, Bildschirmaufnahmen, Aufzeichnungen, Lebenszyklusinformationen und eine optionale, von der Anwendung festgelegte Synchronisierung. Zu den Operationen gehören:
+
+| Operation | Aktion |
+| --- | --- |
+| `GET  /automation-bridge/v1/health` | Statusbericht, unterstützte API-Funktionen und Kompatibilität |
+| `POST /automation-bridge/v1/input/click` | Für Eingabeinteraktionen zur Laufzeit |
+| `GET  /automation-bridge/v1/screenshot` | Für Bildschirmaufnahmen zur Laufzeit |
+
+Verwende die [Dokumentation der nativen API](https://github.com/defold/extension-automation-bridge/tree/master/automation_bridge) und die [Dokumentation der Python-Hilfsfunktionen](https://github.com/defold/extension-automation-bridge/tree/master/automation_bridge/automation-bridge-python) der Erweiterung für die im Projekt installierte Version.
+
+Automation Bridge stellt in Release-Builds weder seine HTTP-API noch sein Lua-Modul bereit.
+
+### Editor- und Laufzeitclients {#editor-and-runtime-clients}
+
+Die Python-Hilfsfunktionen von Automation Bridge veranschaulichen die Architektur mit zwei Clients. Die Funktion `editor.open_project()` gibt einen Editor-Projektclient zurück, und `project.build_and_run()` gibt einen separaten Engine-Client zurück.
+
+| Client | Zweck |
+| --- | --- |
+| Projekt | HTTP-API des Editors, Befehle, Debugger, Konsole, Editoreinstellungen, Referenz, Vorschauen, Build und Ermitteln des Ports |
+| Spiel - Engine-Dienst | Szene, Eingabe, Bildschirmaufnahmen, Laufzeitzustand und Synchronisierung |
+
+Die Aufteilung in `project` und `game` macht die Prozessgrenze deutlich. Editoroperationen bleiben auf dem Editorserver, während Beobachtungen und Aktionen am laufenden Spiel auf dem Engine-Dienst bleiben.
+
+```python
+from automation_bridge import editor
+
+project = editor.open_project(".")
+game = project.build_and_run()
+```
+
+## Einschränkungen und Sicherheit {#limitations-and-security}
+
+Der Engine-Dienst und die von Erweiterungen definierten Routen sind Entwicklungswerkzeuge und sollten als solche behandelt werden.
+
+::: important
+Der Engine-Dienst veröffentlicht derzeit kein OpenAPI-Dokument. Integrationen sollten sich auf dokumentiertes Verhalten oder auf die versionierte API einer Erweiterung beschränken.
+:::
+
+Laufzeitskripte, Physik, Eingaben, dynamisch erstellte Objekte und plattformspezifisches Rendering benötigen eine laufende Engine und sollten durch [automatisiertes Testen zur Laufzeit](/manuals/automated-testing) überprüft werden.
+
+* Mache den Dienst nicht über einen Router, eine öffentliche Schnittstelle oder einen nicht vertrauenswürdigen Tunnel zugänglich.
+* Gehe nicht davon aus, dass die Routen des Engine-Dienstes eine Authentifizierung erfordern.
+* Laufzeitrouten können je nach Erweiterungsversion, Plattform, Grafik-Backend und unterstützten Engine-Funktionen variieren.
+* Handle bei aktuellen, von Erweiterungen definierten APIs die Version oder die unterstützten Funktionen aus.

--- a/docs/de/manuals/extender-docker-images.md
+++ b/docs/de/manuals/extender-docker-images.md
@@ -1,0 +1,46 @@
+---
+title: Verfügbare Docker-Images
+brief: Dieses Dokument beschreibt die verfügbaren Docker-Images und die Defold-Versionen, die sie verwendet haben.
+---
+
+# Verfügbare Docker-Images {#available-docker-images}
+Die folgende Liste enthält alle Docker-Images, die in der öffentlichen Registry verfügbar sind. Mit diesen Images kannst du Extender in einer Umgebung mit alten SDKs ausführen, die nicht mehr unterstützt werden.
+
+|SDK               |Image-Tag                                                                                                |Plattformname (in der Extender-Konfiguration) |Defold-Version, die das Image verwendet hat |
+|------------------|---------------------------------------------------------------------------------------------------------|-------------------------------------|-------------------------------|
+|Linux latest      |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-linux-env:latest`         |`linux-latest`                       |Alle Defold-Versionen          |
+|Android NDK25     |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-android-ndk25-env:latest` |`android-ndk25`                      |Seit 1.4.3                     |
+|Emscripten 2.0.11 |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-2011-env:latest`    |`emsdk-2011`                         |Bis 1.7.0                      |
+|Emscripten 3.1.55 |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-3155-env:latest`    |`emsdk-3155`                         |[1.8.0-1.9.3]                  |
+|Emscripten 3.1.65 |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-3165-env:latest`    |`emsdk-3165`                         |Seit 1.9.4                     |
+|Winsdk 2019       |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-winsdk-2019-env:latest`   |`winsdk-2019`                        |Bis 1.6.1                      |
+|Winsdk 2022       |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-winsdk-2022-env:latest`   |`winsdk-2022`                        |Seit 1.6.2                     |
+
+# Alte Docker-Images verwenden {#how-to-use-old-docker-images}
+Um eine alte Umgebung zu verwenden, solltest du die folgenden Schritte ausführen:
+1. Ändere `docker-compose.yml` aus dem Extender-Repository [Link](https://github.com/defold/extender/blob/dev/server/docker/docker-compose.yml). Du musst eine weitere Dienstdefinition mit dem benötigten Docker-Image hinzufügen. Wenn wir beispielsweise ein Docker-Image verwenden möchten, das Emscripten 2.0.11 enthält, müssen wir die folgende Dienstdefinition hinzufügen:
+    ```yml
+    emscripten_2011-dev:
+        image: europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-2011-env:latest
+        extends:
+        file: common-services.yml
+        service: remote_builder
+        profiles:
+        - all
+        - web
+        networks:
+        default:
+            aliases:
+            - emsdk-2011
+    ```
+    Wichtige Felder sind:
+    * **profiles** - Liste der Profile, die den Start des Dienstes auslösen. Die Profilnamen werden über das Argument `--profile <profile_name>` an den Befehl `docker compose` übergeben.
+    * **networks** - Liste der Netzwerke, die der Docker-Container verwenden soll. Zum Ausführen von Extender wird das Netzwerk mit dem Namen `default` verwendet. Es ist wichtig, die Netzwerk-Aliase des Dienstes festzulegen (sie werden später in der Extender-Konfiguration verwendet).
+2. Füge die Definition eines entfernten Build-Servers (remote builder) in [`application-local-dev-app.yml`](https://github.com/defold/extender/blob/dev/server/configs/application-local-dev-app.yml) im Abschnitt `extender.remote-builder.platforms` hinzu. In unserem Beispiel sieht sie so aus:
+    ```yml
+        emsdk-2011:
+            url: http://emsdk-2011:9000
+            instanceId: emsdk-2011
+    ```
+    Die URL sollte das folgende Format haben: `http://<service_network_alias>:9000`, wobei `service_network_alias` der Netzwerk-Alias aus Schritt 1 ist. 9000 ist der Standardport für Extender (er kann abweichen, wenn du eine benutzerdefinierte Extender-Konfiguration verwendest).
+3. Starte den lokalen Extender wie unter [Einen lokalen Extender mit vorkonfigurierten Artefakten ausführen](/manuals/extender-local-setup#how-to-run-local-extender-with-preconfigured-artifacts) beschrieben.

--- a/docs/de/manuals/extender-local-setup.md
+++ b/docs/de/manuals/extender-local-setup.md
@@ -1,0 +1,133 @@
+---
+title: Lokalen Build-Server einrichten
+brief: Dieses Handbuch beschreibt, wie du einen lokalen Build-Server einrichtest und betreibst.
+---
+
+# Lokalen Build-Server einrichten {#build-server-local-setup}
+
+Es gibt zwei Möglichkeiten, einen lokalen Build-Server (auch „Extender“ genannt) zu betreiben:
+1. Lokalen Build-Server mit vorkonfigurierten Artefakten betreiben.
+2. Lokalen Build-Server mit lokal erstellten Artefakten betreiben.
+
+## Lokalen Extender mit vorkonfigurierten Artefakten betreiben {#how-to-run-local-extender-with-preconfigured-artifacts}
+
+Bevor du einen lokalen Cloud-Build-Server betreiben kannst, musst du die folgende Software installieren:
+
+* [Docker](https://www.docker.com/) - Docker ist eine Reihe von Platform-as-a-Service-Produkten, die Virtualisierung auf Betriebssystemebene nutzen, um Software in Paketen bereitzustellen, die Container genannt werden. Um die Cloud-Build-Server auf deinem lokalen Entwicklungsrechner zu betreiben, musst du [Docker Desktop](https://www.docker.com/products/docker-desktop/) installieren.
+* Google Cloud CLI - Die Google Cloud CLI ist eine Sammlung von Werkzeugen zum Erstellen und Verwalten von Google-Cloud-Ressourcen. Du kannst die Werkzeuge [direkt von Google installieren](https://cloud.google.com/sdk/docs/install) oder einen Paketmanager wie Brew, Chocolatey oder Snap verwenden.
+* Du benötigst außerdem ein Google-Konto, um die Container mit den plattformspezifischen Build-Servern herunterzuladen.
+
+Sobald du die oben genannte Software installiert hast, führe die folgenden Schritte aus, um die Cloud-Build-Server von Defold zu installieren und zu betreiben:
+
+**Hinweis für Windows-Nutzer**: Verwende das Git-Bash-Terminal, um die folgenden Befehle auszuführen.
+
+1. __Autorisierung bei Google Cloud und Erstellung von Standardanmeldedaten für Anwendungen__ - Du benötigst ein Google-Konto, um die Docker-Container-Images herunterzuladen. Dadurch kann das Defold-Team die faire Nutzung der öffentlichen Container-Registry überwachen und sicherstellen sowie Konten vorübergehend sperren, die übermäßig viele Images herunterladen.
+
+   ```sh
+   gcloud auth login
+   ```
+2. __Docker für die Nutzung von Artefakt-Registrys konfigurieren__ - Docker muss so konfiguriert werden, dass es `gcloud` als Hilfsprogramm für Zugangsdaten verwendet, wenn Container-Images aus der öffentlichen Container-Registry unter `europe-west1-docker.pkg.dev` heruntergeladen werden.
+
+   ```sh
+   gcloud auth configure-docker europe-west1-docker.pkg.dev
+   ```
+3. __Überprüfen, ob Docker und Google Cloud richtig konfiguriert sind__ - Überprüfe, ob Docker und Google Cloud erfolgreich eingerichtet sind, indem du das Basis-Image herunterlädst, das alle Container-Images der Build-Server verwenden. Stelle sicher, dass Docker Desktop läuft, bevor du den folgenden Befehl ausführst:
+   ```sh
+   docker pull --platform linux/amd64 europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:latest
+   ```
+4. __Extender-Repository klonen__ - Wenn Docker und Google Cloud richtig eingerichtet sind, sind wir fast bereit, die Server zu starten. Bevor wir den Server starten können, müssen wir das Git-Repository klonen, das den Build-Server enthält:
+   ```sh
+   git clone https://github.com/defold/extender.git
+   cd extender
+   ```
+5. __Vorgefertigte JAR-Dateien herunterladen__ - Als Nächstes lädst du den vorgefertigten Server (`extender.jar`) und das Werkzeug zum Zusammenführen von Manifesten (`manifestmergetool.jar`) herunter:
+   ```sh
+    TMP_DIR=$(pwd)/server/_tmp
+    APPLICATION_DIR=$(pwd)/server/app
+    # set necessary version of Extender and Manifest merge tool
+    # versions can be found at Github release page https://github.com/defold/extender/releases
+    # or you can pull latest version (see code sample below)
+    EXTENDER_VERSION=2.6.5
+    MANIFESTMERGETOOL_VERSION=1.3.0
+    echo "Download prebuild jars to ${APPLICATION_DIR}"
+    rm -rf ${TMP_DIR}
+    mkdir -p ${TMP_DIR}
+    rm -rf ${APPLICATION_DIR}
+    mkdir -p ${APPLICATION_DIR}
+
+    gcloud artifacts files download \
+    --project=extender-426409 \
+    --location=europe-west1 \
+    --repository=extender-maven \
+    --destination=${TMP_DIR} \
+    com/defold/extender/server/${EXTENDER_VERSION}/server-${EXTENDER_VERSION}.jar
+
+    gcloud artifacts files download \
+    --project=extender-426409 \
+    --location=europe-west1 \
+    --repository=extender-maven \
+    --destination=${TMP_DIR} \
+    com/defold/extender/manifestmergetool/${MANIFESTMERGETOOL_VERSION}/manifestmergetool-${MANIFESTMERGETOOL_VERSION}.jar
+
+    cp ${TMP_DIR}/$(ls ${TMP_DIR} | grep server-${EXTENDER_VERSION}.jar) ${APPLICATION_DIR}/extender.jar
+    cp ${TMP_DIR}/$(ls ${TMP_DIR} | grep manifestmergetool-${MANIFESTMERGETOOL_VERSION}.jar) ${APPLICATION_DIR}/manifestmergetool.jar
+   ```
+6. __Server starten__ - Wir können den Server jetzt starten, indem wir den Hauptbefehl von docker compose ausführen:
+```sh
+docker compose -p extender -f server/docker/docker-compose.yml --profile <profile> up
+```
+Dabei kann *profile* einen der folgenden Werte haben:
+* **all** - startet Remote-Instanzen für jede Plattform
+* **android** - startet die Frontend-Instanz + Remote-Instanzen zum Erstellen der Android-Version
+* **web** - startet die Frontend-Instanz + Remote-Instanzen zum Erstellen der Webversion
+* **linux** - startet die Frontend-Instanz + Remote-Instanzen zum Erstellen der Linux-Version
+* **windows** - startet die Frontend-Instanz + Remote-Instanzen zum Erstellen der Windows-Version
+* **consoles** - startet die Frontend-Instanz + Remote-Instanzen zum Erstellen der Versionen für Nintendo Switch/PS4/PS5
+* **nintendo** - startet die Frontend-Instanz + Remote-Instanzen zum Erstellen der Nintendo-Switch-Version
+* **playstation** - startet die Frontend-Instanz + Remote-Instanzen zum Erstellen der PS4/PS5-Versionen
+* **metrics** - startet VictoriaMetrics + Grafana als Backend für Metriken und als Werkzeug zur Visualisierung
+Weitere Informationen zu den Argumenten von `docker compose` findest du unter https://docs.docker.com/reference/cli/docker/compose/.
+
+Sobald docker compose läuft, kannst du **http://localhost:9000** als `Build server address` in den Editoreinstellungen verwenden oder als Wert für `--build-server`, wenn du das Projekt mit Bob erstellst.
+
+Du kannst mehrere Profile auf der Kommandozeile übergeben. Zum Beispiel:
+```sh
+docker compose -p extender -f server/docker/docker-compose.yml --profile android --profile web --profile windows up
+```
+Das obige Beispiel startet Instanzen für das Frontend, Android, Web und Windows.
+
+Um die Dienste zu stoppen, drücke Ctrl+C, wenn docker compose im Vordergrund läuft, oder führe folgenden Befehl aus, 
+```sh
+docker compose -p extender down
+```
+wenn docker compose im Hintergrund gestartet wurde (z. B. wenn die Option '-d' an den Befehl `docker compose up` übergeben wurde).
+
+Wenn du die neuesten Versionen der JAR-Dateien herunterladen möchtest, kannst du mit dem folgenden Befehl die jeweils neueste Version ermitteln:
+```sh
+    EXTENDER_VERSION=$(gcloud artifacts versions list \
+        --project=extender-426409 \
+        --location=europe-west1 \
+        --repository=extender-maven \
+        --package="com.defold.extender:server" \
+        --sort-by="~createTime" \
+        --limit=1 \
+        --format="value(name)")
+
+    MANIFESTMERGETOOL_VERSION=$(gcloud artifacts versions list \
+        --project=extender-426409 \
+        --location=europe-west1 \
+        --repository=extender-maven \
+        --package="com.defold.extender:manifestmergetool" \
+        --sort-by="~createTime" \
+        --limit=1 \
+        --format="value(name)")
+```
+
+### Wie sieht es mit macOS und iOS aus? {#what-about-macos-and-ios}
+
+Die Builds für macOS und iOS werden auf echter Apple-Hardware mit einem Build-Server erstellt, der eigenständig ohne Docker läuft. Stattdessen werden XCode, Java und andere erforderliche Werkzeuge direkt auf dem Rechner installiert, und der Build-Server läuft als normaler Java-Prozess. Wie du das einrichtest, erfährst du in der [Dokumentation zum Build-Server auf GitHub](https://github.com/defold/extender?tab=readme-ov-file#running-as-a-stand-alone-server-on-macos).
+
+
+## Lokalen Extender mit lokal erstellten Artefakten betreiben {#how-to-run-local-extender-with-locally-built-artifacts}
+
+Befolge die [Anweisungen im Extender-Repository auf GitHub](https://github.com/defold/extender), um einen lokalen Build-Server manuell zu erstellen und zu betreiben.

--- a/docs/de/manuals/extensions-best-practices.md
+++ b/docs/de/manuals/extensions-best-practices.md
@@ -1,0 +1,129 @@
+---
+title: Native Erweiterungen - Bewährte Vorgehensweisen
+brief: Dieses Handbuch beschreibt bewährte Vorgehensweisen bei der Entwicklung nativer Erweiterungen.
+---
+
+# Bewährte Vorgehensweisen {#best-practices}
+
+Plattformübergreifenden Code zu schreiben kann schwierig sein. Es gibt jedoch einige Möglichkeiten, sowohl die Entwicklung als auch die Wartung solchen Codes zu erleichtern.
+
+
+## Projektstruktur {#project-structure}
+
+Beim Erstellen einer nativen Erweiterung (native extension) gibt es einige Dinge, die sowohl bei der Entwicklung als auch bei der Wartung helfen.
+
+### Lua-API
+
+Es sollte nur eine Lua-API und eine Implementierung davon geben. Dadurch lässt sich auf allen Plattformen wesentlich leichter dasselbe Verhalten erreichen.
+
+Wenn die betreffende Plattform die Erweiterung nicht unterstützen soll, empfiehlt es sich, überhaupt kein Lua-Modul zu registrieren. So kannst du die Unterstützung erkennen, indem du auf `nil` prüfst:
+
+```lua
+    if myextension ~= nil then
+        myextension.do_something()
+    end
+```
+
+### Ordnerstruktur {#folder-structure}
+
+Die folgende Ordnerstruktur wird häufig für Erweiterungen verwendet:
+
+```
+    /root
+        /input
+        /main                            -- All the files for the actual example project
+            /...
+        /myextension                     -- The actual root folder of the extension
+            ext.manifest
+            /include                     -- External includes, used by other extensions
+            /libs
+                /<platform>              -- External libraries for all supported platforms
+            /src
+                myextension.cpp          -- The extension Lua api and the extension life cycle functions
+                                            Also contains generic implementations of your Lua api functions.
+                myextension_private.h    -- Your internal api that each platform will implement (I.e. `myextension_Init` etc)
+                myextension.mm           -- If native calls are needed for iOS/macOS. Implements `myextension_Init` etc for iOS/macOS
+                myextension_android.cpp  -- If JNI calls are needed for Android. Implements `myextension_Init` etc for Android
+                /java
+                    /<platform>          -- Any java files needed for Android
+            /res                         -- Any resources needed for a platform
+            /external
+                README.md                -- Notes/scripts on how to build or package any external libraries
+        /bundleres                       -- Resources that should be bundles for (see game.project and the [bundle_resources setting]([physics scale setting](/manuals/project-settings/#project))
+            /<platform>
+        game.project
+        game.appmanifest                 -- Any extra app configuration info
+```
+
+Beachte, dass `myextension.mm` und `myextension_android.cpp` nur benötigt werden, wenn du spezielle native Aufrufe für die jeweilige Plattform ausführst.
+
+#### Plattformordner {#platform-folders}
+
+An bestimmten Stellen wird die Plattformarchitektur als Ordnername verwendet, um festzulegen, welche Dateien beim Kompilieren und bei der Bundle-Erstellung der Anwendung verwendet werden. Diese Namen haben die Form:
+
+    <architecture>-<platform>
+
+Die aktuelle Liste lautet:
+
+    arm64-ios, arm64_sim-ios, arm64-android, armv7-android, x86_64-android, x86_64-linux, x86_64-osx, x86_64-win32, x86-win32
+
+Lege plattformspezifische Bibliotheken also beispielsweise hier ab:
+
+    /libs
+        /arm64-ios
+                            /libFoo.a
+        /arm64-android
+                            /libFoo.a
+
+
+## Nativen Code schreiben {#writing-native-code}
+
+Im Defold-Quellcode wird C++ sehr sparsam eingesetzt, und der Großteil des Codes ähnelt stark C. Abgesehen von einigen Containerklassen gibt es kaum Templates, da sie sowohl die Kompilierungszeiten als auch die Größe der ausführbaren Datei erhöhen.
+
+### C++-Version
+
+Beim Erstellen der Kern-Engine verwendet das Defold-Team C++11, unter Windows jedoch C++14. Konsolen-Builds erfordern inzwischen im Allgemeinen C++14 oder neuer.
+
+Für native Erweiterungen verwendet das Defold-Team keine festgelegte C++-Version, sondern verlässt sich auf die Standardversion der Toolchain der jeweiligen Plattform.
+
+Der Defold-Quellcode vermeidet die neuesten Sprachmerkmale oder Versionen von C++. Das liegt vor allem daran, dass neue Sprachmerkmale beim Entwickeln einer Game-Engine nicht benötigt werden. Außerdem ist es zeitaufwendig, die neuesten Sprachmerkmale von C++ zu verfolgen, und sie wirklich zu beherrschen erfordert viel wertvolle Zeit.
+
+Für die Entwicklung von Erweiterungen hat dies den zusätzlichen Vorteil, dass Defold eine stabile ABI beibehält. Beachte auch, dass die Verwendung der neuesten C++-Sprachmerkmale aufgrund unterschiedlicher Unterstützung verhindern kann, dass der Code auf verschiedenen Plattformen kompiliert werden kann.
+
+### Keine C++-Ausnahmen {#no-c-exceptions}
+
+Defold verwendet in der Engine keine Ausnahmen. In Game-Engines werden Ausnahmen im Allgemeinen vermieden, da die Daten während der Entwicklung bereits größtenteils bekannt sind. Das Entfernen der Unterstützung für C++-Ausnahmen verringert die Größe der ausführbaren Datei und verbessert die Leistung zur Laufzeit.
+
+### Standard-Template-Bibliotheken - STL {#standard-template-libraries-stl}
+
+Da die Defold-Engine abgesehen von einigen Algorithmen und mathematischen Funktionen (`std::sort`, `std::upper_bound` usw.) keinen STL-Code verwendet, kann die Verwendung von STL in deiner Erweiterung funktionieren.
+
+Bedenke auch hier, dass ABI-Inkompatibilitäten Probleme verursachen können, wenn du deine Erweiterung zusammen mit anderen Erweiterungen oder Bibliotheken von Drittanbietern verwendest.
+
+Der Verzicht auf die STL-Bibliotheken, die stark auf Templates setzen, verkürzt außerdem die Build-Zeiten von Defold und verringert vor allem die Größe der ausführbaren Datei.
+
+#### Zeichenfolgen {#strings}
+
+In der Defold-Engine wird `const char*` anstelle von `std::string` verwendet. Die Verwendung von `std::string` ist eine häufige Fehlerquelle, wenn verschiedene C++-Versionen oder Compilerversionen kombiniert werden, da dies zu einer ABI-Inkompatibilität führen kann. Die Verwendung von `const char*` und einigen Hilfsfunktionen vermeidet dieses Problem.
+
+### Funktionen verbergen {#make-functions-hidden}
+
+Verwende nach Möglichkeit das Schlüsselwort `static` für Funktionen, die nur innerhalb deiner Kompilierungseinheit verwendet werden. Dadurch kann der Compiler einige Optimierungen vornehmen, die sowohl die Leistung verbessern als auch die Größe der ausführbaren Datei verringern können.
+
+## Bibliotheken von Drittanbietern {#3rd-party-libraries}
+
+Berücksichtige bei der Auswahl einer Bibliothek von Drittanbietern unabhängig von der Sprache Folgendes:
+
+* Funktionalität - Löst sie dein konkretes Problem?
+* Leistung - Verursacht sie Leistungseinbußen zur Laufzeit?
+* Bibliotheksgröße - Um wie viel größer wird die endgültige ausführbare Datei? Ist das akzeptabel?
+* Abhängigkeiten - Benötigt sie zusätzliche Bibliotheken?
+* Unterstützung - In welchem Zustand befindet sich die Bibliothek? Hat sie viele offene Issues? Wird sie noch gepflegt?
+* Lizenz - Darfst du sie für dieses Projekt verwenden?
+
+
+## Open-Source-Abhängigkeiten {#open-source-dependencies}
+
+Stelle immer sicher, dass du Zugriff auf deine Abhängigkeiten hast. Wenn du beispielsweise von etwas auf GitHub abhängig bist, gibt es nichts, was verhindert, dass das Repository entfernt wird oder sich plötzlich seine Ausrichtung oder seine Eigentümerschaft ändert. Du kannst dieses Risiko verringern, indem du einen Fork des Repositorys erstellst und diesen anstelle des Ursprungsprojekts verwendest.
+
+Denke daran, dass der Code der Bibliothek in dein Spiel eingebunden wird. Stelle also sicher, dass die Bibliothek genau das tut, was sie tun soll, und nichts darüber hinaus!

--- a/docs/de/manuals/extensions-cocoapods.md
+++ b/docs/de/manuals/extensions-cocoapods.md
@@ -1,0 +1,27 @@
+---
+title: CocoaPods-Abhängigkeiten in iOS- und macOS-Builds verwenden
+brief: Dieses Handbuch erklärt, wie du mit CocoaPods Abhängigkeiten in iOS- und macOS-Builds auflöst.
+---
+
+# CocoaPods
+
+[CocoaPods](https://cocoapods.org/) ist ein Abhängigkeitsmanager für Cocoa-Projekte in Swift und Objective-C. CocoaPods wird üblicherweise verwendet, um Abhängigkeiten in Xcode-Projekten zu verwalten und einzubinden. Defold verwendet beim Erstellen von Builds für iOS und macOS kein Xcode, nutzt aber dennoch CocoaPods, um Abhängigkeiten auf dem Build-Server aufzulösen.
+
+
+## Abhängigkeiten auflösen {#resolving-dependencies}
+
+Native Erweiterungen (native extensions) können eine Datei namens `Podfile` in den Ordnern `manifests/ios` und `manifests/osx` enthalten, um die Abhängigkeiten der Erweiterung anzugeben. Beispiel:
+
+```
+platform :ios '11.0'
+
+pod 'FirebaseCore', '10.22.0'
+pod 'FirebaseInstallations', '10.22.0'
+```
+
+Der Build-Server sammelt die `Podfile`-Dateien aller Erweiterungen und verwendet sie, um sämtliche Abhängigkeiten aufzulösen und beim Erstellen des nativen Codes einzubinden.
+
+Beispiele:
+
+* [Firebase](https://github.com/defold/extension-firebase/blob/master/firebase/manifests/ios/Podfile)
+* [Facebook](https://github.com/defold/extension-facebook/blob/master/facebook/manifests/ios/Podfile)

--- a/docs/de/manuals/extensions-debugging-android.md
+++ b/docs/de/manuals/extensions-debugging-android.md
@@ -1,0 +1,6 @@
+---
+title: Debugging auf Android
+brief: Dieses Handbuch beschreibt, wie du einen Build debuggst, der auf einem Android-Gerät läuft.
+---
+
+Verschoben nach [Nativen Code auf Android debuggen](/manuals/debugging-native-code-android)

--- a/docs/de/manuals/extensions-debugging-ios.md
+++ b/docs/de/manuals/extensions-debugging-ios.md
@@ -1,0 +1,6 @@
+---
+title: Debugging unter iOS/macOS
+brief: Dieses Handbuch beschreibt, wie du einen Build mit Xcode debuggst.
+---
+
+Verschoben nach [Debugging von nativem Code unter iOS](/manuals/debugging-native-code-ios).

--- a/docs/de/manuals/extensions-debugging.md
+++ b/docs/de/manuals/extensions-debugging.md
@@ -1,0 +1,6 @@
+---
+title: Erweiterungen debuggen
+brief: Dieses Handbuch beschreibt einige Möglichkeiten, eine Anwendung mit nativen Erweiterungen (native extensions) zu debuggen.
+---
+
+Weitere Informationen findest du im [Handbuch zum Debuggen von nativem Code](/manuals/debugging-native-code).

--- a/docs/de/manuals/extensions-defold-sdk.md
+++ b/docs/de/manuals/extensions-defold-sdk.md
@@ -1,0 +1,26 @@
+---
+title: Native Erweiterungen - Defold SDK
+brief: Dieses Handbuch beschreibt, wie du beim Erstellen nativer Erweiterungen mit dem Defold SDK arbeitest.
+---
+
+# Das Defold SDK {#the-defold-sdk}
+
+Das Defold SDK enthält die erforderlichen Funktionen, um eine native Erweiterung (native extension) zu deklarieren und sowohl mit der systemnahen nativen Plattformschicht, auf der die Anwendung läuft, als auch mit der übergeordneten Lua-Schicht, in der die Spiellogik erstellt wird, zu interagieren.
+
+## Verwendung {#usage}
+
+C++-Erweiterungen können die Sammelheaderdatei `dmsdk/sdk.h` einbinden:
+
+```cpp
+#include <dmsdk/sdk.h>
+```
+
+Der Sammelheader enthält C++-Deklarationen und kann nicht in eine C-Quelldatei eingebunden werden. C-Quelldateien sollten die einzelnen C-kompatiblen `.h`-Headerdateien einbinden, die sie benötigen, zum Beispiel:
+
+```c
+#include <dmsdk/extension/extension.h>
+#include <dmsdk/dlib/configfile.h>
+#include <dmsdk/resource/resource.h>
+```
+
+Nur ein Teil von dmSDK verfügt derzeit über eine reine C-Schnittstelle; nicht jedes C++-Subsystem hat eine Entsprechung in C. Die verfügbaren Funktionen und Typen sind in der [Übersicht der C-API](/ref/overview_defoldc/) und der [Übersicht der C++-API](/ref/overview_defoldcpp/) dokumentiert. Die Headerdateien des Defold SDK sind als separates Archiv `defoldsdk_headers.zip` in jeder [Defold-Veröffentlichung auf GitHub](https://github.com/defold/defold/releases) enthalten. Du kannst diese Headerdateien für die Codevervollständigung im Editor deiner Wahl verwenden.

--- a/docs/de/manuals/extensions-ext-manifests.md
+++ b/docs/de/manuals/extensions-ext-manifests.md
@@ -1,0 +1,75 @@
+---
+title: Native Erweiterungen - Erweiterungsmanifeste
+brief: Dieses Handbuch beschreibt das Erweiterungsmanifest und seinen Zusammenhang mit dem Anwendungsmanifest und dem Engine-Manifest.
+---
+
+# Manifestdateien für Erweiterungen, Anwendungen und die Engine {#extension-application-and-engine-manifest-files}
+
+Das Erweiterungsmanifest (extension manifest) ist eine Konfigurationsdatei mit Optionen und Präprozessor-Definitionen, die beim Erstellen eines Builds für eine einzelne Erweiterung verwendet werden. Diese Konfiguration wird mit einer Konfiguration auf Anwendungsebene und einer Basiskonfiguration für die Defold-Engine selbst kombiniert.
+
+## Anwendungsmanifest {#app-manifest}
+
+Das Anwendungsmanifest (application manifest, Dateierweiterung `.appmanifest`) ist eine Konfiguration auf Anwendungsebene, die festlegt, wie dein Spiel auf den Build-Servern erstellt wird. Mit dem Anwendungsmanifest kannst du Teile der Engine entfernen, die du nicht verwendest. Wenn du keine Physik-Engine benötigst, kannst du sie aus der ausführbaren Datei entfernen, um deren Größe zu reduzieren. Wie du ungenutzte Funktionen ausschließt, erfährst du [im Handbuch zum Anwendungsmanifest](/manuals/app-manifest).
+
+## Engine-Manifest
+
+Die Defold-Engine hat ein Build-Manifest (`build.yml`), das in jeder Veröffentlichung der Engine und des Defold-SDK enthalten ist. Das Manifest legt fest, welche SDK-Versionen verwendet werden, welche Compiler, Linker und anderen Werkzeuge ausgeführt werden und welche standardmäßigen Build- und Linker-Optionen an diese Werkzeuge übergeben werden. Du findest das Manifest unter share/extender/build_input.yml [auf GitHub](https://github.com/defold/defold/blob/dev/share/extender/build_input.yml).
+
+## Erweiterungsmanifest {#extension-manifest}
+
+Das Erweiterungsmanifest (`ext.manifest`) hingegen ist eine Konfigurationsdatei speziell für eine Erweiterung. Das Erweiterungsmanifest legt fest, wie der Quellcode der Erweiterung kompiliert und gelinkt wird und welche zusätzlichen Bibliotheken eingebunden werden. 
+
+Die drei verschiedenen Manifestdateien verwenden alle dieselbe Syntax, sodass sie zusammengeführt werden können und vollständig steuern, wie die Erweiterungen und das Spiel erstellt werden.
+
+Für jede Erweiterung, für die ein Build erstellt wird, werden die Manifeste wie folgt kombiniert:
+
+	manifest = merge(game.appmanifest, ext.manifest, build.yml)
+
+Dadurch kannst du das Standardverhalten der Engine und auch jeder Erweiterung überschreiben. Für den abschließenden Link-Vorgang führen wir das Anwendungsmanifest mit dem Defold-Manifest zusammen:
+
+	manifest = merge(game.appmanifest, build.yml)
+
+
+### Die Datei ext.manifest {#the-extmanifest-file}
+
+Neben dem Namen der Erweiterung kann die Manifestdatei plattformspezifische Kompilieroptionen, Linker-Optionen, Bibliotheken und Frameworks enthalten. Wenn die Datei *ext.manifest* keinen Abschnitt "platforms" enthält oder eine Plattform in der Liste fehlt, wird der Build für die Plattform, für die du ein Bundle erstellst, trotzdem erstellt, jedoch ohne zusätzliche Optionen.
+
+Hier ist ein Beispiel:
+
+```yaml
+name: "AdExtension"
+
+platforms:
+    arm64-ios:
+        context:
+            frameworks: ["CoreGraphics", "CFNetwork", "GLKit", "CoreMotion", "MessageUI", "MediaPlayer", "StoreKit", "MobileCoreServices", "AdSupport", "AudioToolbox", "AVFoundation", "CoreGraphics", "CoreMedia", "CoreMotion", "CoreTelephony", "CoreVideo", "Foundation", "GLKit", "JavaScriptCore", "MediaPlayer", "MessageUI", "MobileCoreServices", "OpenGLES", "SafariServices", "StoreKit", "SystemConfiguration", "UIKit", "WebKit"]
+            flags:      ["-stdlib=libc++"]
+            linkFlags:  ["-ObjC"]
+            libs:       ["z", "c++", "sqlite3"]
+            defines:    ["MY_DEFINE"]
+
+    arm64_sim-ios:
+        context:
+            frameworks: ["CoreGraphics", "CFNetwork", "GLKit", "CoreMotion", "MessageUI", "MediaPlayer", "StoreKit", "MobileCoreServices", "AdSupport", "AudioToolbox", "AVFoundation", "CoreGraphics", "CoreMedia", "CoreMotion", "CoreTelephony", "CoreVideo", "Foundation", "GLKit", "JavaScriptCore", "MediaPlayer", "MessageUI", "MobileCoreServices", "OpenGLES", "SafariServices", "StoreKit", "SystemConfiguration", "UIKit", "WebKit"]
+            flags:      ["-stdlib=libc++"]
+            linkFlags:  ["-ObjC"]
+            libs:       ["z", "c++", "sqlite3"]
+            defines:    ["MY_DEFINE"]
+```
+
+#### Zulässige Schlüssel {#allowed-keys}
+
+Die zulässigen Schlüssel für plattformspezifische Kompilieroptionen sind:
+
+* `frameworks` - Apple-Frameworks, die beim Erstellen eines Builds eingebunden werden sollen (iOS und macOS)
+* `weakFrameworks` - Apple-Frameworks, die beim Erstellen eines Builds optional eingebunden werden sollen (iOS und macOS)
+* `flags` - Optionen, die an den Compiler übergeben werden sollen
+* `linkFlags` - Optionen, die an den Linker übergeben werden sollen
+* `libs` - Zusätzliche Bibliotheken, die beim Linken eingebunden werden sollen
+* `defines` - Präprozessor-Definitionen, die beim Erstellen eines Builds gesetzt werden sollen
+* `aaptExtraPackages` - Zusätzlicher Paketname, der generiert werden soll (Android)
+* `aaptExcludePackages` - Reguläre Ausdrücke (oder genaue Namen) der auszuschließenden Pakete (Android)
+* `aaptExcludeResourceDirs` - Reguläre Ausdrücke (oder genaue Namen) der auszuschließenden Ressourcenverzeichnisse (Android)
+* `excludeLibs`, `excludeJars`, `excludeSymbols` - Diese Optionen dienen dazu, zuvor im Plattformkontext definierte Elemente zu entfernen.
+
+Für alle Schlüsselwörter wenden wir einen Filter mit einer Positivliste an. Dadurch sollen unzulässige Pfadoperationen und Zugriffe auf Dateien außerhalb des Upload-Ordners für den Build verhindert werden.

--- a/docs/de/manuals/extensions-gradle.md
+++ b/docs/de/manuals/extensions-gradle.md
@@ -1,0 +1,31 @@
+---
+title: Gradle-Abhängigkeiten in Android-Builds verwenden
+brief: Dieses Handbuch erklärt, wie du Gradle zum Auflösen von Abhängigkeiten in Android-Builds verwendest.
+---
+
+# Gradle für Android {#gradle-for-android}
+
+Anders als beim üblichen Erstellen von Android-Anwendungen verwendet Defold [Gradle](https://gradle.org/) nicht für den gesamten Build-Vorgang. Stattdessen verwendet Defold beim lokalen Build direkt Android-Kommandozeilenwerkzeuge wie `aapt2` und `bundletool` und setzt Gradle nur zum Auflösen von Abhängigkeiten auf dem Build-Server ein.
+
+
+## Abhängigkeiten auflösen {#resolving-dependencies}
+
+Native Erweiterungen (native extensions) können eine Datei `build.gradle` im Ordner `manifests/android` enthalten, um die Abhängigkeiten der Erweiterung anzugeben. Beispiel:
+
+```
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.google.firebase:firebase-installations:17.2.0'
+    implementation 'com.google.android.gms:play-services-base:18.2.0'
+}
+```
+
+Der Build-Server sammelt die Dateien `build.gradle` aus allen Erweiterungen und verwendet sie, um alle Abhängigkeiten aufzulösen und sie beim Erstellen des nativen Codes einzubeziehen.
+
+Beispiele:
+
+* [Firebase](https://github.com/defold/extension-firebase/blob/master/firebase/manifests/android/)build.gradle
+* [Facebook](https://github.com/defold/extension-facebook/blob/master/facebook/manifests/android/build.gradle)

--- a/docs/de/manuals/extensions-manifest-merge-tool.md
+++ b/docs/de/manuals/extensions-manifest-merge-tool.md
@@ -1,0 +1,359 @@
+---
+title: Native Erweiterungen - Werkzeuge zum Zusammenführen von Manifesten
+brief: Dieses Handbuch beschreibt, wie das Zusammenführen von Anwendungsmanifesten funktioniert
+---
+
+# Anwendungsmanifeste {#application-manifests}
+
+Auf einigen Plattformen unterstützt Defold Erweiterungen (extensions), die Ausschnitte (oder Stubs) von Anwendungsmanifesten bereitstellen.
+Dabei kann es sich um einen Teil einer Datei namens `AndroidManifest.xml`, `Info.plist` oder `engine_template.html` handeln.
+
+Die Manifest-Stubs der Erweiterungen werden nacheinander angewendet, ausgehend vom Basismanifest der Anwendung.
+Das Basismanifest ist entweder das Standardmanifest (in `builtins\manifests\<platforms>\...`) oder ein benutzerdefiniertes Manifest, das du bereitstellst.
+
+## Benennung und Struktur {#naming-and-structure}
+
+Die Manifeste der Erweiterung müssen in einer bestimmten Verzeichnisstruktur abgelegt werden, damit die Erweiterung wie vorgesehen funktioniert.
+
+    /myextension
+        ext.manifest
+        /manifests
+            /android
+                AndroidManifest.xml
+            /ios
+                Info.plist
+            /osx
+                Info.plist
+            /web
+                engine_template.html
+
+
+## Android
+
+Die Android-Plattform verfügt bereits über ein Werkzeug zum Zusammenführen von Manifesten (auf Basis von `ManifestMerger2`), das Defold innerhalb von `bob.jar` zum Zusammenführen von Manifesten verwendet.
+Eine vollständige Anleitung zum Ändern deiner Android-Manifeste findest du in der [Android-Dokumentation](https://developer.android.com/studio/build/manifest-merge).
+
+::: important
+Wenn du `android:targetSdkVersion` für deine App nicht im Manifest deiner Erweiterung festlegst, werden die folgenden Berechtigungen automatisch hinzugefügt:  `WRITE_EXTERNAL_STORAGE`, `READ_PHONE_STATE`, `READ_EXTERNAL_STORAGE`. Weitere Informationen dazu findest du [hier](https://developer.android.com/studio/build/manifest-merge#implicit_system_permissions) in der offiziellen Dokumentation.
+Das Defold-Team empfiehlt folgende Angabe: `<uses-sdk android:targetSdkVersion="{{android.target_sdk_version}}" />`
+:::
+### Beispiel {#example}
+
+Basismanifest
+
+```xml
+    <?xml version='1.0' encoding='utf-8'?>
+    <manifest xmlns:android='http://schemas.android.com/apk/res/android'
+            package='com.defold.testmerge'
+            android:versionCode='14'
+            android:versionName='1.0'
+            android:installLocation='auto'>
+        <uses-feature android:required='true' android:glEsVersion='0x00020000' />
+        <uses-sdk android:minSdkVersion='21' android:targetSdkVersion='26' />
+        <application android:label='Test Project' android:hasCode='true'>
+        </application>
+        <uses-permission android:name='android.permission.VIBRATE' />
+    </manifest>
+```
+
+Manifest der Erweiterung:
+
+```xml
+    <?xml version='1.0' encoding='utf-8'?>
+    <manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.defold.testmerge'>
+         <uses-sdk android:targetSdkVersion="{{android.target_sdk_version}}" />
+        <uses-feature android:required='true' android:glEsVersion='0x00030000' />
+        <application>
+            <meta-data android:name='com.facebook.sdk.ApplicationName'
+                android:value='Test Project' />
+            <activity android:name='com.facebook.FacebookActivity'
+              android:theme='@android:style/Theme.Translucent.NoTitleBar'
+              android:configChanges='keyboard|keyboardHidden|screenLayout|screenSize|orientation'
+              android:label='Test Project' />
+        </application>
+    </manifest>
+```
+
+Ergebnis
+
+```xml
+    <?xml version='1.0' encoding='utf-8'?>
+    <manifest xmlns:android='http://schemas.android.com/apk/res/android'
+        package='com.defold.testmerge'
+        android:installLocation='auto'
+        android:versionCode='14'
+        android:versionName='1.0' >
+        <uses-sdk
+            android:minSdkVersion='21'
+            android:targetSdkVersion='26' />
+        <uses-permission android:name='android.permission.VIBRATE' />
+        <uses-feature
+            android:glEsVersion='0x00030000'
+            android:required='true' />
+        <application
+            android:hasCode='true'
+            android:label='Test Project' >
+            <meta-data
+                android:name='com.facebook.sdk.ApplicationName'
+                android:value='Test Project' />
+            <activity
+                android:name='com.facebook.FacebookActivity'
+                android:configChanges='keyboard|keyboardHidden|screenLayout|screenSize|orientation'
+                android:label='Test Project'
+                android:theme='@android:style/Theme.Translucent.NoTitleBar' />
+        </application>
+    </manifest>
+```
+
+## iOS / macOS
+
+Für die Datei `Info.plist` verwendet Defold eine eigene Implementierung zum Zusammenführen von Listen und Wörterbüchern (Dictionaries). Du kannst an Schlüsseln die Attribute zur Steuerung der Zusammenführung `merge`, `keep` oder `replace` angeben; dabei ist `merge` der Standard.
+
+### Beispiel {#example-1}
+
+Basismanifest
+
+```xml
+    <?xml version='1.0' encoding='UTF-8'?>
+    <!DOCTYPE plist PUBLIC '-//Apple//DTD PLIST 1.0//EN' 'http://www.apple.com/DTDs/PropertyList-1.0.dtd'>
+    <plist version='1.0'>
+    <dict>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSExceptionDomains</key>
+            <dict>
+                <key>foobar.net</key>
+                <dict>
+                    <key>testproperty</key>
+                    <true/>
+                </dict>
+            </dict>
+        </dict>
+        <key>INT</key>
+        <integer>8</integer>
+
+        <key>REAL</key>
+        <real>8.0</real>
+
+        <!-- Keep this value even if an extension manifest contains the same key -->
+        <key merge='keep'>BASE64</key>
+        <data>SEVMTE8gV09STEQ=</data>
+
+        <!-- If an extension manifest also has an array with this key then any dictionary values will be merged with the first dictionary value of the base array -->
+        <key>Array1</key>
+        <array>
+            <dict>
+                <key>Foobar</key>
+                <array>
+                    <string>a</string>
+                </array>
+            </dict>
+        </array>
+
+        <!-- Do not attempt to merge the values of this array, instead values from extension manifests should be added to the end of the array -->
+        <key merge='keep'>Array2</key>
+        <array>
+            <dict>
+                <key>Foobar</key>
+                <array>
+                    <string>a</string>
+                </array>
+            </dict>
+        </array>
+    </dict>
+    </plist>
+```
+
+Manifest der Erweiterung:
+
+```xml
+    <?xml version='1.0' encoding='UTF-8'?>
+    <!DOCTYPE plist PUBLIC '-//Apple//DTD PLIST 1.0//EN' 'http://www.apple.com/DTDs/PropertyList-1.0.dtd'>
+    <plist version='1.0'>
+    <dict>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSExceptionDomains</key>
+            <dict>
+                <key>facebook.com</key>
+                <dict>
+                    <key>NSIncludesSubdomains</key>
+                    <true/>
+                    <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+                    <false/>
+                </dict>
+            </dict>
+        </dict>
+        <key>INT</key>
+        <integer>42</integer>
+
+        <!-- Replace the existing value in the base manifest -->
+        <key merge='replace'>REAL</key>
+        <integer>16.0</integer>
+
+        <key>BASE64</key>
+        <data>Rk9PQkFS</data>
+
+        <key>Array1</key>
+        <array>
+            <dict>
+                <key>Foobar</key>
+                <array>
+                    <string>b</string>
+                </array>
+            </dict>
+        </array>
+
+        <key>Array2</key>
+        <array>
+            <dict>
+                <key>Foobar</key>
+                <array>
+                    <string>b</string>
+                </array>
+            </dict>
+        </array>
+    </dict>
+    </plist>
+```
+
+Ergebnis:
+
+```xml
+    <?xml version='1.0'?>
+    <!DOCTYPE plist SYSTEM 'file://localhost/System/Library/DTDs/PropertyList.dtd'>
+    <plist version='1.0'>
+        <!-- Nested merge of dictionaries from base and extension manifests -->
+        <dict>
+            <key>NSAppTransportSecurity</key>
+            <dict>
+                <key>NSExceptionDomains</key>
+                <dict>
+                    <key>foobar.net</key>
+                    <dict>
+                        <key>testproperty</key>
+                        <true/>
+                    </dict>
+                    <key>facebook.com</key>
+                    <dict>
+                        <key>NSIncludesSubdomains</key>
+                        <true/>
+                        <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+                        <false/>
+                    </dict>
+                </dict>
+            </dict>
+
+            <!-- From the base manifest -->
+            <key>INT</key>
+            <integer>8</integer>
+
+            <!-- The value from the base manifest was replaced since the merge marker was set to "replace" in the extension manifest -->
+            <key>REAL</key>
+            <real>16.0</real>
+
+            <!-- The value from the base manifest was used since the merge marker was set to "keep" in the base manifest -->
+            <key>BASE64</key>
+            <data>SEVMTE8gV09STEQ=</data>
+
+            <!-- The value from the extender manifest was added since no merge marker was specified -->
+            <key>INT</key>
+            <integer>42</integer>
+
+            <!-- The dictionary values of the array were merged since the base manifest defaults to "merge" -->
+            <key>Array1</key>
+            <array>
+                <dict>
+                    <key>Foobar</key>
+                    <array>
+                        <string>a</string>
+                        <string>b</string>
+                    </array>
+                </dict>
+            </array>
+
+            <!-- The dictionary values were added to the array since the base manifest used "keep" -->
+            <key>Array2</key>
+            <array>
+                <dict>
+                    <key>Foobar</key>
+                    <array>
+                        <string>a</string>
+                    </array>
+                </dict>
+                <dict>
+                    <key>Foobar</key>
+                    <array>
+                        <string>b</string>
+                    </array>
+                </dict>
+            </array>
+        </dict>
+    </plist>
+```
+
+
+## HTML5
+
+In der HTML-Vorlage hat jeder Abschnitt einen Namen, damit die Abschnitte einander zugeordnet werden können (z. B. „engine-start“).
+Du kannst dann die Attribute `merge` oder `keep` angeben. `merge` ist der Standard.
+
+### Beispiel {#example-2}
+
+Basismanifest
+
+```html
+    <!DOCTYPE html>
+    <html>
+    <body>
+     <script id='engine-loader' type='text/javascript' src='dmloader.js'></script>
+     <script id='engine-setup' type='text/javascript'>
+     function load_engine() {
+         var engineJS = document.createElement('script');
+         engineJS.type = 'text/javascript';
+         engineJS.src = '{{exe-name}}_wasm.js';
+         document.head.appendChild(engineJS);
+     }
+     </script>
+     <script id='engine-start' type='text/javascript'>
+         load_engine();
+     </script>
+    </body>
+    </html>
+```
+
+Manifest der Erweiterung
+
+```html
+    <html>
+    <body>
+     <script id='engine-loader' type='text/javascript' src='mydmloader.js'></script>
+     <script id='engine-start' type='text/javascript' merge='keep'>
+         my_load_engine();
+     </script>
+    </body>
+    </html>
+```
+
+Ergebnis
+
+```html
+    <!doctype html>
+    <html>
+    <head></head>
+    <body>
+        <script id='engine-loader' type='text/javascript' src='mydmloader.js'></script>
+        <script id='engine-setup' type='text/javascript'>
+            function load_engine() {
+                var engineJSdocument.createElement('script');
+                engineJS.type = 'text/javascript';
+                engineJS.src = '{{exe-name}}_wasm.js';
+                document.head.appendChild(engineJS);
+            }
+        </script>
+        <script id='engine-start' type='text/javascript' merge='keep'>
+            my_load_engine(
+        </script>
+    </body>
+    </html>
+```

--- a/docs/de/manuals/extensions-script-api.md
+++ b/docs/de/manuals/extensions-script-api.md
@@ -1,0 +1,54 @@
+---
+title: Einer nativen Erweiterung Codevervollständigung im Editor hinzufügen
+brief: Dieses Handbuch erklärt, wie du eine Skript-API-Definition erstellst, damit der Defold-Editor bei der Verwendung einer Erweiterung Codevervollständigung anbieten kann.
+---
+
+# Codevervollständigung für native Erweiterungen {#auto-complete-for-native-extensions}
+
+Der Defold-Editor bietet Vorschläge zur Codevervollständigung für alle Defold-API-Funktionen und erzeugt Vorschläge für Lua-Module, die deine Skripte einbinden. Der Editor kann jedoch nicht automatisch Vorschläge zur Codevervollständigung für die Funktionalität bereitstellen, die native Erweiterungen (native extensions) zugänglich machen. Eine native Erweiterung kann eine API-Definition in einer separaten Datei bereitstellen, um Vorschläge zur Codevervollständigung auch für die API der Erweiterung zu ermöglichen.
+
+
+## Eine Skript-API-Definition erstellen {#creating-a-script-api-definition}
+
+Eine Datei mit einer Skript-API-Definition hat die Dateierweiterung `.script_api`. Sie muss im [YAML-Format](https://yaml.org/) vorliegen und zusammen mit den Dateien der Erweiterung abgelegt sein. Das erwartete Format einer Skript-API-Definition ist:
+
+```yml
+- name: The name of the extension
+  type: table
+  desc: Extension description
+  members:
+  - name: Name of the first member
+    type: Member type
+    desc: Member description
+    # if member type is "function"
+    parameters:
+    - name: Name of the first parameter
+      type: Parameter type
+      desc: Parameter description
+    - name: Name of the second parameter
+      type: Parameter type
+      desc: Parameter description
+    # if member type is "function"
+    returns:
+    - name: Name of first return value
+      type: Return value type
+      desc: Return value description
+    examples:
+    - desc: First example of member usage
+    - desc: Second example of member usage
+
+  - name: Name of the second member
+    ...
+```
+
+Als Typen sind `table, string , boolean, number, function` möglich. Wenn ein Wert mehrere Datentypen haben kann, wird dies als `[type1, type2, type3]` geschrieben.
+::: sidenote
+Typen werden derzeit nicht im Editor angezeigt. Es wird empfohlen, sie trotzdem anzugeben, damit sie verfügbar sind, sobald der Editor die Anzeige von Typinformationen unterstützt.
+:::
+
+## Beispiele {#examples}
+
+Konkrete Anwendungsbeispiele findest du in den folgenden Projekten:
+
+* [Facebook-Erweiterung](https://github.com/defold/extension-facebook/tree/master/facebook/api)
+* [WebView-Erweiterung](https://github.com/defold/extension-webview/blob/master/webview/api/webview.script_api)

--- a/docs/de/manuals/extensions.md
+++ b/docs/de/manuals/extensions.md
@@ -1,0 +1,297 @@
+---
+title: Native Erweiterungen für Defold schreiben
+brief: Dieses Handbuch erklärt, wie du eine native Erweiterung für die Defold-Game-Engine schreibst und sie mit den Cloud-Build-Diensten ohne Einrichtungsaufwand kompilierst.
+---
+
+# Native Erweiterungen {#native-extensions}
+
+Wenn du eine angepasste Interaktion mit externer Software oder Hardware auf niedriger Ebene benötigst, für die Lua nicht ausreicht, kannst du mit dem Defold-SDK native Erweiterungen (native extensions) für die Engine in C, C++, C#, Objective-C, Java oder JavaScript schreiben, abhängig von der Zielplattform. Typische Anwendungsfälle für native Erweiterungen sind:
+
+- Interaktion mit bestimmter Hardware, beispielsweise der Kamera von Mobiltelefonen.
+- Interaktion mit externen APIs auf niedriger Ebene, beispielsweise APIs von Werbenetzwerken, die keine Interaktion über Netzwerk-APIs zulassen, bei denen Luasocket verwendet werden könnte.
+- Berechnungen und Datenverarbeitung mit hoher Leistung.
+
+::: sidenote
+Die Unterstützung für C# ist experimentell und für native Erweiterungen vorgesehen, nicht für Skriptkomponenten (script components) von Defold. Sie verwendet .NET 9 NativeAOT, um eine statische Bibliothek zu erzeugen. Füge `.cs`-Quelldateien zum Ordner `src` einer Erweiterung hinzu; der Build-Dienst erzeugt die Projektdatei. Die Unterstützung von Zielplattformen richtet sich nach den aktuellen Möglichkeiten von NativeAOT und des Build-Dienstes. Den aktuellen Arbeitsablauf und die getestete Einrichtung findest du im offiziellen [Sprachbeispiel für native Erweiterungen](https://github.com/defold/example-languages).
+:::
+
+## Der Build-Server {#the-build-server}
+
+Defold bietet mit einer cloudbasierten Build-Lösung einen Einstieg in native Erweiterungen ohne Einrichtungsaufwand. Jede native Erweiterung, die entwickelt und einem Spielprojekt entweder direkt oder über ein [Bibliotheksprojekt](/manuals/libraries/) hinzugefügt wird, wird Teil des gewöhnlichen Projektinhalts. Du musst keine speziellen Versionen der Engine erstellen und an Teammitglieder verteilen. Das geschieht automatisch---jedes Teammitglied, das einen Build des Projekts erstellt und ausführt, erhält eine projektspezifische ausführbare Engine-Datei mit allen eingebundenen nativen Erweiterungen.
+
+![Cloud-Build](images/extensions/cloud_build.png)
+
+Defold stellt den Cloud-Build-Server kostenlos und ohne Nutzungsbeschränkungen bereit. Der Server wird in Europa gehostet. Die URL, an die nativer Code gesendet wird, wird im [Fenster für die Editoreinstellungen](/manuals/editor-preferences/#extensions) oder über die Befehlszeilenoption `--build-server` von [bob](/manuals/bob/#usage) konfiguriert. Wenn du deinen eigenen Server einrichten möchtest, [folge dieser Anleitung](/manuals/extender-local-setup).
+
+## Projektstruktur {#project-layout}
+
+Um eine neue Erweiterung zu erstellen, lege einen Ordner im Stammverzeichnis des Projekts an. Dieser Ordner enthält alle Einstellungen, den Quellcode, die Bibliotheken und die Ressourcen der Erweiterung. Der Build-Dienst für Erweiterungen erkennt die Ordnerstruktur und sammelt alle Quelldateien und Bibliotheken.
+
+```
+ myextension/
+ │
+ ├── ext.manifest
+ │
+ ├── src/
+ │
+ ├── include/
+ │
+ ├── lib/
+ │   └──[platforms]
+ │
+ ├── manifests/
+ │   └──[platforms]
+ │
+ └── res/
+     └──[platforms]
+
+```
+*ext.manifest*
+: Der Erweiterungsordner _muss_ eine Datei *ext.manifest* enthalten. Diese Konfigurationsdatei enthält Flags und Defines, die beim Erstellen eines Builds einer einzelnen Erweiterung verwendet werden. Die Definition des Dateiformats findest du im [Handbuch zum Erweiterungsmanifest](https://defold.com/manuals/extensions-ext-manifests/).
+
+*src*
+: Dieser Ordner sollte alle Quellcodedateien enthalten.
+
+*include*
+: Dieser optionale Ordner enthält Include-Dateien.
+
+*lib*
+: Dieser optionale Ordner enthält kompilierte Bibliotheken, von denen die Erweiterung abhängt. Bibliotheksdateien sollten in Unterordnern mit Namen nach dem Schema `platform` oder `architecture-platform` abgelegt werden, je nachdem, welche Architekturen deine Bibliotheken unterstützen.
+
+  :[platforms](../shared/platforms.md)
+
+*manifests*
+: Dieser optionale Ordner enthält zusätzliche Dateien, die beim Build-Vorgang oder bei der Bundle-Erstellung verwendet werden. Einzelheiten findest du weiter unten.
+
+*res*
+: Dieser optionale Ordner enthält zusätzliche Ressourcen, von denen die Erweiterung abhängt. Ressourcendateien sollten in Unterordnern mit Namen nach dem Schema `platform` oder `architecture-platform` abgelegt werden, genauso wie im Ordner `lib`. Ein Unterordner `common` ist ebenfalls zulässig. Er enthält Ressourcendateien, die allen Plattformen gemeinsam sind.
+
+### Manifestdateien {#manifest-files}
+
+Der optionale Ordner *manifests* einer Erweiterung enthält zusätzliche Dateien, die beim Build-Vorgang und bei der Bundle-Erstellung verwendet werden. Dateien sollten in Unterordnern mit Namen nach dem Schema `platform` abgelegt werden:
+
+* `android` - Dieser Ordner nimmt eine Manifest-Teildatei auf, die mit dem Manifest der Hauptanwendung zusammengeführt wird ([wie hier beschrieben](/manuals/extensions-manifest-merge-tool)).
+  * Der Ordner kann auch eine Datei `build.gradle` mit Abhängigkeiten enthalten, die [von Gradle aufgelöst werden](/manuals/extensions-gradle).
+  * Erweiterungen mit Java-Code sollten eine [Datei mit R8-Keep-Regeln](#r8-keep-rules-for-android) (`.keep`) für die Klassen enthalten, die sie zur Laufzeit benötigen.
+* `ios` - Dieser Ordner nimmt eine Manifest-Teildatei auf, die mit dem Manifest der Hauptanwendung zusammengeführt wird ([wie hier beschrieben](/manuals/extensions-manifest-merge-tool)).
+  * Der Ordner kann auch eine Datei `Podfile` mit Abhängigkeiten enthalten, die [von Cocoapods aufgelöst werden](/manuals/extensions-cocoapods).
+* `osx` - Dieser Ordner nimmt eine Manifest-Teildatei auf, die mit dem Manifest der Hauptanwendung zusammengeführt wird ([wie hier beschrieben](/manuals/extensions-manifest-merge-tool)).
+* `web` - Dieser Ordner nimmt eine Manifest-Teildatei auf, die mit dem Manifest der Hauptanwendung zusammengeführt wird ([wie hier beschrieben](/manuals/extensions-manifest-merge-tool)).
+
+
+### R8-Keep-Regeln für Android {#r8-keep-rules-for-android}
+
+Füge im Verzeichnis `manifests/android` der Erweiterung neben `build.gradle` eine Datei mit der Endung `.keep` hinzu. Beispielsweise kann `/myextension/manifests/android/myextension.keep` die Java-Klassen der Erweiterung mit folgender Regel erhalten:
+
+```proguard
+-keep,allowoptimization class com.example.myextension.** { *; }
+```
+
+Ersetze `com.example.myextension` durch das Paket, das die Java-Klassen deiner Erweiterung enthält. Diese Regel erhält die Klassen und ihre Mitglieder, erlaubt R8 aber, ihren Code zu optimieren. Füge Regeln für weitere Klassen hinzu, auf die über das Java Native Interface (JNI) oder Reflexion zugegriffen wird, da R8 diese Verwendungen möglicherweise nicht automatisch erkennt.
+
+Wenn die Erweiterung zur Laufzeit auf Annotationen angewiesen ist, füge außerdem Folgendes hinzu:
+
+```proguard
+-keepattributes *Annotation*
+```
+
+Diese Regeln werden mit der ausgewählten Keep-Datei des Projekts kombiniert, wenn [R8 aktiviert ist](/manuals/android/#enabling-r8).
+
+
+## Benutzerdefinierte Ressourcen {#custom-resources}
+
+Eine Erweiterung kann Daten in das Spielarchiv aufnehmen, indem sie benutzerdefinierte Ressourcen in einer Datei `ext.properties` neben ihrer Datei `ext.manifest` deklariert:
+
+```ini
+[project]
+custom_resources.default = /myextension/data
+```
+
+Lege beispielsweise eine JSON-Datei unter `/myextension/data/settings.json` ab. Der Pfad ist relativ zum Stammverzeichnis des Projekts und enthält den Erweiterungsordner. Wenn du die Erweiterung als Bibliothek teilst, nimm `myextension` in die [Include Dirs](/manuals/libraries/#setting-up-library-sharing) der Bibliothek auf, damit Projekte, die sie verwenden, die Erweiterung und ihre Daten erhalten.
+
+Diese Pfade werden mit `project.custom_resources` aus *game.project* und den Einträgen anderer Erweiterungen kombiniert. Das Festlegen benutzerdefinierter Ressourcen im Projekt ersetzt die Einträge der Erweiterungen nicht. Sowohl Editor-Builds als auch Bob-Archive enthalten die Dateien, die zur Laufzeit geladen werden können:
+
+```lua
+local data, err = sys.load_resource("/myextension/data/settings.json")
+if data then
+    local settings = json.decode(data)
+    pprint(settings)
+else
+    print(err)
+end
+```
+
+Unter [Dateizugriff](/manuals/file-access/#custom-resources) erfährst du, wie sich benutzerdefinierte Ressourcen von Bundle-Ressourcen unterscheiden.
+
+## Eine Erweiterung teilen {#sharing-an-extension}
+
+Erweiterungen werden genauso behandelt wie alle anderen Assets in deinem Projekt und können auf dieselbe Weise geteilt werden. Wenn ein Ordner mit einer nativen Erweiterung als Bibliotheksordner hinzugefügt wird, kann er geteilt und von anderen als Projektabhängigkeit verwendet werden. Weitere Informationen findest du im [Handbuch zu Bibliotheksprojekten](/manuals/libraries/).
+
+
+## Eine einfache Beispielerweiterung {#a-simple-example-extension}
+
+Erstellen wir eine sehr einfache Erweiterung. Zuerst legen wir einen neuen Ordner *`myextension`* im Stammverzeichnis an und fügen eine Datei *`ext.manifest`* hinzu, die den Namen der Erweiterung „`MyExtension`“ enthält. Beachte, dass der Name ein C++-Symbol ist und mit dem ersten Argument von `DM_DECLARE_EXTENSION` übereinstimmen muss (siehe unten).
+
+![Manifest](images/extensions/manifest.png)
+
+```yaml
+# C++ symbol in your extension
+name: "MyExtension"
+```
+
+Die Erweiterung besteht aus einer einzigen C++-Datei, *`myextension.cpp`*, die im Ordner „`src`“ erstellt wird.
+
+![C++-Datei](images/extensions/cppfile.png)
+
+Die Quelldatei der Erweiterung enthält den folgenden Code:
+
+```cpp
+// myextension.cpp
+// Extension lib defines
+#define LIB_NAME "MyExtension"
+#define MODULE_NAME "myextension"
+
+// include the Defold SDK
+#include <dmsdk/sdk.h>
+
+static int Reverse(lua_State* L)
+{
+    // The number of expected items to be on the Lua stack
+    // once this struct goes out of scope
+    DM_LUA_STACK_CHECK(L, 1);
+
+    // Check and get parameter string from stack
+    char* str = (char*)luaL_checkstring(L, 1);
+
+    // Reverse the string
+    int len = strlen(str);
+    for(int i = 0; i < len / 2; i++) {
+        const char a = str[i];
+        const char b = str[len - i - 1];
+        str[i] = b;
+        str[len - i - 1] = a;
+    }
+
+    // Put the reverse string on the stack
+    lua_pushstring(L, str);
+
+    // Return 1 item
+    return 1;
+}
+
+// Functions exposed to Lua
+static const luaL_reg Module_methods[] =
+{
+    {"reverse", Reverse},
+    {0, 0}
+};
+
+static void LuaInit(lua_State* L)
+{
+    int top = lua_gettop(L);
+
+    // Register lua names
+    luaL_register(L, MODULE_NAME, Module_methods);
+
+    lua_pop(L, 1);
+    assert(top == lua_gettop(L));
+}
+
+dmExtension::Result AppInitializeMyExtension(dmExtension::AppParams* params)
+{
+    return dmExtension::RESULT_OK;
+}
+
+dmExtension::Result InitializeMyExtension(dmExtension::Params* params)
+{
+    // Init Lua
+    LuaInit(params->m_L);
+    printf("Registered %s Extension\n", MODULE_NAME);
+    return dmExtension::RESULT_OK;
+}
+
+dmExtension::Result AppFinalizeMyExtension(dmExtension::AppParams* params)
+{
+    return dmExtension::RESULT_OK;
+}
+
+dmExtension::Result FinalizeMyExtension(dmExtension::Params* params)
+{
+    return dmExtension::RESULT_OK;
+}
+
+
+// Defold SDK uses a macro for setting up extension entry points:
+//
+// DM_DECLARE_EXTENSION(symbol, name, app_init, app_final, init, update, on_event, final)
+
+// MyExtension is the C++ symbol that holds all relevant extension data.
+// It must match the name field in the `ext.manifest`
+DM_DECLARE_EXTENSION(MyExtension, LIB_NAME, AppInitializeMyExtension, AppFinalizeMyExtension, InitializeMyExtension, 0, 0, FinalizeMyExtension)
+```
+
+Beachte das Makro `DM_DECLARE_EXTENSION`, mit dem die verschiedenen Einstiegspunkte in den Code der Erweiterung deklariert werden. Das erste Argument `symbol` muss mit dem in *ext.manifest* angegebenen Namen übereinstimmen. Für dieses einfache Beispiel sind keine Einstiegspunkte für `update` oder `on_event` nötig. Daher wird dem Makro an diesen Stellen `0` übergeben.
+
+Jetzt musst du nur noch einen Build des Projekts erstellen (<kbd>Project ▸ Build</kbd>). Dadurch wird die Erweiterung zum Build-Dienst für Erweiterungen hochgeladen, der eine angepasste Engine mit der neuen Erweiterung erzeugt. Falls der Build-Dienst Fehler feststellt, erscheint ein Dialogfeld mit den Build-Fehlern.
+
+Um die Erweiterung zu testen, erstelle ein Spielobjekt (game object) und füge eine Skriptkomponente mit etwas Testcode hinzu:
+
+```lua
+local s = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+local reverse_s = myextension.reverse(s)
+print(reverse_s) --> ZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedcba
+```
+
+Das war's! Wir haben eine vollständig funktionsfähige native Erweiterung erstellt.
+
+
+## Lebenszyklus einer Erweiterung {#extension-lifecycle}
+
+Wie oben gezeigt, wird das Makro `DM_DECLARE_EXTENSION` verwendet, um die verschiedenen Einstiegspunkte in den Code der Erweiterung zu deklarieren:
+
+`DM_DECLARE_EXTENSION(symbol, name, app_init, app_final, init, update, on_event, final)`
+
+Über die Einstiegspunkte kannst du Code zu verschiedenen Zeitpunkten im Lebenszyklus einer Erweiterung ausführen:
+
+* Start der Engine
+  * Die Systeme der Engine starten
+  * `app_init` der Erweiterung
+  * `init` der Erweiterung - Alle Defold-APIs wurden initialisiert. Dies ist der empfohlene Zeitpunkt im Lebenszyklus der Erweiterung, um Lua-Anbindungen an den Code der Erweiterung zu erstellen.
+  * Initialisierung der Skripte - Die Funktion `init()` der Skriptdateien wird aufgerufen.
+* Engine-Schleife
+  * Aktualisierung der Engine
+    * `update` der Erweiterung
+    * Aktualisierung der Skripte - Die Funktion `update()` der Skriptdateien wird aufgerufen.
+  * Engine-Ereignisse (Fenster minimieren/maximieren usw.)
+    * `on_event` der Erweiterung
+* Beenden der Engine (oder Neustart)
+  * Finalisierung der Skripte - Die Funktion `final()` der Skriptdateien wird aufgerufen.
+  * `final` der Erweiterung
+  * `app_final` der Erweiterung
+
+## Definierte Plattformbezeichner {#defined-platform-identifiers}
+
+Die folgenden Bezeichner werden vom Build-Dienst auf der jeweiligen Plattform definiert:
+
+* `DM_PLATFORM_WINDOWS`
+* `DM_PLATFORM_OSX`
+* `DM_PLATFORM_IOS`
+* `DM_PLATFORM_ANDROID`
+* `DM_PLATFORM_LINUX`
+* `DM_PLATFORM_HTML5`
+
+## Protokolle des Build-Servers {#build-server-logs}
+
+Protokolle des Build-Servers sind verfügbar, wenn das Projekt native Erweiterungen verwendet. Das Protokoll des Build-Servers (`log.txt`) wird beim Erstellen eines Builds des Projekts zusammen mit der angepassten Engine heruntergeladen, in der Datei `.internal/%platform%/build.zip` gespeichert und außerdem in den Build-Ordner deines Projekts entpackt.
+
+## Beispielerweiterungen {#example-extensions}
+
+* [Einfaches Erweiterungsbeispiel](https://github.com/defold/template-native-extension) (die Erweiterung aus diesem Handbuch)
+* [Beispiel für eine Android-Erweiterung](https://github.com/defold/extension-android)
+* [Beispiel für eine HTML5-Erweiterung](https://github.com/defold/extension-html5)
+* [Videoplayer-Erweiterung für macOS, iOS und Android](https://github.com/defold/extension-videoplayer)
+* [Kamera-Erweiterung für macOS und iOS](https://github.com/defold/extension-camera)
+* [Erweiterung für In-App-Käufe unter iOS und Android](https://github.com/defold/extension-iap)
+* [Firebase-Analytics-Erweiterung für iOS und Android](https://github.com/defold/extension-firebase-analytics)
+
+Das [Defold Asset Portal](https://www.defold.com/assets/) enthält ebenfalls mehrere native Erweiterungen.

--- a/docs/de/manuals/facebook.md
+++ b/docs/de/manuals/facebook.md
@@ -1,0 +1,6 @@
+---
+title: Facebook in Defold
+brief: Facebook in Defold.
+---
+
+[Dieses Handbuch wurde verschoben](/extension-facebook)

--- a/docs/de/manuals/factory.md
+++ b/docs/de/manuals/factory.md
@@ -1,0 +1,274 @@
+---
+title: Handbuch zu Fabrikkomponenten
+brief: Dieses Handbuch erklärt, wie du Fabrikkomponenten verwendest, um Spielobjekte zur Laufzeit dynamisch zu erzeugen.
+---
+
+# Fabrikkomponenten {#factory-components}
+
+Eine Fabrik (factory) ist eine Komponente (component), die Spielobjekte (game objects) aus einem Objektpool dynamisch in einem laufenden Spiel erzeugt.
+
+Wenn du einem Spielobjekt eine Fabrikkomponente hinzufügst, legst du in der Eigenschaft *Prototype* fest, welche Spielobjektdatei die Fabrik als Prototyp (in anderen Engines auch als „Prefabs“ oder „Blueprints“ bekannt) für alle neuen Spielobjekte verwenden soll, die sie erzeugt.
+
+![Fabrikkomponente](images/factory/factory_collection.png)
+
+![Fabrikkomponente](images/factory/factory_component.png)
+
+Rufe `factory.create()` auf, um die Erzeugung eines Spielobjekts auszulösen:
+
+```lua
+-- factory.script
+local p = go.get_position()
+p.y = vmath.lerp(math.random(), min_y, max_y)
+local component = "#star_factory"
+factory.create(component, p)
+```
+
+![Dynamisch erzeugtes Spielobjekt](images/factory/factory_spawned.png)
+
+`factory.create()` nimmt 5 Parameter entgegen:
+
+`url`
+: Der Bezeichner (ID) der Fabrikkomponente, die ein neues Spielobjekt erzeugen soll.
+
+`[position]`
+: (optional) Die Position des neuen Spielobjekts im Weltkoordinatensystem. Sie sollte als `vector3` angegeben werden. Wenn du keine Position angibst, wird das Spielobjekt an der Position des Spielobjekts erzeugt, das `factory.create()` aufruft.
+
+`[rotation]`
+: (optional) Die Drehung des neuen Spielobjekts im Weltkoordinatensystem. Sie sollte als `quat` angegeben werden.
+
+`[properties]`
+: (optional) Eine Lua-Tabelle mit beliebigen Werten für Skripteigenschaften, mit denen das Spielobjekt initialisiert werden soll. Informationen zu Skripteigenschaften findest du im [Handbuch zu Skripteigenschaften](/manuals/script-properties).
+
+`[scale]`
+: (optional) Die Skalierung des erzeugten Spielobjekts. Die Skalierung kann als Wert vom Typ `number` (größer als 0) angegeben werden, der eine gleichmäßige Skalierung entlang aller Achsen festlegt. Du kannst auch einen `vector3` angeben, bei dem jede Komponente die Skalierung entlang der entsprechenden Achse festlegt.
+
+Zum Beispiel:
+
+```lua
+-- factory.script
+local p = go.get_position()
+p.y = vmath.lerp(math.random(), min_y, max_y)
+local component = "#star_factory"
+-- Spawn with no rotation but double scale.
+-- Set the score of the star to 10.
+factory.create(component, p, nil, { score = 10 }, 2.0) -- <1>
+```
+1. Legt die Eigenschaft „score“ des Stern-Spielobjekts fest.
+
+```lua
+-- star.script
+go.property("score", 1) -- <1>
+
+local speed = -240
+
+function update(self, dt)
+    local p = go.get_position()
+    p.x = p.x + speed * dt
+    if p.x < -32 then
+        go.delete()
+    end
+    go.set_position(p)
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("collision_response") then
+        msg.post("main#gui", "add_score", {amount = self.score}) -- <2>
+        go.delete()
+    end
+end
+```
+1. Die Skripteigenschaft „score“ wird mit einem Standardwert definiert.
+2. Greife auf die Skripteigenschaft „score“ als einen in „self“ gespeicherten Wert zu.
+
+![Dynamisch erzeugtes Spielobjekt mit Eigenschaft und Skalierung](images/factory/factory_spawned2.png)
+
+::: sidenote
+Defold unterstützt derzeit keine ungleichmäßige Skalierung von Kollisionsformen. Wenn du einen ungleichmäßigen Skalierungswert angibst, zum Beispiel `vmath.vector3(1.0, 2.0, 1.0)`, wird das Sprite korrekt skaliert, die Kollisionsformen jedoch nicht.
+:::
+
+
+## Adressierung von Objekten, die eine Fabrik erzeugt hat {#addressing-of-factory-created-objects}
+
+Mit dem Adressierungsmechanismus von Defold kannst du auf jedes Objekt und jede Komponente in einem laufenden Spiel zugreifen. Das [Handbuch zur Adressierung](/manuals/addressing/) erklärt ausführlich, wie das System funktioniert. Du kannst denselben Adressierungsmechanismus auch für dynamisch erzeugte Spielobjekte und deren Komponenten verwenden. Oft genügt die ID des erzeugten Objekts, zum Beispiel beim Senden einer Nachricht:
+
+```lua
+local function create_hunter(target_id)
+    local id = factory.create("#hunterfactory")
+    msg.post(id, "hunt", { target = target_id })
+    return id
+end
+```
+
+::: sidenote
+Wenn du eine Nachricht an das Spielobjekt selbst statt an eine bestimmte Komponente sendest, wird sie tatsächlich an alle Komponenten gesendet. Das ist normalerweise kein Problem, aber du solltest es im Hinterkopf behalten, wenn das Objekt viele Komponenten hat.
+:::
+
+Was aber, wenn du auf eine bestimmte Komponente eines erzeugten Spielobjekts zugreifen musst, zum Beispiel um ein Kollisionsobjekt zu deaktivieren oder das Bild eines Sprites zu ändern? Die Lösung besteht darin, eine URL aus der ID des Spielobjekts und der ID der Komponente zusammenzusetzen.
+
+```lua
+local function create_guard(unarmed)
+    local id = factory.create("#guardfactory")
+    if unarmed then
+        local weapon_sprite_url = msg.url(nil, id, "weapon")
+        msg.post(weapon_sprite_url, "disable")
+
+        local body_sprite_url = msg.url(nil, id, "body")
+        sprite.play_flipbook(body_sprite_url, hash("red_guard"))
+    end
+end
+```
+
+
+## Erzeugte und übergeordnete Objekte nachverfolgen {#tracking-spawned-and-parent-objects}
+
+Wenn du `factory.create()` aufrufst, erhältst du die ID des neuen Spielobjekts zurück und kannst sie für spätere Zugriffe speichern. Häufig erzeugst du Objekte und fügst ihre IDs einer Tabelle hinzu, damit du sie später alle löschen kannst, zum Beispiel beim Zurücksetzen einer Level-Anordnung:
+
+```lua
+-- spawner.script
+self.spawned_coins = {}
+
+...
+
+-- Spawn a coin and store it in the "coins" table.
+local id = factory.create("#coinfactory", coin_position)
+table.insert(self.spawned_coins, id)
+```
+
+Und später:
+
+```lua
+-- spawner.script
+-- Delete all spawned coins.
+for _, coin_id in ipairs(self.spawned_coins) do
+    go.delete(coin_id)
+end
+
+-- or alternatively
+go.delete(self.spawned_coins)
+```
+
+Häufig soll das erzeugte Objekt auch das Spielobjekt kennen, das es erzeugt hat. Ein Beispiel wäre ein autonomes Objekt, von dem jeweils nur eines erzeugt werden kann. Das erzeugte Objekt muss dann seinen Erzeuger benachrichtigen, wenn es gelöscht oder deaktiviert wird, damit ein weiteres erzeugt werden kann:
+
+```lua
+-- spawner.script
+-- Spawn a drone and set its parent to the url of this script component
+self.spawned_drone = factory.create("#dronefactory", drone_position, nil, { parent = msg.url() })
+
+...
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("drone_dead") then
+        self.spawned_drone = nil
+    end
+end
+```
+
+Und die Logik des erzeugten Objekts:
+
+```lua
+-- drone.script
+go.property("parent", msg.url())
+
+...
+
+function final(self)
+    -- I'm dead.
+    msg.post(self.parent, "drone_dead")
+end
+```
+
+## Dynamisches Laden von Fabrikressourcen {#dynamic-loading-of-factory-resources}
+
+Wenn du das Kontrollkästchen *Load Dynamically* in den Eigenschaften der Fabrik aktivierst, verschiebt die Engine das Laden der mit der Fabrik verknüpften Ressourcen auf einen späteren Zeitpunkt.
+
+![Dynamisch laden](images/factory/load_dynamically.png)
+
+Wenn das Kontrollkästchen deaktiviert ist, lädt die Engine die Prototypressourcen beim Laden der Fabrikkomponente, sodass sie sofort zum Erzeugen von Objekten bereitstehen.
+
+Wenn das Kontrollkästchen aktiviert ist, hast du zwei Möglichkeiten:
+
+Synchrones Laden
+: Rufe [`factory.create()`](/ref/factory/#factory.create) auf, wenn du Objekte erzeugen möchtest. Dadurch werden die Ressourcen synchron geladen, was zu einem kurzen Ruckler führen kann. Anschließend werden neue Instanzen erzeugt.
+
+  ```lua
+  function init(self)
+      -- No factory resources are loaded when the factory’s parent
+      -- collection is loaded. Calling create without having called
+      -- load will create the resources synchronously.
+      self.go_id = factory.create("#factory")
+  end
+
+  function final(self)  
+      -- Delete game objects. Will decref resources.
+      -- In this case resources are deleted since the factory component
+      -- holds no reference.
+      go.delete(self.go_id)
+
+      -- Calling unload will do nothing since factory holds no references
+      factory.unload("#factory")
+  end
+  ```
+
+Asynchrones Laden
+: Rufe [`factory.load()`](/ref/factory/#factory.load) auf, um die Ressourcen ausdrücklich asynchron zu laden. Sobald die Ressourcen zum Erzeugen von Objekten bereitstehen, wird ein Callback aufgerufen.
+
+  ```lua
+  function load_complete(self, url, result)
+      -- Loading is complete, resources are ready to spawn
+      self.go_id = factory.create(url)
+  end
+
+  function init(self)
+      -- No factory resources are loaded when the factory’s parent
+      -- collection is loaded. Calling load will load the resources.
+      factory.load("#factory", load_complete)
+  end
+
+  function final(self)
+      -- Delete game object. Will decref resources.
+      -- In this case resources aren’t deleted since the factory component
+      -- still holds a reference.
+      go.delete(self.go_id)
+
+      -- Calling unload will decref resources held by the factory component,
+      -- resulting in resources being destroyed.
+      factory.unload("#factory")
+  end
+  ```
+
+## Dynamischer Prototyp {#dynamic-prototype}
+
+Du kannst ändern, welchen *Prototype* eine Fabrik erzeugen kann, indem du das Kontrollkästchen *Dynamic Prototype* in den Eigenschaften der Fabrik aktivierst.
+
+![Dynamischer Prototyp](images/factory/dynamic_prototype.png)
+
+Wenn die Option *Dynamic Prototype* aktiviert ist, kann die Fabrikkomponente den Prototyp mit der Funktion `factory.set_prototype()` ändern. Beispiel:
+
+```lua
+factory.unload("#factory") -- unload the previous resources
+factory.set_prototype("#factory", "/main/levels/enemyA.goc")
+local enemy_id = factory.create("#factory")
+```
+
+::: important
+Wenn die Option *Dynamic Prototype* aktiviert ist, kann die Anzahl der Komponenten in der Sammlung (collection) nicht optimiert werden. Die Sammlung, zu der die Fabrik gehört, verwendet dann die Standardanzahlen für Komponenten aus der Datei *game.project*.
+:::
+
+
+## Instanzgrenzen {#instance-limits}
+
+Die Projekteinstellung *Max Instances* unter *Collection* ist die Obergrenze für die Anzahl der Spielobjekte in jeder Sammlung (Welt). Beim Build kann Defold eine kleinere Kapazität zuweisen, wenn sich feststellen lässt, dass dies sicher ist. Alle gleichzeitig existierenden Spielobjekte in einer Welt zählen zu dieser Kapazität, unabhängig davon, ob sie im Editor platziert oder zur Laufzeit erzeugt wurden.
+
+![Maximale Anzahl der Instanzen](images/factory/factory_max_instances.png)
+
+Die tatsächliche Zuweisung hängt von der Analyse beim Build ab:
+
+* Wenn beim Build eine feste Anzahl von Spielobjekten ermittelt werden kann (in der Regel, wenn die Sammlung weder eine Fabrik noch eine Sammlungsfabrik (collection factory) enthält), entspricht die Kapazität der kompilierten Anzahl, begrenzt durch *Max Instances*.
+* Eine Sammlung, die eine Fabrik oder Sammlungsfabrik enthält, verwendet *Max Instances* als Kapazität für Spielobjekte. Bei einem statisch referenzierten Prototyp ermittelt der Build, welche Komponententypen die Fabrik erzeugen kann. Diese Typen verwenden ihre jeweiligen im Projekt festgelegten Höchstanzahlen, während nicht betroffene Komponententypen weiterhin genaue Anzahlen verwenden können.
+* Wenn du *Dynamic Prototype* aktivierst, wird die Analyse der Komponentenanzahl für die Sammlung, zu der die Fabrik gehört, deaktiviert. Sie verwendet deshalb *Max Instances* und die konfigurierten Höchstanzahlen für die einzelnen Komponententypen.
+
+Richte *Max Instances* nach der größten Anzahl von Spielobjekten aus, die in einer dynamischen Welt gleichzeitig existieren können. Unter [Optimierung der maximalen Komponentenanzahl](/manuals/project-settings/#component-max-count-optimizations) erfährst du, wie die übrigen Komponentengrenzen berechnet werden.
+
+## Spielobjekte in Pools verwalten {#pooling-of-game-objects}
+
+Es mag sinnvoll erscheinen, erzeugte Spielobjekte in einem Pool zu speichern und wiederzuverwenden. Die Engine verwendet jedoch intern bereits Objektpooling, sodass zusätzlicher Verwaltungsaufwand die Abläufe nur verlangsamt. Spielobjekte zu löschen und neue zu erzeugen ist sowohl schneller als auch sauberer.

--- a/docs/de/manuals/file-access.md
+++ b/docs/de/manuals/file-access.md
@@ -1,0 +1,147 @@
+---
+title: Mit Dateien arbeiten
+brief: Dieses Handbuch erklärt, wie du Dateien speicherst und lädst und andere Dateioperationen ausführst.
+---
+
+# Mit Dateien arbeiten {#working-with-files}
+Es gibt viele verschiedene Möglichkeiten, Dateien zu erstellen und/oder auf sie zuzugreifen. Die Dateipfade und die Art des Zugriffs unterscheiden sich je nach Dateityp und Speicherort der Datei.
+
+## Funktionen für den Zugriff auf Dateien und Ordner {#functions-for-file-and-folder-access}
+Defold bietet verschiedene Funktionen für die Arbeit mit Dateien:
+
+* Du kannst die standardmäßigen [`io.*`-Funktionen](https://defold.com/ref/stable/io/) verwenden, um Dateien zu lesen und zu schreiben. Mit diesen Funktionen kannst du den gesamten Ein-/Ausgabeprozess sehr genau steuern.
+
+```lua
+-- open myfile.txt for writing in binary mode
+-- returns nil plus error message on failure
+local f, err = io.open("path/to/myfile.txt", "wb")
+if not f then
+	print("Something went wrong while opening the file", err)
+	return
+end
+
+-- write to the file, flush it to disk and then close the file
+f:write("Foobar")
+f:flush()
+f:close()
+
+-- open myfile.txt for reading in binary mode
+-- returns nil plus error message on failure
+local f, err = io.open("path/to/myfile.txt", "rb")
+if not f then
+	print("Something went wrong while opening the file", err)
+	return
+end
+
+-- read the entire file as a string
+-- returns nil on failure
+local s = f:read("*a")
+if not s then
+	print("Error while reading file")
+	return
+end
+
+print(s) -- Foobar
+```
+
+* Du kannst [`os.rename()`](https://defold.com/ref/stable/os/#os.rename:oldname-newname) und [`os.remove()`](https://defold.com/ref/stable/os/#os.remove:filename) verwenden, um Dateien umzubenennen und zu löschen.
+
+* Du kannst [`sys.save()`](https://defold.com/ref/stable/sys/#sys.save:filename-table) und [`sys.load()`](https://defold.com/ref/stable/sys/#sys.load:filename) verwenden, um Lua-Tabellen zu lesen und zu schreiben. Weitere [`sys.*`](https://defold.com/ref/stable/sys/)-Funktionen helfen dabei, Dateipfade plattformunabhängig zu ermitteln.
+
+```lua
+-- get a platform independent path to the file "highscore" for application "mygame"
+local path = sys.get_save_file("mygame", "highscore")
+
+-- save a Lua table with some data
+local ok = sys.save(path, { highscore = 100 })
+if not ok then
+	print("Failed to save", path)
+	return
+end
+
+-- load the data
+local ok, data = pcall(sys.load, path)
+if not ok then
+	-- The file exists, but is corrupt, foreign, or uses an unsupported format.
+	print("Failed to load save data:", data)
+	data = {}
+end
+print(data.highscore) -- 100
+```
+
+`sys.load()` gibt eine leere Tabelle zurück, wenn die Datei nicht existiert. Wenn die Datei existiert, aber nicht mit `sys.save()` erstellt wurde, beschädigt ist oder ein nicht unterstütztes Format für serialisierte Tabellen verwendet, löst `sys.load()` einen Lua-Fehler aus. Verwende wie oben gezeigt `pcall()`, wenn die Anwendung Fehler durch beschädigte oder extern veränderte Speicherdaten abfangen können muss.
+
+
+## Speicherorte von Dateien und Ordnern {#file-and-folder-locations}
+Die Speicherorte von Dateien und Ordnern lassen sich in drei Kategorien einteilen:
+
+* Anwendungsspezifische Dateien, die deine Anwendung erstellt
+* Dateien und Ordner, die mit deiner Anwendung gebündelt werden
+* Systemspezifische Dateien, auf die deine Anwendung zugreift
+
+### Anwendungsspezifische Dateien speichern und laden {#how-to-save-and-load-application-specific-files}
+Es wird empfohlen, anwendungsspezifische Dateien wie Höchstpunktzahlen, Benutzereinstellungen und den Spielzustand an einem Speicherort zu speichern und zu laden, den das Betriebssystem eigens für diesen Zweck bereitstellt. Mit [`sys.get_save_file()`](https://defold.com/ref/stable/sys/#sys.get_save_file:application_id-file_name) kannst du den betriebssystemspezifischen absoluten Pfad zu einer Datei ermitteln. Sobald du den absoluten Pfad hast, kannst du die Funktionen `sys.*`, `io.*` und `os.*` verwenden (siehe oben).
+
+[Sieh dir das Beispiel zur Verwendung von `sys.save()` und `sys.load()` an](/examples/file/sys_save_load/).
+
+### Auf Dateien zugreifen, die mit der Anwendung gebündelt sind {#how-to-access-files-bundled-with-the-application}
+Mit Bundle-Ressourcen (bundle resources) und benutzerdefinierten Ressourcen (custom resources) kannst du Dateien in deine Anwendung aufnehmen.
+
+#### Benutzerdefinierte Ressourcen {#custom-resources}
+:[Custom Resources](../shared/custom-resources.md)
+
+Erweiterungen können diese Dateien auch über `ext.properties` bereitstellen. Ihre Pfade werden sowohl bei Editor-Builds als auch bei Bob-Archiven mit den benutzerdefinierten Ressourcen des Projekts zusammengeführt. Siehe [benutzerdefinierte Ressourcen von Erweiterungen](/manuals/extensions/#custom-resources).
+
+```lua
+-- Load level data into a string
+local data, error = sys.load_resource("/assets/level_data.json")
+-- Decode json string to a Lua table
+if data then
+  local data_table = json.decode(data)
+  pprint(data_table)
+else
+  print(error)
+end
+```
+
+#### Bundle-Ressourcen {#bundle-resources}
+:[Bundle Resources](../shared/bundle-resources.md)
+
+```lua
+local path = sys.get_application_path()
+local f = io.open(path .. "/mycommonfile.txt", "rb")
+local txt, err = f:read("*a")
+if not txt then
+	print(err)
+	return
+end
+print(txt)
+```
+
+::: sidenote
+Aus Sicherheitsgründen dürfen Browser (und damit auch jeglicher JavaScript-Code, der in einem Browser ausgeführt wird) nicht auf Systemdateien zugreifen. Dateioperationen funktionieren in HTML5-Builds von Defold weiterhin, allerdings nur in einem „virtuellen Dateisystem“, das die IndexedDB-API des Browsers verwendet. Das bedeutet, dass du mit den Funktionen `io.*` oder `os.*` nicht auf Bundle-Ressourcen zugreifen kannst. Du kannst jedoch mit `http.request()` auf Bundle-Ressourcen zugreifen.
+:::
+
+
+#### Benutzerdefinierte Ressourcen und Bundle-Ressourcen – Vergleich {#custom-and-bundle-resources-comparison}
+
+| Merkmal                     | Benutzerdefinierte Ressourcen             | Bundle-Ressourcen                              |
+|-----------------------------|-------------------------------------------|------------------------------------------------|
+| Ladegeschwindigkeit         | Schneller – Dateien werden aus einem Binärarchiv geladen | Langsamer – Dateien werden aus dem Dateisystem geladen |
+| Dateien teilweise laden     | Nein – nur vollständige Dateien           | Ja – beliebige Bytes aus einer Datei lesen     |
+| Dateien nach der Bundle-Erstellung ändern | Nein – Dateien sind in einem Binärarchiv gespeichert | Ja – Dateien sind im lokalen Dateisystem gespeichert |
+| HTML5-Unterstützung         | Ja                                        | Ja – aber Zugriff über HTTP und nicht über Datei-Ein-/Ausgabe |
+
+
+### Zugriff auf Systemdateien {#system-file-access}
+Das Betriebssystem kann den Zugriff auf Systemdateien aus Sicherheitsgründen einschränken. Mit der nativen Erweiterung (native extension) [`extension-directories`](https://defold.com/assets/extensiondirectories/) kannst du den absoluten Pfad zu einigen gängigen Systemverzeichnissen ermitteln (z. B. `documents`, `resource`, `temp`). Sobald du den absoluten Pfad dieser Dateien hast, kannst du mit den Funktionen `io.*` und `os.*` auf die Dateien zugreifen (siehe oben).
+
+::: sidenote
+Aus Sicherheitsgründen dürfen Browser (und damit auch jeglicher JavaScript-Code, der in einem Browser ausgeführt wird) nicht auf Systemdateien zugreifen. Dateioperationen funktionieren in HTML5-Builds von Defold weiterhin, allerdings nur in einem „virtuellen Dateisystem“, das die IndexedDB-API des Browsers verwendet. Das bedeutet, dass du in HTML5-Builds nicht auf Systemdateien zugreifen kannst.
+:::
+
+## Erweiterungen {#extensions}
+Das [Asset Portal](https://defold.com/assets/) enthält verschiedene Assets, die den Zugriff auf Dateien und Ordner vereinfachen. Einige Beispiele:
+
+* [Lua File System (LFS)](https://defold.com/assets/luafilesystemlfs/) - Funktionen für die Arbeit mit Verzeichnissen, Dateiberechtigungen usw.
+* [DefSave](https://defold.com/assets/defsave/) - Ein Modul, mit dem du Konfigurations- und Spielerdaten über Sitzungen hinweg speichern und laden kannst.

--- a/docs/de/manuals/flash.md
+++ b/docs/de/manuals/flash.md
@@ -1,0 +1,355 @@
+---
+title: Defold für Flash-Nutzer
+brief: Dieses Handbuch stellt Defold als Alternative für die Entwicklung von Flash-Spielen vor. Es behandelt einige der wichtigsten Konzepte der Spieleentwicklung mit Flash und erläutert die entsprechenden Werkzeuge und Methoden in Defold.
+---
+
+# Defold für Flash-Nutzer {#defold-for-flash-users}
+
+Dieses Handbuch stellt Defold als Alternative für die Entwicklung von Flash-Spielen vor. Es behandelt einige der wichtigsten Konzepte der Spieleentwicklung mit Flash und erläutert die entsprechenden Werkzeuge und Methoden in Defold.
+
+## Einführung {#introduction}
+
+Zu den wichtigsten Vorteilen von Flash gehörten seine Zugänglichkeit und die niedrige Einstiegshürde. Neue Nutzer konnten das Programm schnell erlernen und mit geringem Zeitaufwand einfache Spiele erstellen. Defold bietet einen ähnlichen Vorteil durch eine Reihe von Werkzeugen, die speziell für die Spieleentwicklung gedacht sind. Gleichzeitig können erfahrene Entwickler fortgeschrittene Lösungen für komplexere Anforderungen erstellen, beispielsweise indem sie das standardmäßige Render-Skript bearbeiten.
+
+Flash-Spiele werden in ActionScript programmiert (wobei 3.0 die neueste Version ist), während Skripte in Defold in Lua geschrieben werden. Dieses Handbuch geht nicht auf einen detaillierten Vergleich von Lua und ActionScript 3.0 ein. Das [Defold-Handbuch](/manuals/lua) bietet eine gute Einführung in die Lua-Programmierung in Defold und verweist auf das äußerst hilfreiche Buch [Programming in Lua](https://www.lua.org/pil/) (erste Auflage), das kostenlos online verfügbar ist.
+
+Ein Artikel von Jesse Warden bietet einen [grundlegenden Vergleich von ActionScript und Lua](http://jessewarden.com/2011/01/lua-for-actionscript-developers.html), der als guter Ausgangspunkt dienen kann. Beachte jedoch, dass sich der Aufbau von Defold und Flash grundlegender unterscheidet, als es auf der Sprachebene sichtbar ist. ActionScript und Flash sind im klassischen Sinn objektorientiert, mit Klassen und Vererbung. Defold hat weder Klassen noch Vererbung. Es enthält das Konzept eines *Spielobjekts* (game object), das audiovisuelle Darstellung, Verhalten und Daten enthalten kann. Operationen an Spielobjekten werden mit *Funktionen* ausgeführt, die in den Defold-APIs verfügbar sind. Darüber hinaus fördert Defold die Verwendung von *Nachrichten* zur Kommunikation zwischen Objekten. Nachrichten sind ein Konstrukt auf einer höheren Abstraktionsebene als Methodenaufrufe und sind nicht dafür gedacht, wie solche verwendet zu werden. Diese Unterschiede sind wichtig und erfordern etwas Eingewöhnung, werden in diesem Handbuch aber nicht im Detail behandelt.
+
+Stattdessen untersucht dieses Handbuch einige der wichtigsten Konzepte der Spieleentwicklung in Flash und zeigt, welche Entsprechungen ihnen in Defold am nächsten kommen. Gemeinsamkeiten und Unterschiede werden ebenso wie häufige Stolperfallen erläutert, damit dir der Wechsel von Flash zu Defold zügig gelingt.
+
+## Movieclips und Spielobjekte {#movie-clips-and-game-objects}
+
+Movieclips sind ein zentraler Bestandteil der Spieleentwicklung mit Flash. Es handelt sich um Symbole, die jeweils eine eigene Zeitleiste enthalten. Das ähnlichste Konzept in Defold ist ein Spielobjekt.
+
+![Spielobjekt und Movieclip](images/flash/go_movieclip.png)
+
+Anders als Flash-Movieclips haben Defold-Spielobjekte keine Zeitleisten. Stattdessen besteht ein Spielobjekt aus mehreren Komponenten (components). Zu den Komponenten gehören unter anderem Sprites, Audiokomponenten und Skripte (weitere Informationen zu den verfügbaren Komponenten findest du in der [Dokumentation zu den Bausteinen](/manuals/building-blocks) und den zugehörigen Artikeln). Das Spielobjekt in der folgenden Bildschirmaufnahme besteht aus einem Sprite und einem Skript. Mit der Skriptkomponente steuerst du das Verhalten und das Aussehen von Spielobjekten während ihres gesamten Lebenszyklus:
+
+![Skriptkomponente](images/flash/script_component.png)
+
+Während Movieclips andere Movieclips enthalten können, können Spielobjekte keine Spielobjekte *enthalten*. Spielobjekte können jedoch anderen Spielobjekten *untergeordnet werden*. Dadurch entstehen Hierarchien, die gemeinsam verschoben, skaliert oder gedreht werden können.
+
+## Flash—Movieclips manuell erstellen {#flashmanually-creating-movie-clips}
+
+In Flash kannst du Instanzen von Movieclips manuell zu deiner Szene hinzufügen, indem du sie aus der Bibliothek auf die Zeitleiste ziehst. Das zeigt die folgende Bildschirmaufnahme, in der jedes Flash-Logo eine Instanz des Movieclips `logo` ist:
+
+![Manuell erstellte Movieclips](images/flash/manual_movie_clips.png)
+
+## Defold—Spielobjekte manuell erstellen {#defoldmanually-creating-game-objects}
+
+Wie bereits erwähnt, gibt es in Defold kein Konzept einer Zeitleiste. Stattdessen werden Spielobjekte in Sammlungen (collections) organisiert. Sammlungen sind Container (oder Prefabs), die Spielobjekte und andere Sammlungen enthalten. Im einfachsten Fall kann ein Spiel aus nur einer Sammlung bestehen. Häufiger verwenden Defold-Spiele mehrere Sammlungen, die entweder manuell zur Startsammlung (bootstrap collection) `main` hinzugefügt oder über [Sammlungs-Proxys](/manuals/collection-proxy) (collection proxies) dynamisch geladen werden. Für dieses Konzept, „Level“ oder „Bildschirme“ zu laden, gibt es keine direkte Entsprechung in Flash.
+
+Im folgenden Beispiel enthält die Sammlung `main` drei Instanzen (rechts im Fenster *Outline* aufgelistet) des Spielobjekts `logo` (links im Browserfenster *Assets* zu sehen):
+
+![Manuell erstellte Spielobjekte](images/flash/manual_game_objects.png)
+
+## Flash—manuell erstellte Movieclips referenzieren {#flashreferencing-manually-created-movie-clips}
+
+Um manuell erstellte Movieclips in Flash zu referenzieren, benötigst du einen manuell festgelegten Instanznamen:
+
+![Instanzname in Flash](images/flash/flash_instance_name.png)
+
+## Defold—Spielobjekt-ID {#defoldgame-object-id}
+
+In Defold werden alle Spielobjekte und Komponenten über eine Adresse referenziert. In den meisten Fällen genügt ein einfacher Name oder eine Kurzform. Zum Beispiel:
+
+- `"."` adressiert das aktuelle Spielobjekt.
+- `"#"` adressiert die aktuelle Komponente (das Skript).
+- `"logo"` adressiert das Spielobjekt mit dem Bezeichner (ID) `logo`.
+- `"#script"` adressiert die Komponente mit der ID `script` im aktuellen Spielobjekt.
+- `"logo#script"` adressiert die Komponente mit der ID `script` im Spielobjekt mit der ID `logo`.
+
+Die Adresse manuell platzierter Spielobjekte wird durch die zugewiesene Eigenschaft *Id* bestimmt (siehe unten rechts in der Bildschirmaufnahme). Die ID muss innerhalb der Sammlungsdatei, in der du gerade arbeitest, eindeutig sein. Der Editor legt automatisch eine ID für dich fest, aber du kannst sie für jede Spielobjektinstanz ändern, die du erstellst.
+
+![Spielobjekt-ID](images/flash/game_object_id.png)
+
+::: sidenote
+Du kannst die ID eines Spielobjekts ermitteln, indem du den folgenden Code in seiner Skriptkomponente ausführst: `print(go.get_id())`. Dadurch wird die ID des aktuellen Spielobjekts in der Konsole ausgegeben.
+:::
+
+Das Adressierungsmodell und die Nachrichtenübermittlung sind zentrale Konzepte der Spieleentwicklung mit Defold. Das [Handbuch zur Adressierung](/manuals/addressing) und das [Handbuch zur Nachrichtenübermittlung](/manuals/message-passing) erläutern sie ausführlich.
+
+## Flash—Movieclips dynamisch erstellen {#flashdynamically-creating-movie-clips}
+
+Um Movieclips in Flash dynamisch zu erstellen, musst du zunächst ActionScript Linkage einrichten:
+
+![ActionScript Linkage](images/flash/actionscript_linkage.png)
+
+Dadurch wird eine Klasse erstellt (in diesem Fall `Logo`), von der du anschließend neue Instanzen erzeugen kannst. Eine Instanz der Klasse `Logo` könntest du wie folgt zur Bühne hinzufügen:
+
+```as
+var logo:Logo = new Logo();
+addChild(logo);
+```
+
+## Defold—Spielobjekte mit Fabriken erstellen {#defoldcreating-game-objects-using-factories}
+
+In Defold werden Spielobjekte mithilfe von *Fabriken* (factories) dynamisch erzeugt. Fabriken sind Komponenten, mit denen du Kopien eines bestimmten Spielobjekts dynamisch erzeugst. In diesem Beispiel wurde eine Fabrik mit dem Spielobjekt `logo` als Prototyp erstellt:
+
+![Fabrik für das Logo](images/flash/logo_factory.png)
+
+Beachte, dass Fabriken wie alle Komponenten einem Spielobjekt hinzugefügt werden müssen, bevor du sie verwenden kannst. In diesem Beispiel haben wir ein Spielobjekt namens `factories` erstellt, das unsere Fabrikkomponente enthält:
+
+![Fabrikkomponente](images/flash/factory_component.png)
+
+Um eine Instanz des Spielobjekts `logo` zu erzeugen, rufst du diese Funktion auf:
+
+```lua
+local logo_id = factory.create("factories#logo_factory")
+```
+
+Die URL ist ein erforderlicher Parameter von `factory.create()`. Zusätzlich kannst du optionale Parameter angeben, um Position, Drehung, Eigenschaften und Skalierung festzulegen. Weitere Informationen zur Fabrikkomponente findest du im [Handbuch zu Fabriken](/manuals/factory). Beachte, dass der Aufruf von `factory.create()` die ID des erstellten Spielobjekts zurückgibt. Diese ID kannst du für spätere Zugriffe in einer Tabelle speichern (die in Lua einem Array entspricht).
+
+## Flash—Bühne {#flashstage}
+
+In Flash kennen wir die Timeline (im oberen Bereich der folgenden Bildschirmaufnahme) und die Stage (unterhalb der Timeline sichtbar):
+
+![Zeitleiste und Bühne](images/flash/stage.png)
+
+Wie oben im Abschnitt über Movieclips erläutert, ist die Bühne im Wesentlichen der oberste Container eines Flash-Spiels und wird bei jedem Export eines Projekts erstellt. Standardmäßig hat die Bühne ein untergeordnetes Objekt, die *`MainTimeline`*. Jeder im Projekt erzeugte Movieclip hat eine eigene Zeitleiste und kann als Container für andere Symbole dienen (einschließlich Movieclips).
+
+## Defold—Sammlungen {#defoldcollections}
+
+Die Entsprechung zur Flash-Bühne in Defold ist eine Sammlung. Beim Start erstellt die Engine anhand des Inhalts einer Sammlungsdatei eine neue Spielwelt. Standardmäßig heißt diese Datei `main.collection`. Du kannst aber ändern, welche Sammlung beim Start geladen wird, indem du die Einstellungsdatei *game.project* im Stammverzeichnis jedes Defold-Projekts öffnest:
+
+![game.project](images/flash/game_project.png)
+
+Sammlungen sind Container, mit denen du im Editor Spielobjekte und andere Sammlungen organisierst. Der Inhalt einer Sammlung kann auch per Skript zur Laufzeit mithilfe einer [Sammlungsfabrik](/manuals/collection-factory/#spawning-a-collection) (collection factory) dynamisch erzeugt werden. Sie funktioniert genauso wie eine normale Spielobjektfabrik. Das ist beispielsweise nützlich, um Gruppen von Gegnern oder eine Anordnung einsammelbarer Münzen dynamisch zu erzeugen. In der folgenden Bildschirmaufnahme haben wir zwei Instanzen der Sammlung `logos` manuell in der Sammlung `main` platziert.
+
+![Sammlung](images/flash/collection.png)
+
+In manchen Fällen möchtest du eine völlig neue Spielwelt laden. Mit der Komponente [Sammlungs-Proxy](/manuals/collection-proxy/) kannst du anhand des Inhalts einer Sammlungsdatei eine neue Spielwelt erstellen. Das ist beispielsweise beim Laden neuer Spiellevel, Minispiele oder Zwischensequenzen nützlich.
+
+## Flash—Zeitleiste {#flashtimeline}
+
+Die Flash-Zeitleiste wird hauptsächlich für Animationen verwendet, mit verschiedenen Einzelbildtechniken oder Form- und Bewegungs-Tweens. Die allgemeine Einstellung der Bildrate des Projekts in Bildern pro Sekunde (FPS) legt fest, wie lange ein Einzelbild angezeigt wird. Erfahrene Nutzer können die allgemeine Bildrate des Spiels oder sogar die einzelner Movieclips ändern.
+
+Form-Tweens ermöglichen die Interpolation von Vektorgrafiken zwischen zwei Zuständen. Das ist meist nur für einfache Formen und Anwendungen nützlich, wie das folgende Beispiel zeigt, in dem ein Quadrat durch Form-Tweening in ein Dreieck übergeht:
+
+![Zeitleiste](images/flash/timeline.png)
+
+Bewegungs-Tweens ermöglichen die Animation verschiedener Eigenschaften eines Objekts, darunter Größe, Position und Drehung. Im folgenden Beispiel wurden alle aufgeführten Eigenschaften verändert.
+
+![Bewegungs-Tween](images/flash/tween.png)
+
+## Defold—Eigenschaftsanimation {#defoldproperty-animation}
+
+Defold arbeitet mit Pixelbildern statt mit Vektorgrafiken und hat daher keine Entsprechung zum Form-Tweening. Für Bewegungs-Tweening gibt es jedoch mit der [Eigenschaftsanimation](/ref/go/#go.animate) eine leistungsfähige Entsprechung. Sie wird per Skript mit der Funktion `go.animate()` ausgeführt. Die Funktion `go.animate()` interpoliert eine Eigenschaft (etwa Farbe, Skalierung, Drehung oder Position) vom Anfangswert zum gewünschten Endwert und verwendet dabei eine der vielen verfügbaren Easing-Funktionen (einschließlich benutzerdefinierter Funktionen). Während du fortgeschrittene Easing-Funktionen in Flash selbst implementieren musstest, sind in Defold [viele Easing-Funktionen](/manuals/property-animation/#easing) direkt in die Engine integriert.
+
+Während Flash Grafiken mithilfe von Schlüsselbildern (keyframes) auf einer Zeitleiste animiert, gehört die Flipbook-Animation importierter Bildfolgen zu den wichtigsten Methoden der Grafikanimation in Defold. Animationen werden in einer Spielobjektkomponente namens Atlas organisiert. In diesem Fall haben wir einen Atlas für eine Spielfigur mit einer Animationssequenz namens `run`. Sie besteht aus einer Reihe von PNG-Dateien:
+
+![Flipbook-Animation](images/flash/flipbook.png)
+
+## Flash—Tiefenindex {#flashdepth-index}
+
+In Flash bestimmt die Anzeigeliste, was in welcher Reihenfolge dargestellt wird. Die Reihenfolge von Objekten in einem Container (beispielsweise der Bühne) wird über einen Index verwaltet. Objekte, die du einem Container mit der Methode `addChild()` hinzufügst, belegen automatisch die oberste Position im Index. Dieser beginnt bei 0 und wird mit jedem weiteren Objekt erhöht. In der folgenden Bildschirmaufnahme haben wir drei Instanzen des Movieclips `logo` erzeugt:
+
+![Tiefenindex](images/flash/depth_index.png)
+
+Die Positionen in der Anzeigeliste sind durch die Zahlen neben jeder Instanz von `logo` angegeben. Ohne den Code für die x/y-Position der Movieclips zu berücksichtigen, könnte das obige Ergebnis wie folgt erzeugt worden sein:
+
+```as
+var logo1:Logo = new Logo();
+var logo2:Logo = new Logo();
+var logo3:Logo = new Logo();
+
+addChild(logo1);
+addChild(logo2);
+addChild(logo3);
+```
+
+Ob ein Objekt über oder unter einem anderen Objekt angezeigt wird, hängt von ihren relativen Positionen im Index der Anzeigeliste ab. Das lässt sich gut veranschaulichen, indem du die Indexpositionen zweier Objekte vertauschst, zum Beispiel:
+
+```as
+swapChildren(logo2,logo3);
+```
+
+Das Ergebnis sähe wie folgt aus (mit aktualisierter Indexposition):
+
+![Tiefenindex](images/flash/depth_index_2.png)
+
+## Defold—z-Position
+
+Die Positionen von Spielobjekten in Defold werden durch Vektoren mit drei Variablen dargestellt: x, y und z. Die z-Position bestimmt die Tiefe eines Spielobjekts. Im standardmäßigen [Render-Skript](/manuals/render) liegen die verfügbaren z-Positionen im Bereich von -1 bis 1.
+
+::: sidenote
+Spielobjekte mit einer z-Position außerhalb des Bereichs von -1 bis 1 werden nicht gerendert und sind daher nicht sichtbar. Das ist eine häufige Stolperfalle beim Einstieg in Defold. Denke daran, wenn ein Spielobjekt nicht sichtbar ist, obwohl du es erwartest.
+:::
+
+Anders als in Flash, wo der Editor die Tiefenindizierung nur indirekt darstellt (und Änderungen mit Befehlen wie *Bring Forward* und *Send Backward* ermöglicht), kannst du in Defold die z-Position von Objekten direkt im Editor festlegen. In der folgenden Bildschirmaufnahme siehst du, dass `logo3` ganz oben dargestellt wird und eine z-Position von 0,2 hat. Die anderen Spielobjekte haben die z-Positionen 0,0 und 0,1.
+
+![z-Reihenfolge](images/flash/z_order.png)
+
+Beachte, dass die z-Position eines Spielobjekts, das in einer oder mehreren Sammlungen verschachtelt ist, durch seine eigene z-Position zusammen mit denen aller übergeordneten Objekte bestimmt wird. Stell dir beispielsweise vor, die obigen Spielobjekte `logo` wären in einer Sammlung `logos` platziert, die wiederum in `main` liegt (siehe folgende Bildschirmaufnahme). Hätte die Sammlung `logos` eine z-Position von 0,9, wären die z-Positionen der enthaltenen Spielobjekte 0,9, 1,0 und 1,1. Daher würde `logo3` nicht gerendert werden, da seine z-Position größer als 1 ist.
+
+![z-Reihenfolge](images/flash/z_order_outline.png)
+
+Die z-Position eines Spielobjekts kannst du natürlich per Skript ändern. Gehe davon aus, dass sich der folgende Code in der Skriptkomponente eines Spielobjekts befindet:
+
+```lua
+local pos = go.get_position()
+pos.z  = 0.5
+go.set_position(pos)
+```
+
+## Kollisionserkennung in Flash mit `hitTestObject` und `hitTestPoint` {#flash-hittestobject-and-hittestpoint-collision-detection}
+
+Eine grundlegende Kollisionserkennung in Flash erreichst du mit der Methode `hitTestObject()`. In diesem Beispiel haben wir zwei Movieclips: `bullet` und `bullseye`. Sie sind in der folgenden Bildschirmaufnahme zu sehen. Das blaue Begrenzungsrechteck wird sichtbar, wenn du die Symbole im Flash-Editor auswählst. Diese Begrenzungsrechtecke bestimmen das Ergebnis der Methode `hitTestObject()`.
+
+![Trefferprüfung](images/flash/hittest.png)
+
+Die Kollisionserkennung mit `hitTestObject()` erfolgt so:
+
+```as
+bullet.hitTestObject(bullseye);
+```
+
+Die Verwendung der Begrenzungsrechtecke wäre in diesem Fall ungeeignet, da im folgenden Szenario ein Treffer registriert würde:
+
+![Trefferprüfung mit Begrenzungsrechteck](images/flash/hitboundingbox.png)
+
+Eine Alternative zu `hitTestObject()` ist die Methode `hitTestPoint()`. Diese Methode hat einen Parameter `shapeFlag`, mit dem Trefferprüfungen anhand der tatsächlichen Pixel eines Objekts statt anhand seines Begrenzungsrechtecks durchgeführt werden können. Die Kollisionserkennung mit `hitTestPoint()` könnte so erfolgen:
+
+```as
+bullseye.hitTestPoint(bullet.x, bullet.y, true);
+```
+
+Diese Zeile würde die x- und y-Position des Geschosses (in diesem Szenario oben links) gegen die Form des Ziels prüfen. Da `hitTestPoint()` einen Punkt gegen eine Form prüft, ist die Auswahl des zu prüfenden Punktes (oder der Punkte!) eine wesentliche Überlegung.
+
+## Defold—Kollisionsobjekte {#defoldcollision-objects}
+
+Defold enthält eine Physik-Engine, die Kollisionen erkennen kann und ein Skript darauf reagieren lässt. Die Kollisionserkennung in Defold beginnt damit, dass du Spielobjekten Kollisionsobjekte (collision objects) als Komponenten zuweist. In der folgenden Bildschirmaufnahme haben wir dem Spielobjekt `bullet` ein Kollisionsobjekt hinzugefügt. Das Kollisionsobjekt wird als rotes transparentes Rechteck dargestellt (das nur im Editor sichtbar ist):
+
+![Kollisionsobjekt](images/flash/collision_object.png)
+
+Defold enthält eine modifizierte Version der Physik-Engine Box2D, die realistische Kollisionen automatisch simulieren kann. Dieses Handbuch geht von der Verwendung kinematischer Kollisionsobjekte aus, da diese der Kollisionserkennung in Flash am nächsten kommen. Mehr über dynamische Kollisionsobjekte erfährst du im [Physikhandbuch](/manuals/physics) von Defold.
+
+Das Kollisionsobjekt hat die folgenden Eigenschaften:
+
+![Eigenschaften des Kollisionsobjekts](images/flash/collision_object_properties.png)
+
+Wir haben eine Rechteckform verwendet, da sie am besten zur Grafik des Geschosses passt. Die andere Form für 2D-Kollisionen, die Kugel, wird für das Ziel verwendet. Wenn du den Typ auf Kinematic setzt, verarbeitet dein Skript die Kollisionen anstelle der integrierten Physik-Engine (weitere Informationen zu den anderen Typen findest du im [Physikhandbuch](/manuals/physics)). Die Eigenschaften *Group* und *Mask* bestimmen, zu welcher Kollisionsgruppe das Objekt gehört beziehungsweise mit welcher Kollisionsgruppe es auf Kollisionen geprüft werden soll. Die aktuelle Konfiguration bedeutet, dass ein `bullet` nur mit einem `target` kollidieren kann. Stell dir vor, die Konfiguration wird wie folgt geändert:
+
+![Kollisionsgruppe und Kollisionsmaske](images/flash/collision_groupmask.png)
+
+Jetzt können Geschosse mit Zielen und anderen Geschossen kollidieren. Zum Vergleich haben wir ein Kollisionsobjekt für das Ziel eingerichtet, das wie folgt aussieht:
+
+![Kollisionsobjekt des Geschosses](images/flash/collision_object_bullet.png)
+
+Beachte, dass die Eigenschaft *Group* auf `target` und *Mask* auf `bullet` gesetzt ist.
+
+In Flash findet die Kollisionserkennung nur statt, wenn das Skript sie ausdrücklich aufruft. In Defold läuft die Kollisionserkennung fortlaufend im Hintergrund, solange ein Kollisionsobjekt aktiviert bleibt. Bei einer Kollision werden Nachrichten an alle Komponenten eines Spielobjekts gesendet (vor allem an die Skriptkomponenten). Das sind die Nachrichten [`collision_response` und `contact_point_response`](/manuals/physics-messages), die alle Informationen enthalten, um die Kollision wie gewünscht zu verarbeiten.
+
+Der Vorteil der Kollisionserkennung in Defold besteht darin, dass sie fortgeschrittener als die von Flash ist und mit sehr geringem Einrichtungsaufwand Kollisionen zwischen relativ komplexen Formen erkennen kann. Die Kollisionserkennung erfolgt automatisch. Du musst also nicht die verschiedenen Objekte in den unterschiedlichen Kollisionsgruppen in Schleifen durchlaufen und ausdrücklich Trefferprüfungen ausführen. Der größte Nachteil ist, dass es keine Entsprechung zum Flash-Parameter `shapeFlag` gibt. Für die meisten Anwendungsfälle reichen jedoch Kombinationen der grundlegenden Rechteck- und Kugelformen aus. Für komplexere Szenarien [sind benutzerdefinierte Formen möglich](//forum.defold.com/t/does-defold-support-only-three-shapes-for-collision-solved/1985).
+
+## Flash—Ereignisverarbeitung {#flashevent-handling}
+
+Ereignisobjekte und die zugehörigen Listener werden verwendet, um verschiedene Ereignisse (z. B. Mausklicks, Tastendrücke oder das Laden von Clips) zu erkennen und als Reaktion Aktionen auszulösen. Es stehen zahlreiche Ereignisse zur Verfügung.
+
+## Defold—Callback-Funktionen und Nachrichtenübermittlung {#defoldcall-back-functions-and-messaging}
+
+Die Defold-Entsprechung zum Ereignisverarbeitungssystem von Flash besteht aus mehreren Aspekten. Zunächst enthält jede Skriptkomponente eine Reihe von Callback-Funktionen, die bestimmte Ereignisse erkennen. Diese sind:
+
+init
+:   Wird aufgerufen, wenn die Skriptkomponente initialisiert wird. Entspricht der Konstruktorfunktion in Flash.
+
+final
+:   Wird aufgerufen, wenn die Skriptkomponente zerstört wird (z. B. wenn ein dynamisch erzeugtes Spielobjekt entfernt wird).
+
+update
+:   Wird in jedem Frame aufgerufen. Entspricht `enterFrame` in Flash.
+
+on_message
+:   Wird aufgerufen, wenn die Skriptkomponente eine Nachricht empfängt.
+
+on_input
+:   Wird aufgerufen, wenn eine Nutzereingabe (z. B. von Maus oder Tastatur) an ein Spielobjekt mit [Eingabefokus](/ref/go/#acquire_input_focus) gesendet wird. Eingabefokus bedeutet, dass das Objekt alle Eingaben empfängt und darauf reagieren kann.
+
+on_reload
+:   Wird aufgerufen, wenn die Skriptkomponente neu geladen wird.
+
+Die oben aufgeführten Callback-Funktionen sind alle optional und können entfernt werden, wenn du sie nicht verwendest. Einzelheiten zum Einrichten der Eingabe findest du im [Eingabehandbuch](/manuals/input). Bei der Arbeit mit Sammlungs-Proxys gibt es eine häufige Stolperfalle. Weitere Informationen dazu findest du in [diesem Abschnitt](/manuals/input/#input-dispatch-and-on_input) des Eingabehandbuchs.
+
+Wie im Abschnitt zur Kollisionserkennung erläutert, werden Kollisionsereignisse verarbeitet, indem Nachrichten an die beteiligten Spielobjekte gesendet werden. Ihre jeweiligen Skriptkomponenten empfangen die Nachricht in ihren Callback-Funktionen `on_message`.
+
+## Flash—Schaltflächensymbole {#flashbutton-symbols}
+
+Flash verwendet einen eigenen Symboltyp für Schaltflächen. Schaltflächen nutzen bestimmte Ereignishandler-Methoden (z. B. `click` und `buttonDown`), um Aktionen auszuführen, wenn eine Nutzerinteraktion erkannt wird. Die grafische Form einer Schaltfläche im Bereich „Hit“ des Schaltflächensymbols bestimmt ihren Trefferbereich.
+
+![Schaltfläche](images/flash/button.png)
+
+## Defold—GUI-Szenen und Skripte {#defoldgui-scenes-and-scripts}
+
+Defold enthält keine native Schaltflächenkomponente. Auch lassen sich Klicks auf die Form eines bestimmten Spielobjekts nicht so einfach erkennen, wie es bei Schaltflächen in Flash der Fall ist. Die Verwendung einer [GUI](/manuals/gui)-Komponente ist die häufigste Lösung, unter anderem, weil die Positionen der GUI-Komponenten in Defold nicht von der Kamera im Spiel beeinflusst werden (falls eine verwendet wird). Die GUI-API enthält außerdem Funktionen, mit denen du erkennen kannst, ob Nutzereingaben wie Klicks und Berührungsereignisse innerhalb der Grenzen eines GUI-Elements liegen.
+
+## Debugging
+
+In Flash ist der Befehl `trace()` dein Helfer bei der Fehlersuche. Die Entsprechung in Defold ist `print()` und wird genauso wie `trace()` verwendet:
+
+```lua
+print("Hello world!"")
+```
+
+Du kannst mit einem Aufruf der Funktion `print()` mehrere Variablen ausgeben:
+
+```lua
+print(score, health, ammo)
+```
+
+Es gibt auch eine Funktion `pprint()` (formatierte Ausgabe), die beim Arbeiten mit Tabellen hilfreich ist. Diese Funktion gibt den Inhalt von Tabellen einschließlich verschachtelter Tabellen aus. Betrachte das folgende Skript:
+
+```lua
+factions = {"red", "green", "blue"}
+world = {name = "Terra", teams = factions}
+pprint(world)
+```
+
+Es enthält eine Tabelle (`factions`), die in einer Tabelle (`world`) verschachtelt ist. Der normale Befehl `print()` würde die eindeutige ID der Tabelle ausgeben, aber nicht ihren eigentlichen Inhalt:
+
+```
+DEBUG:SCRIPT: table: 0x7ff95de63ce0
+```
+
+Die Verwendung der Funktion `pprint()` wie oben gezeigt liefert aussagekräftigere Ergebnisse:
+
+```
+DEBUG:SCRIPT:
+{
+  name = Terra,
+  teams = {
+    1 = red,
+    2 = green,
+    3 = blue,
+  }
+}
+```
+
+Wenn dein Spiel Kollisionserkennung verwendet, kannst du das Physik-Debugging durch Senden der folgenden Nachricht umschalten:
+
+```lua
+msg.post("@system:", "toggle_physics_debug")
+```
+
+Du kannst das Physik-Debugging auch in den Projekteinstellungen aktivieren. Bevor wir das Physik-Debugging einschalten, sieht unser Projekt so aus:
+
+![Ohne Debugging](images/flash/no_debug.png)
+
+Wenn du das Physik-Debugging einschaltest, werden die Kollisionsobjekte angezeigt, die wir unseren Spielobjekten hinzugefügt haben:
+
+![Mit Debugging](images/flash/with_debug.png)
+
+Bei Kollisionen leuchten die betreffenden Kollisionsobjekte auf. Zusätzlich wird der Kollisionsvektor angezeigt:
+
+![Kollision](images/flash/collision.png)
+
+Informationen zur Überwachung der CPU-Auslastung und des Speicherverbrauchs findest du schließlich in der [Profiler-Dokumentation](/ref/profiler/). Weitere Informationen zu fortgeschrittenen Debugging-Techniken findest du im [Abschnitt zum Debugging](/manuals/debugging) des Defold-Handbuchs.
+
+## Wie es weitergeht {#where-to-go-from-here}
+
+- [Defold-Beispiele](/examples)
+- [Tutorials](/tutorials)
+- [Handbücher](/manuals)
+- [Referenz](/ref/go)
+- [FAQ](/faq/faq)
+
+Wenn du Fragen hast oder nicht weiterkommst, sind die [Defold-Foren](//forum.defold.com) eine gute Anlaufstelle für Hilfe.

--- a/docs/de/manuals/flipbook-animation.md
+++ b/docs/de/manuals/flipbook-animation.md
@@ -1,0 +1,107 @@
+---
+title: Handbuch zu Flipbook-Animationen in Defold
+brief: Dieses Handbuch beschreibt, wie du Flipbook-Animationen in Defold verwendest.
+---
+
+# Flipbook-Animation {#flip-book-animation}
+
+Eine Flipbook-Animation (flipbook animation) besteht aus einer Reihe von Einzelbildern, die nacheinander angezeigt werden. Die Technik ähnelt stark der traditionellen Folienanimation (siehe http://en.wikipedia.org/wiki/Traditional_animation). Sie bietet unbegrenzte Möglichkeiten, da jedes Einzelbild unabhängig bearbeitet werden kann. Da jedoch jedes Einzelbild als eigenes Bild gespeichert wird, kann der Speicherbedarf hoch sein. Wie flüssig die Animation wirkt, hängt auch von der Anzahl der pro Sekunde angezeigten Bilder ab. Eine höhere Anzahl von Bildern bedeutet allerdings meist auch mehr Arbeit. In Defold werden Flipbook-Animationen entweder als einzelne Bilder gespeichert, die einem [Atlas](/manuals/atlas) hinzugefügt werden, oder als [Kachelquelle](/manuals/tilesource) (tile source), in der alle Einzelbilder in einer horizontalen Folge angeordnet sind.
+
+  ![Animationsbogen](images/animation/animsheet.png){.inline}
+  ![Laufanimation in Schleife](images/animation/runloop.gif){.inline}
+
+## Flipbook-Animationen abspielen {#playing-flip-book-animations}
+
+Sprites und GUI-Box-Knoten (GUI box nodes) können Flipbook-Animationen abspielen, und du kannst ihre Wiedergabe zur Laufzeit umfassend steuern.
+
+Sprites
+: Um eine Animation zur Laufzeit abzuspielen, verwendest du die Funktion [`sprite.play_flipbook()`](/ref/sprite/?q=play_flipbook#sprite.play_flipbook:url-id-[complete_function]-[play_properties]). Ein Beispiel findest du weiter unten.
+
+GUI-Box-Knoten
+: Um eine Animation zur Laufzeit abzuspielen, verwendest du die Funktion [`gui.play_flipbook()`](/ref/gui/?q=play_flipbook#gui.play_flipbook:node-animation-[complete_function]-[play_properties]). Ein Beispiel findest du weiter unten.
+
+::: sidenote
+Der Wiedergabemodus `Once Ping Pong` spielt die Animation bis zum letzten Einzelbild ab, kehrt dann die Reihenfolge um und spielt sie rückwärts bis zum **zweiten** Einzelbild der Animation ab, nicht bis zum ersten. Dadurch lassen sich Animationen leichter aneinanderreihen.
+:::
+
+### Sprite-Beispiel {#sprite-example}
+
+Angenommen, dein Spiel hat eine Ausweichfunktion namens "dodge", mit der die Spielfigur durch Drücken einer bestimmten Taste ausweichen kann. Du hast vier Animationen erstellt, um die Funktion durch visuelle Rückmeldungen zu unterstützen:
+
+"idle"
+: Eine wiederholt abgespielte Animation der Spielfigur im Ruhezustand.
+
+"dodge_idle"
+: Eine wiederholt abgespielte Animation der Spielfigur im Ruhezustand in der Ausweichhaltung.
+
+"start_dodge"
+: Eine einmal abgespielte Übergangsanimation, die die Spielfigur vom Stehen in die Ausweichhaltung versetzt.
+
+"stop_dodge"
+: Eine einmal abgespielte Übergangsanimation, die die Spielfigur aus der Ausweichhaltung zurück ins Stehen versetzt.
+
+Das folgende Skript stellt die Logik bereit:
+
+```lua
+
+local function play_idle_animation(self)
+    if self.dodge then
+        sprite.play_flipbook("#sprite", hash("dodge_idle"))
+    else
+        sprite.play_flipbook("#sprite", hash("idle"))
+    end
+end
+
+function on_input(self, action_id, action)
+    -- "dodge" is our input action
+    if action_id == hash("dodge") then
+        if action.pressed then
+            sprite.play_flipbook("#sprite", hash("start_dodge"), play_idle_animation)
+            -- remember that we are dodging
+            self.dodge = true
+        elseif action.released then
+            sprite.play_flipbook("#sprite", hash("stop_dodge"), play_idle_animation)
+            -- we are not dodging anymore
+            self.dodge = false
+        end
+    end
+end
+```
+
+### Beispiel für einen GUI-Box-Knoten {#gui-box-node-example}
+
+Wenn du eine Animation oder ein Bild für einen Knoten auswählst, weist du ihm tatsächlich die Bildquelle (Atlas oder Kachelquelle) und die Standardanimation in einem Schritt zu. Die Bildquelle ist im Knoten statisch festgelegt, aber die aktuell abzuspielende Animation kann zur Laufzeit geändert werden. Standbilder werden als Animationen mit einem Einzelbild behandelt. Ein Bild zur Laufzeit zu ändern, entspricht daher dem Abspielen einer anderen Flipbook-Animation für den Knoten:
+
+```lua
+function init(self)
+    local character_node = gui.get_node("character")
+    -- This requires that the node has a default animation in the same atlas or tile source as
+    -- the new animation/image we're playing.
+    gui.play_flipbook(character_node, "jump_left")
+end
+```
+
+
+## Callbacks bei Abschluss {#completion-callbacks}
+
+Die Funktionen `sprite.play_flipbook()` und `gui.play_flipbook()` unterstützen eine optionale Lua-Callback-Funktion als letztes Argument. Diese Funktion wird aufgerufen, wenn die Animation bis zum Ende abgespielt wurde. Bei wiederholt abgespielten Animationen wird die Funktion nie aufgerufen. Mit dem Callback kannst du nach Abschluss einer Animation Ereignisse auslösen oder mehrere Animationen aneinanderreihen. Beispiele:
+
+```lua
+local function flipbook_done(self)
+    msg.post("#", "jump_completed")
+end
+
+function init(self)
+    sprite.play_flipbook("#character", "jump_left", flipbook_done)
+end
+```
+
+```lua
+local function flipbook_done(self)
+    msg.post("#", "jump_completed")
+end
+
+function init(self)
+    gui.play_flipbook(gui.get_node("character"), "jump_left", flipbook_done)
+end
+```

--- a/docs/de/manuals/font-richtext.md
+++ b/docs/de/manuals/font-richtext.md
@@ -1,0 +1,666 @@
+---
+title: Rich-Text-Markup in Defold
+brief: Dieses Handbuch erklärt, wie du Beschriftungskomponenten und GUI-Textknoten mit Rich-Text-Markup gestaltest und Links und Sprites in Lua untersuchst.
+---
+
+# Rich-Text-Markup
+
+Verwende Markup in Beschriftungskomponenten (Label components) und GUI-Textknoten (GUI text nodes), um verschachtelte visuelle Stile und Effekte anzuwenden und Links und Sprites in Lua zu untersuchen.
+
+```lua
+go.set("#label", "text", "Score: <color=#69D2E7>1200</color>")
+```
+
+Alternativ kannst du einen wiederverwendbaren benannten Objektstil für die Schriftressource definieren und ihn in einem Link auswählen:
+
+```lua
+local fontpath = "/fonts/ui.fontc"
+font.set_style(fontpath, "menu_link", "<color=#69D2E7>")
+go.set("#label", "text", "Open <link style=menu_link src=inventory>inventory</link>")
+```
+
+## Tag-Referenz {#tag-reference}
+
+| Tag | Zweck | Beispiel |
+| --- | --- | --- |
+| [`color`](#color) | Legt die Füllfarbe der Glyphen fest. | <img src="/manuals/images/richtext/color_green.webp" alt="Grüner Text" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`size`](#size) | Ändert die Glyphenformung und die Layoutgröße. | <img src="/manuals/images/richtext/size_24.webp" alt="Text mit einer Größe von 24 Pixeln" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`gradient`](#gradient) | Wendet einen statischen oder animierten Farbverlauf an. | <img src="/manuals/images/richtext/gradient_horizontal.webp" alt="Text mit einem horizontalen Farbverlauf" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`ul`](#ul) | Unterstreicht Text. | <img src="/manuals/images/richtext/underline_solid.webp" alt="Unterstrichener Text" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`strike`](#strike) | Streicht Text durch. | <img src="/manuals/images/richtext/strike_solid.webp" alt="Durchgestrichener Text" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`outline`](#outline) | Legt die Breite und Farbe der Glyphenkontur fest. | <img src="/manuals/images/richtext/outline.webp" alt="Text mit Kontur" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`shadow`](#shadow) | Fügt Text einen Schatten hinzu. | <img src="/manuals/images/richtext/shadow.webp" alt="Text mit einem Schatten" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`shake`](#shake) | Wendet einen animierten zufälligen Versatz an. | <img src="/manuals/images/richtext/shake_glyph.webp" alt="Zitternder Text" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`wave`](#wave) | Bewegt Text in einer animierten Sinuswelle. | <img src="/manuals/images/richtext/wave_glyph.webp" alt="Wellenförmig bewegter Text" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`sprite`](#sprite) | Fügt ein Sprite-Objekt in den Textfluss ein. | <img src="/manuals/images/richtext/sprite.webp" alt="Sprite im Textfluss" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`link`](#link) | Fügt ein interaktives Link-Objekt hinzu. | <img src="/manuals/images/richtext/link.webp" alt="Verlinkter Text" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+
+## Syntax
+
+Bei Tags und Attributnamen wird zwischen Groß- und Kleinschreibung unterschieden. Ein Tag-Paar wirkt auf den darin enthaltenen sichtbaren UTF-32-Text. Sprite-Objekte verwenden selbstschließende Tags.
+
+```text
+<color=#69D2E7>colored text</color>
+<ul pattern=dashed>underlined text</ul>
+<outline size=2 color=#000000>outlined text</outline>
+<shadow x=2 y=-2 color=#00000080>shadowed text</shadow>
+<sprite src=images/icon.png width=2em/>
+```
+
+### Attribute {#attributes}
+
+Attributwerte dürfen ohne Anführungszeichen stehen, wenn sie keine Leerraumzeichen enthalten, oder in einfachen oder doppelten Anführungszeichen eingeschlossen sein. `color` und `size` unterstützen sowohl einen ersten Wert in Kurzschreibweise als auch die benannte Form `value`.
+
+```text
+<color=#FF8800>Orange</color>
+<color value="#FF8800">Orange</color>
+<size='120%'>Larger</size>
+```
+
+### Verschachtelung {#nesting}
+
+Tags müssen in umgekehrter Reihenfolge ihres Öffnens geschlossen werden. Innere Stilwerte überschreiben dieselbe Eigenschaft eines äußeren Stils. Unterschiedliche Eigenschaften werden kombiniert. Effekte auf Textbereiche bleiben unabhängig voneinander aktiv. Verschachtelte Farbverläufe multiplizieren daher ihre Farben, und verschachtelte Positionseffekte addieren ihre Versätze.
+
+```text
+<color=#FFCC00>
+    Gold <outline size=2 color=#000000>with a black outline</outline>
+</color>
+```
+
+### Entitäten {#entities}
+
+Verwende `&amp;`, `&apos;`, `&gt;`, `&lt;` und `&quot;` für reservierte Zeichen im sichtbaren Text. Numerische Entitäten werden derzeit nicht unterstützt.
+
+## Tags
+
+Rich-Text-Tags gestalten entweder einen eingeschlossenen Textbereich oder beschreiben ein Objekt, das in Lua untersucht werden kann. Stil-Tags verwenden ein passendes schließendes Tag. Das Objekt `sprite` ist selbstschließend, während `link` den verlinkten Text einschließt.
+
+### `color`
+
+Legt die Füllfarbe der Glyphen fest. Farben verwenden `#RRGGBB` oder `#RRGGBBAA`. Das vorangestellte Rautezeichen ist erforderlich; `0xFF0000` und `FF0000` sind ungültig. Das Ergebnis multipliziert die Grundfarbe der Beschriftung oder des Renderers.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `=color` oder `value=color` | Ja | Kein Standardwert | Füllfarbe in hexadezimaler RGB- oder RGBA-Form. |
+
+```text
+<color=#00FF00>Opaque green</color>
+<color=#00FF0080>Half-alpha green</color>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*#00FF00*
+
+![Beispieltext in deckendem Grün](images/richtext/color_green.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*#00FF0080*
+
+![Beispieltext in Grün mit halbem Alphawert](images/richtext/color_green_alpha.webp)
+
+</div>
+</div>
+
+### `size`
+
+Ändert die Glyphenformung und die Layoutgröße, nicht nur die Vertex-Skalierung. Relative Werte beziehen sich immer auf die Basisschriftgröße des Layouts. Sie werden nicht mit einem umschließenden `size`-Tag verrechnet.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `=size` oder `value=size` | Ja | Kein Standardwert | Absolute Größe, Prozentsatz, Vielfaches der Basisgröße oder vorzeichenbehafteter Versatz gegenüber der Basisgröße in einer der folgenden Formen. |
+
+| Form | Beispiel bei 32 px | Berechnete Größe |
+| --- | --- | --- |
+| Zahl ohne Einheit oder `px` | `24`, `24px` | 24 px |
+| Prozentsatz der Basisgröße | `120%` | 38,4 px |
+| Vielfaches der Basisgröße | `2em` | 64 px |
+| Vorzeichenbehafteter Versatz gegenüber der Basisgröße | `+4`, `-4` | 36 px, 28 px |
+
+```text
+<size=24px>Exactly 24 pixels</size>
+<size=120%>120% of the layout base size</size>
+<size=2em>Twice the layout base size</size>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*24px*
+
+![Beispieltext mit einer Größe von 24 Pixeln](images/richtext/size_24.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*120% von 32px*
+
+![Beispieltext mit 120 Prozent von 32 Pixeln](images/richtext/size_120.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*2em bei 32px*
+
+![Beispieltext mit dem Doppelten der Basisgröße von 32 Pixeln](images/richtext/size_2em.webp)
+
+</div>
+</div>
+
+### `gradient`
+
+Ein Farbverlauf akzeptiert genau einen vollständigen Attributsatz. Das Mischen von Sätzen oder das Auslassen eines zugehörigen Attributs ist ungültig.
+
+| Modus | Erforderliche Attribute | Interpolation |
+| --- | --- | --- |
+| Horizontal | `left`, `right` | Interpoliert zwischen den beiden horizontalen Farben. |
+| Vertikal | `bottom`, `top` | Interpoliert zwischen der unteren und der oberen Farbe. |
+| Vier Ecken | `tl`, `tr`, `bl`, `br` | Interpoliert zwischen vier Vertex-Farben. |
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `left`, `right` | Für den horizontalen Modus | Keiner | Farben der horizontalen Endpunkte in der Form `#RRGGBB` oder `#RRGGBBAA`. Beide müssen vorhanden sein. |
+| `bottom`, `top` | Für den vertikalen Modus | Keiner | Farben der vertikalen Endpunkte. Beide müssen vorhanden sein. |
+| `tl`, `tr`, `bl`, `br` | Für den Modus mit vier Ecken | Keiner | Farben oben links, oben rechts, unten links und unten rechts. Alle vier müssen vorhanden sein. |
+| `fit` | Nein | `span` | `glyph` tastet jede geformte Textposition ab; `span` verteilt den Farbverlauf über den gesamten vom Tag eingeschlossenen Text. |
+| `hz` | Nein | `0` | Vollständige Durchlaufzyklen pro Sekunde im Bereich `[0,)`; null hält den Farbverlauf statisch. |
+| `direction` | Nein | `forward` | `forward` oder `reverse`. Steuert die Flussrichtung, wenn `hz` ungleich null ist. |
+
+Wenn `fit` weggelassen wird, verteilt `fit=span` den Farbverlauf über den gesamten vom Tag eingeschlossenen Text. `fit=glyph` tastet jede geformte Textposition unabhängig ab. Das optionale Attribut `hz` gibt die Anzahl vollständiger Durchlaufzyklen der Animation pro Sekunde an; sein Standardwert null hält den Farbverlauf statisch. Die sich wiederholende, gespiegelte Farbskala fließt kontinuierlich und beginnt ohne Farbsprung wieder von vorn. `direction=forward` ist der Standardwert; verwende `direction=reverse`, um die Flussrichtung umzukehren.
+
+```text
+<gradient left=#FF00FF right=#FFFFFF>Horizontal Gradient</gradient>
+
+<gradient hz=0.25 fit=glyph bottom=#182848 top=#4B6CB7>Animated vertical glyphs</gradient>
+
+<gradient hz=0.25 direction=reverse left=#FF0000 right=#0000FF>Reverse flow</gradient>
+
+<gradient hz=0.25 direction=reverse fit=span left=#FF0000 right=#0000FF>One animated span color</gradient>
+
+<gradient fit=glyph tl=#FF0000 tr=#00FF00 bl=#0000FF br=#FFFFFF>
+    Four corners
+</gradient>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Horizontal*
+
+![Beispieltext mit einem horizontalen Farbverlauf von Magenta zu Weiß](images/richtext/gradient_horizontal.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Vertikal*
+
+![Beispieltext mit einem vertikalen blauen Farbverlauf](images/richtext/gradient_vertical.webp)
+
+</div>
+</div>
+
+**Vier Ecken**
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=glyph`*
+
+![Beispieltext mit einem an jede Glyphe angepassten Farbverlauf zwischen vier Ecken](images/richtext/gradient_four_glyph.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=span`*
+
+![Beispieltext mit einem an den Textbereich angepassten Farbverlauf zwischen vier Ecken](images/richtext/gradient_four_text.webp)
+
+</div>
+</div>
+
+**Animiert**
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=glyph`*
+
+![Animierter fließender Farbverlauf, an jede Glyphe angepasst](images/richtext/gradient_flow_glyph.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=span`*
+
+![Animierter fließender Farbverlauf, an den Textbereich angepasst](images/richtext/gradient_flow_span.webp)
+
+</div>
+</div>
+
+Die Farben des Farbverlaufs multiplizieren die aktuelle Füllfarbe. Ein Farbverlauf innerhalb von `color=#808080` kann daher keinen Farbkanal erzeugen, der heller als dieser Basismultiplikator ist.
+
+### `ul`
+
+Zeichnet eine Unterstreichung anhand der Unterstreichungsmetriken der Schriftart, sofern diese verfügbar sind. Das Tag hat keine eigene Farbe: Die Linie erbt die wirksame Füllfarbe, einschließlich horizontaler und vertikaler Farbverläufe sowie Farbverläufe zwischen vier Ecken.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `pattern` | Nein | `solid` | `solid` oder `dashed`. |
+
+```text
+<ul>Solid underline</ul>
+<ul pattern=dashed>Dashed underline</ul>
+<ul><gradient left=#FF00FF right=#FFFFFF>Gradient line</gradient></ul>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Durchgezogen*
+
+![Beispieltext mit einer durchgezogenen Unterstreichung](images/richtext/underline_solid.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Gestrichelt*
+
+![Beispieltext mit einer gestrichelten Unterstreichung](images/richtext/underline_dashed.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Farbverlauf*
+
+![Beispieltext mit einer Unterstreichung mit Farbverlauf](images/richtext/underline_gradient.webp)
+
+</div>
+</div>
+
+### `strike`
+
+Zeichnet eine Linie durch den eingeschlossenen Text. Akzeptiert dieselben Werte für `pattern` wie `ul` und erbt ebenfalls die wirksame Füllfarbe.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `pattern` | Nein | `solid` | `solid` oder `dashed`. |
+
+```text
+<strike>No longer available</strike>
+<strike pattern=dashed>Dashed strikethrough</strike>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Durchgezogen*
+
+![Beispieltext mit einer durchgezogenen Durchstreichung](images/richtext/strike_solid.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Gestrichelt*
+
+![Beispieltext mit einer gestrichelten Durchstreichung](images/richtext/strike_dashed.webp)
+
+</div>
+</div>
+
+### `outline`
+
+Legt die Konturbreite, die Konturfarbe oder beides fest. Mindestens ein Attribut ist erforderlich. Eine Breite von null deaktiviert die Kontur für den Textbereich ausdrücklich.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `size` | Eines von size/color | Geerbt; `0` bei einer Standardschriftart | Breite in Layout-Einheiten, Bereich `[0,)`. Einheitensuffixe werden nicht akzeptiert. |
+| `color` | Eines von size/color | Geerbt; `#000000` bei einer Standardbeschriftung | Eine einzelne Konturfarbe in hexadezimaler RGB- (`#RRGGBB`) oder RGBA-Form (`#RRGGBBAA`); die Alpha-Komponente steuert die Deckkraft. |
+
+```text
+<outline size=3 color=#000000>Black outline</outline>
+<outline color=#FF0000>Keep inherited width, change color</outline>
+<outline size=0>Disable inherited outline</outline>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Äußere schwarze Kontur*
+
+![Beispieltext mit einer äußeren schwarzen Kontur](images/richtext/outline.webp)
+
+</div>
+</div>
+
+### `shadow`
+
+Fügt dem eingeschlossenen Text einen harten Schatten hinzu. Mindestens ein Attribut ist erforderlich. Attribute, die ein verschachteltes Tag auslässt, behalten den Schattenwert des umschließenden Tags bei; Attribute, die das äußerste Tag auslässt, behalten den Basisschattenwert der Schriftart bei.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `color` | Nein | Geerbt; `#000000` bei einer Standardbeschriftung | Schattenfarbe in der Form `#RRGGBB` oder `#RRGGBBAA`. |
+| `x` | Nein | Geerbt; `0` bei einer Standardschriftart | Horizontaler Schattenversatz in Layout-Einheiten. Positive Werte verschieben ihn nach rechts. |
+| `y` | Nein | Geerbt; `0` bei einer Standardschriftart | Vertikaler Schattenversatz in Layout-Einheiten. Positive Werte verschieben ihn nach oben. |
+| `blur` | Nein | Geerbt; `0` bei einer Standardschriftart | Weichzeichnungsradius in Layout-Einheiten, Bereich `[0,)`. |
+
+```text
+<shadow x=6 y=-6 blur=4 color=#000000A0>Shadow</shadow>
+<shadow x=-2>Override only the horizontal offset</shadow>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*x=6, y=-6, blur=4*
+
+![Beispieltext mit einem versetzten Schatten](images/richtext/shadow.webp)
+
+</div>
+</div>
+
+::: sidenote
+Die Schattenweichzeichnung wird erzeugt und im Glyphenatlas gespeichert. Ein Textbereich kann eine geringere Weichzeichnung als die in der Schriftart vorberechnete Weichzeichnung anfordern; größere Werte bleiben im Layout erhalten, werden derzeit aber mit der größten im Atlas verfügbaren Weichzeichnung gerendert.
+:::
+
+### `shake`
+
+Wendet einen deterministischen animierten zufälligen Versatz an, ohne den Zeilenumbruch oder die Layoutgrenzen zu ändern. Der Effekt verwaltet seine Zeit intern; Skripte müssen den Beschriftungstext nicht für jeden Animationsframe ändern.
+
+| Attribut | Erforderlich | Standardwert | Gültige Werte | Bedeutung |
+| --- | --- | --- | --- | --- |
+| `hz` | Nein | 20 | `[0,)` | Übergänge zu zufälligen Zielen pro Sekunde. Null pausiert den Effekt. |
+| `amplitude` | Nein | 0.5 | `[0,)` | Maximale Verschiebung in Layout-Einheiten. |
+| `fit` | Nein | `glyph` | `glyph` oder `span` | `glyph` tastet für jede geformte Glypheneinheit einen Versatz ab, der zusammengehörige Zeichencluster erhält. `span` bewegt den gesamten vom Tag eingeschlossenen Textbereich als eine starre Einheit. |
+
+```text
+<shake>Default shake</shake>
+<shake hz=12 amplitude=0.8 fit=glyph>Glyph shake</shake>
+<shake hz=12 amplitude=0.8 fit=span>Rigid span shake</shake>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=glyph`*
+
+![Beispieltext mit einem animierten Zittern jeder Glyphe](images/richtext/shake_glyph.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=span`*
+
+![Beispieltext mit einem animierten Zittern des gesamten Textbereichs](images/richtext/shake_span.webp)
+
+</div>
+</div>
+
+### `wave`
+
+Bewegt Zeichen in einer animierten Sinuswelle auf und ab, ohne den Zeilenumbruch oder die Layoutgrenzen zu ändern. Das Layout summiert bei jeder Aktualisierung die Animationszeit.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `amplitude` | Nein | 1 | Maximale vertikale Verschiebung in Layout-Einheiten, Bereich `[0,)`. |
+| `hz` | Nein | 1 | Vollständige zeitliche Zyklen pro Sekunde, Bereich `[0,)`. Null pausiert die Welle. |
+| `wavelength` | Nein | 6 | Sichtbare UTF-32-Textpositionen pro vollständigem räumlichem Zyklus, Bereich `[1,)`. Zeichen, die die Schriftart gemeinsam formt, etwa ein Basiszeichen und sein kombinierender Akzent, bewegen sich als Einheit. |
+| `fit` | Nein | `glyph` | `glyph` wendet die räumliche Welle über den Text hinweg an. `span` gibt dem gesamten vom Tag eingeschlossenen Textbereich einen gemeinsamen vertikalen Sinusversatz. |
+| `direction` | Nein | `forward` | `forward` bewegt die Welle normal vorwärts. `reverse` kehrt die Bewegungsrichtung der Welle um. |
+
+```text
+<wave>Animated character wave</wave>
+<wave amplitude=4 hz=3 wavelength=8 fit=glyph>Travelling wave</wave>
+<wave amplitude=4 hz=3 wavelength=8 fit=glyph direction=reverse>Reverse travelling wave</wave>
+<wave amplitude=4 hz=1 fit=span>Whole span moves together</wave>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=glyph`*
+
+![Beispieltext mit einer animierten Wellenbewegung jeder Glyphe](images/richtext/wave_glyph.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=span`*
+
+![Beispieltext, der sich als ein animierter Textbereich bewegt](images/richtext/wave_span.webp)
+
+</div>
+</div>
+
+### `sprite`
+
+Fügt an der aktuellen Position im sichtbaren Text ein selbstschließendes Sprite-Objekt ein. Seine Attribute bleiben als Metadaten für `label.get_layout_objects()` und `gui.get_layout_objects()` erhalten.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `id` | Nein | Generiert | Stabiler Bezeichner, dessen Hash als `id` des zurückgegebenen Layout-Objekts verwendet wird. |
+| `src` | Nein | Keiner | Von der Anwendung definierter Bezeichner einer Sprite-Ressource, etwa ein Projektpfad zu einem Bild oder Atlas. |
+| `animation` | Nein | Keiner | Von der Anwendung definierter Animationsbezeichner innerhalb der Ressource. |
+| `width` | Nein | `1em` | Berechnete Sprite-Breite. |
+| `height` | Nein | `1em` | Berechnete Sprite-Höhe. |
+| Beliebiges anderes Attribut | Nein | Nicht vorhanden | Von der Anwendung definierte Metadaten, die für die Objektauflösung und die Layout-Objekt-APIs erhalten bleiben. |
+
+```text
+A <sprite src=engine/engine/content/builtins/assets/images/logo/logo_256.png/> logo
+<sprite src=images/banner.png width=4em height=2em/>
+<sprite src=images/icons.atlas animation=coin width=2em/>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Aufgelöstes Sprite im Textfluss*
+
+![Ein im Textfluss gerendertes Defold-Logo](images/richtext/sprite.webp)
+
+</div>
+</div>
+
+Abmessungen akzeptieren positive Layout-Einheiten ohne Suffix sowie `px`, `em` oder `%`. Sowohl `em` als auch `%` beziehen sich auf die Basisschriftgröße des Textlayouts.
+
+Jede fehlende Abmessung erhält unabhängig den Standardwert `1em`. Werden beide weggelassen, entsteht ein Objekt mit `1em × 1em`; wird nur die Breite angegeben, wird die Höhe nicht automatisch aus dem Seitenverhältnis einer Ressource abgeleitet.
+
+::: important
+Das Sprite-Tag ist lediglich ein Platzhalter, an dessen Stelle du ein beliebiges Objekt einfügen kannst!
+:::
+
+### `link`
+
+Beschreibt einen Bereich des sichtbaren Textes als Link-Objekt. Der eingeschlossene Text erhält das normale Layout und standardmäßig den benannten Stil `link`. Beschriftungs- und GUI-Komponenten wählen als Reaktion auf Eingaben `link:hover` und `link:active` aus, ohne den Text erneut zu formen. Unter [Interaktionsnachrichten](#interaction-messages) findest du die Nachrichten, die durch Eingaben auf Links erzeugt werden.
+
+| Attribut | Erforderlich | Standardwert | Bedeutung |
+| --- | --- | --- | --- |
+| `src` | Nein | Keiner | Von der Anwendung definiertes Linkziel. Der Wert wird als Zeichenfolge ohne automatische Validierung oder Navigation zurückgegeben. |
+| `id` | Nein | Generiert | Stabiler Bezeichner, dessen Hash als `id` des zurückgegebenen Layout-Objekts verwendet wird. |
+| `style` | Nein | `link` | Benannter Standardstil für den Linktext. |
+| Beliebiges anderes Attribut | Nein | Nicht vorhanden | Von der Anwendung definierte Metadaten, etwa ein Bezeichner, eine Aktion, ein Tooltip oder ein Analysewert. |
+
+```text
+<ul><link id=website src=https://www.defold.com>www.defold.com</link></ul>
+<link id=inventory style=menu_link action=open_inventory item=sword>Iron sword</link>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`style=link`*
+
+![www.defold.com mit dem Standard-Linkstil und einer Unterstreichung gerendert](images/richtext/link.webp)
+
+</div>
+</div>
+
+Die Komponente verfolgt den Zeigerzustand jedes Links. Sie wendet `link:hover` an, solange sich der Zeiger über dem Link befindet, und `link:active`, solange die Zeigereingabe gedrückt gehalten wird. Wenn keiner der beiden Zustände zutrifft, stellt die Komponente den im Attribut `style` des Links benannten Stil wieder her oder `link`, wenn das Attribut fehlt.
+
+### Interaktionsnachrichten {#interaction-messages}
+
+Die Interaktion mit Links verwendet Defolds normales Eingabesystem. Füge unter Mouse Trigger eine Eingabebindung (input binding) für `MOUSE_BUTTON_LEFT` hinzu, die auch Single-Touch-Eingaben aktiviert, und fordere den Eingabefokus im Skript des Spielobjekts (game object) oder im GUI-Skript an:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus")
+end
+```
+
+Einzelheiten zur Einrichtung findest du unter [Eingabefokus](/manuals/input/#input-focus) und [Maus- und Touch-Eingaben](/manuals/input-mouse-and-touch).
+
+Wenn eine Beschriftungs- oder GUI-Komponente Zeigereingaben empfängt, erzeugen Links die folgenden Nachrichten. Beschriftungsnachrichten werden an das zugehörige Spielobjekt gesendet; GUI-Nachrichten werden an das GUI-Skript gesendet.
+
+| Nachricht | Sendezeitpunkt |
+| --- | --- |
+| `text_object_hovered` | Der Zeiger tritt in einen Link ein. |
+| `text_object_unhovered` | Der Zeiger verlässt einen Link. |
+| `text_object_clicked` | Nach dem Drücken über einem Link wird über demselben Link losgelassen. |
+
+Jede Nachricht enthält diese Felder:
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `id` | `hash` | Das Attribut `id` des Objekts oder seine generierte Layout-Objekt-ID. |
+| `type` | `hash` | Der Typ des Layout-Objekts, derzeit `hash("link")`. |
+| `src` | `string` | Der von der Anwendung definierte Wert des Attributs `src` des Objekts oder eine leere Zeichenfolge, wenn es fehlt. |
+
+```lua
+function on_message(self, message_id, message)
+    if message_id == hash("text_object_clicked") then
+        assert(message.type == hash("link"))
+        print(message.id, message.src)
+    end
+end
+```
+
+## Benannte Stile {#named-styles}
+
+Jede Schriftsammlung (font collection) enthält benannte Objektstile, die ausschließlich das Rendering beeinflussen. Ein Link verwendet den im Attribut `style` benannten Stil oder `link`, wenn das Attribut fehlt. Es gibt kein allgemeines `<style>`-Tag für Textbereiche.
+
+Defold stellt die folgenden Standardwerte bereit:
+
+| Stil | Multiplikator der Füllfarbe | Textauszeichnung |
+| --- | --- | --- |
+| `link` | `(0.10, 0.45, 0.90, 1.0)` | Durchgezogene Unterstreichung |
+| `link:hover` | `(0.30, 0.65, 1.00, 1.0)` | Keine |
+| `link:active` | `(0.05, 0.30, 0.70, 1.0)` | Keine |
+
+Definiere einen Stil mit einer Zeichenfolge, die öffnende Tags enthält. Die Tags werden implizit in umgekehrter Reihenfolge geschlossen; schließende Tags und sichtbarer Text sind daher nicht erlaubt.
+
+```lua
+font.set_style("/fonts/ui.fontc", "link",
+    "<color=#2673ff><outline color=#000000 size=1>")
+
+font.set_style("/fonts/ui.fontc", "link:hover",
+    "<color=#66b3ff><shake amplitude=0.2 hz=20>")
+```
+
+Tags werden von links nach rechts angewendet, als wären sie um den Objekttext verschachtelt. Ein vom Aufrufer ausgewählter Objektstil wird nach dem Standardstil angewendet. Wenn mehrere Tags dieselbe Rendering-Eigenschaft setzen, überschreibt der später angewendete Wert die früheren Werte. Effekte werden in der Reihenfolge von links nach rechts angehängt.
+
+::: sidenote
+Ein Aufruf von `font.set_style()` ersetzt die Rendering-Eigenschaften und Effekte dieses benannten Stils. In der Ressource definierte Textauszeichnungen bleiben unverändert. Eine Neudefinition von `link` entfernt daher seine standardmäßige Unterstreichung nicht. Benannte Stile akzeptieren Tags, die ausschließlich das Rendering beeinflussen, etwa `color`, `outline`, `shadow`, `gradient`, `wave` und `shake`. Tags, die das Layout ändern, sowie Textauszeichnungs- und Objekt-Tags werden abgelehnt.
+:::
+
+## API für Layout-Objekte {#layout-object-api}
+
+Verwende `label.get_layout_objects()` oder `gui.get_layout_objects()`, um die Objekte `sprite` und `link` aus Text mit berechnetem Layout abzurufen.
+
+### `label.get_layout_objects()`
+
+```lua
+objects = label.get_layout_objects(url)
+```
+
+| Argument | Typ | Beschreibung |
+| --- | --- | --- |
+| `url` | `string`, `hash` oder `url` | Die zu untersuchende Beschriftungskomponente, zum Beispiel `"#label"`. |
+
+### `gui.get_layout_objects()`
+
+```lua
+objects = gui.get_layout_objects(node)
+```
+
+| Argument | Typ | Beschreibung |
+| --- | --- | --- |
+| `node` | `node` | Der zu untersuchende GUI-Textknoten, zum Beispiel `gui.get_node("rich_text")`. |
+
+Beide Funktionen geben ein neu erstelltes Array mit den aktuellen Layout-Objekten in der Reihenfolge ihres Auftretens im Quelltext zurück. Sie geben ein leeres Array zurück, wenn der Text keine Objekt-Tags enthält. Da die Objekte und ihre Attribute bei jedem Aufruf nach Lua kopiert werden, speichere das Ergebnis zwischen und frage es erneut ab, nachdem du den Text oder eine andere Eigenschaft geändert hast, die sein Layout verändert.
+
+### Zurückgegebene Objektfelder {#returned-object-fields}
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `type` | `string` | `"sprite"` oder `"link"`. |
+| `id` | `hash` | Objektbezeichner, der in Interaktionsnachrichten verwendet wird. |
+| `text_offset` | `number` | Bei null beginnende Position im sichtbaren Text, gemessen in Unicode-Codepunkten. Markup wird nicht mitgezählt, und Entitäten zählen als ihre dekodierten Zeichen. Bei einem Sprite ist dies seine Einfügeposition. |
+| `text_length` | `number` | Länge des eingeschlossenen sichtbaren Textes in Unicode-Codepunkten. Ein Sprite hat die Länge eins für seinen eingefügten Codepunkt U+FFFC, das Objektersetzungszeichen. |
+| `width` | `number` | Berechnete Breite in Textlayout-Einheiten. Links haben derzeit die Breite null. |
+| `height` | `number` | Berechnete Höhe in Textlayout-Einheiten. Links haben derzeit die Höhe null. |
+| `x` | `number` | Horizontale Position der unteren linken Ecke des Objekts relativ zum Ursprung oben links im Textlayout. |
+| `y` | `number` | Vertikale Position der unteren linken Ecke des Objekts relativ zum Ursprung oben links im Textlayout. |
+| `attributes` | `table` | Alle Tag-Attribute als Schlüssel-Wert-Paare aus Zeichenfolgen. Attributwerte behalten ihre Darstellung aus dem Quelltext bei, etwa `"2em"`. Ein unbenannter Wert in Kurzschreibweise wird unter dem Schlüssel `value` gespeichert. |
+
+::: sidenote
+`text_offset` und `text_length` sind keine UTF-8-Byte-Offsets. Ein Nicht-ASCII-Zeichen wie `å` oder `猫` zählt als eine Position.
+:::
+
+### Lua-Beispiel {#lua-example}
+
+```lua
+local text = [[
+Read the <link src=https://defold.com/manuals/ id=manual>manual</link>
+or inspect <sprite src=images/info.png width=2em/> for more information.
+]]
+
+go.set("#label", "text", text)
+
+local objects = label.get_layout_objects("#label")
+for _, object in ipairs(objects) do
+    if object.type == "link" then
+        print("link", object.attributes.src)
+        print("visible range", object.text_offset, object.text_length)
+        print("position", object.x, object.y)
+    elseif object.type == "sprite" then
+        print("sprite", object.x, object.y, object.width, object.height)
+        pprint(object.attributes)
+    end
+end
+
+local gui_objects = gui.get_layout_objects(gui.get_node("rich_text"))
+```
+
+## Nützliche Kombinationen {#useful-combinations}
+
+### Farbige Kontur mit horizontalem Farbverlauf {#colored-outline-with-a-horizontal-gradient}
+
+```text
+<outline size=2 color=#101820>
+    <gradient left=#FEE715 right=#FF6F61>Gradient title</gradient>
+</outline>
+```
+
+Der Farbverlauf multipliziert nur die Füllfarbe; die Kontur behält ihre eigene Farbe.
+
+### Einen Satz zittern lassen und ein Wort mit einem Farbverlauf versehen {#shake-a-sentence-gradient-one-word}
+
+```text
+<shake hz=20 amplitude=0.5>
+    This <gradient left=#FF00FF right=#FFFFFF>whole</gradient> text shakes!
+</shake>
+```
+
+Der äußere Positionseffekt wirkt auf jede Glyphe. Der verschachtelte Farbeffekt wirkt nur auf „whole“.
+
+### Eine Eigenschaft überschreiben, ohne die anderen zu verlieren {#override-one-property-without-losing-the-others}
+
+```text
+<color=#FFFFFF><outline size=2 color=#000000>
+    Normal <color=#FF4040>warning</color> normal
+</outline></color>
+```
+
+Die innere Farbe ändert die Füllung und behält dabei die geerbte Konturbreite und -farbe bei.

--- a/docs/de/manuals/font.md
+++ b/docs/de/manuals/font.md
@@ -1,0 +1,279 @@
+---
+title: Handbuch zu Schriftarten in Defold
+brief: Dieses Handbuch beschreibt, wie Defold mit Schriftarten umgeht und wie du Text in deinen Spielen auf dem Bildschirm darstellst.
+---
+
+# Schriftdateien {#font-files}
+
+Schriftarten werden verwendet, um Text in Beschriftungskomponenten (label components) und GUI-Textknoten zu rendern. Defold unterstützt mehrere Schriftdateiformate:
+
+- TrueType
+- OpenType
+- BMFont
+
+Seit Defold 1.13.2 unterstützen sowohl die bisherige als auch die vollständige Textlayout-Engine TrueType-Konturen und OpenType-CFF1/CFF2-Konturen, einschließlich der Erzeugung zur Laufzeit aus `.ttf`- und `.otf`-Ressourcen.
+
+Informationen zum Gestalten einzelner Textabschnitte und zum Arbeiten mit Links und eingebetteten Sprites findest du im [Handbuch zur Rich-Text-Auszeichnung](/manuals/font-richtext).
+
+Schriftarten, die du deinem Projekt hinzufügst, werden automatisch in ein Texturformat umgewandelt, das Defold rendern kann. Es stehen zwei Verfahren zum Rendern von Schriftarten zur Verfügung, die jeweils eigene Vor- und Nachteile haben:
+
+- Bitmap
+- Distanzfeld
+
+## Offline- oder Laufzeitschriftarten {#offline-or-runtime-fonts}
+
+Standardmäßig erfolgt die Umwandlung in gerasterte Glyphenbilder während des Builds (offline). Das hat den Nachteil, dass für jede Schriftart während des Builds alle möglichen Glyphen gerastert werden müssen. Dabei können sehr große Texturen entstehen, die Speicher belegen und außerdem das Bundle vergrößern.
+
+Bei Verwendung von „Laufzeitschriftarten“ (runtime fonts) werden die `.ttf`- und `.otf`-Schriftarten unverändert in das Bundle aufgenommen, und die Rasterisierung erfolgt bei Bedarf zur Laufzeit. Das minimiert sowohl den Speicherverbrauch zur Laufzeit als auch die Bundle-Größe.
+
+## Unterstützung für Textlayout (z. B. von rechts nach links) {#text-layout-support-eg-right-to-left}
+
+Laufzeitschriftarten bieten außerdem den Vorteil, vollständiges Textlayout zu unterstützen, z. B. von rechts nach links.
+Das Defold-Team verwendet dafür derzeit die Bibliotheken [HarfBuzz](https://github.com/harfbuzz/harfbuzz), [SheenBidi](https://github.com/Tehreer/SheenBidi), [libunibreak](https://github.com/adah1972/libunibreak) und [SkriBidi](https://github.com/memononen/Skribidi).
+
+Siehe [Laufzeitschriftarten aktivieren](/manuals/font#enabling-runtime-fonts)
+
+Der Editor verwendet den Schrift-Renderer der Engine für die Vorschau von Schriftarten und Text in Szenen. Die Ausformung von Text (text shaping) und das Layout von rechts nach links erfordern [Laufzeitschriftarten](#enabling-runtime-fonts) und die Option **Use full text layout system** im Anwendungsmanifest. Bei Offline-Schriftarten berücksichtigt die Vorschau die Einstellungen **Characters** und **All Chars** der Schriftart.
+
+## Schriftsammlung {#font-collection}
+
+Das Dateiformat `.fontc` wird auch als Schriftsammlung (font collection) bezeichnet. Im Offline-Modus ist ihm nur eine Schriftart zugeordnet.
+Wenn du Laufzeitschriftarten verwendest, kannst du einer Schriftsammlung mehr als eine Schriftdatei (`.ttf` oder `.otf`) zuordnen.
+
+So kannst du eine Schriftsammlung zum Rendern mehrerer Texte in unterschiedlichen Sprachen verwenden und gleichzeitig den Speicherbedarf gering halten.
+Du kannst beispielsweise eine Sammlung mit der japanischen Schriftart laden, diese Schriftart der aktuellen Hauptschriftart zuordnen und anschließend die japanische Schriftsammlung entladen.
+
+## Eine Schriftressource erstellen {#creating-a-font}
+
+Um eine Schriftressource zur Verwendung in Defold zu erstellen, lege eine neue Font-Datei an. Wähle dazu im Menü <kbd>File ▸ New...</kbd> und anschließend <kbd>Font</kbd>. Du kannst auch an einer Stelle im Browser *Assets* einen <kbd>Rechtsklick</kbd> ausführen und <kbd>New... ▸ Font</kbd> wählen.
+
+![Name der neuen Schriftressource](images/font/new_font_name.png)
+
+Gib der neuen Schriftressource einen Namen und klicke auf <kbd>Ok</kbd>. Die neue Schriftressource wird nun im Editor geöffnet.
+
+![Neue Schriftressource](images/font/new_font.png)
+
+Ziehe die Schriftart, die du verwenden möchtest, in den Browser *Assets* und lege sie an einer geeigneten Stelle ab.
+
+Setze die Eigenschaft *Font* auf die Schriftdatei und passe die Schrifteigenschaften nach Bedarf an.
+
+## Eigenschaften {#properties}
+
+*Font*
+: Die TTF-, OTF- oder *`.fnt`*-Datei, aus der die Schriftdaten erzeugt werden.
+
+*Material*
+: Das Material, das zum Rendern dieser Schriftart verwendet wird. Achte darauf, es für Distanzfeldschriften und BMFonts zu ändern (Einzelheiten dazu findest du weiter unten).
+
+*Output Format*
+: Der Typ der erzeugten Schriftdaten.
+
+  - `TYPE_BITMAP` wandelt die importierte OTF- oder TTF-Datei in eine Schriftbogentextur um, deren Bitmap-Daten zum Rendern von Textknoten verwendet werden. Die Farbkanäle codieren die Zeichenform, den Umriss und den Schlagschatten. Bei *`.fnt`*-Dateien wird die Bitmap der Quelltextur unverändert verwendet.
+  - `TYPE_DISTANCE_FIELD` Die importierte Schriftart wird in eine Schriftbogentextur umgewandelt, deren Pixeldaten Abstände zum Rand der Schriftzeichen statt Bildschirmpixel darstellen. Einzelheiten findest du weiter unten.
+
+*Render Mode*
+: Der Rendermodus für das Rendern von Glyphen.
+
+  - `MODE_SINGLE_LAYER` erzeugt für jedes Zeichen ein einzelnes Quad.
+  - `MODE_MULTI_LAYER` erzeugt separate Quads für die Glyphenform, den Umriss und die Schatten. Die Ebenen werden von hinten nach vorne gerendert. Dadurch verdeckt ein Zeichen keine zuvor gerenderten Zeichen, wenn der Umriss breiter als der Abstand zwischen den Glyphen ist. Dieser Rendermodus ermöglicht außerdem den korrekten Versatz des Schlagschattens entsprechend den Eigenschaften Shadow X/Y in der Schriftressource.
+
+*Size*
+: Die Zielgröße der Glyphen in Pixeln.
+
+*Antialias*
+: Gibt an, ob die Schriftart beim Übertragen in die Ziel-Bitmap mit Kantenglättung versehen werden soll. Setze den Wert auf 0, wenn du die Schrift pixelgenau rendern möchtest.
+
+*Alpha*
+: Die Transparenz der Glyphe. 0.0--1.0, wobei 0.0 transparent und 1.0 undurchsichtig bedeutet.
+
+*Outline Alpha*
+: Die Transparenz des erzeugten Umrisses. 0.0--1.0.
+
+*Outline Width*
+: Die Breite des erzeugten Umrisses in Pixeln. Setze den Wert auf 0, um keinen Umriss zu erzeugen.
+
+*Shadow Alpha*
+: Die Transparenz des erzeugten Schattens. 0.0--1.0.
+
+::: sidenote
+Die Shader der integrierten Schriftmaterialien ermöglichen Schatten sowohl im einlagigen als auch im mehrlagigen Rendermodus. Wenn du weder mehrlagiges Schriftrendering noch Schatten benötigst, verwendest du am besten einen einfacheren Shader wie *`builtins/font-singlelayer.fp`*.
+:::
+
+*Shadow Blur*
+: Bei Bitmap-Schriften gibt diese Einstellung an, wie oft ein kleiner Weichzeichnungskern auf jede Glyphe der Schriftart angewendet wird. Bei Distanzfeldschriften entspricht sie der tatsächlichen Breite der Weichzeichnung in Pixeln.
+
+*Shadow X/Y*
+: Der horizontale und vertikale Versatz des erzeugten Schattens in Pixeln. Diese Einstellung wirkt sich nur auf den Glyphenschatten aus, wenn Render Mode auf `MODE_MULTI_LAYER` gesetzt ist.
+
+*Characters*
+: Die Zeichen, die in die Schriftart aufgenommen werden sollen. Standardmäßig enthält dieses Feld die druckbaren ASCII-Zeichen (Zeichencodes 32-126). Du kannst in diesem Feld Zeichen hinzufügen oder entfernen, um mehr oder weniger Zeichen in die Schriftart aufzunehmen.
+
+Bei Laufzeitschriftarten dient dieser Text dazu, den Cache mit den passenden Glyphen vorab zu füllen. Dies geschieht beim Laden. Siehe `font.prewarm_text()`.
+
+::: sidenote
+Die druckbaren ASCII-Zeichen sind:
+Leerzeichen ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ \` a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~
+:::
+
+*All Chars*
+: Wenn du diese Eigenschaft aktivierst, werden alle in der Quelldatei verfügbaren Glyphen in die Ausgabe aufgenommen.
+
+*Cache Width/Height*
+: Begrenzt die Größe der Bitmap für den Glyphen-Cache. Wenn die Engine Text rendert, sucht sie die Glyphe in der Cache-Bitmap. Ist sie dort nicht vorhanden, wird sie vor dem Rendern zum Cache hinzugefügt. Wenn die Cache-Bitmap zu klein ist, um alle von der Engine zu rendernden Glyphen aufzunehmen, wird ein Fehler gemeldet (`ERROR:RENDER: Out of available cache cells! Consider increasing cache_width or cache_height for the font.`).
+
+  Bei einem Wert von 0 wird die Cache-Größe automatisch festgelegt und kann auf höchstens 2048x4096 anwachsen.
+
+## Distanzfeldschriften {#distance-field-fonts}
+
+Distanzfeldschriften (distance field fonts) speichern statt Bitmap-Daten den Abstand zum Rand der Glyphe in der Textur. Wenn die Engine die Schriftart rendert, ist ein spezieller Shader erforderlich, der die Abstandsdaten interpretiert und damit die Glyphe zeichnet. Distanzfeldschriften benötigen mehr Ressourcen als Bitmap-Schriften, bieten aber mehr Flexibilität bei der Größenänderung.
+
+![Distanzfeldschrift](images/font/df_font.png)
+
+Achte beim Erstellen der Schriftressource darauf, die Eigenschaft *Material* auf *`builtins/fonts/font-df.material`* (oder ein anderes Material, das Distanzfelddaten verarbeiten kann) zu setzen. Andernfalls verwendet die Schriftart beim Rendern auf den Bildschirm nicht den richtigen Shader.
+
+## Bitmap-Schriften im BMFont-Format {#bitmap-bmfonts}
+
+Neben erzeugten Bitmaps unterstützt Defold vorab gerasterte Bitmap-Schriften im Format „BMFont“. Diese Schriftarten bestehen aus einem PNG-Schriftbogen mit allen Glyphen. Zusätzlich enthält eine *`.fnt`*-Datei Angaben dazu, wo sich jede Glyphe auf dem Bogen befindet, sowie Informationen zu Größe und Unterschneidung. (Beachte, dass Defold die XML-Version des *`.fnt`*-Formats, die Phaser und einige andere Werkzeuge verwenden, nicht unterstützt.)
+
+Diese Schriftarten bieten keinen Leistungsvorteil gegenüber Bitmap-Schriften, die aus TrueType- oder OpenType-Schriftdateien erzeugt werden. Sie können jedoch beliebige Grafiken, Farben und Schatten direkt im Bild enthalten.
+
+Füge die erzeugten Dateien *`.fnt`* und *`.png`* deinem Defold-Projekt hinzu. Diese Dateien sollten sich im selben Ordner befinden. Erstelle eine neue Schriftressource und setze die Eigenschaft *font* auf die *`.fnt`*-Datei. Achte darauf, dass *output_format* auf `TYPE_BITMAP` gesetzt ist. Defold erzeugt keine Bitmap, sondern verwendet die im PNG bereitgestellte.
+
+::: sidenote
+Um eine BMFont zu erstellen, benötigst du ein Werkzeug, das die entsprechenden Dateien erzeugen kann. Dafür gibt es mehrere Möglichkeiten:
+
+* [Bitmap Font Generator](http://www.angelcode.com/products/bmfont/), ein nur für Windows verfügbares Werkzeug von AngelCode.
+* [Shoebox](http://renderhjs.net/shoebox/), eine kostenlose Anwendung für Windows und macOS auf Basis von Adobe Air.
+* [Hiero](https://libgdx.com/wiki/tools/hiero), ein Open-Source-Werkzeug auf Basis von Java.
+* [Glyph Designer](https://71squared.com/glyphdesigner), ein kommerzielles macOS-Werkzeug von 71 Squared.
+* [bmGlyph](https://www.bmglyph.com), ein kommerzielles macOS-Werkzeug von Sovapps.
+:::
+
+![BMFont](images/font/bm_font.png)
+
+Damit die Schriftart korrekt gerendert wird, vergiss beim Erstellen der Schriftressource nicht, die Materialeigenschaft auf *`builtins/fonts/font-fnt.material`* zu setzen.
+
+## Artefakte und bewährte Vorgehensweisen {#artifacts-and-best-practices}
+
+Bitmap-Schriften eignen sich im Allgemeinen am besten, wenn die Schriftart ohne Skalierung gerendert wird. Sie lassen sich schneller auf den Bildschirm rendern als Distanzfeldschriften.
+
+Distanzfeldschriften lassen sich sehr gut vergrößern. Bitmap-Schriften bestehen dagegen nur aus Pixelbildern: Beim Vergrößern der Schriftart wachsen auch die Pixel, wodurch blockartige Artefakte entstehen. Das folgende Beispiel zeigt eine Schriftgröße von 48 Pixeln, die auf das 4-Fache vergrößert wurde.
+
+![Vergrößerte Schriftarten](images/font/scale_up.png)
+
+Beim Verkleinern kann die GPU Bitmap-Texturen ansprechend und effizient skalieren und mit Kantenglättung versehen. Eine Bitmap-Schrift behält ihre Farbe besser bei als eine Distanzfeldschrift. Hier siehst du eine vergrößerte Ansicht derselben Beispielschrift mit einer Größe von 48 Pixeln, verkleinert auf 1/5 ihrer Größe:
+
+![Verkleinerte Schriftarten](images/font/scale_down.png)
+
+Distanzfeldschriften müssen in einer Zielgröße gerendert werden, die groß genug ist, um Abstandsinformationen zur Darstellung der Kurven ihrer Glyphen aufzunehmen. Dies ist dieselbe Schriftart wie oben, jedoch mit einer Größe von 18 Pixeln und auf das 10-Fache vergrößert. Es ist deutlich erkennbar, dass diese Größe zu klein ist, um die Formen dieser Schrift zu codieren:
+
+![Artefakte bei Distanzfeldschriften](images/font/df_artifacts.png)
+
+Wenn du keine Schatten oder Umrisse benötigst, setze deren jeweilige Alphawerte auf null. Andernfalls werden weiterhin Schatten- und Umrissdaten erzeugt, die unnötig Speicher belegen.
+
+## Schrift-Cache {#font-cache}
+Eine Schriftressource in Defold führt zur Laufzeit zu zwei Dingen: einer Textur und den Schriftdaten.
+
+* Die Schriftdaten bestehen aus einer Liste von Glypheneinträgen, die jeweils grundlegende Informationen zur Unterschneidung und die Bitmap-Daten der Glyphe enthalten.
+* Die Textur wird intern „Glyphen-Cache-Textur“ genannt und beim Rendern von Text mit einer bestimmten Schriftart verwendet.
+
+Zur Laufzeit durchläuft die Engine beim Rendern von Text zunächst die zu rendernden Glyphen, um zu prüfen, welche davon im Textur-Cache verfügbar sind. Für jede Glyphe, die im Glyphen-Textur-Cache fehlt, werden die in den Schriftdaten gespeicherten Bitmap-Daten in die Textur hochgeladen.
+
+Jede Glyphe wird intern entsprechend der Schriftgrundlinie im Cache platziert. Dadurch lassen sich in einem Shader die lokalen Texturkoordinaten der Glyphe innerhalb ihrer zugehörigen Cache-Zelle berechnen. So kannst du bestimmte Texteffekte wie Farbverläufe oder Texturüberlagerungen dynamisch umsetzen. Die Engine stellt dem Shader über die spezielle Shader-Konstante `texture_size_recip` Kennwerte zum Cache bereit. Ihre Vektorkomponenten enthalten folgende Informationen:
+
+* `texture_size_recip.x` ist der Kehrwert der Cache-Breite
+* `texture_size_recip.y` ist der Kehrwert der Cache-Höhe
+* `texture_size_recip.z` ist das Verhältnis der Cache-Zellenbreite zur Cache-Breite
+* `texture_size_recip.w` ist das Verhältnis der Cache-Zellenhöhe zur Cache-Höhe
+
+Um beispielsweise in einem Fragment-Shader einen Farbverlauf zu erzeugen, schreibe einfach:
+
+`float horizontal_gradient = fract(var_texcoord0.y / texture_size_recip.w);`
+
+Weitere Informationen zu Shader-Uniforms findest du im [Shader-Handbuch](/manuals/shader).
+
+## Laufzeitschriftarten aktivieren {#enabling-runtime-fonts}
+
+Für Schriftarten vom Typ SDF ist die Erzeugung zur Laufzeit möglich, wenn du TrueType- (`.ttf`) oder OpenType-Schriftarten (`.otf`) verwendest. Die Erzeugung zur Laufzeit aus `.otf`-Ressourcen wird seit Defold 1.13.2 unterstützt.
+Dieser Ansatz kann die Downloadgröße und den Speicherverbrauch eines Defold-Spiels zur Laufzeit erheblich reduzieren.
+Der kleine Nachteil besteht darin, dass die Erzeugung jeder Glyphe asynchron erfolgt.
+
+* Aktiviere die Funktion, indem du `font.runtime_generation` in game.project setzt.
+
+* Füge ein [Anwendungsmanifest](/manuals/app-manifest) hinzu und aktiviere die Option `Use full text layout system`.
+Dadurch wird eine angepasste Engine erstellt, in der diese Funktion aktiviert ist.
+
+::: sidenote
+Diese Funktion ist derzeit experimentell, soll aber in Zukunft zum Standardarbeitsablauf werden.
+:::
+
+::: important
+Die Einstellung `font.runtime_generation` wirkt sich auf alle `.ttf`- und `.otf`-Schriftarten im Projekt aus.
+:::
+
+
+### Schriftarten per Skript steuern {#font-scripting}
+
+#### Den Glyphen-Cache vorab füllen {#prewarming-glyph-cache}
+
+Um Laufzeitschriftarten leichter verwenden zu können, unterstützen sie das Vorabfüllen des Glyphen-Caches.
+Das bedeutet, dass die unter *Characters* in der Schriftressource aufgeführten Glyphen erzeugt werden.
+
+::: sidenote
+Wenn `All Chars` ausgewählt ist, wird der Cache nicht vorab gefüllt, da dies dem Zweck widerspricht, nicht alle Glyphen gleichzeitig erzeugen zu müssen.
+:::
+
+Wenn das Feld `Characters` der `.fontc`-Datei ausgefüllt ist, wird sein Inhalt als Text verwendet, um zu ermitteln, welche Glyphen im Glyphen-Cache aktualisiert werden müssen.
+
+Du kannst den Glyphen-Cache auch manuell aktualisieren, indem du `font.prewarm_text(font_collection, text, callback)` aufrufst. Ein Callback informiert dich darüber, wann alle fehlenden Glyphen zum Glyphen-Cache hinzugefügt wurden und der Text auf dem Bildschirm angezeigt werden kann.
+
+### Schriftarten zu einer Schriftsammlung hinzufügen oder daraus entfernen {#addingremoving-fonts-to-a-font-collection}
+
+Bei Laufzeitschriftarten kannst du Schriftarten (`.ttf`) zu einer Schriftsammlung hinzufügen oder daraus entfernen.
+Das ist nützlich, wenn eine große Schriftart in mehrere Dateien für verschiedene Zeichensätze (z. B. CJK) aufgeteilt wurde.
+
+::: important
+Wenn du eine Schriftart zu einer Schriftsammlung hinzufügst, werden dadurch nicht automatisch alle Glyphen geladen oder gerendert.
+:::
+
+```lua
+function init(self)
+    -- Get the target font collection.
+    self.font_collection = go.get("#label", "font")
+
+    -- Get the first font assigned to the selected language collection.
+    local language_collection = go.get("localization_japanese#label", "font")
+    local font_info = font.get_info(language_collection)
+    self.language_ttf_hash = font_info.fonts[1].path_hash
+
+    -- Associate it with the target collection and increase its reference count.
+    font.add_font(self.font_collection, self.language_ttf_hash)
+end
+```
+
+```lua
+function final(self)
+    -- Remove the association and release the font reference.
+    font.remove_font(self.font_collection, self.language_ttf_hash)
+end
+```
+
+### Glyphen vorab erzeugen {#prewarming-glyphs}
+
+Damit ein Text mit einer Laufzeitschriftart korrekt angezeigt werden kann, müssen die Glyphen aufgelöst werden. `font.prewarm_text()` übernimmt das für dich.
+Dies ist ein asynchroner Vorgang. Sobald er abgeschlossen ist und der Callback aufgerufen wurde, kannst du mit der Anzeige jeder Meldung fortfahren, die diese Glyphen enthält.
+
+::: important
+Wenn der Glyphen-Cache voll wird, wird die älteste Glyphe aus dem Cache entfernt.
+:::
+
+```lua
+font.prewarm_text(self.font_collection, info.text, function (self, request_id, result, err)
+    if result then
+      print("PREWARMING OK!")
+      go.set(self.label, "text", info.text)
+    else
+      print("Error prewarming text:", err)
+    end
+  end)
+```

--- a/docs/de/manuals/getting-help.md
+++ b/docs/de/manuals/getting-help.md
@@ -1,0 +1,99 @@
+---
+title: So bekommst du Hilfe
+brief: Dieses Handbuch beschreibt, wie du Hilfe bekommst, wenn bei der Verwendung von Defold ein Problem auftritt.
+---
+
+# Hilfe bekommen {#getting-help}
+
+Wenn bei der Verwendung von Defold ein Problem auftritt, möchten wir davon erfahren, damit wir den Fehler beheben und/oder dir helfen können, das Problem zu umgehen! Es gibt mehrere Möglichkeiten, Probleme zu besprechen und zu melden. Wähle die für dich passende Möglichkeit:
+
+## Ein Problem im Forum melden {#report-a-problem-on-the-forum}
+
+Eine gute Möglichkeit, ein Problem zu besprechen und Hilfe zu erhalten, ist eine Frage in unserem [Forum](https://forum.defold.com). Veröffentliche deinen Beitrag je nach Art des Problems in der Kategorie [Questions](https://forum.defold.com/c/questions) oder [Bugs](https://forum.defold.com/c/bugs). Denke daran, vor dem Fragen nach deiner Frage oder deinem Problem zu [suchen](https://forum.defold.com/search), da es möglicherweise bereits eine Lösung gibt.
+
+Wenn du mehrere Fragen hast, erstelle mehrere Beiträge. Stelle keine Fragen zu unterschiedlichen Themen im selben Beitrag.
+
+### Erforderliche Informationen {#required-information}
+Wir können dir nur helfen, wenn du die benötigten Informationen angibst:
+
+**Titel**
+Verwende einen kurzen und aussagekräftigen Titel. Ein guter Titel wäre „Wie bewege ich ein Spielobjekt (game object) in die Richtung, in die es gedreht ist?“ oder „Wie blende ich ein Sprite aus?“. Ein schlechter Titel wäre „Ich brauche Hilfe mit Defold!“ oder „Mein Spiel funktioniert nicht!“.
+
+**Beschreibung des Fehlers (ERFORDERLICH)**
+Eine klare und knappe Beschreibung des Fehlers.
+
+**Schritte zum Nachstellen (ERFORDERLICH)**
+Schritte zum Nachstellen des Verhaltens:
+1. Gehe zu '...'
+2. Klicke auf '....'
+3. Scrolle nach unten zu '....'
+4. Beobachte den Fehler
+
+**Erwartetes Verhalten (ERFORDERLICH)**
+Eine klare und knappe Beschreibung dessen, was du erwartet hast.
+
+**Defold-Version (ERFORDERLICH):**
+  - Version [z. B. 1.2.155]
+
+**Plattformen (ERFORDERLICH):**
+ - Plattformen: [z. B. iOS, Android, Windows, macOS, Linux, HTML5]
+ - Betriebssystem: [z. B. iOS8.1, Windows 10, High Sierra]
+ - Gerät: [z. B. iPhone6]
+
+**Minimales Beispielprojekt zum Nachstellen des Fehlers (OPTIONAL):**
+Bitte füge ein minimales Projekt bei, in dem sich der Fehler nachstellen lässt. Das hilft der Person, die den Fehler untersucht und behebt, erheblich.
+
+**Protokolle (OPTIONAL):**
+Bitte stelle relevante Protokolle der Engine, des Editors oder des Build-Servers bereit. Wo die Protokolle gespeichert werden, erfährst du [hier](#log-files).
+
+**Behelfslösung (OPTIONAL):**
+Falls es eine Behelfslösung gibt, beschreibe sie bitte hier.
+
+**Bildschirmaufnahmen (OPTIONAL):**
+Füge gegebenenfalls Bildschirmaufnahmen hinzu, um dein Problem zu veranschaulichen.
+
+**Zusätzlicher Kontext (OPTIONAL):**
+Ergänze hier weitere Hintergrundinformationen zum Problem.
+
+
+### Code teilen {#sharing-code}
+Wenn du Code teilst, empfehlen wir, ihn als Text und nicht als Bildschirmaufnahme zu teilen. Text lässt sich leichter durchsuchen und ermöglicht es, Fehler hervorzuheben sowie Änderungen vorzuschlagen und vorzunehmen. Um Code zu teilen, umschließe ihn mit drei \`\`\` oder rücke ihn mit 4 Leerzeichen ein.
+
+Beispiel:
+
+\`\`\`
+print("Hello code!")
+\`\`\`
+
+Ergebnis:
+
+```
+print("Hello code!")
+```
+
+
+## Ein Problem aus dem Editor melden {#report-a-problem-from-the-editor}
+
+Der Editor bietet eine bequeme Möglichkeit, Probleme zu melden. Wähle im Editor den Menüpunkt <kbd>Help->Report Issue</kbd>, um ein Problem zu melden.
+
+![](images/getting_help/report_issue.png)
+
+Dieser Menüpunkt führt dich zu einem Issue-Tracker auf GitHub. Stelle [Protokolldateien](#log-files), Informationen zu deinem Betriebssystem, Schritte zum Nachstellen des Problems, mögliche Behelfslösungen usw. bereit.
+
+::: sidenote
+Du benötigst ein GitHub-Konto, um auf diese Weise einen Fehlerbericht einzureichen.
+:::
+
+
+## Ein Problem auf Discord besprechen {#discuss-a-problem-on-discord}
+
+Wenn bei der Verwendung von Defold ein Problem auftritt, kannst du versuchen, deine Frage auf [Discord](https://www.defold.com/discord/) zu stellen. Wir empfehlen jedoch, komplexe Fragen und ausführliche Diskussionen im Forum zu veröffentlichen. Beachte außerdem, dass wir keine Fehlerberichte über Discord annehmen.
+
+
+# Protokolldateien {#log-files}
+
+Die Engine, der Editor und der Build-Server erzeugen Protokollinformationen, die bei der Bitte um Hilfe und bei der Fehlersuche sehr wertvoll sein können. Stelle beim Melden eines Problems immer Protokolldateien bereit:
+
+* [Engine-Protokolle](/manuals/debugging-game-and-system-logs)
+* [Editor-Protokolle](/manuals/editor#editor-logs)
+* [Build-Server-Protokolle](/manuals/extensions#build-server-logs)

--- a/docs/de/manuals/glossary.md
+++ b/docs/de/manuals/glossary.md
@@ -1,0 +1,172 @@
+---
+title: Defold-Glossar
+brief: Dieses Handbuch enthält kurze Beschreibungen zu allem, was dir bei der Arbeit mit Defold begegnet.
+---
+
+# Defold-Glossar {#defold-glossary}
+
+Dieses Glossar beschreibt kurz alles, was dir in Defold begegnet. In den meisten Fällen findest du einen Link zu weiterführender Dokumentation.
+
+## Animationssatz {#animation-set}
+
+![Animationssatz](images/icons/animationset.png){.left} Eine Animationssatz-Ressource enthält eine Liste von glTF-Dateien oder anderen .animationset-Dateien, aus denen Animationen gelesen werden. Eine .animationset-Datei zu einer anderen hinzuzufügen ist praktisch, wenn du Teilmengen von Animationen für mehrere Modelle gemeinsam verwendest. Einzelheiten findest du im [Handbuch zur Modellanimation](/manuals/model-animation/).
+
+## Atlas
+
+![Atlas](images/icons/atlas.png){.left} Ein Atlas ist eine Zusammenstellung einzelner Bilder, die aus Leistungs- und Speichergründen zu einem größeren Bildbogen zusammengefügt werden. Atlanten können Standbilder oder Bildfolgen für Flipbook-Animationen enthalten. Verschiedene Komponenten (components) verwenden Atlanten, um Grafikressourcen gemeinsam zu nutzen. Weitere Informationen findest du in der [Atlas-Dokumentation](/manuals/atlas).
+
+## Builtins
+
+![Builtins](images/icons/builtins.png){.left} Der Projektordner builtins ist ein schreibgeschützter Ordner mit nützlichen Standardressourcen. Hier findest du den Standard-Renderer, das Standard-Render-Skript, Materialien und mehr. Wenn du eine dieser Ressourcen anpassen musst, kopiere sie einfach in dein Projekt und bearbeite sie nach Bedarf.
+
+## Kamera {#camera}
+
+![Kamera](images/icons/camera.png){.left} Die Kamerakomponente hilft dir festzulegen, welcher Teil der Spielwelt sichtbar sein und wie er projiziert werden soll. Ein häufiger Anwendungsfall besteht darin, eine Kamera am Spielobjekt (game object) des Spielers anzubringen oder ein separates Spielobjekt mit einer Kamera zu verwenden, die dem Spieler mithilfe eines Glättungsalgorithmus folgt. Weitere Informationen findest du in der [Kamera-Dokumentation](/manuals/camera).
+
+## Kollisionsobjekt {#collision-object}
+
+![Kollisionsobjekt](images/icons/collision-object.png){.left} Kollisionsobjekte sind Komponenten, die Spielobjekte um physikalische Eigenschaften erweitern, etwa räumliche Form, Gewicht, Reibung und Rückprallkoeffizient. Diese Eigenschaften bestimmen, wie das Kollisionsobjekt mit anderen Kollisionsobjekten kollidieren soll. Die häufigsten Arten von Kollisionsobjekten sind kinematische Objekte, dynamische Objekte und Trigger. Ein kinematisches Objekt liefert detaillierte Kollisionsinformationen, auf die du manuell reagieren musst. Ein dynamisches Objekt wird von der Physik-Engine automatisch nach den Newtonschen Bewegungsgesetzen simuliert. Trigger sind einfache Formen, die erkennen, ob andere Formen in den Trigger eingetreten sind oder ihn verlassen haben. Einzelheiten zur Funktionsweise findest du in der [Physik-Dokumentation](/manuals/physics).
+
+## Komponente {#component}
+
+Komponenten geben Spielobjekten ein bestimmtes Erscheinungsbild und/oder bestimmte Funktionen, etwa Grafik, Animation, programmiertes Verhalten und Audio. Sie existieren nicht unabhängig, sondern müssen in Spielobjekten enthalten sein. In Defold stehen viele Arten von Komponenten zur Verfügung. Eine Beschreibung der Komponenten findest du im [Handbuch zu den Bausteinen](/manuals/building-blocks).
+
+## Sammlung {#collection}
+
+![Sammlung](images/icons/collection.png){.left} Eine Sammlung (collection) ist Defolds Mechanismus zum Erstellen von Vorlagen, die in anderen Engines „Prefabs“ heißen und mit denen sich Hierarchien von Spielobjekten wiederverwenden lassen. Sammlungen sind Baumstrukturen, die Spielobjekte und andere Sammlungen enthalten. Eine Sammlung wird immer in einer Datei gespeichert und entweder statisch durch manuelles Platzieren im Editor oder dynamisch durch das Erzeugen ihrer Inhalte ins Spiel eingebracht. Eine Beschreibung der Sammlungen findest du im [Handbuch zu den Bausteinen](/manuals/building-blocks).
+
+## Sammlungsfabrik {#collection-factory}
+
+![Sammlungsfabrik](images/icons/collection-factory.png){.left} Eine Sammlungsfabrik (collection factory) ist eine Komponente, mit der du Hierarchien von Spielobjekten dynamisch in einem laufenden Spiel erzeugst. Einzelheiten findest du im [Handbuch zu Sammlungsfabriken](/manuals/collection-factory).
+
+## Sammlungs-Proxy {#collection-proxy}
+
+![Sammlung](images/icons/collection.png){.left} Ein Sammlungs-Proxy (collection proxy) wird verwendet, um Sammlungen während der Ausführung einer Anwendung oder eines Spiels zu laden und zu aktivieren. Der häufigste Anwendungsfall für Sammlungs-Proxys ist das Laden von Levels, sobald sie gespielt werden sollen. Einzelheiten findest du in der [Dokumentation zu Sammlungs-Proxys](/manuals/collection-proxy).
+
+## Cubemap
+
+![Cubemap](images/icons/cubemap.png){.left} Eine Cubemap ist ein besonderer Texturtyp, der aus 6 verschiedenen Texturen besteht, die auf die Seiten eines Würfels abgebildet werden. Das ist nützlich zum Rendern von Skyboxen und verschiedenen Arten von Reflexions- und Beleuchtungstexturen.
+
+## Debugging
+
+Irgendwann wird sich dein Spiel unerwartet verhalten und du musst herausfinden, was schiefläuft. Debuggen zu lernen ist eine Kunst. Glücklicherweise enthält Defold einen integrierten Debugger, der dir dabei hilft. Weitere Informationen findest du im [Debugging-Handbuch](/manuals/debugging).
+
+## Anzeigeprofile {#display-profiles}
+
+![Anzeigeprofile](images/icons/display-profiles.png){.left} Die Ressourcendatei für Anzeigeprofile legt GUI-Layouts abhängig von der Ausrichtung, dem Seitenverhältnis oder dem Gerätemodell fest. Sie hilft dir, deine Benutzeroberfläche an alle Arten von Geräten anzupassen. Mehr dazu erfährst du im [Handbuch zu Layouts](/manuals/gui-layouts).
+
+## Fabrik {#factory}
+
+![Fabrik](images/icons/factory.png){.left} In manchen Situationen kannst du nicht alle benötigten Spielobjekte manuell in einer Sammlung platzieren, sondern musst sie dynamisch während des Spiels erzeugen. Beispielsweise kann ein Spieler Geschosse abfeuern, wobei jedes Geschoss dynamisch erzeugt und abgeschossen werden soll, sobald der Spieler den Abzug betätigt. Um Spielobjekte dynamisch aus einem vorab reservierten Pool von Objekten zu erzeugen, verwendest du eine Fabrikkomponente (factory). Einzelheiten findest du im [Handbuch zu Fabriken](/manuals/factory).
+
+## Schriftart {#font}
+
+![Schriftdatei](images/icons/font.png){.left} Eine Schriftressource wird aus einer TrueType- oder OpenType-Schriftdatei erstellt. Sie legt fest, in welcher Größe die Schrift gerendert wird und welche Verzierungen (Kontur und Schatten) die gerenderte Schrift haben soll. Schriftarten werden von GUI- und Beschriftungskomponenten verwendet. Einzelheiten findest du im [Handbuch zu Schriftarten](/manuals/font/).
+
+## Fragment-Shader
+
+![Fragment-Shader](images/icons/fragment-shader.png){.left} Dies ist ein Programm, das auf dem Grafikprozessor für jedes Pixel (Fragment) eines Polygons ausgeführt wird, wenn es auf den Bildschirm gezeichnet wird. Der Fragment-Shader bestimmt die Farbe jedes resultierenden Fragments. Dies geschieht durch Berechnungen, einen oder mehrere Texturzugriffe oder eine Kombination aus Texturzugriffen und Berechnungen. Weitere Informationen findest du im [Shader-Handbuch](/manuals/shader).
+
+## Gamepads
+
+![Gamepads](images/icons/gamepad.png){.left} Eine Gamepads-Ressourcendatei definiert, wie die Eingaben bestimmter Gamepad-Geräte auf einer bestimmten Plattform den Eingabeauslösern für Gamepads zugeordnet werden. Einzelheiten findest du im [Handbuch zur Eingabe](/manuals/input).
+
+## Spielobjekt {#game-object}
+
+![Spielobjekt](images/icons/game-object.png){.left} Spielobjekte sind einfache Objekte, die während der Ausführung deines Spiels eine eigene Lebensdauer haben. Spielobjekte sind Container und werden üblicherweise mit sichtbaren oder hörbaren Komponenten ausgestattet, etwa einer Audiokomponente oder einem Sprite. Durch Skriptkomponenten können sie auch Verhalten erhalten. Du erstellst Spielobjekte und platzierst sie im Editor in Sammlungen oder erzeugst sie zur Laufzeit dynamisch mit Fabriken. Eine Beschreibung der Spielobjekte findest du im [Handbuch zu den Bausteinen](/manuals/building-blocks).
+
+## GUI
+
+![GUI-Komponente](images/icons/gui.png){.left} Eine GUI-Komponente enthält Elemente zum Aufbau von Benutzeroberflächen: Text sowie farbige und/oder texturierte Blöcke. Die Elemente lassen sich in hierarchischen Strukturen organisieren, per Skript steuern und animieren. GUI-Komponenten werden üblicherweise verwendet, um eingeblendete Spielinformationen (HUDs), Menüsysteme und Bildschirmbenachrichtigungen zu erstellen. GUI-Komponenten werden mit GUI-Skripten gesteuert, die das Verhalten der GUI definieren und die Interaktion der Benutzer mit ihr steuern. Mehr dazu erfährst du in der [GUI-Dokumentation](/manuals/gui).
+
+## GUI-Skript {#gui-script}
+
+![GUI-Skript](images/icons/script.png){.left} GUI-Skripte steuern das Verhalten von GUI-Komponenten. Sie steuern GUI-Animationen und die Interaktion der Benutzer mit der GUI. Einzelheiten zur Verwendung von Lua-Skripten in Defold findest du im [Handbuch zu Lua in Defold](/manuals/lua).
+
+## Hot Reload
+
+Mit dem Defold-Editor kannst du Inhalte in einem bereits laufenden Spiel aktualisieren, sowohl auf dem Desktop als auch auf einem Gerät. Diese Funktion ist äußerst leistungsfähig und kann den Arbeitsablauf bei der Entwicklung erheblich verbessern. Weitere Informationen findest du im [Handbuch zu Hot Reload](/manuals/hot-reload).
+
+## Eingabebindung {#input-binding}
+
+![Eingabebindung](images/icons/input-binding.png){.left} Dateien für die Eingabebindung (input binding) definieren, wie das Spiel Hardwareeingaben von Maus, Tastatur, Touchscreen und Gamepad interpretieren soll. Die Datei bindet Hardwareeingaben an übergeordnete _Eingabeaktionen_ wie "jump" und "move_forward". In Skriptkomponenten, die Eingaben empfangen, kannst du programmieren, welche Aktionen das Spiel oder die Anwendung bei bestimmten Eingaben ausführen soll. Einzelheiten findest du in der [Dokumentation zur Eingabe](/manuals/input).
+
+## Beschriftung {#label}
+
+![Beschriftung](images/icons/label.png){.left} Mit der Beschriftungskomponente kannst du jedem Spielobjekt Text hinzufügen. Sie rendert einen Text in einer bestimmten Schriftart im Spielraum auf den Bildschirm. Weitere Informationen findest du im [Handbuch zu Beschriftungen](/manuals/label).
+
+## Bibliothek {#library}
+
+![Spielobjekt](images/icons/builtins.png){.left} Defold ermöglicht es dir, Daten über einen leistungsfähigen Bibliotheksmechanismus zwischen Projekten zu teilen. Damit kannst du gemeinsame Bibliotheken einrichten, auf die du von all deinen Projekten aus zugreifen kannst, entweder für dich allein oder für das gesamte Team. Mehr über den Bibliotheksmechanismus erfährst du in der [Dokumentation zu Bibliotheken](/manuals/libraries).
+
+## Programmiersprache Lua {#lua-language}
+
+Die Programmiersprache Lua wird in Defold verwendet, um Spiellogik zu erstellen. Lua ist eine leistungsfähige, effiziente und sehr kleine Skriptsprache. Sie unterstützt prozedurale Programmierung, objektorientierte Programmierung, funktionale Programmierung, datengetriebene Programmierung und Datenbeschreibung. Mehr über die Sprache erfährst du auf der offiziellen Lua-Website unter https://www.lua.org/ und im [Handbuch zu Lua in Defold](/manuals/lua).
+
+## Lua-Modul {#lua-module}
+
+![Lua-Modul](images/icons/lua-module.png){.left} Mit Lua-Modulen kannst du dein Projekt strukturieren und wiederverwendbaren Bibliothekscode erstellen. Mehr dazu erfährst du im [Handbuch zu Lua-Modulen](/manuals/modules/)
+
+## Material
+
+![Material](images/icons/material.png){.left} Materialien legen durch die Angabe von Shadern und deren Eigenschaften fest, wie verschiedene Objekte gerendert werden sollen. Weitere Informationen findest du im [Handbuch zu Materialien](/manuals/material).
+
+## Nachricht {#message}
+
+Komponenten kommunizieren untereinander und mit anderen Systemen durch Nachrichtenübermittlung. Komponenten reagieren außerdem auf eine Reihe vordefinierter Nachrichten, die sie verändern oder bestimmte Aktionen auslösen. Du sendest Nachrichten, um Grafiken auszublenden oder Physikobjekten einen Anstoß zu geben. Die Engine verwendet Nachrichten außerdem, um Komponenten über Ereignisse zu informieren, etwa wenn Physikformen kollidieren. Der Mechanismus zur Nachrichtenübermittlung benötigt für jede gesendete Nachricht einen Empfänger. Deshalb hat alles im Spiel eine eindeutige Adresse. Um die Kommunikation zwischen Objekten zu ermöglichen, erweitert Defold Lua um die Nachrichtenübermittlung. Defold stellt außerdem eine Bibliothek mit nützlichen Funktionen bereit.
+
+Der Lua-Code zum Ausblenden einer Sprite-Komponente auf einem Spielobjekt sieht beispielsweise so aus:
+
+```lua
+msg.post("#weapon", "disable")
+```
+
+Hier ist `"#weapon"` die Adresse der Sprite-Komponente des aktuellen Objekts. `"disable"` ist eine Nachricht, auf die Sprite-Komponenten reagieren. Eine ausführliche Erklärung zur Funktionsweise der Nachrichtenübermittlung findest du in der [Dokumentation zur Nachrichtenübermittlung](/manuals/message-passing).
+
+## Modell {#model}
+
+![Modell](images/icons/model.png){.left} Die 3D-Modellkomponente kann glTF-Assets für Meshes, Skelette und Animationen in dein Spiel importieren. Weitere Informationen findest du im [Handbuch zu Modellen](/manuals/model/).
+
+## ParticleFX
+
+![ParticleFX](images/icons/particlefx.png){.left} Partikel sind sehr nützlich, um ansprechende visuelle Effekte zu erstellen, insbesondere in Spielen. Du kannst damit Nebel, Rauch, Feuer, Regen oder fallende Blätter erzeugen. Defold enthält einen leistungsfähigen Editor für Partikeleffekte, mit dem du Effekte erstellen und anpassen kannst, während sie in deinem Spiel in Echtzeit laufen. Die [ParticleFX-Dokumentation](/manuals/particlefx) beschreibt die Funktionsweise im Detail.
+
+## Profiling
+
+Gute Leistung ist für Spiele entscheidend. Daher musst du Leistungs- und Speicherprofiling durchführen können, um dein Spiel zu vermessen und Leistungsengpässe sowie Speicherprobleme zu erkennen, die behoben werden müssen. Weitere Informationen zu den für Defold verfügbaren Profiling-Werkzeugen findest du im [Profiling-Handbuch](/manuals/profiling).
+
+## Render-Ressource {#render}
+
+![Render-Ressource](images/icons/render.png){.left} Render-Dateien enthalten Einstellungen, die beim Rendern des Spiels auf den Bildschirm verwendet werden. Sie legen fest, welches Render-Skript und welche Materialien beim Rendern verwendet werden. Weitere Einzelheiten findest du im [Handbuch zum Rendering](/manuals/render/).
+
+## Render-Skript {#render-script}
+
+![Render-Skript](images/icons/script.png){.left} Ein Render-Skript ist ein Lua-Skript, das steuert, wie das Spiel oder die Anwendung auf den Bildschirm gerendert werden soll. Es gibt ein Standard-Render-Skript, das die häufigsten Fälle abdeckt. Du kannst aber auch ein eigenes schreiben, wenn du benutzerdefinierte Beleuchtungsmodelle und andere Effekte benötigst. Weitere Einzelheiten zur Funktionsweise der Rendering-Pipeline findest du im [Handbuch zum Rendering](/manuals/render/). Einzelheiten zur Verwendung von Lua-Skripten in Defold findest du im [Handbuch zu Lua in Defold](/manuals/lua).
+
+## Skript {#script}
+
+![Skript](images/icons/script.png){.left}  Ein Skript ist eine Komponente, die ein Programm enthält, das das Verhalten von Spielobjekten definiert. Mit Skripten legst du die Regeln deines Spiels fest und bestimmst, wie Objekte auf verschiedene Interaktionen mit dem Spieler und mit anderen Objekten reagieren sollen. Alle Skripte werden in der Programmiersprache Lua geschrieben. Um mit Defold arbeiten zu können, musst du oder jemand aus deinem Team lernen, in Lua zu programmieren. Einen Überblick über Lua und Einzelheiten zur Verwendung von Lua-Skripten in Defold findest du im [Handbuch zu Lua in Defold](/manuals/lua).
+
+## Audio {#sound}
+
+![Audio](images/icons/sound.png){.left} Die Audiokomponente ist für die Wiedergabe eines bestimmten Klangs zuständig. Defold unterstützt Dateien in den Formaten WAV, Ogg Vorbis und Ogg Opus. Die Unterstützung für Opus muss im Anwendungsmanifest aktiviert werden. Weitere Informationen findest du im [Handbuch zu Audio](/manuals/sound).
+
+## Sprite
+
+![Sprite](images/icons/sprite.png){.left} Ein Sprite ist eine Komponente, die Spielobjekte um Grafik erweitert. Es zeigt ein Bild aus einer Kachelquelle oder einem Atlas an. Sprites bieten integrierte Unterstützung für Flipbook- und Skelettanimationen. Sprites werden üblicherweise für Figuren und Gegenstände verwendet.
+
+## Texturprofile {#texture-profiles}
+
+![Texturprofile](images/icons/texture-profiles.png){.left} Die Ressourcendatei für Texturprofile wird bei der Bundle-Erstellung verwendet, um Bilddaten automatisch zu verarbeiten und zu komprimieren. Dazu zählen Bilddaten in Atlanten, Kachelquellen, Cubemaps und eigenständigen Texturen, die für Modelle, GUIs usw. verwendet werden. Mehr dazu erfährst du im [Handbuch zu Texturprofilen](/manuals/texture-profiles).
+
+## Kachelkarte {#tile-map}
+
+![Kachelkarte](images/icons/tilemap.png){.left} Komponenten vom Typ Kachelkarte (tile map) zeigen Bilder aus einer Kachelquelle in einem oder mehreren überlagerten Rastern an. Sie werden am häufigsten zum Aufbau von Spielumgebungen verwendet: Boden, Wände, Gebäude und Hindernisse. Eine Kachelkarte kann mehrere übereinander ausgerichtete Ebenen mit einem festgelegten Mischmodus anzeigen. Das ist beispielsweise nützlich, um Blattwerk über Hintergrundkacheln mit Gras zu legen. Außerdem kannst du das in einer Kachel angezeigte Bild dynamisch ändern. So kannst du etwa eine Brücke zerstören und unpassierbar machen, indem du die Kacheln einfach durch solche ersetzt, die die zerstörte Brücke darstellen und die entsprechende Physikform enthalten. Weitere Informationen findest du in der [Dokumentation zu Kachelkarten](/manuals/tilemap).
+
+## Kachelquelle {#tile-source}
+
+![Kachelquelle](images/icons/tilesource.png){.left} Eine Kachelquelle beschreibt eine Textur, die aus mehreren kleineren Bildern gleicher Größe besteht. Du kannst Flipbook-Animationen aus einer Bildfolge in einer Kachelquelle definieren. Kachelquellen können außerdem automatisch Kollisionsformen aus Bilddaten berechnen. Das ist sehr nützlich, um Levels aus Kacheln zu erstellen, mit denen Objekte kollidieren und interagieren können. Kachelkartenkomponenten sowie Sprite- und ParticleFX-Komponenten verwenden Kachelquellen, um Grafikressourcen gemeinsam zu nutzen. Beachte, dass Atlanten oft besser geeignet sind als Kachelquellen. Weitere Informationen findest du in der [Dokumentation zu Kachelkarten](/manuals/tilemap).
+
+## Vertex-Shader
+
+![Vertex-Shader](images/icons/vertex-shader.png){.left} Der Vertex-Shader berechnet die Bildschirmgeometrie der primitiven Polygonformen einer Komponente. Bei jeder Art von visueller Komponente, ob Sprite, Kachelkarte oder Modell, wird die Form durch eine Menge von Vertex-Positionen der Polygone dargestellt. Das Vertex-Shader-Programm verarbeitet jeden Vertex im Weltkoordinatensystem und berechnet die resultierende Koordinate, die jeder Vertex eines Primitivs haben soll. Weitere Informationen findest du im [Shader-Handbuch](/manuals/shader).

--- a/docs/de/manuals/gpgs.md
+++ b/docs/de/manuals/gpgs.md
@@ -1,0 +1,6 @@
+---
+title: Google Play Game Services in Defold
+brief: Dieses Dokument beschreibt, wie du Google Play Game Services einrichtest und verwendest
+---
+
+[Dieses Handbuch wurde verschoben](/extension-gpgs)

--- a/docs/de/manuals/graphics.md
+++ b/docs/de/manuals/graphics.md
@@ -1,0 +1,10 @@
+---
+title: Grafikhandbuch für Defold
+brief: Dieses Handbuch gibt einen Überblick über die Unterstützung grafischer Elemente in Defold.
+---
+
+Dieses Handbuch ist veraltet und zur Ablösung vorgesehen!
+
+* Lies hier mehr darüber, [wie du 2D-Grafiken importierst und verwendest](/manuals/importing-graphics)
+* Lies mehr über die [Texturfilterung](/manuals/texture-filtering)
+* Lies mehr über [Materialien](/manuals/material)

--- a/docs/de/manuals/gui-box.md
+++ b/docs/de/manuals/gui-box.md
@@ -1,0 +1,28 @@
+---
+title: GUI-Box-Knoten in Defold
+brief: Dieses Handbuch erklärt, wie du GUI-Box-Knoten verwendest.
+---
+
+# GUI-Box-Knoten {#gui-box-nodes}
+
+Ein Box-Knoten (box node) ist ein Rechteck, das mit einer Farbe, einer Textur oder einer Animation gefüllt ist.
+
+## Box-Knoten hinzufügen {#adding-box-nodes}
+
+Füge neue Box-Knoten hinzu, indem du in der Ansicht *Outline* einen <kbd>Rechtsklick</kbd> ausführst und <kbd>Add ▸ Box</kbd> wählst, oder drücke <kbd>A</kbd> und wähle <kbd>Box</kbd>.
+
+Du kannst Bilder und Animationen aus Atlanten oder Kachelquellen (tile sources) verwenden, die der GUI hinzugefügt wurden. Du fügst Texturen hinzu, indem du in der Ansicht *Outline* einen <kbd>Rechtsklick</kbd> auf das Ordnersymbol *Textures* ausführst und <kbd>Add ▸ Textures...</kbd> wählst. Lege anschließend die Eigenschaft *Texture* des Box-Knotens fest:
+
+![Texturen](images/gui-box/create.png)
+
+Beachte, dass die Farbe des Box-Knotens die Grafik einfärbt. Die Farbe für die Einfärbung wird mit den Bilddaten multipliziert. Wenn du die Farbe auf Weiß (den Standardwert) setzt, wird daher keine Einfärbung angewendet.
+
+![Eingefärbte Textur](images/gui-box/tinted.png)
+
+Box-Knoten werden immer gerendert, auch wenn ihnen keine Textur zugewiesen ist, ihr Alpha auf `0` gesetzt ist oder ihre Größe `0, 0, 0` beträgt. Box-Knoten sollten immer eine Textur zugewiesen bekommen, damit der Renderer ihre Zeichenoperationen korrekt bündeln (Batching) und die Anzahl der Zeichenaufrufe (draw calls) verringern kann.
+
+## Animationen abspielen {#playing-animations}
+
+Box-Knoten können Animationen aus Atlanten oder Kachelquellen abspielen. Weitere Informationen findest du im [Handbuch zur Flipbook-Animation](/manuals/flipbook-animation).
+
+:[Slice-9](../shared/slice-9-texturing.md)

--- a/docs/de/manuals/gui-clipping.md
+++ b/docs/de/manuals/gui-clipping.md
@@ -1,0 +1,75 @@
+---
+title: Handbuch zum Beschneiden in der GUI
+brief: Dieses Handbuch beschreibt, wie du GUI-Knoten erstellst, die andere Knoten mithilfe von Stencil-Masken beschneiden.
+---
+
+# Beschneiden {#clipping}
+
+GUI-Knoten können als Knoten zum *Beschneiden* (Clipping) verwendet werden---Masken, die steuern, wie andere Knoten gerendert werden. Dieses Handbuch erklärt, wie diese Funktion arbeitet.
+
+## Einen Knoten zum Beschneiden erstellen {#creating-a-clipping-node}
+
+Knoten der Typen Box, Text und Pie können zum Beschneiden verwendet werden. Um einen beschneidenden Knoten zu erstellen, füge deiner GUI einen Knoten hinzu und lege seine Eigenschaften entsprechend fest:
+
+Clipping Mode
+: Der Modus, der zum Beschneiden verwendet wird.
+  - `None` rendert den Knoten, ohne dass ein Beschneiden stattfindet.
+  - `Stencil` bewirkt, dass der Knoten in die aktuelle Stencil-Maske schreibt.
+
+Clipping Visible
+: Aktiviere dieses Kontrollkästchen, um den Inhalt des Knotens zu rendern.
+
+Clipping Inverted
+: Aktiviere dieses Kontrollkästchen, um die Umkehrung der Knotenform in die Maske zu schreiben.
+
+Füge anschließend die Knoten, die du beschneiden möchtest, als untergeordnete Knoten des beschneidenden Knotens hinzu.
+
+![Beschneiden einrichten](images/gui-clipping/create.png)
+
+## Stencil-Maske {#stencil-mask}
+
+Das Beschneiden funktioniert, indem Knoten in einen *Stencil-Puffer* schreiben. Dieser Puffer enthält Beschneidemasken: Informationen, die der Grafikkarte mitteilen, ob ein Pixel gerendert werden soll oder nicht.
+
+- Ein Knoten, der keinen übergeordneten beschneidenden Knoten hat und dessen Beschneidemodus auf `Stencil` gesetzt ist, schreibt seine Form (oder deren Umkehrung) in eine neue Beschneidemaske, die im Stencil-Puffer gespeichert wird.
+- Hat ein beschneidender Knoten einen übergeordneten beschneidenden Knoten, beschneidet er stattdessen dessen Beschneidemaske. Ein untergeordneter beschneidender Knoten kann die aktuelle Beschneidemaske niemals _erweitern_, sondern nur weiter beschneiden.
+- Knoten, die selbst nicht beschneiden und beschneidenden Knoten untergeordnet sind, werden mit der Beschneidemaske gerendert, die durch die Hierarchie der übergeordneten Knoten entsteht.
+
+![Hierarchie beim Beschneiden](images/gui-clipping/setup.png)
+
+Hier sind drei Knoten in einer Hierarchie angeordnet:
+
+- Sowohl das Sechseck als auch das Quadrat sind beschneidende Stencil-Knoten.
+- Das Sechseck erstellt eine neue Beschneidemaske, das Quadrat beschneidet sie weiter.
+- Der kreisförmige Knoten ist ein gewöhnlicher Kreissektor-Knoten und wird daher mit der Beschneidemaske gerendert, die seine übergeordneten beschneidenden Knoten erstellen.
+
+Für diese Hierarchie sind vier Kombinationen aus normalen und invertierten beschneidenden Knoten möglich. Der grüne Bereich markiert den Teil des Kreises, der gerendert wird. Der Rest wird maskiert:
+
+![Stencil-Masken](images/gui-clipping/modes.png)
+
+## Einschränkungen von Stencil-Masken {#stencil-limitations}
+
+- Die Gesamtzahl beschneidender Stencil-Knoten darf 256 nicht überschreiten.
+- Die maximale Verschachtelungstiefe untergeordneter _Stencil_-Knoten beträgt 8 Ebenen. (Es zählen nur Knoten, die mit Stencil-Masken beschneiden.)
+- Die maximale Anzahl von Stencil-Knoten auf derselben Ebene mit demselben übergeordneten Knoten beträgt 127. Mit jeder tieferen Ebene in einer Stencil-Hierarchie halbiert sich diese Obergrenze.
+- Invertierte Knoten verursachen einen höheren Aufwand. Es sind höchstens 8 invertierte beschneidende Knoten möglich, und jeder halbiert die maximale Anzahl nicht invertierter beschneidender Knoten.
+- Stencils rendern eine Stencil-Maske aus der _Geometrie_ des Knotens (nicht aus der Textur). Du kannst die Maske invertieren, indem du die Eigenschaft *Inverted clipper* aktivierst.
+
+
+## Ebenen {#layers}
+
+Mit Ebenen kannst du die Renderreihenfolge (und die Bündelung von Zeichenoperationen, Batching) von Knoten steuern. Wenn du Ebenen und beschneidende Knoten verwendest, wird die übliche Ebenenreihenfolge überschrieben. Die Ebenenreihenfolge hat immer Vorrang vor der Beschneidereihenfolge---wenn Ebenenzuweisungen mit beschneidenden Knoten kombiniert werden, kann das Beschneiden in der falschen Reihenfolge erfolgen, falls ein übergeordneter Knoten mit aktiviertem Beschneiden zu einer höheren Ebene als seine untergeordneten Knoten gehört. Untergeordnete Knoten ohne zugewiesene Ebene halten sich weiterhin an die Hierarchie und werden daher nach dem übergeordneten Knoten gezeichnet und beschnitten.
+
+::: sidenote
+Ein beschneidender Knoten und seine Hierarchie werden zuerst gezeichnet, wenn ihm eine Ebene zugewiesen ist, und in der regulären Reihenfolge, wenn ihm keine Ebene zugewiesen ist.
+:::
+
+![Ebenen und Beschneiden](images/gui-clipping/layers.png)
+
+In diesem Beispiel verwenden die beiden beschneidenden Knoten „`Donut BG`“ und „`BG`“ dieselbe Ebene 1. Ihre Renderreihenfolge entspricht ihrer Reihenfolge in der Hierarchie, in der „`Donut BG`“ vor „`BG`“ gerendert wird. Der untergeordnete Knoten „`Donut Shadow`“ ist jedoch Ebene 2 zugewiesen, die in der Ebenenreihenfolge höher liegt, und wird deshalb nach den beiden beschneidenden Knoten gerendert. In diesem Fall lautet die Renderreihenfolge:
+
+- `Donut BG`
+- `BG`
+- `BG Frame`
+- `Donut Shadow`
+
+Hier siehst du, dass das Objekt „`Donut Shadow`“ aufgrund der Ebenenzuweisung von beiden beschneidenden Knoten beschnitten wird, obwohl es nur einem von ihnen untergeordnet ist.

--- a/docs/de/manuals/gui-layouts.md
+++ b/docs/de/manuals/gui-layouts.md
@@ -1,0 +1,139 @@
+---
+title: GUI-Layouts in Defold
+brief: Defold unterstützt GUIs, die sich automatisch an Änderungen der Bildschirmausrichtung auf Mobilgeräten anpassen. Dieses Dokument erklärt, wie diese Funktion funktioniert.
+---
+
+# Layouts
+
+Defold unterstützt GUIs, die sich automatisch an Änderungen der Bildschirmausrichtung auf Mobilgeräten anpassen. Mit dieser Funktion kannst du GUIs gestalten, die sich an die Ausrichtung und das Seitenverhältnis verschiedener Bildschirmgrößen anpassen. Du kannst auch Layouts erstellen, die zu bestimmten Gerätemodellen passen.
+
+## Anzeigeprofile erstellen {#creating-display-profiles}
+
+Standardmäßig ist in den Einstellungen von *game.project* festgelegt, dass eine integrierte Einstellungsdatei für Anzeigeprofile (display profiles) verwendet wird ("builtins/render/default.display_profiles"). Die Standardprofile sind "Landscape" (1280 Pixel breit und 720 Pixel hoch) und "Portrait" (720 Pixel breit und 1280 Pixel hoch). In den Profilen sind keine Gerätemodelle festgelegt, sodass sie auf jedes Gerät passen.
+
+Um eine neue Einstellungsdatei für Profile zu erstellen, kopiere entweder die Datei aus dem Ordner "builtins" oder öffne mit einem <kbd>Rechtsklick</kbd> auf eine geeignete Stelle in der Ansicht *Assets* das Kontextmenü und wähle <kbd>New... ▸ Display Profiles</kbd>. Gib der neuen Datei einen passenden Namen und klicke auf <kbd>Ok</kbd>.
+
+Der Editor öffnet die neue Datei jetzt zum Bearbeiten. Füge neue Profile hinzu, indem du in der Liste *Profiles* auf <kbd>+</kbd> klickst. Füge jedem Profil einen Satz von *Qualifikatoren* (qualifiers) hinzu:
+
+Width
+: Die Breite des Qualifikators in Pixeln.
+
+Height
+: Die Höhe des Qualifikators in Pixeln.
+
+Device Models
+: Eine durch Kommas getrennte Liste von Gerätemodellen. Der Eintrag für das Gerätemodell wird mit dem Anfang des Gerätemodellnamens abgeglichen. Beispielsweise passt `iPhone10` zu Modellen mit dem Namen "iPhone10,\*". Modellnamen mit Kommas sollten in Anführungszeichen eingeschlossen werden. So passt `"iPhone10,3", "iPhone10,6"` zu iPhone-X-Modellen (siehe [iPhone-Wiki](https://www.theiphonewiki.com/wiki/Models)). Beachte, dass nur Android und iOS beim Aufruf von `sys.get_sys_info()` ein Gerätemodell melden. Andere Plattformen geben eine leere Zeichenfolge zurück und wählen deshalb niemals ein Anzeigeprofil aus, das einen Qualifikator für ein Gerätemodell enthält.
+
+![Neue Anzeigeprofile](images/gui-layouts/new_profiles.png)
+
+Du musst außerdem festlegen, dass die Engine deine neuen Profile verwenden soll. Öffne *game.project* und wähle unter *display* in der Einstellung *Display Profiles* die Datei mit den Anzeigeprofilen aus:
+
+![Einstellungen](images/gui-layouts/settings.png)
+
+Wenn die Engine beim Drehen des Geräts automatisch zwischen Hochformat- und Querformatlayouts wechseln soll, aktiviere das Kontrollkästchen *Dynamic Orientation*. Die Engine wählt dynamisch ein passendes Layout aus und ändert die Auswahl auch, wenn sich die Ausrichtung des Geräts ändert.
+
+### Auto Layout Selection (Display Profiles)
+
+Die Ressource für Anzeigeprofile bietet die Option „Auto Layout Selection“ (standardmäßig ON). Wenn sie auf ON gesetzt ist, wählt die Engine automatisch das am besten passende GUI-Layout aus, sowohl beim Erstellen der Szene als auch bei Änderungen der Fenster- oder Bildschirmgröße. Wenn sie auf OFF gesetzt ist, ändert die Engine die Layouts nicht automatisch. Verwende dann `gui.set_layout()` in deinem GUI-Skript, um Layouts manuell zu wechseln. Diese Einstellung wird in der Datei mit den Anzeigeprofilen gespeichert und wirkt sich auf alle GUI-Szenen (GUI scenes) aus.
+
+## GUI-Layouts
+
+Mit den aktuell vorhandenen Anzeigeprofilen kannst du Layoutvarianten für die Anordnung deiner GUI-Knoten (GUI nodes) erstellen. Um einer GUI-Szene ein neues Layout hinzuzufügen, klicke in der Ansicht *Outline* mit der rechten Maustaste auf das Symbol *Layouts* und wähle <kbd>Add ▸ Layout ▸ ...</kbd>:
+
+![Layout zur Szene hinzufügen](images/gui-layouts/add_layout.png)
+
+Beim Bearbeiten einer GUI-Szene werden alle Knoten in einem bestimmten Layout bearbeitet. Das aktuell ausgewählte Layout wird in der Auswahlliste für das Layout der GUI-Szene in der Werkzeugleiste angezeigt. Wenn kein Layout ausgewählt ist, werden die Knoten im Layout *Default* bearbeitet.
+
+![Werkzeugleiste für Layouts](images/gui-layouts/toolbar.png)
+
+![Bearbeiten im Hochformat](images/gui-layouts/portrait.png)
+
+Jede Änderung an einer Knoteneigenschaft, die du bei ausgewähltem Layout vornimmst, _überschreibt_ die Eigenschaft gegenüber dem Layout *Default*. Überschriebene Eigenschaften sind blau markiert. Knoten mit überschriebenen Eigenschaften sind ebenfalls blau markiert. Du kannst auf die Schaltfläche zum Zurücksetzen neben einer überschriebenen Eigenschaft klicken, um sie auf ihren ursprünglichen Wert zurückzusetzen.
+
+![Bearbeiten im Querformat](images/gui-layouts/landscape.png)
+
+Ein Layout kann keine Knoten löschen oder neu erstellen, sondern nur Eigenschaften überschreiben. Wenn du einen Knoten aus einem Layout entfernen musst, kannst du ihn entweder außerhalb des Bildschirms verschieben oder mithilfe von Skriptlogik löschen. Achte außerdem auf das aktuell ausgewählte Layout. Wenn du deinem Projekt ein Layout hinzufügst, wird das neue Layout anhand des aktuell ausgewählten Layouts eingerichtet. Auch beim Kopieren und Einfügen von Knoten wird das aktuell ausgewählte Layout berücksichtigt, sowohl beim Kopieren *als auch* beim Einfügen.
+
+## Dynamische Profilauswahl {#dynamic-profile-selection}
+
+Wenn Auto Layout Selection aktiviert ist, wählt die Engine automatisch das am besten passende Layout aus. Beim dynamischen Layoutabgleich wird jeder Qualifikator eines Anzeigeprofils nach den folgenden Regeln bewertet:
+
+1. Wenn kein Gerätemodell festgelegt ist oder das Gerätemodell übereinstimmt, wird für den Qualifikator ein Bewertungswert (S) berechnet.
+
+2. Der Bewertungswert (S) wird aus der Fläche des Bildschirms (A), der Fläche des Qualifikators (A_Q), dem Seitenverhältnis des Bildschirms (R) und dem Seitenverhältnis des Qualifikators (R_Q) berechnet:
+
+<img src="https://latex.codecogs.com/svg.latex?\inline&space;S=\left|1&space;-&space;\frac{A}{A_Q}\right|&space;&plus;&space;\left|1&space;-&space;\frac{R}{R_Q}\right|" title="S=\left|1 - \frac{A}{A_Q}\right| + \left|1 - \frac{R}{R_Q}\right|" />
+
+3. Das Profil, dessen Qualifikator den niedrigsten Bewertungswert hat, wird ausgewählt, wenn die Ausrichtung des Qualifikators (Quer- oder Hochformat) mit der des Bildschirms übereinstimmt.
+
+4. Wenn kein Profil mit einem Qualifikator derselben Ausrichtung gefunden wird, wird das Profil mit dem am besten bewerteten Qualifikator der anderen Ausrichtung ausgewählt.
+
+5. Wenn kein Profil ausgewählt werden kann, wird das Ersatzprofil *Default* verwendet.
+
+Da das Layout *Default* zur Laufzeit als Ersatz dient, wenn es kein besser passendes Layout gibt, ist ein hinzugefügtes Layout "Landscape" für *alle* Ausrichtungen die beste Übereinstimmung, bis du auch ein Layout "Portrait" hinzufügst.
+
+## Nachrichten bei Layoutänderungen {#layout-change-messages}
+
+Wenn sich das Layout ändert, wird eine Nachricht `layout_changed` an das Skript der GUI-Komponente (GUI component) gesendet. Das geschieht, wenn die Engine das Layout automatisch ändert (Auto Layout Selection auf ON) oder wenn dein Skript `gui.set_layout()` aufruft und sich das Layout tatsächlich ändert. Die Nachricht enthält den gehashten Bezeichner des Layouts, sodass das Skript abhängig vom ausgewählten Layout Logik ausführen kann:
+
+```lua
+function on_message(self, message_id, message, sender)
+  if message_id == hash("layout_changed") and message.id == hash("My Landscape") then
+    -- switching layout to landscape
+  elseif message_id == hash("layout_changed") and message.id == hash("My Portrait") then
+    -- switching layout to portrait
+  end
+end
+```
+
+Außerdem erhält das aktuelle Render-Skript bei jeder Änderung des Fensters (der Spielansicht) eine Nachricht. Dazu gehören auch Änderungen der Ausrichtung.
+
+```lua
+function on_message(self, message_id, message)
+  if message_id == hash("window_resized") then
+    -- The window was resized. message.width and message.height contain the
+    -- new dimensions of the window.
+  end
+end
+```
+
+Wenn die Ausrichtung wechselt, skaliert der GUI-Layoutmanager die GUI-Knoten automatisch und positioniert sie anhand deines Layouts und der Knoteneigenschaften neu. Spielinhalte werden dagegen standardmäßig in einem separaten Renderdurchlauf mit einer Projektion gerendert, die sie durch Strecken in das aktuelle Fenster einpasst. Um dieses Verhalten zu ändern, verwende entweder ein eigenes angepasstes Render-Skript oder eine Kamera-[Bibliothek](/assets/).
+
+## Manuelle Layoutauswahl (Lua) {#manual-layout-selection-lua}
+
+Wenn Auto Layout Selection für die verwendeten Anzeigeprofile auf OFF gesetzt ist, wechselt die Engine die Layouts nicht automatisch. Verwende die folgenden Funktionen in einem GUI-Skript, um Layouts manuell zu verwalten:
+
+### gui.set_layout(layout)
+
+- Akzeptiert eine Zeichenfolge oder einen Hashwert (Layout-Bezeichner).
+- Gibt einen booleschen Wert zurück: `true`, wenn das Layout in der Szene vorhanden ist und angewendet wurde, andernfalls `false`.
+- Wenn das Layout in den Anzeigeprofilen vorhanden ist, wird die Szenenauflösung auf die Breite/Höhe des Profils aktualisiert.
+- Sendet `layout_changed`, wenn sich das Layout tatsächlich ändert.
+
+Beispiel:
+
+```lua
+function init(self)
+    -- Manually apply the "Portrait" layout
+    local ok = gui.set_layout("Portrait")
+    if not ok then
+        print("Portrait layout not found in this scene")
+    end
+end
+```
+
+### gui.get_layouts()
+
+- Gibt eine Tabelle zurück, die dem Hashwert jedes Layout-Bezeichners `vmath.vector3(width, height, 0)` zuordnet.
+- Gibt für das Standardlayout die aktuelle Szenenauflösung zurück.
+
+Beispiel:
+
+```lua
+local layouts = gui.get_layouts()
+for id, size in pairs(layouts) do
+    print(id, size.x, size.y)
+end
+```
+
+Hinweis: Wenn ein GUI-Layout in der Szene vorhanden ist, aber in den Anzeigeprofilen fehlt, wendet `gui.set_layout()` weiterhin die layoutspezifischen Überschreibungen der Knoteneigenschaften an, ändert jedoch die Szenenauflösung nicht.

--- a/docs/de/manuals/gui-particlefx.md
+++ b/docs/de/manuals/gui-particlefx.md
@@ -1,0 +1,34 @@
+---
+title: GUI-Partikeleffekte in Defold
+brief: Dieses Handbuch erklärt, wie Partikeleffekte in der GUI von Defold funktionieren.
+---
+
+# GUI-Partikeleffektknoten {#gui-particlefx-nodes}
+
+Ein Partikeleffektknoten (particle effect node) dient dazu, Partikeleffektsysteme im Bildschirmkoordinatensystem der GUI abzuspielen.
+
+## Partikeleffektknoten hinzufügen {#adding-particle-fx-nodes}
+
+Füge neue Partikelknoten hinzu, indem du in der Ansicht *Outline* einen <kbd>Rechtsklick</kbd> ausführst und <kbd>Add ▸ ParticleFX</kbd> auswählst, oder drücke <kbd>A</kbd> und wähle <kbd>ParticleFX</kbd>.
+
+Du kannst Partikeleffekte, die du der GUI hinzugefügt hast, als Quelle für den Effekt verwenden. Füge Partikeleffekte hinzu, indem du einen <kbd>Rechtsklick</kbd> auf das Ordnersymbol *Particle FX* in der Ansicht *Outline* ausführst und <kbd>Add ▸ Particle FX...</kbd> auswählst. Lege dann die Eigenschaft *Particlefx* des Knotens fest:
+
+![Partikeleffekt](images/gui-particlefx/create.png)
+
+## Den Effekt steuern {#controlling-the-effect}
+
+Du kannst den Effekt starten und stoppen, indem du den Knoten aus einem Skript heraus steuerst:
+
+```lua
+-- start the particle effect
+local particles_node = gui.get_node("particlefx")
+gui.play_particlefx(particles_node)
+```
+
+```lua
+-- stop the particle effect
+local particles_node = gui.get_node("particlefx")
+gui.stop_particlefx(particles_node)
+```
+
+Weitere Informationen zur Funktionsweise von Partikeleffekten findest du im [Handbuch zu Partikeleffekten](/manuals/particlefx).

--- a/docs/de/manuals/gui-pie.md
+++ b/docs/de/manuals/gui-pie.md
@@ -1,0 +1,56 @@
+---
+title: GUI-Kreissektor-Knoten in Defold
+brief: Dieses Handbuch erklärt, wie du Kreissektor-Knoten in GUI-Szenen von Defold verwendest.
+---
+
+# GUI-Kreissektor-Knoten {#gui-pie-nodes}
+
+Mit Kreissektor-Knoten (pie nodes) kannst du kreisförmige oder ellipsenförmige Objekte erstellen, von einfachen Kreisen über Kreissektoren bis hin zu quadratischen Ringformen.
+
+## Einen Kreissektor-Knoten erstellen {#creating-a-pie-node}
+
+Klicke mit der <kbd>rechten Maustaste</kbd> auf den Bereich *Nodes* in der Ansicht *Outline* und wähle <kbd>Add ▸ Pie</kbd>. Der neue Kreissektor-Knoten ist ausgewählt und du kannst seine Eigenschaften ändern.
+
+![Kreissektor-Knoten erstellen](images/gui-pie/create.png)
+
+Die folgenden Eigenschaften gibt es nur bei Kreissektor-Knoten:
+
+Inner Radius
+: Der innere Radius des Knotens, angegeben entlang der X-Achse.
+
+Outer Bounds
+: Die Form der äußeren Begrenzung des Knotens.
+
+  - `Ellipse` erweitert den Knoten bis zum äußeren Radius.
+  - `Rectangle` erweitert den Knoten bis zu seinem Begrenzungsrechteck.
+
+Perimeter Vertices
+: Die Anzahl der Segmente, aus denen die Form aufgebaut wird, angegeben als Anzahl der Vertices, die benötigt werden, um den vollständigen Umfang des Knotens von 360 Grad zu umschreiben.
+
+Pie Fill Angle
+: Wie viel des Kreissektors gefüllt werden soll. Angegeben als Winkel gegen den Uhrzeigersinn, ausgehend von rechts.
+
+![Eigenschaften](images/gui-pie/properties.png)
+
+Wenn du dem Knoten eine Textur zuweist, wird das Texturbild flächig aufgebracht. Dabei entsprechen die Ecken der Textur den Ecken des Begrenzungsrechtecks des Knotens.
+
+## Kreissektor-Knoten zur Laufzeit ändern {#modify-pie-nodes-at-runtime}
+
+Kreissektor-Knoten unterstützen alle allgemeinen Funktionen zur Bearbeitung von Knoten, etwa zum Festlegen von Größe, Bezugspunkt (pivot), Farbe und so weiter. Außerdem gibt es einige Funktionen und Eigenschaften, die nur für Kreissektor-Knoten gelten:
+
+```lua
+local pienode = gui.get_node("my_pie_node")
+
+-- get the outer bounds
+local fill_angle = gui.get_fill_angle(pienode)
+
+-- increase perimeter vertices
+local vertices = gui.get_perimeter_vertices(pienode)
+gui.set_perimeter_vertices(pienode, vertices + 1)
+
+-- change outer bounds
+gui.set_outer_bounds(pienode, gui.PIEBOUNDS_RECTANGLE)
+
+-- animate the inner radius
+gui.animate(pienode, "inner_radius", 100, gui.EASING_INOUTSINE, 2, 0, nil, gui.PLAYBACK_LOOP_PINGPONG)
+```

--- a/docs/de/manuals/gui-script.md
+++ b/docs/de/manuals/gui-script.md
@@ -1,0 +1,149 @@
+---
+title: GUI-Skripte in Defold
+brief: Dieses Handbuch erklärt die Skriptprogrammierung für GUIs.
+---
+
+# GUI-Skripte {#gui-scripts}
+
+Mit Lua-Skripten steuerst du die Logik deiner GUI und animierst Knoten (nodes). GUI-Skripte (GUI scripts) funktionieren wie normale Skripte für Spielobjekte (game objects), werden aber als anderer Dateityp gespeichert und haben Zugriff auf einen anderen Satz von Funktionen: die Funktionen des Moduls `gui`.
+
+## Einer GUI ein Skript hinzufügen {#adding-a-script-to-a-gui}
+
+Um einer GUI ein Skript hinzuzufügen, erstelle zunächst eine GUI-Skriptdatei, indem du im *Assets*-Browser an der gewünschten Stelle einen <kbd>Rechtsklick</kbd> ausführst und im eingeblendeten Kontextmenü <kbd>New ▸ Gui Script</kbd> auswählst.
+
+Der Editor öffnet die neue Skriptdatei automatisch. Sie basiert auf einer Vorlage und enthält wie Spielobjekt-Skripte leere Lebenszyklusfunktionen:
+
+```lua
+function init(self)
+   -- Add initialization code here
+   -- Remove this function if not needed
+end
+
+function final(self)
+   -- Add finalization code here
+   -- Remove this function if not needed
+end
+
+function update(self, dt)
+   -- Add update code here
+   -- Remove this function if not needed
+end
+
+function on_message(self, message_id, message, sender)
+   -- Add message-handling code here
+   -- Remove this function if not needed
+end
+
+function on_input(self, action_id, action)
+   -- Add input-handling code here
+   -- Remove this function if not needed
+end
+
+function on_reload(self)
+   -- Add input-handling code here
+   -- Remove this function if not needed
+end
+```
+
+Um das Skript einer GUI-Komponente (GUI component) zuzuweisen, öffne die Prototypdatei der GUI-Komponente (in anderen Engines auch als „Prefabs“ oder „Blueprints“ bezeichnet) und wähle den obersten Eintrag in *Outline* aus, um den Bereich *Properties* der GUI anzuzeigen. Setze die Eigenschaft *Script* auf die Skriptdatei.
+
+![Skript](images/gui-script/set_script.png)
+
+Wenn die GUI-Komponente einem Spielobjekt irgendwo in deinem Spiel hinzugefügt wurde, wird das Skript jetzt ausgeführt.
+
+## Der Namensraum „gui“ {#the-gui-namespace}
+
+GUI-Skripte haben Zugriff auf den Namensraum `gui` und [alle `gui`-Funktionen](/ref/gui). Der Namensraum `go` ist nicht verfügbar. Du musst die Logik der Spielobjekte daher in Skriptkomponenten auslagern und die GUI-Skripte und Spielobjekt-Skripte miteinander kommunizieren lassen. Jeder Versuch, die `go`-Funktionen zu verwenden, führt zu einem Fehler:
+
+```lua
+function init(self)
+   local id = go.get_id()
+end
+```
+
+```txt
+ERROR:SCRIPT: /main/my_gui.gui_script:2: You can only access go.* functions and values from a script instance (.script file)
+stack traceback:
+   [C]: in function 'get_id'
+   /main/my_gui.gui_script:2: in function </main/my_gui.gui_script:1>
+```
+
+## Nachrichtenübermittlung {#message-passing}
+
+Jede GUI-Komponente mit einem zugewiesenen Skript kann durch Nachrichtenübermittlung mit anderen Objekten in der Laufzeitumgebung deines Spiels kommunizieren. Sie verhält sich dabei wie jede andere Skriptkomponente.
+
+Du adressierst die GUI-Komponente wie jede andere Skriptkomponente:
+
+```lua
+local stats = { score = 4711, stars = 3, health = 6 }
+msg.post("hud#gui", "set_stats", stats)
+```
+
+![Nachrichtenübermittlung](images/gui-script/message_passing.png)
+
+## Knoten adressieren {#addressing-nodes}
+
+GUI-Knoten lassen sich durch ein GUI-Skript verändern, das der Komponente zugewiesen ist. Jeder Knoten muss eine eindeutige *Id* haben, die im Editor festgelegt wird:
+
+![Nachrichtenübermittlung](images/gui-script/node_id.png)
+
+Über die *Id* kann ein Skript eine Referenz auf den Knoten erhalten und ihn mit den [Funktionen des Namensraums `gui`](/ref/gui) verändern:
+
+```lua
+-- extend the health bar by 10 units
+local healthbar_node = gui.get_node("healthbar")
+local size = gui.get_size(healthbar_node)
+size.x = size.x + 10
+gui.set_size(healthbar_node, size)
+```
+
+## Dynamisch erstellte Knoten {#dynamically-created-nodes}
+
+Um zur Laufzeit mit einem Skript einen neuen Knoten zu erstellen, hast du zwei Möglichkeiten. Die erste Möglichkeit ist, Knoten durch Aufrufe der Funktionen `gui.new_[type]_node()` neu zu erstellen. Diese geben eine Referenz auf den neuen Knoten zurück, mit der du ihn verändern kannst:
+
+```lua
+-- Create a new box node
+local new_position = vmath.vector3(400, 300, 0)
+local new_size = vmath.vector3(450, 400, 0)
+local new_boxnode = gui.new_box_node(new_position, new_size)
+gui.set_color(new_boxnode, vmath.vector4(0.2, 0.26, 0.32, 1))
+
+-- Create a new text node
+local new_textnode = gui.new_text_node(new_position, "Hello!")
+gui.set_font(new_textnode, "sourcesans")
+gui.set_color(new_textnode, vmath.vector4(0.69, 0.6, 0.8, 1.0))
+```
+
+![Dynamischer Knoten](images/gui-script/dynamic_nodes.png)
+
+Alternativ kannst du neue Knoten erstellen, indem du einen vorhandenen Knoten mit der Funktion `gui.clone()` oder einen Knotenbaum mit der Funktion `gui.clone_tree()` klonst:
+
+```lua
+-- clone the healthbar
+local healthbar_node = gui.get_node("healthbar")
+local healthbar_node_2 = gui.clone(healthbar_node)
+
+-- clone button node-tree
+local button = gui.get_node("my_button")
+local new_button_nodes = gui.clone_tree(button)
+
+-- get the new tree root
+local new_root = new_button_nodes["my_button"]
+
+-- move the root (and children) 300 to the right
+local root_position = gui.get_position(new_root)
+root_position.x = root_position.x + 300
+gui.set_position(new_root, root_position)
+```
+
+## Bezeichner dynamischer Knoten {#dynamic-node-ids}
+
+Dynamisch erstellten Knoten wird kein Bezeichner zugewiesen. Das ist beabsichtigt. Die von `gui.new_[type]_node()`, `gui.clone()` und `gui.clone_tree()` zurückgegebenen Referenzen sind alles, was du für den Zugriff auf die Knoten brauchst. Du solltest diese Referenzen daher aufbewahren.
+
+```lua
+-- Add a text node
+local new_textnode = gui.new_text_node(vmath.vector3(100, 100, 0), "Hello!")
+-- "new_textnode" contains the reference to the node.
+-- The node has no id, and that is fine. There's no reason why we want
+-- to do gui.get_node() when we already have the reference.
+```

--- a/docs/de/manuals/gui-spine.md
+++ b/docs/de/manuals/gui-spine.md
@@ -1,0 +1,6 @@
+---
+title: Spine-Knoten in der Defold-GUI
+brief: Dieses Handbuch erklärt, wie du Spine-Knoten mit Skelettanimation in GUI-Szenen von Defold verwendest.
+---
+
+[Dieses Handbuch ist umgezogen](/extension-spine)

--- a/docs/de/manuals/gui-template.md
+++ b/docs/de/manuals/gui-template.md
@@ -1,0 +1,56 @@
+---
+title: Handbuch zu GUI-Vorlagen
+brief: Dieses Handbuch erklärt das GUI-Vorlagensystem von Defold, mit dem du wiederverwendbare visuelle GUI-Komponenten auf Grundlage gemeinsam genutzter Vorlagen oder „Prefabs“ erstellst.
+---
+
+# GUI-Vorlagenknoten {#gui-template-nodes}
+
+GUI-Vorlagenknoten (GUI template nodes) bieten einen leistungsfähigen Mechanismus, um wiederverwendbare GUI-Komponenten (GUI components) auf Grundlage gemeinsam genutzter Vorlagen oder „Prefabs“ zu erstellen. Dieses Handbuch erklärt die Funktion und ihre Verwendung.
+
+Eine GUI-Vorlage (GUI template) ist eine GUI-Szene (GUI scene), die Knoten für Knoten in einer anderen GUI-Szene instanziiert wird. Anschließend kannst du beliebige Eigenschaftswerte der ursprünglichen Vorlagenknoten überschreiben.
+
+## Eine Vorlage erstellen {#creating-a-template}
+
+Eine GUI-Vorlage ist eine gewöhnliche GUI-Szene und wird daher wie jede andere GUI-Szene erstellt. <kbd>Klicke mit der rechten Maustaste</kbd> auf einen Ort im Bereich *Assets* und wähle <kbd>New... ▸ Gui</kbd>.
+
+![Vorlage erstellen](images/gui-templates/create.png)
+
+Erstelle die Vorlage und speichere sie. Beachte, dass die Knoten der Instanz relativ zum Ursprung platziert werden. Daher empfiehlt es sich, die Vorlage an der Position 0, 0, 0 zu erstellen.
+
+## Instanzen aus einer Vorlage erstellen {#creating-instances-from-a-template}
+
+Du kannst beliebig viele Instanzen auf Grundlage der Instanz erstellen. Erstelle oder öffne die GUI-Szene, in der du die Vorlage platzieren möchtest. <kbd>Klicke dann mit der rechten Maustaste</kbd> auf den Abschnitt *Nodes* in *Outline* und wähle <kbd>Add ▸ Template</kbd>.
+
+![Instanz erstellen](images/gui-templates/create_instance.png)
+
+Setze die Eigenschaft *Template* auf die GUI-Szenendatei der Vorlage.
+
+Du kannst beliebig viele Vorlageninstanzen hinzufügen. Für jede Instanz kannst du die Eigenschaften jedes Knotens überschreiben und die Position, Farbgebung, Größe, Textur und weitere Eigenschaften der Instanzknoten ändern.
+
+![Instanzen](images/gui-templates/instances.png)
+
+Jede Eigenschaft, die du änderst, wird im Editor blau markiert. Klicke auf die Schaltfläche zum Zurücksetzen neben der Eigenschaft, um ihren Wert auf den Vorlagenwert zurückzusetzen:
+
+![Eigenschaften](images/gui-templates/properties.png)
+
+Jeder Knoten mit überschriebenen Eigenschaften wird auch in *Outline* blau dargestellt:
+
+![Outline](images/gui-templates/outline.png)
+
+Die Vorlageninstanz wird als einklappbarer Eintrag in der Ansicht *Outline* aufgeführt. Beachte jedoch, dass dieser Eintrag in der Übersicht *kein Knoten ist*. Die Vorlageninstanz existiert auch zur Laufzeit nicht, wohl aber alle Knoten, die zur Instanz gehören.
+
+Knoten, die zu einer Vorlageninstanz gehören, werden automatisch benannt, indem ein Präfix und ein Schrägstrich (`"/"`) vor ihre *Id* gesetzt werden. Das Präfix ist die *Id*, die in der Vorlageninstanz festgelegt ist.
+
+## Vorlagen zur Laufzeit ändern {#modifying-templates-in-runtime}
+
+Skripte, die über den Vorlagenmechanismus hinzugefügte Knoten ändern oder abfragen, müssen lediglich die Benennung der Instanzknoten berücksichtigen und die *Id* der Vorlageninstanz als Präfix des Knotennamens einbeziehen:
+
+```lua
+if gui.pick_node(gui.get_node("button_1/button"), x, y) then
+    -- Do something...
+end
+```
+
+Es gibt keinen Knoten, der der Vorlageninstanz selbst entspricht. Wenn du einen Wurzelknoten für eine Instanz benötigst, füge ihn zur Vorlage hinzu.
+
+Wenn einer GUI-Szene als Vorlage ein Skript zugeordnet ist, gehört dieses Skript nicht zum Knotenbaum der Instanz. Du kannst jeder GUI-Szene nur ein einziges Skript zuordnen. Daher muss deine Skriptlogik in der GUI-Szene liegen, in der du deine Vorlagen instanziiert hast.

--- a/docs/de/manuals/gui-text.md
+++ b/docs/de/manuals/gui-text.md
@@ -1,0 +1,59 @@
+---
+title: GUI-Textknoten in Defold
+brief: Dieses Handbuch beschreibt, wie du Text zu GUI-Szenen hinzufügst.
+---
+
+# GUI-Textknoten {#gui-text-nodes}
+
+Defold unterstützt eine spezielle Art von GUI-Knoten (GUI node), mit der sich Text in einer GUI-Szene rendern lässt. Jede Schriftressource, die einem Projekt hinzugefügt wurde, kann zum Rendern von Textknoten (text nodes) verwendet werden.
+
+Die Editorvorschau unterstützt die Formung von Schriftzeichen (text shaping) und Layouts von rechts nach links mithilfe des Schriftrenderers der Engine. Die erforderlichen Einstellungen für die Schriftart und das Anwendungsmanifest (App Manifest) findest du unter [Unterstützung für Textlayout](/manuals/font/#text-layout-support-eg-right-to-left).
+
+## Textknoten hinzufügen {#adding-text-nodes}
+
+Die Schriftarten, die du in GUI-Textknoten verwenden möchtest, müssen zur GUI-Komponente (GUI component) hinzugefügt werden. Klicke dazu entweder mit der rechten Maustaste auf den Ordner *Fonts*, verwende das Menü <kbd>GUI</kbd> in der Menüleiste oder drücke die entsprechende Tastenkombination.
+
+![Schriftarten](images/gui-text/fonts.png)
+
+Textknoten haben eine Reihe besonderer Eigenschaften:
+
+*Font*
+: Bei jedem Textknoten, den du erstellst, muss die Eigenschaft *Font* festgelegt sein.
+
+*Text*
+: Diese Eigenschaft enthält den angezeigten Text.
+
+*Line Break*
+: Die Textausrichtung richtet sich nach der Einstellung des Bezugspunkts (pivot). Wenn du diese Eigenschaft aktivierst, kann der Text über mehrere Zeilen fließen. Die Breite des Knotens bestimmt, wo der Text umgebrochen wird.
+
+## Ausrichtung {#alignment}
+
+Indem du den Bezugspunkt des Knotens festlegst, kannst du den Ausrichtungsmodus für den Text ändern.
+
+*Zentriert*
+: Wenn der Bezugspunkt auf `Center`, `North` oder `South` eingestellt ist, wird der Text zentriert.
+
+*Linksbündig*
+: Wenn der Bezugspunkt auf einen der `West`-Modi eingestellt ist, wird der Text linksbündig ausgerichtet.
+
+*Rechtsbündig*
+: Wenn der Bezugspunkt auf einen der `East`-Modi eingestellt ist, wird der Text rechtsbündig ausgerichtet.
+
+![Textausrichtung](images/gui-text/align.png)
+
+## Textknoten zur Laufzeit ändern {#modifying-text-nodes-in-runtime}
+
+Textknoten unterstützen alle allgemeinen Funktionen zur Bearbeitung von Knoten, mit denen sich Größe, Bezugspunkt, Farbe und weitere Eigenschaften festlegen lassen. Einige Funktionen sind ausschließlich für Textknoten vorgesehen:
+
+* Um die Schriftart eines Textknotens zu ändern, verwende die Funktion [`gui.set_font()`](/ref/gui/#gui.set_font).
+* Um das Verhalten beim Zeilenumbruch eines Textknotens zu ändern, verwende die Funktion [`gui.set_line_break()`](/ref/gui/#gui.set_line_break).
+* Um den Inhalt eines Textknotens zu ändern, verwende die Funktion [`gui.set_text()`](/ref/gui/#gui.set_text).
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("set_score") then
+        local s = gui.get_node("score")
+        gui.set_text(s, message.score)
+    end
+end
+```

--- a/docs/de/manuals/gui.md
+++ b/docs/de/manuals/gui.md
@@ -1,0 +1,421 @@
+---
+title: GUI-Szenen in Defold
+brief: Dieses Handbuch behandelt den GUI-Editor von Defold, die verschiedenen Arten von GUI-Knoten und GUI-Skripte.
+---
+
+# GUI
+
+Defold bietet dir einen eigens entwickelten GUI-Editor und leistungsfähige Skriptmöglichkeiten, die auf die Gestaltung und Implementierung von Benutzeroberflächen zugeschnitten sind.
+
+Eine grafische Benutzeroberfläche in Defold ist eine Komponente (component), die du erstellst, einem Spielobjekt (game object) hinzufügst und in einer Sammlung (collection) platzierst. Diese Komponente hat die folgenden Eigenschaften:
+
+* Sie bietet einfache, aber leistungsfähige Layoutfunktionen, mit denen deine Benutzeroberfläche unabhängig von Auflösung und Seitenverhältnis gerendert werden kann.
+* Du kannst ihr durch ein *GUI-Skript (GUI script)* ein logisches Verhalten geben.
+* Sie wird (standardmäßig) über anderen Inhalten gerendert, unabhängig von der Kameraansicht. Auch wenn sich deine Kamera bewegt, bleiben deine GUI-Elemente also an ihrer Position auf dem Bildschirm. Das Rendering-Verhalten lässt sich ändern.
+
+GUI-Komponenten werden unabhängig von der Spielansicht gerendert. Deshalb werden sie nicht an einer bestimmten Position im Sammlungseditor platziert und haben dort auch keine visuelle Darstellung. GUI-Komponenten müssen jedoch zu einem Spielobjekt gehören, das eine Position in einer Sammlung hat. Das Ändern dieser Position hat keine Auswirkung auf die GUI.
+
+## Eine GUI-Komponente erstellen {#creating-a-gui-component}
+
+GUI-Komponenten werden aus einer Prototypdatei für eine GUI-Szene erstellt (in anderen Engines auch als „Prefabs“ oder „Baupläne“ bekannt). Um eine neue GUI-Komponente zu erstellen, klicke mit der <kbd>rechten Maustaste</kbd> auf eine Stelle im Browser *Assets* und wähle <kbd>New ▸ Gui</kbd>. Gib einen Namen für die neue GUI-Datei ein und drücke <kbd>Ok</kbd>.
+
+![Neue GUI-Datei](images/gui/new_gui_file.png)
+
+Defold öffnet die Datei nun automatisch im GUI-Szeneneditor.
+
+![Neue GUI](images/gui/new_gui.png)
+
+Die Ansicht *Outline* listet den gesamten Inhalt der GUI auf: die Liste ihrer Knoten (nodes) und alle Abhängigkeiten (siehe unten).
+
+Der zentrale Bearbeitungsbereich zeigt die GUI. Die Werkzeugleiste oben rechts im Bearbeitungsbereich enthält die Werkzeuge *Move*, *Rotate* und *Scale* sowie eine Auswahl für das [Layout](/manuals/gui-layouts).
+
+![Werkzeugleiste](images/gui/toolbar.png)
+
+Ein weißes Rechteck zeigt die Grenzen des aktuell ausgewählten Layouts mit der standardmäßigen Anzeigebreite und -höhe aus den Projekteinstellungen.
+
+## GUI-Eigenschaften {#gui-properties}
+
+Wenn du den Wurzelknoten „Gui“ in der Ansicht *Outline* auswählst, zeigt *Properties* die Eigenschaften der GUI-Komponente an:
+
+*Script*
+: Das GUI-Skript, das an diese GUI-Komponente gebunden ist.
+
+*Material*
+: Das Material, das beim Rendern dieser GUI verwendet wird. Beachte, dass du einer GUI über den Bereich *Outline* auch mehrere Materialien hinzufügen und diese einzelnen Knoten zuweisen kannst.
+
+*Adjust Reference*
+: Steuert, wie der *Adjust Mode* jedes Knotens berechnet werden soll:
+
+  - `Per Node` passt jeden Knoten an die angepasste Größe des übergeordneten Knotens oder an den Bildschirm mit geänderter Größe an.
+  - `Disable` schaltet den Anpassungsmodus der Knoten aus. Dadurch behalten alle Knoten ihre eingestellte Größe bei.
+
+*Current Nodes*
+: Die Anzahl der Knoten, die derzeit in dieser GUI verwendet werden.
+
+*Max Nodes*
+: Die maximale Anzahl der Knoten für diese GUI.
+
+*Max Dynamic Textures*
+: Die maximale Anzahl dynamischer Texturen, die diese GUI-Komponente verwaltet, standardmäßig `128`. Dazu gehören Texturen, die mit [`gui.new_texture()`](/ref/stable/gui/#gui.new_texture:texture_id-width-height-type-buffer-flip) erstellt werden, sowie externe Texturen, die der GUI mit `go.set(..., "textures", ...)` oder `gui.set(msg.url(), "textures", ...)` zugewiesen werden. Projekte, die viele externe Texturen ersetzen, müssen diesen Grenzwert möglicherweise erhöhen.
+
+
+## Änderungen zur Laufzeit {#runtime-manipulation}
+
+Du kannst GUI-Eigenschaften zur Laufzeit aus einer Skriptkomponente heraus mit `go.get()` und `go.set()` ändern:
+
+Schriftarten
+: Eine in einer GUI verwendete Schriftart abrufen oder festlegen.
+
+![Schriftart abrufen und festlegen](images/gui/get_set_font.png)
+
+```lua
+go.property("mybigfont", resource.font("/assets/mybig.font"))
+
+function init(self)
+  -- get the font file currently assigned to the font with id 'default'
+  print(go.get("#gui", "fonts", { key = "default" })) -- /builtins/fonts/default.font
+
+  -- set the font with id 'default' to the font file assigned to the resource property 'mybigfont'
+  go.set("#gui", "fonts", self.mybigfont, { key = "default" })
+
+  -- get the new font file assigned to the font with id 'default'
+  print(go.get("#gui", "fonts", { key = "default" })) -- /assets/mybig.font
+end
+```
+
+Materialien
+: Ein in einer GUI verwendetes Material abrufen oder festlegen.
+
+![Material abrufen und festlegen](images/gui/get_set_material.png)
+
+```lua
+go.property("myeffect", resource.material("/assets/myeffect.material"))
+
+function init(self)
+  -- get the material file currently assigned to the material with id 'effect'
+  print(go.get("#gui", "materials", { key = "effect" })) -- /effect.material
+
+  -- set the material id 'effect' to the material file assigned to the resource property 'myeffect'
+  go.set("#gui", "materials", self.myeffect, { key = "effect" })
+
+  -- get the new material file assigned to the material with id 'effect'
+  print(go.get("#gui", "materials", { key = "effect" })) -- /assets/myeffect.material
+end
+```
+
+Texturen
+: Eine in einer GUI verwendete Textur (Atlas) abrufen oder festlegen.
+
+![Textur abrufen und festlegen](images/gui/get_set_texture.png)
+
+```lua
+go.property("mytheme", resource.atlas("/assets/mytheme.atlas"))
+
+function init(self)
+  -- get the texture file currently assigned to the texture with id 'theme'
+  print(go.get("#gui", "textures", { key = "theme" })) -- /theme.atlas
+
+  -- set the texture with id 'theme' to the texture file assigned to the resource property 'mytheme'
+  go.set("#gui", "textures", self.mytheme, { key = "theme" })
+
+  -- get the new texture file assigned to the texture with id 'theme'
+  print(go.get("#gui", "textures", { key = "theme" })) -- /assets/mytheme.atlas
+end
+```
+
+## Abhängigkeiten {#dependencies}
+
+Der Ressourcenbaum eines Defold-Spiels ist statisch. Daher musst du alle Abhängigkeiten, die du für deine GUI-Knoten benötigst, zur Komponente hinzufügen. Die Ansicht *Outline* gruppiert alle Abhängigkeiten nach Typ in „Ordnern“:
+
+![Abhängigkeiten](images/gui/dependencies.png)
+
+Um eine neue Abhängigkeit hinzuzufügen, ziehe sie aus dem Bereich *Asset* in die Editoransicht und lege sie dort ab.
+
+Alternativ kannst du mit der <kbd>rechten Maustaste</kbd> auf den Wurzelknoten „Gui“ in der Ansicht *Outline* klicken und anschließend <kbd>Add ▸ [type]</kbd> aus dem eingeblendeten Kontextmenü wählen.
+
+Du kannst auch mit der <kbd>rechten Maustaste</kbd> auf das Ordnersymbol des Typs klicken, den du hinzufügen möchtest, und <kbd>Add ▸ [type]</kbd> wählen.
+
+## Knotentypen {#node-types}
+
+Eine GUI-Komponente besteht aus einer Menge von Knoten. Knoten sind einfache Elemente. Du kannst sie entweder im Editor oder zur Laufzeit per Skript transformieren (verschieben, skalieren und drehen) und in Eltern-Kind-Hierarchien anordnen. Es gibt die folgenden Knotentypen:
+
+Box-Knoten
+: ![Box-Knoten](images/icons/gui-box-node.png){.left}
+  Rechteckiger Knoten mit einer einzelnen Farbe, einer Textur oder einer Flipbook-Animation. Einzelheiten findest du in der [Dokumentation zu Box-Knoten](/manuals/gui-box).
+
+<div style="clear: both;"></div>
+
+Textknoten
+: ![Textknoten](images/icons/gui-text-node.png){.left}
+  Zeigt Text an. Einzelheiten findest du in der [Dokumentation zu Textknoten](/manuals/gui-text).
+
+<div style="clear: both;"></div>
+
+Kreissektor-Knoten
+: ![Kreissektor-Knoten](images/icons/gui-pie-node.png){.left}
+  Ein kreisförmiger oder elliptischer Knoten, der teilweise gefüllt oder invertiert werden kann. Einzelheiten findest du in der [Dokumentation zu Kreissektor-Knoten](/manuals/gui-pie).
+
+<div style="clear: both;"></div>
+
+Vorlagenknoten
+: ![Vorlagenknoten](images/icons/gui.png){.left}
+  Vorlagen werden verwendet, um Instanzen auf Basis anderer GUI-Szenendateien zu erstellen. Einzelheiten findest du in der [Dokumentation zu Vorlagenknoten](/manuals/gui-template).
+
+<div style="clear: both;"></div>
+
+Partikeleffektknoten
+: ![Partikeleffektknoten](images/icons/particlefx.png){.left}
+  Spielt einen Partikeleffekt ab. Einzelheiten findest du in der [Dokumentation zu Partikeleffektknoten](/manuals/gui-particlefx).
+
+<div style="clear: both;"></div>
+
+Füge Knoten hinzu, indem du mit der rechten Maustaste auf den Ordner *Nodes* klickst und <kbd>Add ▸</kbd> und anschließend <kbd>Box</kbd>, <kbd>Text</kbd>, <kbd>Pie</kbd>, <kbd>Template</kbd> oder <kbd>ParticleFx</kbd> wählst.
+
+![Knoten hinzufügen](images/gui/add_node.png)
+
+Du kannst auch <kbd>A</kbd> drücken und den Typ auswählen, den du der GUI hinzufügen möchtest.
+
+## Knoteneigenschaften {#node-properties}
+
+Jeder Knoten verfügt über eine umfangreiche Menge von Eigenschaften, die sein Aussehen steuern:
+
+Id
+: Der Bezeichner des Knotens. Dieser Name muss innerhalb der GUI-Szene eindeutig sein.
+
+Position, Rotation und Scale
+: Steuern die Position, Ausrichtung und Streckung des Knotens. Du kannst die Werkzeuge *Move*, *Rotate* und *Scale* verwenden, um diese Werte zu ändern. Die Werte lassen sich per Skript animieren ([mehr erfahren](/manuals/property-animation)).
+
+Size (Box-Knoten, Textknoten und Kreissektor-Knoten)
+: Die Größe des Knotens wird standardmäßig automatisch festgelegt. Wenn du *Size Mode* auf `Manual` setzt, kannst du den Wert jedoch ändern. Die Größe legt die Grenzen des Knotens fest und wird verwendet, um Knoten bei Eingaben zu ermitteln. Dieser Wert lässt sich per Skript animieren ([mehr erfahren](/manuals/property-animation)).
+
+Size Mode (Box- und Kreissektor-Knoten)
+: Bei `Automatic` legt der Editor eine Größe für den Knoten fest. Bei `Manual` kannst du die Größe selbst festlegen.
+
+Enabled
+: Wenn dieses Kontrollkästchen nicht aktiviert ist, wird der Knoten weder gerendert noch animiert und kann nicht mit `gui.pick_node()` ermittelt werden. Verwende `gui.set_enabled()` und `gui.is_enabled()`, um diese Eigenschaft per Code zu ändern und zu prüfen.
+
+Visible
+: Wenn dieses Kontrollkästchen nicht aktiviert ist, wird der Knoten nicht gerendert, kann aber weiterhin animiert und mit `gui.pick_node()` ermittelt werden. Verwende `gui.set_visible()` und `gui.get_visible()`, um diese Eigenschaft per Code zu ändern und zu prüfen.
+
+Text (Textknoten)
+: Der Text, der auf dem Knoten angezeigt werden soll.
+
+Line Break (Textknoten)
+: Aktivieren, damit der Text entsprechend der Breite des Knotens umgebrochen wird.
+
+Font (Textknoten)
+: Die Schriftart, die beim Rendern des Textes verwendet werden soll.
+
+Texture (Box- und Kreissektor-Knoten)
+: Die Textur, die auf dem Knoten gezeichnet werden soll. Dies ist eine Referenz auf ein Bild oder eine Animation in einem Atlas oder einer Kachelquelle (tile source).
+
+Material (Box-Knoten, Kreissektor-Knoten, Textknoten und Partikeleffektknoten)
+: Das Material, das beim Zeichnen des Knotens verwendet werden soll. Du kannst hier ein Material angeben, das dem Abschnitt Materials in der Ansicht *Outline* hinzugefügt wurde, oder das Feld leer lassen, um das Standardmaterial der GUI-Komponente zu verwenden.
+
+Slice 9 (Box-Knoten)
+: Aktivieren, um die Pixelgröße der Knotentextur an den Rändern beizubehalten, wenn die Größe des Knotens geändert wird. Einzelheiten findest du in der [Dokumentation zu Box-Knoten](/manuals/gui-box).
+
+Inner Radius (Kreissektor-Knoten)
+: Der innere Radius des Knotens, angegeben entlang der X-Achse. Einzelheiten findest du in der [Dokumentation zu Kreissektor-Knoten](/manuals/gui-pie).
+
+Outer Bounds (Kreissektor-Knoten)
+: Steuert das Verhalten der äußeren Grenzen. Einzelheiten findest du in der [Dokumentation zu Kreissektor-Knoten](/manuals/gui-pie).
+
+Perimeter Vertices (Kreissektor-Knoten)
+: Die Anzahl der Segmente, aus denen die Form aufgebaut wird. Einzelheiten findest du in der [Dokumentation zu Kreissektor-Knoten](/manuals/gui-pie).
+
+Pie Fill Angle (Kreissektor-Knoten)
+: Wie viel des Kreissektors gefüllt werden soll. Einzelheiten findest du in der [Dokumentation zu Kreissektor-Knoten](/manuals/gui-pie).
+
+Template (Vorlagenknoten)
+: Die GUI-Szenendatei, die als Vorlage für den Knoten verwendet werden soll. Einzelheiten findest du in der [Dokumentation zu Vorlagenknoten](/manuals/gui-template).
+
+ParticleFX (Partikeleffektknoten)
+: Der Partikeleffekt, der auf diesem Knoten verwendet werden soll. Einzelheiten findest du in der [Dokumentation zu Partikeleffektknoten](/manuals/gui-particlefx).
+
+Color
+: Die Farbe des Knotens. Wenn der Knoten eine Textur hat, färbt die Farbe diese Textur ein. Die Farbe lässt sich per Skript animieren ([mehr erfahren](/manuals/property-animation)).
+
+Alpha
+: Die Transparenz des Knotens. Der Alphawert lässt sich per Skript animieren ([mehr erfahren](/manuals/property-animation)).
+
+Inherit Alpha
+: Wenn du dieses Kontrollkästchen aktivierst, erbt ein Knoten den Alphawert des übergeordneten Knotens. Der Alphawert des Knotens wird dann mit dem Alphawert des übergeordneten Knotens multipliziert.
+
+Leading (Textknoten)
+: Ein Skalierungsfaktor für den Zeilenabstand. Ein Wert von `0` ergibt keinen Zeilenabstand. `1` (der Standardwert) ergibt den normalen Zeilenabstand.
+
+Tracking (Textknoten)
+: Ein Skalierungsfaktor für den Zeichenabstand. Der Standardwert ist 0.
+
+Layer
+: Wenn du dem Knoten eine Ebene zuweist, wird die normale Zeichenreihenfolge überschrieben und stattdessen die Reihenfolge der Ebenen verwendet. Einzelheiten findest du weiter unten.
+
+Blend mode
+: Steuert, wie die Grafik des Knotens mit der Hintergrundgrafik gemischt wird:
+  - `Alpha` mischt die Pixelwerte des Knotens anhand des Alphawerts mit dem Hintergrund. Dies entspricht dem Mischmodus „Normal“ in Grafikprogrammen.
+  - `Add` addiert die Pixelwerte des Knotens zu denen des Hintergrunds. Dies entspricht „Linear dodge“ in manchen Grafikprogrammen.
+  - `Multiply` multipliziert die Pixelwerte des Knotens mit denen des Hintergrunds.
+  - `Screen` multipliziert die Pixelwerte des Knotens mit denen des Hintergrunds invers. Dies entspricht dem Mischmodus „Screen“ in Grafikprogrammen.
+
+Pivot
+: Legt den Bezugspunkt (pivot) für den Knoten fest. Dieser kann als „Mittelpunkt“ des Knotens betrachtet werden. Jede Drehung, Skalierung oder Größenänderung erfolgt um diesen Punkt.
+
+  Mögliche Werte sind `Center`, `North`, `South`, `East`, `West`, `North West`, `North East`, `South West` oder `South East`.
+
+  ![Bezugspunkt](images/gui/pivot.png)
+
+  Wenn du den Bezugspunkt eines Knotens änderst, wird der Knoten so verschoben, dass sich der neue Bezugspunkt an der Position des Knotens befindet. Textknoten werden so ausgerichtet, dass `Center` den Text zentriert, `West` ihn linksbündig und `East` ihn rechtsbündig ausrichtet.
+
+X Anchor, Y Anchor
+: Die Verankerung steuert, wie die vertikale und horizontale Position des Knotens geändert wird, wenn die Grenzen der Szene oder des übergeordneten Knotens gestreckt werden, um sie an die physische Bildschirmgröße anzupassen.
+
+  ![Verankerung ohne Anpassung](images/gui/anchoring_unadjusted.png)
+
+  Die folgenden Verankerungsmodi sind verfügbar:
+
+  - `None` (sowohl für *X Anchor* als auch für *Y Anchor*) behält die Position des Knotens vom Mittelpunkt des übergeordneten Knotens oder der Szene aus relativ zu dessen bzw. deren *angepasster* Größe bei.
+  - `Left` oder `Right` (*X Anchor*) skaliert die horizontale Position des Knotens so, dass der prozentuale Abstand zum linken und rechten Rand des übergeordneten Knotens oder der Szene gleich bleibt.
+  - `Top` oder `Bottom` (*Y Anchor*) skaliert die vertikale Position des Knotens so, dass der prozentuale Abstand zum oberen und unteren Rand des übergeordneten Knotens oder der Szene gleich bleibt.
+
+  ![Verankerung](images/gui/anchoring.png)
+
+Adjust Mode
+: Legt den Anpassungsmodus für den Knoten fest. Diese Einstellung steuert, was mit einem Knoten geschieht, wenn die Grenzen der Szene oder des übergeordneten Knotens an die physische Bildschirmgröße angepasst werden.
+
+  Ein Knoten, der in einer Szene mit einer typischen logischen Auflösung im Querformat erstellt wurde:
+
+  ![Ohne Anpassung](images/gui/unadjusted.png)
+
+  Wenn die Szene an einen Bildschirm im Hochformat angepasst wird, wird sie gestreckt. Das Begrenzungsrechteck jedes Knotens wird auf dieselbe Weise gestreckt. Über den Anpassungsmodus lässt sich jedoch das Seitenverhältnis des Knoteninhalts beibehalten. Die folgenden Modi sind verfügbar:
+
+  - `Fit` skaliert den Knoteninhalt so, dass er der Breite oder Höhe des gestreckten Begrenzungsrechtecks entspricht, je nachdem, welcher Wert kleiner ist. Mit anderen Worten: Der Inhalt passt vollständig in das gestreckte Begrenzungsrechteck des Knotens.
+  - `Zoom` skaliert den Knoteninhalt so, dass er der Breite oder Höhe des gestreckten Begrenzungsrechtecks entspricht, je nachdem, welcher Wert größer ist. Mit anderen Worten: Der Inhalt bedeckt das gestreckte Begrenzungsrechteck des Knotens vollständig.
+  - `Stretch` streckt den Knoteninhalt so, dass er das gestreckte Begrenzungsrechteck des Knotens ausfüllt.
+
+  ![Anpassungsmodi](images/gui/adjusted.png)
+
+  Wenn die Eigenschaft *Adjust Reference* der GUI-Szene auf `Disabled` gesetzt ist, wird diese Einstellung ignoriert.
+
+Clipping Mode (Box- und Kreissektor-Knoten)
+: Legt den Modus zum Beschneiden (Clipping) des Knotens fest:
+
+  - `None` rendert den Knoten wie gewohnt.
+  - `Stencil` lässt die Knotengrenzen eine Stencil-Maske definieren, mit der die untergeordneten Knoten beschnitten werden.
+
+  Einzelheiten findest du im [Handbuch zum Beschneiden von GUIs](/manuals/gui-clipping).
+
+Clipping Visible (Box- und Kreissektor-Knoten)
+: Aktivieren, um den Inhalt des Knotens im Stencil-Bereich zu rendern. Einzelheiten findest du im [Handbuch zum Beschneiden von GUIs](/manuals/gui-clipping).
+
+Clipping Inverted (Box- und Kreissektor-Knoten)
+: Invertiert die Stencil-Maske. Einzelheiten findest du im [Handbuch zum Beschneiden von GUIs](/manuals/gui-clipping).
+
+
+## Bezugspunkt, Verankerungen und Anpassungsmodus {#pivot-anchors-and-adjust-mode}
+
+Die Kombination aus Bezugspunkt, Verankerungen und Anpassungsmodus ermöglicht eine sehr flexible Gestaltung von GUIs. Ohne ein konkretes Beispiel kann es jedoch etwas schwierig sein, ihr Zusammenspiel zu verstehen. Nehmen wir diesen GUI-Entwurf für einen Bildschirm mit 640 × 1136 Pixeln als Beispiel:
+
+![](images/gui/adjustmode_example_original.png)
+
+Die Benutzeroberfläche wurde erstellt, indem X Anchor und Y Anchor auf None gesetzt wurden und Adjust Mode für jeden Knoten auf dem Standardwert Fit belassen wurde. Der Bezugspunkt Pivot des oberen Bereichs ist North, der Bezugspunkt des unteren Bereichs ist South und die Bezugspunkte der Balken im oberen Bereich sind auf West gesetzt. Bei den übrigen Knoten sind die Bezugspunkte auf Center gesetzt. Wenn wir das Fenster verbreitern, geschieht Folgendes:
+
+![](images/gui/adjustmode_example_resized.png)
+
+Was ist nun, wenn der obere und der untere Balken immer so breit wie der Bildschirm sein sollen? Wir können Adjust Mode für die grauen Hintergrundbereiche oben und unten auf Stretch ändern:
+
+![](images/gui/adjustmode_example_resized_stretch.png)
+
+Das ist besser. Die grauen Hintergrundbereiche werden nun immer auf die Breite des Fensters gestreckt, aber die Balken im oberen Bereich und die beiden Rechtecke unten sind nicht richtig positioniert. Wenn die oberen Balken links positioniert bleiben sollen, müssen wir X Anchor von None auf Left ändern:
+
+![](images/gui/adjustmode_example_top_anchor_left.png)
+
+Genau so soll der obere Bereich aussehen. Die Bezugspunkte Pivot der Balken im oberen Bereich waren bereits auf West gesetzt. Dadurch werden die Balken passend positioniert: Ihr linker bzw. westlicher Rand (Pivot) ist am linken Rand des übergeordneten Bereichs verankert (X Anchor).
+
+Wenn wir nun X Anchor für das linke Rechteck auf Left und X Anchor für das rechte Rechteck auf Right setzen, erhalten wir folgendes Ergebnis:
+
+![](images/gui/adjustmode_example_bottom_anchor_left_right.png)
+
+Das ist nicht ganz das erwartete Ergebnis. Die beiden Rechtecke sollten genauso nahe am linken und rechten Rand bleiben wie die beiden Balken im oberen Bereich. Der Grund dafür ist der falsche Bezugspunkt Pivot:
+
+![](images/gui/adjustmode_example_bottom_pivot_center.png)
+
+Bei beiden Rechtecken ist der Bezugspunkt Pivot auf Center gesetzt. Das bedeutet, dass der Mittelpunkt (der Bezugspunkt) der Rechtecke bei einer Verbreiterung des Bildschirms denselben relativen Abstand von den Rändern behält. Beim linken Rechteck betrug er im ursprünglichen Fenster mit 640 × 1136 Pixeln 17 % vom linken Rand:
+
+![](images/gui/adjustmode_example_original_ratio.png)
+
+Wenn die Bildschirmgröße geändert wird, bleibt der Mittelpunkt des linken Rechtecks beim selben Abstand von 17 % vom linken Rand:
+
+![](images/gui/adjustmode_example_resized_stretch_ratio.png)
+
+Wenn wir den Bezugspunkt Pivot für das linke Rechteck von Center auf West und für das rechte Rechteck auf East ändern und die Rechtecke neu positionieren, erhalten wir auch bei einer Änderung der Bildschirmgröße das gewünschte Ergebnis:
+
+![](images/gui/adjustmode_example_bottom_pivot_west_east.png)
+
+
+## Zeichenreihenfolge {#draw-order}
+
+Alle Knoten werden in der Reihenfolge gerendert, in der sie im Ordner „Nodes“ aufgelistet sind. Der oberste Knoten in der Liste wird zuerst gezeichnet und erscheint daher hinter allen anderen Knoten. Der letzte Knoten in der Liste wird zuletzt gezeichnet und erscheint somit vor allen anderen Knoten. Das Ändern des Z-Werts eines Knotens steuert nicht seine Zeichenreihenfolge. Wenn du den Z-Wert jedoch außerhalb des Renderbereichs deines Render-Skripts setzt, wird der Knoten nicht mehr auf dem Bildschirm gerendert. Du kannst die Indexreihenfolge der Knoten mit Ebenen überschreiben (siehe unten).
+
+![Zeichenreihenfolge](images/gui/draw_order.png)
+
+Wähle einen Knoten aus und drücke <kbd>Alt + Up/Down</kbd>, um ihn nach oben oder unten zu verschieben und seine Indexreihenfolge zu ändern.
+
+Die Zeichenreihenfolge lässt sich per Skript ändern:
+
+```lua
+local bean_node = gui.get_node("bean")
+local shield_node = gui.get_node("shield")
+
+if gui.get_index(shield_node) < gui.get_index(bean_node) then
+  gui.move_above(shield_node, bean_node)
+end
+```
+
+## Eltern-Kind-Hierarchien {#parent-child-hierarchies}
+
+Du ordnest einen Knoten einem anderen unter, indem du ihn auf den Knoten ziehst, der sein übergeordneter Knoten werden soll. Ein untergeordneter Knoten erbt die Transformation (Position, Drehung und Skalierung), die auf den übergeordneten Knoten angewendet wird, relativ zu dessen Bezugspunkt.
+
+![Über- und untergeordnete Knoten](images/gui/parent_child.png)
+
+Übergeordnete Knoten werden vor ihren untergeordneten Knoten gezeichnet. Verwende Ebenen, um die Zeichenreihenfolge über- und untergeordneter Knoten zu ändern und das Rendering der Knoten zu optimieren (siehe unten).
+
+
+## Ebenen und Zeichenaufrufe {#layers-and-draw-calls}
+
+Ebenen ermöglichen eine genaue Steuerung, wie Knoten gezeichnet werden, und können die Anzahl der Zeichenaufrufe (draw calls) verringern, die die Engine zum Zeichnen einer GUI-Szene erzeugen muss. Bevor die Engine die Knoten einer GUI-Szene zeichnet, bündelt sie deren Zeichenoperationen (Batching) anhand der folgenden Bedingungen:
+
+- Die Knoten müssen denselben Typ verwenden.
+- Die Knoten müssen denselben Atlas oder dieselbe Kachelquelle verwenden.
+- Die Knoten müssen mit demselben Mischmodus gerendert werden.
+- Sie müssen dieselbe Schriftart verwenden.
+
+Wenn sich ein Knoten in einem dieser Punkte vom vorherigen unterscheidet, unterbricht er die Bündelung und erzeugt einen weiteren Zeichenaufruf. Beschneidende Knoten unterbrechen die Bündelung immer, ebenso jeder Stencil-Gültigkeitsbereich.
+
+Die Möglichkeit, Knoten in Hierarchien anzuordnen, erleichtert die Gruppierung von Knoten zu überschaubaren Einheiten. Wenn du verschiedene Knotentypen mischst, können Hierarchien das gebündelte Rendern jedoch praktisch unterbinden:
+
+![Hierarchie unterbricht die Bündelung](images/gui/break_batch.png)
+
+Wenn die Rendering-Pipeline die Knotenliste durchläuft, muss sie für jeden einzelnen Knoten eine eigene Gruppe von Zeichenoperationen anlegen, weil sich die Typen unterscheiden. Insgesamt erfordern diese drei Schaltflächen sechs Zeichenaufrufe.
+
+Indem du den Knoten Ebenen zuweist, kannst du sie anders anordnen. Dadurch kann die Rendering-Pipeline die Knoten in weniger Zeichenaufrufen zusammenfassen. Füge zunächst der Szene die benötigten Ebenen hinzu. Klicke mit der <kbd>rechten Maustaste</kbd> auf das Ordnersymbol „Layers“ in der Ansicht *Outline* und wähle <kbd>Add ▸ Layer</kbd>. Markiere die neue Ebene und weise ihr für die Eigenschaft *Name* in der Ansicht *Properties* einen Wert zu.
+
+![Ebenen](images/gui/layers.png)
+
+Setze anschließend die Eigenschaft *Layer* jedes Knotens auf die entsprechende Ebene. Die Zeichenreihenfolge der Ebenen hat Vorrang vor der regulären Indexreihenfolge der Knoten. Wenn du die Box-Knoten mit den Schaltflächengrafiken auf „graphics“ und die Textknoten der Schaltflächen auf „text“ setzt, ergibt sich daher folgende Zeichenreihenfolge:
+
+* Zuerst alle Knoten der Ebene „graphics“, von oben nach unten:
+
+  1. "button-1"
+  2. "button-2"
+  3. "button-3"
+
+* Dann alle Knoten der Ebene „text“, von oben nach unten:
+
+  4. "button-text-1"
+  5. "button-text-2"
+  6. "button-text-3"
+
+Die Knoten können nun in zwei statt sechs Zeichenaufrufen gebündelt werden. Ein großer Leistungsgewinn!
+
+Beachte, dass ein untergeordneter Knoten ohne festgelegte Ebene die Ebeneneinstellung seines übergeordneten Knotens implizit erbt. Wenn du für einen Knoten keine Ebene festlegst, wird er implizit der Ebene „null“ hinzugefügt, die vor allen anderen Ebenen gezeichnet wird.

--- a/docs/de/manuals/hot-reload.md
+++ b/docs/de/manuals/hot-reload.md
@@ -1,0 +1,122 @@
+---
+title: Hot Reload
+brief: Dieses Handbuch erklärt die Hot-Reload-Funktion in Defold.
+---
+
+# Ressourcen per Hot Reload neu laden {#hot-reloading-resources}
+
+Defold ermöglicht es dir, Ressourcen (resources) per Hot Reload neu zu laden. Bei der Entwicklung eines Spiels beschleunigt diese Funktion bestimmte Aufgaben enorm. Du kannst damit Code und Inhalte eines Spiels ändern, während es läuft. Häufige Anwendungsfälle sind:
+
+- Gameplay-Parameter in Lua-Skripten anpassen.
+- Grafische Elemente (wie Partikeleffekte oder GUI-Elemente) bearbeiten und anpassen und die Ergebnisse im passenden Kontext betrachten.
+- Shader-Code bearbeiten und anpassen und die Ergebnisse im passenden Kontext betrachten.
+- Das Testen des Spiels erleichtern, indem du Level neu startest, Zustände festlegst und ähnliche Aktionen ausführst---ohne das Spiel anzuhalten.
+
+## Hot Reload verwenden {#how-to-hot-reload}
+
+Starte dein Spiel über den Editor (<kbd>Project ▸ Build</kbd>).
+
+Um anschließend eine aktualisierte Ressource neu zu laden, wähle einfach den Menüpunkt <kbd>File ▸ Hot Reload</kbd> oder drücke die entsprechende Tastenkombination:
+
+![Ressourcen neu laden](images/hot-reload/menu.png)
+
+## Hot Reload auf Geräten {#hot-reloading-on-device}
+
+Hot Reload funktioniert sowohl auf Geräten als auch auf Desktop-Computern. Um es auf einem Gerät zu verwenden, starte einen Debug-Build deines Spiels oder die [Entwicklungs-App](/manuals/dev-app) auf deinem Mobilgerät und wähle es anschließend im Editor als Ziel aus:
+
+![Zielgerät](images/hot-reload/target.png)
+
+Wenn du nun einen Build erstellst und startest, überträgt der Editor alle Assets an die laufende App auf dem Gerät und startet das Spiel. Ab diesem Zeitpunkt wird jede Datei, die du per Hot Reload neu lädst, auf dem Gerät aktualisiert.
+
+Wenn du beispielsweise einer GUI, die in einem laufenden Spiel auf deinem Smartphone angezeigt wird, ein paar Schaltflächen hinzufügen möchtest, öffne einfach die GUI-Datei:
+
+![GUI neu laden](images/hot-reload/gui.png)
+
+Füge die neuen Schaltflächen hinzu, speichere die GUI-Datei und lade sie per Hot Reload neu. Die neuen Schaltflächen sind jetzt auf dem Bildschirm des Smartphones zu sehen:
+
+![Neu geladene GUI](images/hot-reload/gui-reloaded.png)
+
+Wenn du eine Datei per Hot Reload neu lädst, gibt die Engine jede neu geladene Ressourcendatei in der Konsole aus.
+
+## Skripte neu laden {#reloading-scripts}
+
+Jede neu geladene Lua-Skriptdatei wird in der laufenden Lua-Umgebung erneut ausgeführt.
+
+```lua
+local my_value = 10
+
+function update(self, dt)
+    print(my_value)
+end
+```
+
+Wenn du `my_value` auf 11 änderst und die Datei per Hot Reload neu lädst, wirkt sich das sofort aus:
+
+```text
+...
+DEBUG:SCRIPT: 10
+DEBUG:SCRIPT: 10
+DEBUG:SCRIPT: 10
+INFO:RESOURCE: /main/hunter.scriptc was successfully reloaded.
+DEBUG:SCRIPT: 11
+DEBUG:SCRIPT: 11
+DEBUG:SCRIPT: 11
+...
+```
+
+Beachte, dass Hot Reload die Ausführung der Lebenszyklusfunktionen nicht verändert. Beispielsweise wird `init()` bei einem Hot Reload nicht aufgerufen. Wenn du die Lebenszyklusfunktionen neu definierst, werden jedoch die neuen Versionen verwendet.
+
+## Lua-Module neu laden {#reloading-lua-modules}
+
+Solange du Variablen in einer Moduldatei zum globalen Gültigkeitsbereich hinzufügst, werden diese globalen Variablen beim erneuten Laden der Datei geändert:
+
+```lua
+--- my_module.lua
+my_module = {}
+my_module.val = 10
+```
+
+```lua
+-- user.script
+require "my_module"
+
+function update(self, dt)
+    print(my_module.val) -- hot reload "my_module.lua" and the new value will print
+end
+```
+
+Ein gängiges Muster für Lua-Module besteht darin, eine lokale Tabelle zu erstellen, sie mit Werten zu füllen und anschließend zurückzugeben:
+
+```lua
+--- my_module.lua
+local M = {} -- a new table object is created here
+M.val = 10
+return M
+```
+
+```lua
+-- user.script
+local mm = require "my_module"
+
+function update(self, dt)
+    print(mm.val) -- will print 10 even if you change and hot reload "my_module.lua"
+end
+```
+
+Das Ändern und erneute Laden von `my_module.lua` verändert das Verhalten von `user.script` _nicht_. Im [Handbuch zu Modulen](/manuals/modules) erfährst du mehr darüber, warum das so ist und wie du diese Falle vermeidest.
+
+## Die Funktion on_reload() {#the-on_reload-function}
+
+Jede Skriptkomponente (script component) kann eine Funktion `on_reload()` definieren. Wenn sie vorhanden ist, wird sie jedes Mal aufgerufen, wenn das Skript neu geladen wird. Das ist nützlich, um Daten zu untersuchen oder zu ändern, Nachrichten zu senden und ähnliche Aufgaben auszuführen:
+
+```lua
+function on_reload(self)
+    print(self.velocity)
+
+    msg.post("/level#controller", "setup")
+end
+```
+
+## Shader-Code neu laden {#reloading-shader-code}
+
+Beim erneuten Laden von Vertex- und Fragment-Shadern kompiliert der Grafiktreiber den GLSL-Code neu und überträgt ihn an die GPU. Wenn der Shader-Code einen Absturz verursacht, stürzt auch die Engine ab. Das kann leicht passieren, da GLSL-Code auf einer sehr niedrigen Abstraktionsebene arbeitet.

--- a/docs/de/manuals/html5.md
+++ b/docs/de/manuals/html5.md
@@ -1,0 +1,386 @@
+---
+title: Entwicklung mit Defold für die HTML5-Plattform
+brief: Dieses Handbuch beschreibt die Erstellung eines HTML5-Spiels sowie bekannte Probleme und Einschränkungen.
+---
+
+# HTML5-Entwicklung {#html5-development}
+
+Defold unterstützt die Erstellung von Spielen für die HTML5-Plattform über das reguläre Menü zur Bundle-Erstellung, ebenso wie für andere Plattformen. Das daraus entstehende Spiel wird außerdem in eine normale HTML-Seite eingebettet, die sich über ein einfaches Vorlagensystem gestalten lässt.
+
+Die Datei *game.project* enthält die HTML5-spezifischen Einstellungen:
+
+![Projekteinstellungen](images/html5/html5_project_settings.png)
+
+## Heap-Größe {#heap-size}
+
+Defolds Unterstützung für HTML5 basiert auf Emscripten (siehe http://en.wikipedia.org/wiki/Emscripten). Vereinfacht gesagt erstellt es einen abgeschirmten Speicherbereich für den Heap, in dem die Anwendung ausgeführt wird. Standardmäßig reserviert die Engine großzügig bemessenen Speicher (256 MB). Das sollte für ein typisches Spiel mehr als ausreichen. Im Rahmen der Optimierung kannst du einen kleineren Wert wählen. Gehe dazu wie folgt vor:
+
+1. Setze *heap_size* auf den gewünschten Wert. Er sollte in Megabyte angegeben werden.
+2. Erstelle dein HTML5-Bundle (siehe unten)
+
+## Einen HTML5-Build testen {#testing-html5-build}
+
+Zum Testen benötigt ein HTML5-Build einen HTTP-Server. Defold erstellt einen für dich, wenn du <kbd>Project ▸ Build HTML5</kbd> wählst.
+
+![Build HTML5](images/html5/html5_build_launch.png)
+
+Wenn du dein Bundle testen möchtest, lade es auf deinen entfernten HTTP-Server hoch oder erstelle einen lokalen Server, beispielsweise mit Python im Bundle-Ordner.
+Python 2:
+
+```sh
+python -m SimpleHTTPServer
+```
+
+Python 3:
+
+```sh
+python -m http.server
+```
+
+oder
+
+```sh
+python3 -m http.server
+```
+
+::: important
+Du kannst das HTML5-Bundle nicht testen, indem du die Datei `index.html` in einem Browser öffnest. Dafür ist ein HTTP-Server erforderlich.
+:::
+
+::: important
+Wenn in der Konsole der Fehler `"wasm streaming compile failed: TypeError: Failed to execute ‘compile’ on ‘WebAssembly’: Incorrect response MIME type. Expected ‘application/wasm’."` erscheint, musst du sicherstellen, dass dein Server den MIME-Typ `application/wasm` für `.wasm`-Dateien verwendet.
+:::
+
+## Ein HTML5-Bundle erstellen {#creating-html5-bundle}
+
+HTML5-Inhalte mit Defold zu erstellen ist einfach und folgt demselben Muster wie bei allen anderen unterstützten Plattformen: Wähle im Menü <kbd>Project ▸ Bundle... ▸ HTML5 Application...</kbd>:
+
+![Ein HTML5-Bundle erstellen](images/html5/html5_bundle.png)
+
+HTML5-Bundles unterstützen zwei WebAssembly-Architekturen:
+
+* `wasm-web` - die reguläre WebAssembly-Engine ohne Thread-Unterstützung.
+* `wasm_pthread-web` - eine WebAssembly-Engine, die Threads verwenden kann.
+
+Du kannst eine der beiden Architekturen oder beide einbinden. Wenn beide enthalten sind, wählt der Loader `wasm_pthread-web`, sofern der Browser und die Hosting-Umgebung dies unterstützen, und greift andernfalls auf `wasm-web` zurück. Die kanonischen Zielnamen findest du im [Bob-Handbuch](/manuals/bob/#usage).
+
+::: important
+Die Engine mit Thread-Unterstützung benötigt `SharedArrayBuffer` auf einer sicheren Seite mit [ursprungsübergreifender Isolation](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated). Stelle das Bundle über HTTPS (oder localhost) bereit und konfiguriere den Server mit kompatiblen Headern zur ursprungsübergreifenden Isolation, üblicherweise:
+
+```txt
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+Ressourcen anderer Ursprünge, die die Seite lädt, müssen ebenfalls kompatible CORS- oder Cross-Origin-Resource-Policy-Header verwenden. Ein Bundle, das nur `wasm_pthread-web` enthält, kann nicht ausgeführt werden, wenn diese Voraussetzungen nicht erfüllt sind. Binde `wasm-web` als Ausweichoption ein, wenn das Spiel möglicherweise auf einer Website gehostet wird, die keine ursprungsübergreifende Isolation unterstützt.
+:::
+
+HTML5-Bundles von Defold benötigen einen modernen Browser mit WebAssembly-Unterstützung. Internet Explorer 11 wird nicht unterstützt.
+
+Wenn du auf die Schaltfläche <kbd>Create bundle</kbd> klickst, wirst du aufgefordert, einen Ordner auszuwählen, in dem deine Anwendung erstellt werden soll. Nach Abschluss des Exports findest du dort alle Dateien, die zum Ausführen der Anwendung benötigt werden.
+
+## WebGL-Kontextversion {#webgl-context-version}
+
+Wähle den angeforderten Grafikkontext über [`graphics.webgl_version_hint`](/manuals/project-settings/#webgl-version-hint). Der Standardwert ist WebGL 2. Fordere WebGL 1 an, um diesen Kontext in Browsern, die beide Versionen unterstützen, zu testen oder als Ziel zu verwenden.
+
+## Downloads überprüfen {#download-verification}
+
+Der HTML5-Loader prüft standardmäßig die Größen heruntergeladener Engine- und Archivdateien. Bei fehlgeschlagenen Prüfungen werden Downloads erneut versucht, bevor der Loader einen Fehler meldet:
+
+* Bei Netzwerkfehlern, HTTP-Fehlerstatuscodes und Größenabweichungen beim Download der JavaScript- oder WebAssembly-Datei der Engine gilt die in `html5.retry_count` festgelegte Obergrenze für erneute Versuche.
+* Die Überprüfung von Archivdateien hat eine eigene Obergrenze für erneute Versuche bei Größen- oder SHA-1-Abweichungen. Bei jeder erneuten Überprüfung werden die Teile der Datei erneut heruntergeladen, wobei für jeden Download die üblichen erneuten Versuche bei Netzwerkfehlern zur Verfügung stehen.
+
+Die Einstellung `html5.retry_time` steuert in beiden Fällen die Wartezeit zwischen erneuten Versuchen.
+
+Wenn dein Server, Proxy oder CDN bereitgestellte Dateien absichtlich umschreibt und dadurch ihre Größe verändert, deaktiviere die Größenprüfung in *game.project*:
+
+```ini
+[html5]
+verify_downloaded_file_size = 0
+```
+
+Wenn du **Verify Downloaded File Size** deaktivierst, bleibt eine im Bundle enthaltene SHA-1-Überprüfung weiterhin aktiviert. Siehe die [HTML5-Projekteinstellungen](/manuals/project-settings/#verify-downloaded-file-size).
+
+## Bekannte Probleme und Einschränkungen {#known-issues-and-limitations}
+
+* Hot Reload - Hot Reload funktioniert in HTML5-Builds nicht. Defold-Anwendungen müssen einen eigenen kleinen Webserver betreiben, um Aktualisierungen vom Editor zu empfangen. Das ist in einem HTML5-Build nicht möglich.
+* Chrome
+  * Langsame Debug-Builds - In Debug-Builds für HTML5 überprüfen wir alle WebGL-Grafikaufrufe, um Fehler zu erkennen. Beim Testen in Chrome ist das leider sehr langsam. Du kannst dies deaktivieren, indem du das Feld *Engine Arguments* in *game.project* auf `--verify-graphics-calls=false` setzt.
+* Gamepad-Unterstützung - [Die Gamepad-Dokumentation](/manuals/input-gamepads/#gamepads-in-html5) beschreibt Besonderheiten und Schritte, die du bei HTML5 möglicherweise beachten oder durchführen musst.
+
+## Ein HTML5-Bundle anpassen {#customizing-html5-bundle}
+
+Beim Erstellen einer HTML5-Version deines Spiels stellt Defold eine Standardwebseite bereit. Sie verweist auf Stil- und Skriptressourcen, die bestimmen, wie dein Spiel dargestellt wird.
+
+Bei jedem Export der Anwendung werden diese Inhalte neu erstellt. Wenn du eines dieser Elemente anpassen möchtest, musst du deine Projekteinstellungen ändern. Öffne dazu *game.project* im Defold-Editor und scrolle zum Abschnitt *html5*:
+
+![HTML5-Abschnitt](images/html5/html5_section.png)
+
+Weitere Informationen zu jeder Option findest du im [Handbuch zu den Projekteinstellungen](/manuals/project-settings/#html5).
+
+::: important
+Du kannst die Dateien der standardmäßigen HTML-/CSS-Vorlage im Ordner `builtins` nicht ändern. Um deine Änderungen anzuwenden, kopiere die benötigte Datei aus `builtins`, füge sie in dein Projekt ein und lege diese Datei in *game.project* fest.
+:::
+
+::: important
+Die Zeichenfläche sollte weder mit einem Rahmen noch mit einem Innenabstand gestaltet werden. Andernfalls sind die Koordinaten der Mauseingabe falsch.
+:::
+
+In *game.project* kannst du die Schaltfläche `Fullscreen` und den Link `Made with Defold` deaktivieren.
+Defold stellt ein dunkles und ein helles Design für `index.html` bereit. Standardmäßig ist das helle Design eingestellt, du kannst es aber durch Ändern der Datei `Custom CSS` wechseln. Im Feld `Scale Mode` stehen außerdem vier vordefinierte Skalierungsmodi zur Auswahl.
+
+::: important
+Die Berechnungen für alle Skalierungsmodi berücksichtigen den aktuellen DPI-Wert des Bildschirms, wenn du die Option `High Dpi` in *game.project* (Abschnitt `Display`) aktivierst.
+:::
+
+### Downscale Fit und Fit {#downscale-fit-and-fit}
+
+Im Modus `Fit` wird die Größe der Zeichenfläche so angepasst, dass die gesamte Zeichenfläche des Spiels mit ihren ursprünglichen Proportionen auf dem Bildschirm zu sehen ist. Der einzige Unterschied bei `Downscale Fit` besteht darin, dass die Größe nur geändert wird, wenn der Innenbereich der Webseite kleiner als die ursprüngliche Zeichenfläche des Spiels ist. Ist die Webseite größer als die ursprüngliche Zeichenfläche des Spiels, wird diese nicht vergrößert.
+
+![HTML5-Abschnitt](images/html5/html5_fit.png)
+
+### Stretch
+
+Im Modus `Stretch` wird die Größe der Zeichenfläche so angepasst, dass sie den Innenbereich der Webseite vollständig ausfüllt.
+
+![HTML5-Abschnitt](images/html5/html5_stretch.png)
+
+### No Scale
+Im Modus `No Scale` entspricht die Größe der Zeichenfläche genau dem Wert, den du in der Datei *game.project* im Abschnitt `[display]` festgelegt hast.
+
+![HTML5-Abschnitt](images/html5/html5_no_scale.png)
+
+## Tokens
+
+Wir verwenden die [Vorlagensprache Mustache](https://mustache.github.io/mustache.5.html) zum Erstellen der Datei `index.html`. Wenn du einen Build oder ein Bundle erstellst, werden die HTML- und CSS-Dateien durch einen Compiler verarbeitet, der bestimmte Tokens durch Werte ersetzen kann, die von deinen Projekteinstellungen abhängen. Diese Tokens stehen immer in doppelten oder dreifachen geschweiften Klammern (`{{TOKEN}}` oder `{{{TOKEN}}}`), je nachdem, ob Zeichenfolgen maskiert werden sollen oder nicht. Diese Funktion kann nützlich sein, wenn du häufig deine Projekteinstellungen änderst oder Material in anderen Projekten wiederverwenden möchtest.
+
+::: sidenote
+Weitere Informationen zur Vorlagensprache Mustache findest du im [Handbuch](https://mustache.github.io/mustache.5.html).
+:::
+
+Jeder Wert in *game.project* kann als Token dienen. Wenn du beispielsweise den Wert von `Width` aus dem Abschnitt `Display` verwenden möchtest:
+
+![Abschnitt Display](images/html5/html5_display.png)
+
+Öffne *game.project* als Text und prüfe `[section_name]` sowie den Namen des Felds, das du verwenden möchtest. Anschließend kannst du es als Token verwenden: `{{section_name.field}}` oder `{{{section_name.field}}}`.
+
+![Abschnitt Display](images/html5/html5_game_project.png)
+
+Zum Beispiel in JavaScript innerhalb der HTML-Vorlage:
+
+```javascript
+function doSomething() {
+    var x = {{display.width}};
+    // ...
+}
+```
+
+Außerdem gibt es die folgenden benutzerdefinierten Tokens:
+
+DEFOLD_SPLASH_IMAGE
+: Gibt den Dateinamen des Startbilds oder `false` aus, wenn `html5.splash_image` in *game.project* leer ist.
+
+
+```css
+{{#DEFOLD_SPLASH_IMAGE}}
+		background-image: url("{{DEFOLD_SPLASH_IMAGE}}");
+{{/DEFOLD_SPLASH_IMAGE}}
+```
+
+exe-name
+: Der Projektname ohne unzulässige Zeichen.
+
+DEFOLD_ARCHIVE_LOCATION_PREFIX
+: Das aufgelöste Präfix des Archivpfads, das der Loader verwendet, basierend auf `html5.archive_location_prefix`.
+
+DEFOLD_ARCHIVE_LOCATION_SUFFIX
+: Das aufgelöste Suffix, das an Archiv-URLs angehängt wird, basierend auf `html5.archive_location_suffix`.
+
+DEFOLD_HAS_ARCHIVE_ORIGIN
+: `true`, wenn das Archivpräfix einen HTTP- oder HTTPS-Ursprung angibt, einschließlich einer protokollrelativen URL wie `//cdn.example.com/archive`. Bei relativen Archivpräfixen ist der Wert `false`. Verfügbar seit Defold 1.13.2.
+
+DEFOLD_ARCHIVE_ORIGIN
+: Der Ursprung des Archivs einschließlich Schema, Host und optionalem Port oder eine leere Zeichenfolge, wenn kein Ursprung angegeben ist. Ein protokollrelatives Präfix erzeugt einen protokollrelativen Ursprung. Wird für den Preconnect-Hinweis verwendet und ist seit Defold 1.13.2 verfügbar.
+
+DEFOLD_HAS_WASM_ENGINE
+: `true`, wenn das Bundle eine WebAssembly-Engine enthält, entweder `wasm-web` oder `wasm_pthread-web`.
+
+DEFOLD_HAS_WASM_PTHREAD_ENGINE
+: `true`, wenn das Bundle `wasm_pthread-web` enthält. Verwende dieses Token, um das Vorladen der falschen Engine-Variante zu vermeiden, wenn der Loader die Architektur zur Laufzeit auswählt.
+
+
+DEFOLD_CUSTOM_CSS_INLINE
+: An dieser Stelle wird der Inhalt der CSS-Datei direkt eingefügt, die in deinen *game.project*-Einstellungen angegeben ist.
+
+
+```html
+<style>
+{{{DEFOLD_CUSTOM_CSS_INLINE}}}
+</style>
+```
+
+::: important
+Dieser direkt eingefügte Block muss vor dem Laden des Hauptskripts der Anwendung stehen. Da er HTML-Tags enthält, sollte dieses Makro in dreifachen geschweiften Klammern `{{{TOKEN}}}` stehen, damit Zeichenfolgen nicht maskiert werden.
+:::
+
+DEFOLD_SCALE_MODE_IS_DOWNSCALE_FIT
+: Dieses Token ist `true`, wenn `html5.scale_mode` auf `Downscale Fit` gesetzt ist.
+
+DEFOLD_SCALE_MODE_IS_FIT
+: Dieses Token ist `true`, wenn `html5.scale_mode` auf `Fit` gesetzt ist.
+
+DEFOLD_SCALE_MODE_IS_NO_SCALE
+: Dieses Token ist `true`, wenn `html5.scale_mode` auf `No Scale` gesetzt ist.
+
+DEFOLD_SCALE_MODE_IS_STRETCH
+: Dieses Token ist `true`, wenn `html5.scale_mode` auf `Stretch` gesetzt ist.
+
+DEFOLD_HEAP_SIZE
+: Die in *game.project* unter `html5.heap_size` angegebene Heap-Größe, umgerechnet in Bytes.
+
+DEFOLD_ENGINE_ARGUMENTS
+: Die in *game.project* unter `html5.engine_arguments` angegebenen Engine-Argumente, getrennt durch das Zeichen `,`.
+
+build-timestamp
+: Der aktuelle Build-Zeitstempel in Sekunden.
+
+
+## Zusätzliche Parameter {#extra-parameters}
+
+Wenn du eine eigene Vorlage erstellst, kannst du Parameter für den Engine-Loader ändern, indem du Werte im globalen Objekt `CUSTOM_PARAMETERS` zuweist. Die integrierte Vorlage stellt für diese Anpassungen einen bewusst leeren Block `<script id="engine-setup">` bereit.
+::: important
+Der Block `engine-setup` muss nach dem Skript stehen, das `dmloader.js` lädt, und vor dem Block `engine-start`, der `EngineLoader.load()` aufruft.
+:::
+Zum Beispiel:
+
+```html
+    <script id="engine-setup" type="text/javascript">
+        CUSTOM_PARAMETERS.disable_context_menu = false;
+        CUSTOM_PARAMETERS.unsupported_webgl_callback = function() {
+            console.log("Oh-oh. WebGL not supported...");
+        };
+    </script>
+```
+
+`CUSTOM_PARAMETERS` kann unter anderem die folgenden Felder enthalten:
+
+```
+'archive_location_filter':
+    Filter function that will run for each archive path.
+
+'unsupported_webgl_callback':
+    Function that is called if WebGL is not supported.
+
+'engine_arguments':
+    List of arguments (strings) that will be passed to the engine.
+
+'custom_heap_size':
+    Number of bytes specifying the memory heap size.
+
+'disable_context_menu':
+    Disables the right-click context menu on the canvas element if true.
+
+'retry_time':
+    Pause in seconds before retry file loading after error.
+
+'retry_count':
+    How many attempts we do when trying to download a file.
+
+'can_not_download_file_callback':
+    Function that is called if you can't download file after 'retry_count' attempts.
+
+'resize_window_callback':
+    Function that is called when resize/orientationchanges/focus events happened
+
+'start_success':
+    Function that is called just before main is called upon successful load.
+
+'update_progress':
+    Function that is called as progress is updated. Parameter progress is updated 0-100.
+```
+
+## Dateioperationen in HTML5 {#file-operations-in-html5}
+
+HTML5-Builds unterstützen Dateioperationen wie `sys.save()`, `sys.load()` und `io.open()`, aber die interne Verarbeitung dieser Operationen unterscheidet sich von anderen Plattformen. Wenn JavaScript in einem Browser ausgeführt wird, gibt es kein eigentliches Dateisystemkonzept, und der Zugriff auf lokale Dateien ist aus Sicherheitsgründen gesperrt. Stattdessen verwendet Emscripten (und damit auch Defold) [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB), eine Datenbank im Browser zur dauerhaften Speicherung von Daten, um ein virtuelles Dateisystem im Browser zu erstellen. Der wesentliche Unterschied zum Dateisystemzugriff auf anderen Plattformen besteht darin, dass zwischen dem Schreiben in eine Datei und dem tatsächlichen Speichern der Änderung in der Datenbank eine kurze Verzögerung auftreten kann. Über die Entwicklerkonsole des Browsers kannst du in der Regel den Inhalt der IndexedDB untersuchen.
+
+
+## Argumente an ein HTML5-Spiel übergeben {#passing-arguments-to-an-html5-game}
+
+Manchmal ist es notwendig, einem Spiel vor oder während des Starts zusätzliche Argumente zu übergeben. Das können beispielsweise eine Nutzer-ID, ein Sitzungstoken oder die Angabe des Levels sein, das beim Spielstart geladen werden soll. Dies lässt sich auf verschiedene Arten erreichen, von denen einige hier beschrieben werden.
+
+### Engine-Argumente {#engine-arguments}
+
+Du kannst beim Konfigurieren und Laden der Engine zusätzliche Engine-Argumente angeben. Diese zusätzlichen Engine-Argumente lassen sich zur Laufzeit mit `sys.get_config_string()` abrufen. Weise die Argumente direkt `CUSTOM_PARAMETERS.engine_arguments` im Block `engine-setup` von `index.html` zu:
+
+
+```html
+    <script id="engine-setup" type="text/javascript">
+        CUSTOM_PARAMETERS.engine_arguments = [
+            "--config=example.foo1=bar1",
+            "--config=example.foo2=bar2"
+        ];
+    </script>
+```
+
+Wenn du ein neues Array zuweist, ersetzt es alle in *game.project* konfigurierten Engine-Argumente. Um diese Argumente beizubehalten und ein weiteres hinzuzufügen, verwende stattdessen `CUSTOM_PARAMETERS.engine_arguments.push("--config=example.foo3=bar3")`.
+
+Du kannst auch `--config=example.foo1=bar1, --config=example.foo2=bar2` im Feld *Engine Arguments* im HTML5-Abschnitt von *game.project* eintragen. Die durch Kommas getrennten Werte werden `CUSTOM_PARAMETERS.engine_arguments` in der erzeugten Datei `dmloader.js` hinzugefügt.
+
+Zur Laufzeit rufst du die Werte folgendermaßen ab:
+
+```lua
+local foo1 = sys.get_config_string("example.foo1")
+local foo2 = sys.get_config_string("example.foo2")
+print(foo1) -- bar1
+print(foo2) -- bar2
+```
+
+
+### Abfrageargumente in der URL {#query-arguments-in-the-url}
+
+Du kannst Argumente als Teil der Abfrageparameter in der Seiten-URL übergeben und sie zur Laufzeit auslesen:
+
+```
+https://www.mygame.com/index.html?foo1=bar1&foo2=bar2
+```
+
+```lua
+local url = html5.run("window.location")
+print(url)
+```
+
+Eine vollständige Hilfsfunktion, um alle Abfrageparameter als Lua-Tabelle abzurufen:
+
+```lua
+local function get_query_parameters()
+    local url = html5.run("window.location")
+    -- get the query part of the url (the bit after ?)
+    local query = url:match(".*?(.*)")
+    if not query then
+        return {}
+    end
+
+    local params = {}
+    -- iterate over all key value pairs
+    for kvp in query:gmatch("([^&]+)") do
+        local key, value = kvp:match("(.+)=(.+)")
+        params[key] = value
+    end
+    return params
+end
+
+function init(self)
+    local params = get_query_parameters()
+    print(params.foo1) -- bar1
+end
+```
+
+## Optimierungen {#optimizations}
+Für HTML5-Spiele gelten in der Regel strenge Anforderungen an die anfängliche Downloadgröße, die Startzeit und den Speicherverbrauch, damit Spiele auch auf leistungsschwachen Geräten und bei langsamen Internetverbindungen schnell laden und gut laufen. Um ein HTML5-Spiel zu optimieren, empfiehlt es sich, auf die folgenden Bereiche zu achten:
+
+* [Speicherverbrauch](/manuals/optimization-memory)
+* [Engine-Größe](/manuals/optimization-size)
+* [Spielgröße](/manuals/optimization-size)
+
+## FAQ
+:[HTML5 FAQ](../shared/html5-faq.md)

--- a/docs/de/manuals/http-requests.md
+++ b/docs/de/manuals/http-requests.md
@@ -1,0 +1,176 @@
+---
+title: HTTP-Anfragen
+brief: Dieses Handbuch erklärt, wie du HTTP-Anfragen sendest.
+---
+
+## HTTP-Anfragen {#http-requests}
+
+Defold kann mit der Funktion `http.request()` normale HTTP-Anfragen senden.
+
+### HTTP GET
+
+Dies ist die einfachste Anfrage, um Daten vom Server abzurufen. Beispiel:
+
+```lua
+local function handle_response(self, id, response)
+	print(response.status, response.response)
+end
+
+http.request("https://www.defold.com", "GET", handle_response)
+```
+
+Dies sendet eine HTTP-GET-Anfrage an https://www.defold.com. Die Funktion ist asynchron und blockiert während der Anfrage nicht. Sobald die Anfrage gesendet wurde und ein Server eine Antwort zurückgegeben hat, ruft sie die angegebene Callback-Funktion auf. Die Callback-Funktion erhält die vollständige Serverantwort einschließlich Statuscode und Antwort-Headern. Weiter unten findest du zusätzliche Informationen dazu, wie du mit der Antworttabelle arbeitest.
+
+::: sidenote
+HTTP-Anfragen werden automatisch im Cache des Clients gespeichert, um die Netzwerkleistung zu verbessern. Die zwischengespeicherten Dateien werden in einem betriebssystemspezifischen Pfad für Anwendungsdaten in einem Ordner namens `defold/http-cache` gespeichert. Normalerweise musst du dich nicht um den HTTP-Cache kümmern. Wenn du den Cache während der Entwicklung leeren musst, kannst du den Ordner mit den zwischengespeicherten Dateien manuell löschen. Unter macOS befindet sich dieser Ordner in `%HOME%/Library/Application Support/Defold/http-cache/` und unter Windows in `%APP_DATA%/defold/http-cache`.
+:::
+
+### HTTP POST
+
+Wenn du Daten wie einen Punktestand oder Authentifizierungsdaten an einen Server sendest, geschieht dies üblicherweise mit einer POST-Anfrage:
+
+```lua
+local function handle_response(self, id, response)
+	print(response.status, response.response)
+end
+
+local body = "12345"
+http.request("https://www.myserver.com/score", "POST", handle_response, nil, body)
+```
+
+
+### Weitere HTTP-Methoden {#other-http-methods}
+
+HTTP-Anfragen in Defold unterstützen auch die Methoden HEAD, DELETE und PUT. Die Methode CONNECT wird ebenfalls unterstützt (siehe den Abschnitt über Proxy-Verbindungen weiter unten).
+
+### Mit der HTTP-Antwort arbeiten {#how-to-work-with-the-http-response}
+
+Die im Callback zurückgegebene Tabelle `response` enthält alle Informationen, die du für eine differenzierte Verarbeitung der Antwort benötigst. Zwei der wichtigsten Felder sind `status` und `response`:
+
+```lua
+
+local function handle_response(self, id, response)
+	-- check the response status code. Common response codes:
+	-- 200 OK - the request completed successfully
+	-- 301 Moved permanently - the requested data has moved, see redirect header
+	-- 307 Temporary redirect - same as above
+	-- 208 Permanent redirect - same as above
+	-- 400 Bad Request - the request was malformed
+	-- 401 Unauthorized - the client must authenticate itself
+	-- 404 Not Found - the server cannot find the information
+	-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
+	if response.status == 200 then
+		-- the response data
+		-- this can be anything from plain text, json encoded data or binary data
+		print(response.response)
+		json.decode(response.response)
+		sys.save(..., response.response)
+	end
+end
+```
+
+Wenn die Antwort einen großen Block binärer Daten enthält, etwa ein Bild oder ein Musikstück, kann es sinnvoll sein, die Daten in eine Datei zu schreiben, statt sie in den Arbeitsspeicher zu laden:
+
+```lua
+-- in this example we download myimage.png and write it directly to a file on disk
+
+local options = {
+	path = sys.get_save_file("mygame", "myimage.png")
+}
+
+local function handle_response(self, id, response)
+	if response.status == 200 then
+		print("File was successfully written to:", response.path)
+		print("File size:", response.document_size)
+		print("File path:", response.path)
+	else
+		print("File was not written to disk:", response.error)
+	end
+end
+
+http.request("https://www.foobar.com/myimage.png", "GET", handle_response, nil, nil, options)
+```
+
+Ein weiterer Anwendungsfall für das Laden großer Datenmengen über das Netzwerk ist Audiostreaming. Dabei werden „Blöcke“ von Audiodaten von einer URL geladen und einer Audioressource zugeführt. Ein vollständiges Beispiel findest du im [Handbuch zum Audiostreaming](/sound-streaming#sound-streaming).
+
+
+### Anfrage-Header {#request-headers}
+
+Beim Senden einer Anfrage kannst du zusätzliche Header setzen. So kannst du beispielsweise einen `Authorization`-Header oder `Content-Type` setzen, um dem Server mitzuteilen, welches Format der Anfrageinhalt hat.
+
+```Lua
+local function handle_response(self, id, response)
+	print(response.status, response.response)
+end
+
+-- send some form data
+local headers = {
+	["Content-Type"] = "application/x-www-form-urlencoded"
+}
+local body = "key1=value1&key2=value2"
+http.request("https://www.myserver.com/post", "POST", handle_response, headers, body)
+
+-- send some json encoded data
+local headers = {
+	["Content-Type"] = "application/json"
+}
+local body = json.encode({ key1 = value1, key2 = value2 })
+http.request("https://www.myserver.com/post", "POST", handle_response, headers, body)
+
+-- request some data which requires authorization to access
+local token = ... -- generate an access token (JWT, OAuth etc)
+local headers = {
+	["Authorization"] = "Bearer " .. token
+}
+http.request("https://www.myserver.com/content", "GET", handle_response, headers)
+```
+
+Defold setzt einige Anfrage-Header automatisch:
+
+* `If-None-Match: <etag>` wird auf den ETag einer zuvor zwischengespeicherten Antwort gesetzt.
+* `Transfer-Encoding: chunked` wird gesetzt, wenn der Anfrageinhalt größer als 16384 Bytes ist.
+* `Content-Length` wird auf die Größe des Anfrageinhalts gesetzt (außer wenn die Anfrage in Blöcken übertragen wird).
+* `Range: bytes=<from>-<to>` wird gesetzt, wenn eine Teilantwort angefordert wird, beispielsweise beim [Streamen von Audiodaten](/sound-streaming#sound-streaming).
+
+
+### Antwort-Header {#response-headers}
+
+Die Serverantwort kann einen oder mehrere Antwort-Header enthalten. Diese sind in der Tabelle `response` verfügbar:
+
+```lua
+local function handle_response(self, id, response)
+	for header,value in pairs(response.headers) do
+		print(header, value)
+	end
+end
+
+http.request("https://www.defold.com", "GET", handle_response)
+```
+
+
+### HTTP-Proxy
+
+Manchmal ist es erwünscht, eine Anfrage über einen Proxyserver zu senden. Dazu kannst du einen Proxyserver angeben, der beim Verbinden mit dem Zielserver verwendet wird. Wenn ein Proxy verwendet wird, wird die Verbindung zum Zielserver über einen HTTP-Tunnel durch den Proxy aufgebaut. Der HTTP-Tunnel wird mit der HTTP-Methode CONNECT aufgebaut. Beispiel:
+
+
+```lua
+-- connect to www.defold.com via localhost proxy on port 8888
+local url = "https://www.defold.com:443"
+local method = "GET"
+local headers = {}
+local post_data = nil
+local options = {
+	proxy = "https://127.0.0.1:8888"
+}
+http.request(url, method, function(self, id, response)
+	pprint(response)
+end, headers, post_data, options)
+```
+
+### API-Referenz {#api-reference}
+
+Weitere Informationen findest du in der [API-Referenz](/ref/http/).
+
+### Erweiterungen {#extensions}
+
+Eine alternative Implementierung für HTTP-Anfragen findest du in der [TinyHTTP-Erweiterung](https://defold.com/assets/tinyhttp/).

--- a/docs/de/manuals/iac.md
+++ b/docs/de/manuals/iac.md
@@ -1,0 +1,44 @@
+---
+title: Kommunikation zwischen Anwendungen in Defold
+brief: Mit der Kommunikation zwischen Anwendungen kannst du die Argumente auslesen, die beim Start deiner Anwendung übergeben wurden. Dieses Handbuch erklärt die dafür verfügbare API von Defold.
+---
+
+# Kommunikation zwischen Anwendungen {#inter-app-communication}
+
+Auf den meisten Betriebssystemen lassen sich Anwendungen auf verschiedene Arten starten:
+
+* Aus der Liste der installierten Anwendungen
+* Über einen anwendungsspezifischen Link
+* Über eine Push-Benachrichtigung
+* Als letzter Schritt eines Installationsvorgangs.
+
+Wenn die Anwendung über einen Link, eine Benachrichtigung oder bei der Installation gestartet wird, können zusätzliche Argumente übergeben werden. Dazu gehören beispielsweise ein Installationsverweis (install referrer) bei der Installation oder ein Deep Link beim Start über einen anwendungsspezifischen Link oder eine Benachrichtigung. Defold bietet über eine native Erweiterung (native extension) eine einheitliche Möglichkeit, Informationen darüber abzurufen, wie die Anwendung aufgerufen wurde.
+
+## Die Erweiterung installieren {#installing-the-extension}
+
+Um die Erweiterung für die Kommunikation zwischen Anwendungen (Inter-app communication) zu verwenden, musst du sie deiner Datei *game.project* als Abhängigkeit hinzufügen. Die neueste stabile Version ist unter dieser Abhängigkeits-URL verfügbar:
+```
+https://github.com/defold/extension-iac/archive/master.zip
+```
+
+Wir empfehlen einen Link zu einer ZIP-Datei einer [bestimmten Version](https://github.com/defold/extension-iac/releases).
+
+## Die Erweiterung verwenden {#using-the-extension}
+
+Die API ist sehr einfach zu verwenden. Du übergibst der Erweiterung eine Listener-Funktion und reagierst auf die Callbacks des Listeners.
+
+```
+local function iac_listener(self, payload, type)
+     if type == iac.TYPE_INVOCATION then
+         -- This was an invocation
+         print(payload.origin) -- origin may be empty string if it could not be resolved
+         print(payload.url)
+     end
+end
+
+function init(self)
+     iac.set_listener(iac_listener)
+end
+```
+
+Die vollständige API-Dokumentation findest du auf der [GitHub-Seite der Erweiterung](https://defold.github.io/extension-iac/).

--- a/docs/de/manuals/iap.md
+++ b/docs/de/manuals/iap.md
@@ -1,0 +1,6 @@
+---
+title: In-App-Käufe in Defold
+brief: In-App-Käufe (oder In-App-Abrechnung) ermöglichen es dir, deinen Spielern oder App-Nutzern zusätzliche Inhalte oder Funktionen in Rechnung zu stellen. Dieses Handbuch erläutert die API, die Defold dafür bereitstellt.
+---
+
+[Dieses Handbuch wurde verschoben](/extension-iap)

--- a/docs/de/manuals/importing-assets.md
+++ b/docs/de/manuals/importing-assets.md
@@ -1,0 +1,43 @@
+---
+title: Assets importieren und bearbeiten
+brief: Dieses Handbuch beschreibt, wie du Assets importierst und bearbeitest.
+---
+
+# Assets importieren und bearbeiten {#importing-and-editing-assets}
+
+Ein Spielprojekt besteht in der Regel aus einer großen Anzahl externer Assets, die in verschiedenen spezialisierten Programmen zur Erstellung von Grafiken, 3D-Modellen, Audiodateien, Animationen und anderen Inhalten entstehen. Defold ist auf einen Arbeitsablauf ausgelegt, bei dem du in deinen externen Werkzeugen arbeitest und die Assets nach ihrer Fertigstellung in Defold importierst.
+
+
+## Assets importieren {#importing-assets}
+
+Alle Assets, die du in deinem Projekt verwendest, müssen sich in der Projekthierarchie befinden. Deshalb musst du alle Assets importieren, bevor du sie verwenden kannst. Ziehe dazu einfach die Dateien aus dem Dateisystem deines Computers an eine geeignete Stelle im Bereich *Assets* des Defold-Editors und lege sie dort ab.
+
+![Dateien importieren](images/graphics/import.png)
+
+::: sidenote
+Defold unterstützt Bilder in den Bildformaten PNG und JPEG. PNG-Bilder müssen im RGBA-Format mit 32 Bit vorliegen. Andere Bildformate müssen konvertiert werden, bevor sie verwendet werden können.
+:::
+
+
+## Assets verwenden {#using-assets}
+
+Nach dem Import in Defold können die Assets von den verschiedenen Arten von Komponenten (components) verwendet werden, die Defold unterstützt:
+
+* Mit Bildern kannst du viele Arten visueller Komponenten erstellen, die häufig in 2D-Spielen verwendet werden. Lies hier mehr darüber, [wie du 2D-Grafiken importierst und verwendest](/manuals/importing-graphics).
+* Audiodateien können von der [Audiokomponente (Sound component)](/manuals/sound) zur Audiowiedergabe verwendet werden.
+* Schriftarten werden von der [Beschriftungskomponente (Label component)](/manuals/label) und von [Textknoten](/manuals/gui-text) in einer GUI verwendet.
+* glTF-Modelle (*.gltf* und *.glb*) können von der [Modellkomponente (Model component)](/manuals/model) verwendet werden, um 3D-Modelle mit Animationen anzuzeigen. Importiere alle vom Modell verwendeten Texturbilder als separate Assets und weise sie den Textureigenschaften des Materials der Modellkomponente zu. Lies hier mehr darüber, [wie du 3D-Modelle importierst und verwendest](/manuals/importing-models).
+
+
+## Externe Assets bearbeiten {#editing-external-assets}
+
+Defold bietet keine Bearbeitungswerkzeuge für Bilder, Audiodateien, Modelle oder Animationen. Solche Assets müssen außerhalb von Defold mit spezialisierten Werkzeugen erstellt und in Defold importiert werden. Defold erkennt automatisch Änderungen an allen Assets in deinen Projektdateien und aktualisiert die Editoransicht entsprechend.
+
+
+## Defold-Assets bearbeiten {#editing-defold-assets}
+
+Der Editor speichert alle Defold-Assets in textbasierten Dateien, die sich gut zusammenführen lassen. Sie lassen sich auch leicht mit einfachen Skripten erstellen und ändern. Weitere Informationen findest du in [diesem Forenthema](https://forum.defold.com/t/deftree-a-python-module-for-editing-defold-files/15210). Beachte jedoch, dass das Defold-Team die Details seiner Dateiformate nicht veröffentlicht, da sich diese gelegentlich ändern. Du kannst auch [Editor-Skripte](/manuals/editor-scripts/) verwenden, um auf bestimmte Lebenszyklusereignisse im Editor zu reagieren und dabei Skripte auszuführen, die Assets erzeugen oder ändern.
+
+Wenn du Defold-Asset-Dateien mit einem Texteditor oder einem externen Werkzeug bearbeitest, solltest du besonders vorsichtig sein. Falls du dabei Fehler einführst, können diese verhindern, dass sich die Datei im Defold-Editor öffnen lässt.
+
+Einige externe Werkzeuge wie [Tiled](/assets/tiled/) und [Tilesetter](https://www.tilesetter.org/beta) können Defold-Assets automatisch erzeugen.

--- a/docs/de/manuals/importing-graphics.md
+++ b/docs/de/manuals/importing-graphics.md
@@ -1,0 +1,73 @@
+---
+title: 2D-Grafiken importieren und verwenden
+brief: Dieses Handbuch beschreibt, wie du 2D-Grafiken importierst und verwendest.
+---
+
+# 2D-Grafiken importieren {#importing-2d-graphics}
+
+Defold unterstützt viele Arten visueller Komponenten (components), die häufig in 2D-Spielen verwendet werden. Mit Defold kannst du statische und animierte Sprites, UI-Komponenten, Partikeleffekte, Kachelkarten (tile maps) und Bitmap-Schriften erstellen. Bevor du eine dieser visuellen Komponenten erstellen kannst, musst du Bilddateien mit den gewünschten Grafiken importieren. Ziehe dazu einfach die Dateien aus dem Dateisystem deines Computers an eine geeignete Stelle im Bereich *Assets* des Defold-Editors und lege sie dort ab.
+
+![Dateien importieren](images/graphics/import.png)
+
+::: sidenote
+Defold unterstützt Bilder in den Formaten PNG und JPEG. Andere Bildformate musst du vor der Verwendung konvertieren.
+:::
+
+
+## Defold-Assets erstellen {#creating-defold-assets}
+
+Nachdem du die Bilder in Defold importiert hast, kannst du daraus Defold-spezifische Assets erstellen:
+
+![Atlas](images/icons/atlas.png){.icon} Atlas
+: Ein Atlas enthält eine Liste einzelner Bilddateien, die automatisch zu einem größeren Texturbild zusammengefügt werden. Atlanten können unbewegte Bilder und *Animationsgruppen (Animation Groups)* enthalten. Das sind Bildfolgen, die zusammen eine Flipbook-Animation bilden.
+
+  ![Atlas](images/graphics/atlas.png)
+
+Mehr über die Atlas-Ressource erfährst du im [Atlas-Handbuch](/manuals/atlas).
+
+![Kachelquelle](images/icons/tilesource.png){.icon} Kachelquelle
+: Eine Kachelquelle (tile source) verweist auf eine Bilddatei, die bereits aus kleineren Teilbildern besteht, die in einem gleichmäßigen Raster angeordnet sind. Ein weiterer gebräuchlicher Begriff für diese Art zusammengesetzter Bilder ist _Sprite-Bogen (sprite sheet)_. Kachelquellen können Flipbook-Animationen enthalten, die durch die erste und letzte Kachel der Animation definiert werden. Du kannst außerdem ein Bild verwenden, um Kacheln automatisch Kollisionsformen zuzuordnen.
+
+  ![Kachelquelle](images/graphics/tilesource.png)
+
+Mehr über die Kachelquellen-Ressource erfährst du im [Handbuch zu Kachelquellen](/manuals/tilesource).
+
+![Bitmap-Schrift](images/icons/font.png){.icon} Bitmap-Schrift
+: Bei einer Bitmap-Schrift (bitmap font) befinden sich die Glyphen in einem PNG-Schriftbogen. Diese Schriftarten bieten keinen Leistungsvorteil gegenüber Schriftarten, die aus TrueType- oder OpenType-Schriftdateien erzeugt werden. Sie können jedoch beliebige Grafiken, Farben und Schatten direkt im Bild enthalten.
+
+Mehr über Bitmap-Schriften erfährst du im [Handbuch zu Schriftarten](/manuals/font/#bitmap-bmfonts).
+
+  ![BMfont](images/font/bm_font.png)
+
+
+## Defold-Assets verwenden {#using-defold-assets}
+
+Wenn du die Bilder in Atlas- und Kachelquellendateien umgewandelt hast, kannst du daraus verschiedene Arten visueller Komponenten erstellen:
+
+![Sprite](images/icons/sprite.png){.icon}
+: Ein Sprite ist entweder ein statisches Bild oder eine Flipbook-Animation, die auf dem Bildschirm angezeigt wird.
+
+  ![Sprite](images/graphics/sprite.png)
+
+Mehr über Sprites erfährst du im [Sprite-Handbuch](/manuals/sprite).
+
+![Kachelkarte](images/icons/tilemap.png){.icon} Kachelkarte
+: Eine Kachelkartenkomponente setzt eine Karte aus Kacheln (Bild und Kollisionsformen) zusammen, die aus einer Kachelquelle stammen. Kachelkarten können keine Atlanten als Quelle verwenden.
+
+  ![Kachelkarte](images/graphics/tilemap.png)
+
+Mehr über Kachelkarten erfährst du im [Handbuch zu Kachelkarten](/manuals/tilemap).
+
+![Partikeleffekt](images/icons/particlefx.png){.icon} Partikeleffekt
+: Partikel, die ein Partikelemitter erzeugt, bestehen aus einem unbewegten Bild oder einer Flipbook-Animation aus einem Atlas oder einer Kachelquelle.
+
+  ![Partikel](images/graphics/particles.png)
+
+Mehr über Partikeleffekte erfährst du im [Handbuch zu Partikeleffekten](/manuals/particlefx).
+
+![GUI](images/icons/gui.png){.icon} GUI
+: Box-Knoten und Kreissektor-Knoten einer GUI können unbewegte Bilder und Flipbook-Animationen aus Atlanten und Kachelquellen verwenden.
+
+  ![GUI](images/graphics/gui.png)
+
+Mehr über GUIs erfährst du im [GUI-Handbuch](/manuals/gui).

--- a/docs/de/manuals/importing-models.md
+++ b/docs/de/manuals/importing-models.md
@@ -1,0 +1,94 @@
+---
+title: Modelle importieren
+brief: Dieses Handbuch beschreibt, wie du 3D-Modelle importierst, die von der Modellkomponente verwendet werden.
+---
+
+# 3D-Modelle importieren {#importing-3d-models}
+Defold unterstützt Modelle, Skelette und Animationen im Format glTF 2.0 (GL Transmission Format). Verwende für 3D-Modelle Dateien im Format *.gltf* oder *.glb*. glTF ist ein modernes Format, das für die Übertragung und das Laden von 3D-Daten in Game-Engines und Echtzeitanwendungen entwickelt wurde.
+
+Du kannst Werkzeuge wie Maya, 3ds Max, SketchUp und Blender verwenden, um 3D-Modelle zu erstellen oder in glTF zu konvertieren.
+
+Blender ist ein leistungsfähiges und beliebtes Programm für 3D-Modellierung, Animation und Rendering. Es läuft unter Windows, macOS und Linux und ist kostenlos unter [https://www.blender.org](https://www.blender.org) verfügbar.
+
+![Modell in Blender](images/model/blender_gltf.png)
+
+## In Defold importieren {#importing-to-defold}
+Um ein Modell zu importieren, ziehe die Datei im Format *.gltf* oder *.glb* in den Bereich *Assets* des Defold-Editors und lege sie dort ab.
+
+glTF kann auf zwei gängige Arten gespeichert werden:
+
+* *.glb* ist eine einzelne Binärdatei. Sie enthält die Modelldaten und kann auch eingebettete Texturbilder enthalten. Das ist praktisch, wenn du ein Modell als eine Datei verschieben oder speichern möchtest.
+* *.gltf* ist eine textbasierte JSON-Datei. Sie verweist normalerweise auf eine separate Datei im Format *.bin* für Mesh-Daten und separate Texturbilder, etwa im Format *.png* oder *.jpg*. Wenn du diese Variante verwendest, füge dem Projekt alle referenzierten Dateien hinzu und behalte ihre relativen Pfade bei.
+
+Wenn das Modell in Defold eine Textur verwenden soll, importiere das Texturbild als separates Asset. Auch wenn die glTF-/GLB-Quelldatei eingebettete Bilder enthält, müssen Texturen der Modellkomponente (model component) über die Materialtextureigenschaften der Komponente zugewiesen werden.
+
+![Importierte Modell-Assets](images/model/assets_gltf.png)
+
+::: sidenote
+Ab Defold 1.13.0 behält Defold die Positionen und Transformationen aus der importierten glTF-Datei bei und zentriert das Modell beim Import nicht mehr automatisch neu. Die Editorvorschau und die Laufzeitumgebung verwenden die importierten Transformationen einheitlich: Meshes mit Skinning oder mit einem Knochen als übergeordnetem Objekt behalten ihre lokalen, auf das Skelett bezogenen Transformationen bei, während starre Meshes ihre nach dem Auflösen der Hierarchie resultierende Platzierung in Weltkoordinaten behalten.
+
+Seit Defold 1.13.2 kann eine [Modellkomponente](/manuals/model/#model-properties) ein einzelnes benanntes Mesh aus der importierten Szene auswählen. Wenn du ihr Feld *Mesh* leer lässt, wird die gesamte Szene verwendet und die oben beschriebenen Transformationen bleiben erhalten. Wenn du ein Mesh auswählst, wird seine lokale Geometrie ohne die Transformationen der glTF-Knoten verwendet. Platziere es daher mithilfe der Transformation der Modellkomponente oder des Spielobjekts (game object).
+
+Wenn sich die Position oder Ausrichtung eines Modells, das mit einer älteren Defold-Version erstellt wurde, nach einem erneuten Import ändert, korrigiere die Transformation in Blender oder einem anderen Erstellungswerkzeug und exportiere die Datei im Format *.gltf* oder *.glb* erneut.
+:::
+
+## Ein Modell verwenden {#using-a-model}
+Nachdem du das Modell importiert hast, verwende es in einer [Modellkomponente](/manuals/model):
+
+1. Erstelle im Bereich *Assets* mit <kbd>New... ▸ Model</kbd> eine Model-Datei oder füge einem Spielobjekt mit <kbd>Add Component ▸ Model</kbd> direkt eine Modellkomponente hinzu.
+2. Setze die Eigenschaft *Scene* auf die importierte Datei im Format *.gltf* oder *.glb*. Lass *Mesh* leer, um die gesamte Szene zu verwenden, oder wähle ein benanntes Mesh aus, um nur seine lokale Geometrie zu verwenden.
+3. Setze bei einem animierten Modell die Eigenschaft *Skeleton* auf die Datei im Format *.gltf* oder *.glb*, die das Skelett enthält. Dies ist häufig dieselbe Datei, die für *Scene* verwendet wird, wenn Mesh, Skelett und Animationen zusammen exportiert werden.
+4. Erstelle für die Animationen eine Datei vom Typ *Animation Set* und weise sie der Eigenschaft *Animations* zu. Lege *Default Animation* fest, wenn eine Animation automatisch starten soll.
+5. Setze die Eigenschaft *Material* auf ein für das Modell geeignetes Material. Die integrierten Dateien *model.material*, *model_instanced.material*, *model_skinned.material* und *model_skinned_instanced.material* sind nützliche Ausgangspunkte. Die Materialien für Skinning verwenden lokale Vertex-Koordinaten, damit das Skinning auf der GPU ausgeführt werden kann. Benutzerdefinierte Materialien für Modelle mit GPU-Skinning oder Instancing sollten ebenfalls lokale Vertex-Koordinaten verwenden. Die Anforderung an den Grafikadapter findest du im [Handbuch zu Modellen](/manuals/model/#material).
+6. Setze die Materialtextureigenschaften, etwa *Texture*, auf die importierten Texturbilddateien. Wenn das Material mehrere Texturen verwendet, weise jede Textur im entsprechenden Texturfeld des Materials zu.
+
+
+## Nach glTF exportieren {#exporting-to-gltf}
+Die exportierte Datei im Format *.gltf* oder *.glb* enthält alle Vertices, Kanten und Flächen, aus denen das Modell besteht, sowie _UV-Koordinaten_ (welcher Teil des Texturbildes auf einen bestimmten Teil des Meshes abgebildet wird), falls du diese definiert hast, die Knochen des Skeletts und Animationsdaten.
+
+* Eine ausführliche Beschreibung von Polygon-Meshes findest du unter http://en.wikipedia.org/wiki/Polygon_mesh.
+
+* UV-Koordinaten und UV-Abbildung werden unter http://en.wikipedia.org/wiki/UV_mapping beschrieben.
+
+Defold legt einige Einschränkungen für exportierte Animationsdaten fest:
+
+* Defold unterstützt derzeit nur vorberechnete Animationen (baked animations). Animationen müssen für jeden animierten Knochen in jedem Schlüsselbild (keyframe) Matrizen enthalten, statt Position, Drehung und Skalierung als separate Schlüsselwerte zu speichern.
+
+* Animationen werden außerdem linear interpoliert. Wenn du eine komplexere Kurveninterpolation verwendest, müssen die Animationen vom Exporter vorberechnet werden.
+
+### Anforderungen {#requirements}
+Beachte beim Export eines Modells, dass sich die glTF-Unterstützung zwischen Werkzeugen und Engines unterscheiden kann. Verwende glTF 2.0, stelle sicher, dass das Modell korrekte UV-Koordinaten hat, wenn es Texturen verwendet, und importiere Texturbilder separat, wenn sie einer Modellkomponente zugewiesen werden sollen.
+
+Unser Ziel ist es, das glTF-Format vollständig zu unterstützen, aber dieses Ziel haben wir noch nicht ganz erreicht.
+Wenn eine Funktion fehlt, reiche bitte einen Funktionswunsch in [unserem Repository](https://github.com/defold/defold/issues) ein.
+
+### Eine Textur exportieren {#exporting-a-texture}
+Wenn du noch keine Textur für dein Modell hast, kannst du mit Blender eine Textur erzeugen. Das solltest du tun, bevor du zusätzliche Materialien aus dem Modell entfernst. Wähle zunächst das Mesh und alle seine Vertices aus:
+
+![Alle auswählen](images/model/blender_select_all_vertices.png)
+
+Wenn alle Vertices ausgewählt sind, wickle das Mesh ab, um das UV-Layout zu erhalten:
+
+![Mesh abwickeln](images/model/blender_unwrap_mesh.png)
+
+Anschließend kannst du das UV-Layout als Bild exportieren, das als Textur verwendet werden kann:
+
+![UV-Layout exportieren](images/model/blender_export_uv_layout.png)
+
+![Ergebnis des UV-Layout-Exports](images/model/blender_export_uv_layout_result.png)
+
+### Mit Blender exportieren {#exporting-using-blender}
+Exportiere dein Modell aus Blender mit <kbd>File ▸ Export ▸ glTF 2.0 (.glb/.gltf)</kbd>.
+
+![Mit Blender exportieren](images/model/export_gltf.png)
+
+Wähle vor dem Export das Objekt oder die Objekte aus und aktiviere *Selected Objects*, wenn du nur die Auswahl exportieren möchtest.
+
+Wähle eine der Optionen unter *Format*:
+
+* *glTF Binary (.glb)* erstellt eine Datei. Verwende diese Option, wenn sich das Modell als einzelnes Asset leicht verschieben oder speichern lassen soll.
+* *glTF Separate (.gltf + .bin + textures)* erstellt separate Dateien für die Modellbeschreibung, Binärdaten und Texturen. Verwende diese Option, wenn du Texturbilder bearbeiten oder sie in Defold separat zuweisen möchtest.
+
+Wenn das Modell Animationen enthält, aktiviere den Animationsexport und stelle sicher, dass die Animationen vorberechnet sind. Wenn das Modell Texturen verwendet, stelle sicher, dass das Mesh für UV-Koordinaten abgewickelt wurde und die Texturbilder in einem Format exportiert werden, das Defold importieren kann, etwa PNG oder JPEG.
+
+![Mit Blender exportieren](images/model/export_settings.png)

--- a/docs/de/manuals/input-gamepads.md
+++ b/docs/de/manuals/input-gamepads.md
@@ -1,0 +1,229 @@
+---
+title: Gamepad-Eingabe in Defold
+brief: Dieses Handbuch erklärt, wie Gamepad-Eingaben funktionieren.
+---
+
+::: sidenote
+Es wird empfohlen, dass du dich damit vertraut machst, wie Eingaben in Defold grundsätzlich funktionieren, wie du sie empfängst und in welcher Reihenfolge deine Skriptdateien sie erhalten. Mehr über das Eingabesystem erfährst du im [Handbuch zur Eingabeübersicht](/manuals/input).
+:::
+
+# Gamepads
+Mit Gamepad-Eingabeauslösern kannst du Standardeingaben von Gamepads an Spielfunktionen binden. Bei Gamepad-Eingaben kannst du eine Eingabebindung (input binding) für folgende Bedienelemente anlegen:
+
+- Linker und rechter Stick (Richtung und Klicks)
+- Linkes und rechtes digitales Steuerkreuz. Das rechte Steuerkreuz entspricht normalerweise den Tasten „A“, „B“, „X“ und „Y“ des Xbox-Controllers sowie den Tasten „Quadrat“, „Kreis“, „Dreieck“ und „Kreuz“ des PlayStation-Controllers.
+- Linker und rechter Trigger
+- Linke und rechte Schultertaste
+- Tasten Start, Back und Guide
+
+![](images/input/gamepad_bindings.png)
+
+::: important
+Die folgenden Beispiele verwenden die Aktionen aus der obigen Abbildung. Wie bei allen Eingaben kannst du deine Eingabeaktionen beliebig benennen.
+:::
+
+## Digitale Tasten {#digital-buttons}
+Digitale Tasten erzeugen die Ereignisse `pressed`, `released` und `repeated`. Das folgende Beispiel zeigt, wie du Eingaben einer digitalen Taste erkennst (Drücken oder Loslassen):
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_lpad_left") then
+        if action.pressed then
+            -- start moving left
+        elseif action.released then
+            -- stop moving left
+        end
+    end
+end
+```
+
+## Analogsticks {#analog-sticks}
+Analogsticks erzeugen fortlaufend Eingabeereignisse, wenn der Stick außerhalb der Totzone bewegt wird, die in der Gamepad-Einstellungsdatei definiert ist (siehe unten). Das folgende Beispiel zeigt, wie du Eingaben eines Analogsticks erkennst:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_lstick_down") then
+        -- left stick was moved down
+        print(action.value) -- a value between 0.0 an -1.0
+    end
+end
+```
+
+Analogsticks erzeugen auch die Ereignisse `pressed` und `released`, wenn sie in eine der vier Hauptrichtungen über einen bestimmten Schwellenwert hinaus bewegt werden. So lässt sich ein Analogstick einfach auch als digitale Richtungseingabe verwenden:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_lstick_down") and action.pressed then
+        -- left stick was moved to its extreme down position
+    end
+end
+```
+
+## Mehrere Gamepads {#multiple-gamepads}
+Defold unterstützt mehrere Gamepads über das Betriebssystem des Geräts. Aktionen setzen das Feld `gamepad` der Tabelle `action` auf die Nummer des Gamepads, von dem die Eingabe stammt:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_start") then
+        if action.gamepad == 0 then
+          -- gamepad 0 wants to join the game
+        end
+    end
+end
+```
+
+## Verbinden und Trennen {#connect-and-disconnect}
+Gamepad-Eingabebindungen bieten auch zwei separate Bindungen namens `Connected` und `Disconnected`, mit denen du erkennst, wenn ein Gamepad verbunden (einschließlich der bereits beim Start verbundenen Geräte) oder getrennt wird.
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_connected") then
+        if action.gamepad == 0 then
+          -- gamepad 0 was connected
+        end
+    elseif action_id == hash("gamepad_disconnected") then
+        if action.gamepad == 0 then
+          -- gamepad 0 was disconnected
+        end
+    end
+end
+```
+
+## Gamepad-Rohdaten {#raw-gamepads}
+
+Gamepad-Eingabebindungen bieten außerdem eine separate Bindung namens `Raw`, die ungefilterte Eingaben (ohne Anwendung der Totzone) der Tasten, Achsen und Rundblickschalter (Hats) jedes verbundenen Gamepads liefert.
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("raw") then
+        pprint(action.gamepad_buttons)
+        pprint(action.gamepad_axis)
+        pprint(action.gamepad_hats)
+    end
+end
+```
+
+## Gamepad-Einstellungsdatei {#gamepads-settings-file}
+Zum Einrichten der Gamepad-Eingabe wird für jeden Gamepad-Hardwaretyp eine separate Zuordnungsdatei verwendet. Die Zuordnungen für bestimmte Gamepad-Modelle werden in einer *gamepads*-Datei festgelegt. Defold enthält eine integrierte gamepads-Datei mit Einstellungen für gängige Gamepads:
+
+![Gamepad-Einstellungen](images/input/gamepads.png)
+
+Wenn du eine neue Gamepad-Einstellungsdatei erstellen musst, steht dir dafür ein einfaches Werkzeug zur Verfügung:
+
+[Klicke hier, um gdc.zip herunterzuladen](https://forum.defold.com/t/big-thread-of-gamepad-testing/56032).
+
+Es enthält ausführbare Dateien für Windows, Linux und macOS. Starte es über die Kommandozeile:
+
+```sh
+./gdc
+```
+
+Das Werkzeug fordert dich auf, verschiedene Tasten auf deinem verbundenen Controller zu drücken. Anschließend gibt es eine neue gamepads-Datei mit den korrekten Zuordnungen für deinen Controller aus. Speichere die neue Datei oder führe sie mit deiner vorhandenen gamepads-Datei zusammen. Aktualisiere dann die Einstellung in *game.project*:
+
+![Gamepad-Einstellungen](images/input/gamepad_setting.png)
+
+### Nicht identifizierte Gamepads {#unidentified-gamepads}
+
+Wenn ein Gamepad verbunden wird und keine Zuordnung dafür vorhanden ist, erzeugt es nur die Aktionen `connected`, `disconnected` und `raw`. In diesem Fall musst du die Gamepad-Rohdaten manuell den Aktionen in deinem Spiel zuordnen.
+
+Du kannst prüfen, ob eine Eingabeaktion für ein Gamepad von einem unbekannten Gamepad stammt, indem du den Wert `gamepad_unknown` aus `action` ausliest:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("connected") then
+        if action.gamepad_unknown then
+            print("The connected gamepad is unidentified and will only generate raw input")
+        else
+            print("The connected gamepad is known and will generate input actions for buttons and sticks")
+        end
+    end
+end
+``` 
+
+## Gamepads in HTML5
+Gamepads werden in HTML5-Builds unterstützt und erzeugen dieselben Eingabeereignisse wie auf anderen Plattformen. Die Gamepad-Unterstützung basiert auf der [Gamepad API](https://www.w3.org/TR/gamepad/), die von den meisten Browsern unterstützt wird ([siehe diese Kompatibilitätsübersicht](https://caniuse.com/?search=gamepad)). Wenn der Browser die Gamepad API nicht unterstützt, ignoriert Defold alle Gamepad-Eingabeauslöser in deinem Projekt ohne Meldung. Du kannst feststellen, ob der Browser die Gamepad API unterstützt, indem du prüfst, ob die Funktion `getGamepads` am Objekt `navigator` vorhanden ist:
+
+```lua
+local function supports_gamepads()
+    return not html5 or (html5.run('typeof navigator.getGamepads === "function"') == "true")
+end
+
+if supports_gamepads() then
+    print("Platform supports gamepads")
+end
+```
+
+Wenn dein Spiel innerhalb eines `iframe` läuft, musst du außerdem sicherstellen, dass dem `iframe` die Berechtigung `gamepad` hinzugefügt wurde:
+
+```html
+<iframe allow="gamepad"></iframe>
+```
+
+### Standard-Gamepad
+
+Wenn der Browser ein verbundenes Gamepad als Standard-Gamepad erkennt, verwendet es die Zuordnung für `Standard Gamepad` in der [Gamepad-Einstellungsdatei](/manuals/input-gamepads/#gamepads-settings-file) (eine Zuordnung für `Standard Gamepad` ist in der Datei `default.gamepads` unter `/builtins` enthalten). Ein Standard-Gamepad ist als Gerät mit 16 Tasten und 2 Analogsticks definiert, dessen Tastenanordnung der eines PlayStation- oder Xbox-Controllers ähnelt (weitere Informationen findest du in der [W3C-Definition und Tastenanordnung](https://w3c.github.io/gamepad/#dfn-standard-gamepad)). Wenn das verbundene Gamepad nicht als Standard-Gamepad erkannt wird, sucht Defold in der Gamepad-Einstellungsdatei nach einer Zuordnung, die dem Gamepad-Hardwaretyp entspricht.
+
+## Gamepads unter Windows {#gamepads-on-windows}
+Unter Windows werden derzeit nur XBox-360-Controller unterstützt. Um deinen 360-Controller mit deinem Windows-Rechner zu verbinden, [stelle sicher, dass er korrekt eingerichtet ist](http://www.wikihow.com/Use-Your-Xbox-360-Controller-for-Windows).
+
+## Gamepads unter Android {#gamepads-on-android}
+
+Gamepads werden in Android-Builds unterstützt und erzeugen dieselben Eingabeereignisse wie auf anderen Plattformen. Die Gamepad-Unterstützung basiert auf dem [Android-Eingabesystem für Tasten- und Bewegungsereignisse](https://developer.android.com/training/game-controllers/controller-input). Die Android-Eingabeereignisse werden mithilfe derselben *gamepad*-Datei wie oben beschrieben in Defold-Gamepad-Ereignisse umgewandelt.
+
+Wenn du unter Android zusätzliche Gamepad-Bindungen hinzufügst, kannst du die folgenden Zuordnungstabellen verwenden, um Android-Eingabeereignisse in Werte für die *gamepad*-Datei zu übersetzen:
+
+| Tastenereignis zu Tastenindex | Index |
+|-----------------------------|-------|
+| `AKEYCODE_BUTTON_A`           | 0     |
+| `AKEYCODE_BUTTON_B`           | 1     |
+| `AKEYCODE_BUTTON_C`           | 2     |
+| `AKEYCODE_BUTTON_X`           | 3     |
+| `AKEYCODE_BUTTON_L1`          | 4     |
+| `AKEYCODE_BUTTON_R1`          | 5     |
+| `AKEYCODE_BUTTON_Y`           | 6     |
+| `AKEYCODE_BUTTON_Z`           | 7     |
+| `AKEYCODE_BUTTON_L2`          | 8     |
+| `AKEYCODE_BUTTON_R2`          | 9     |
+| `AKEYCODE_DPAD_CENTER`        | 10    |
+| `AKEYCODE_DPAD_DOWN`          | 11    |
+| `AKEYCODE_DPAD_LEFT`          | 12    |
+| `AKEYCODE_DPAD_RIGHT`         | 13    |
+| `AKEYCODE_DPAD_UP`            | 14    |
+| `AKEYCODE_BUTTON_START`       | 15    |
+| `AKEYCODE_BUTTON_SELECT`      | 16    |
+| `AKEYCODE_BUTTON_THUMBL`      | 17    |
+| `AKEYCODE_BUTTON_THUMBR`      | 18    |
+| `AKEYCODE_BUTTON_MODE`        | 19    |
+| `AKEYCODE_BUTTON_1`           | 20    |
+| `AKEYCODE_BUTTON_2`           | 21    |
+| `AKEYCODE_BUTTON_3`           | 22    |
+| `AKEYCODE_BUTTON_4`           | 23    |
+| `AKEYCODE_BUTTON_5`           | 24    |
+| `AKEYCODE_BUTTON_6`           | 25    |
+| `AKEYCODE_BUTTON_7`           | 26    |
+| `AKEYCODE_BUTTON_8`           | 27    |
+| `AKEYCODE_BUTTON_9`           | 28    |
+| `AKEYCODE_BUTTON_10`          | 29    |
+| `AKEYCODE_BUTTON_11`          | 30    |
+| `AKEYCODE_BUTTON_12`          | 31    |
+| `AKEYCODE_BUTTON_13`          | 32    |
+| `AKEYCODE_BUTTON_14`          | 33    |
+| `AKEYCODE_BUTTON_15`          | 34    |
+| `AKEYCODE_BUTTON_16`          | 35    |
+
+([Android-Definitionen für `KeyEvent`](https://developer.android.com/ndk/reference/group/input#group___input_1gafccd240f973cf154952fb917c9209719))
+
+| Bewegungsereignis zu Achsenindex | Index |
+|-----------------------------|-------|
+| `AMOTION_EVENT_AXIS_X`        | 0     |
+| `AMOTION_EVENT_AXIS_Y`        | 1     |
+| `AMOTION_EVENT_AXIS_Z`        | 2     |
+| `AMOTION_EVENT_AXIS_RZ`       | 3     |
+| `AMOTION_EVENT_AXIS_LTRIGGER` | 4     |
+| `AMOTION_EVENT_AXIS_RTRIGGER` | 5     |
+| `AMOTION_EVENT_AXIS_HAT_X`    | 6     |
+| `AMOTION_EVENT_AXIS_HAT_Y`    | 7     |
+
+([Android-Definitionen für `MotionEvent`](https://developer.android.com/ndk/reference/group/input#group___input_1ga157d5577a5b2f5986037d0d09c7dc77d))
+
+Verwende diese Zuordnungstabelle zusammen mit einer Gamepad-Test-App aus dem Google Play Store, um herauszufinden, welchem Tastenereignis jede Taste deines Gamepads zugeordnet ist.

--- a/docs/de/manuals/input-key-and-text.md
+++ b/docs/de/manuals/input-key-and-text.md
@@ -1,0 +1,53 @@
+---
+title: Tasten- und Texteingabe in Defold
+brief: Dieses Handbuch erklärt, wie Tasten- und Texteingabe funktionieren.
+---
+
+::: sidenote
+Es wird empfohlen, dass du dich damit vertraut machst, wie Eingaben in Defold grundsätzlich funktionieren, wie du Eingaben empfängst und in welcher Reihenfolge sie in deinen Skriptdateien empfangen werden. Weitere Informationen zum Eingabesystem findest du im [Handbuch zur Eingabeübersicht](/manuals/input).
+:::
+
+# Tastenauslöser {#key-triggers}
+Mit Tastenauslösern (key triggers) kannst du einzelne Tasten auf der Tastatur Aktionen im Spiel zuordnen. Jede Taste wird separat einer entsprechenden Aktion zugeordnet. Tastenauslöser verknüpfen bestimmte Tasten mit bestimmten Funktionen, beispielsweise die Bewegung einer Spielfigur mit den Pfeil- oder WASD-Tasten. Wenn du beliebige Tastatureingaben lesen musst, verwende Textauslöser (siehe unten).
+
+![](images/input/key_bindings.png)
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("left") then
+        if action.pressed then
+            -- start moving left
+        elseif action.released then
+            -- stop moving left
+        end
+    end
+end
+```
+
+# Textauslöser {#text-triggers}
+Textauslöser (text triggers) dienen dazu, beliebige Texteingaben zu lesen. Es gibt zwei Arten von Textauslösern: `text` und `marked-text`.
+
+![](images/input/text_bindings.png)
+
+## Text
+Der Auslöser `text` erfasst normale Texteingaben. Er setzt das Feld `text` der Aktionstabelle auf eine Zeichenfolge, die das eingegebene Zeichen enthält. Die Aktion wird nur beim Drücken der Taste ausgelöst; es wird keine Aktion für `release` oder `repeated` gesendet.
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("text") then
+        -- Concatenate the typed character to the "user" node...
+        local node = gui.get_node("user")
+        local name = gui.get_text(node)
+        name = name .. action.text
+        gui.set_text(node, name)
+    end
+end
+```
+
+## Markierter Text {#marked-text}
+Der Auslöser `marked-text` wird hauptsächlich für asiatische Tastaturen verwendet, bei denen mehrere Tastendrücke einer einzelnen Eingabe entsprechen können. Bei der iOS-Tastatur „Japanese-Kana“ kannst du beispielsweise Kombinationen eingeben. Oben auf der Tastatur werden dann verfügbare Zeichen oder Zeichenfolgen angezeigt, die du eingeben kannst.
+
+![Eingabe von markiertem Text](images/input/marked_text.png)
+
+- Jeder Tastendruck erzeugt eine separate Aktion und setzt das Aktionsfeld `text` auf die aktuell eingegebene Zeichenfolge (den „markierten Text“).
+- Wenn du ein Zeichen oder eine Zeichenkombination auswählst, wird eine separate Auslöseraktion vom Typ `text` gesendet (sofern eine solche in der Liste der Eingabebindungen (input bindings) eingerichtet ist). Die separate Aktion setzt das Aktionsfeld `text` auf die endgültige Zeichenfolge.

--- a/docs/de/manuals/input-mouse-and-touch.md
+++ b/docs/de/manuals/input-mouse-and-touch.md
@@ -1,0 +1,121 @@
+---
+title: Maus- und Berührungseingaben in Defold
+brief: Dieses Handbuch erklärt, wie Maus- und Berührungseingaben funktionieren.
+---
+
+::: sidenote
+Du solltest dich damit vertraut machen, wie Eingaben in Defold grundsätzlich funktionieren, wie du Eingaben empfängst und in welcher Reihenfolge deine Skriptdateien sie empfangen. Mehr über das Eingabesystem erfährst du im [Handbuch zur Eingabeübersicht](/manuals/input).
+:::
+
+# Mausauslöser {#mouse-triggers}
+Mit Mausauslösern kannst du Eingaben von Maustasten und Mausrädern an Spielaktionen binden.
+
+![](images/input/mouse_bindings.png)
+
+::: sidenote
+Die Maustasteneingaben `MOUSE_BUTTON_LEFT`, `MOUSE_BUTTON_RIGHT` und `MOUSE_BUTTON_MIDDLE` entsprechen `MOUSE_BUTTON_1`, `MOUSE_BUTTON_2` und `MOUSE_BUTTON_3`.
+:::
+
+::: important
+Die folgenden Beispiele verwenden die Aktionen aus der Abbildung oben. Wie bei allen Eingaben kannst du deine Eingabeaktionen beliebig benennen.
+:::
+
+## Maustasten {#mouse-buttons}
+Maustasten erzeugen die Ereignisse `pressed`, `released` und `repeated`. Dieses Beispiel zeigt, wie du Eingaben der linken Maustaste erkennst (Drücken oder Loslassen):
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("mouse_button_left") then
+        if action.pressed then
+            -- left mouse button pressed
+        elseif action.released then
+            -- left mouse button released
+        end
+    end
+end
+```
+
+::: important
+Eingabeaktionen für `MOUSE_BUTTON_LEFT` (oder `MOUSE_BUTTON_1`) werden auch bei einzelnen Berührungseingaben gesendet.
+:::
+
+## Mausrad {#mouse-wheel}
+Mausradeingaben erkennen Scrollaktionen. Das Feld `action.value` ist `1`, wenn das Rad gedreht wird, und andernfalls `0`. (Scrollaktionen werden wie Tastendrücke behandelt. Defold unterstützt derzeit keine fein abgestuften Scrolleingaben auf Touchpads.)
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("mouse_wheel_up") then
+        if action.value == 1 then
+            -- mouse wheel is scrolled up
+        end
+    end
+end
+```
+
+## Mausbewegung {#mouse-movement}
+Mausbewegungen werden gesondert behandelt. Ereignisse für Mausbewegungen werden nur empfangen, wenn in deinen Eingabebindungen (input bindings) mindestens ein Mausauslöser eingerichtet ist.
+
+Mausbewegungen werden nicht in den Eingabebindungen zugeordnet. Stattdessen wird `action_id` auf `nil` gesetzt und die Tabelle `action` mit der Position und der Positionsänderung der Maus gefüllt.
+
+```lua
+function on_input(self, action_id, action)
+    if action.x and action.y then
+        -- let game object follow mouse/touch movement
+        local pos = vmath.vector3(action.x, action.y, 0)
+        go.set_position(pos)
+    end
+end
+```
+
+# Auslöser für Berührungseingaben {#touch-triggers}
+Auslöser für einzelne Berührungseingaben und Mehrfacheingaben per Berührung sind auf iOS- und Android-Geräten in nativen Anwendungen und in HTML5-Bundles verfügbar.
+
+![](images/input/touch_bindings.png)
+
+## Einzelne Berührungseingabe {#single-touch}
+Auslöser für einzelne Berührungseingaben werden nicht im Abschnitt Touch Triggers der Eingabebindungen eingerichtet. Stattdessen **werden Auslöser für einzelne Berührungseingaben automatisch eingerichtet, wenn du Maustasteneingaben für `MOUSE_BUTTON_LEFT` oder `MOUSE_BUTTON_1` eingerichtet hast**.
+
+## Mehrfacheingabe per Berührung {#multi-touch}
+Auslöser für Mehrfacheingaben per Berührung füllen eine Tabelle namens `touch` innerhalb der Aktionstabelle. Die Elemente dieser Tabelle sind mit den ganzen Zahlen `1`--`N` indiziert, wobei `N` die Anzahl der Berührungspunkte ist. Jedes Element der Tabelle enthält Felder mit Eingabedaten:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("touch_multi") then
+        -- Spawn at each touch point
+        for i, touchdata in ipairs(action.touch) do
+            local pos = vmath.vector3(touchdata.x, touchdata.y, 0)
+            factory.create("#factory", pos)
+        end
+    end
+end
+```
+
+::: important
+Mehrfacheingaben per Berührung darf nicht dieselbe Aktion zugewiesen werden wie Maustasteneingaben für `MOUSE_BUTTON_LEFT` oder `MOUSE_BUTTON_1`. Wenn du dieselbe Aktion zuweist, werden einzelne Berührungseingaben überschrieben, und du kannst keine Ereignisse für einzelne Berührungseingaben mehr empfangen.
+:::
+
+::: sidenote
+Mit dem [Asset Defold-Input](https://defold.com/assets/defoldinput/) kannst du leicht virtuelle Bildschirmsteuerelemente wie Schaltflächen und Analogsticks mit Unterstützung für Mehrfacheingaben per Berührung einrichten.
+:::
+
+
+## Klicks oder Antippen auf Objekten erkennen {#detecting-click-or-tap-on-objects}
+Zu erkennen, wann jemand eine visuelle Komponente (component) angeklickt oder angetippt hat, ist ein sehr häufiger Vorgang, der in vielen Spielen benötigt wird. Dabei kann es sich um die Interaktion mit einer Schaltfläche oder einem anderen UI-Element handeln oder um die Interaktion mit einem Spielobjekt (game object), etwa einer vom Spieler gesteuerten Einheit in einem Strategiespiel, einem Schatz in einem Level eines Dungeon-Crawlers oder einem Auftraggeber in einem RPG. Welche Vorgehensweise du verwendest, hängt von der Art der visuellen Komponente ab.
+
+### Interaktionen mit GUI-Knoten erkennen {#detecting-interaction-with-gui-nodes}
+Für UI-Elemente gibt es die Funktion `gui.pick_node(node, x, y)`. Sie gibt `true` oder `false` zurück, je nachdem, ob die angegebene Koordinate innerhalb der Grenzen eines GUI-Knotens (GUI node) liegt. Weitere Informationen findest du in der [API-Dokumentation](/ref/gui/#gui.pick_node:node-x-y), im [Beispiel für das Bewegen des Mauszeigers über einen Knoten](/examples/gui/pointer_over/) oder im [Schaltflächenbeispiel](/examples/gui/button/).
+
+### Interaktionen mit Spielobjekten erkennen {#detecting-interaction-with-game-objects}
+Bei Spielobjekten ist es komplizierter, Interaktionen zu erkennen, da beispielsweise die Verschiebung der Kamera und die Projektion des Render-Skripts die erforderlichen Berechnungen beeinflussen. Es gibt zwei grundsätzliche Vorgehensweisen, um Interaktionen mit Spielobjekten zu erkennen:
+
+  1. Verfolge die Position und Größe der Spielobjekte, mit denen interagiert werden kann, und prüfe, ob die Maus- oder Berührungskoordinate innerhalb der Grenzen eines dieser Objekte liegt.
+  2. Füge den Spielobjekten, mit denen interagiert werden kann, Kollisionsobjekte (collision objects) hinzu. Füge außerdem ein Kollisionsobjekt hinzu, das der Maus oder dem Finger folgt, und prüfe auf Kollisionen zwischen ihnen.
+
+::: sidenote
+Eine einsatzbereite Lösung, die mit Kollisionsobjekten Eingaben erkennt und dabei Ziehen und Klicken unterstützt, findest du im [Asset Defold-Input](https://defold.com/assets/defoldinput/).
+:::
+
+In beiden Fällen musst du zwischen den Koordinaten des Maus- oder Berührungsereignisses im Bildschirmkoordinatensystem und den Koordinaten der Spielobjekte im Weltkoordinatensystem umrechnen. Das ist auf verschiedene Arten möglich:
+
+  * Verfolge manuell, welche Ansicht und Projektion das Render-Skript verwendet, und nutze diese Informationen, um in das Weltkoordinatensystem und daraus zurück umzurechnen. Ein Beispiel dafür findest du im [Kamerahandbuch](/manuals/camera/#converting-mouse-to-world-coordinates).
+  * Verwende eine [Kameralösung eines Drittanbieters](/manuals/camera/#third-party-camera-solutions) und nutze die bereitgestellten Funktionen zur Umrechnung vom Bildschirm- in das Weltkoordinatensystem.

--- a/docs/de/manuals/input.md
+++ b/docs/de/manuals/input.md
@@ -1,0 +1,221 @@
+---
+title: Geräteeingabe in Defold
+brief: Dieses Handbuch erklärt, wie Eingaben funktionieren, wie du Eingabeaktionen erfasst und interaktive Reaktionen in Skripten erstellst.
+---
+
+# Eingabe {#input}
+
+Die Engine erfasst alle Benutzereingaben und leitet sie als Aktionen an Komponenten (components) vom Typ Skript oder GUI-Skript in Spielobjekten (game objects) weiter, die den Eingabefokus erhalten haben und die Funktion `on_input()` implementieren. Dieses Handbuch erklärt, wie du Eingabebindungen (input bindings) zum Erfassen von Eingaben einrichtest und Code erstellst, der darauf reagiert.
+
+Das Eingabesystem verwendet einige einfache und leistungsfähige Konzepte, mit denen du Eingaben so verwalten kannst, wie es für dein Spiel sinnvoll ist.
+
+![Eingabebindungen](images/input/overview.png)
+
+Geräte
+: Eingabegeräte, die Teil deines Computers oder Mobilgeräts oder daran angeschlossen sind, liefern unverarbeitete Eingaben auf Systemebene an die Defold-Laufzeitumgebung. Die folgenden Gerätetypen werden unterstützt:
+
+  1. Tastatur (einzelne Tasten sowie Texteingabe)
+  2. Maus (Position, Tastenklicks und Mausradaktionen)
+  3. Berührungseingabe mit einer oder mehreren Berührungen (auf iOS- und Android-Geräten sowie in HTML5 auf Mobilgeräten)
+  4. Gamepads (soweit sie vom Betriebssystem unterstützt und in der Datei [gamepads](/manuals/input-gamepads/#gamepads-settings-file) zugeordnet werden)
+
+Eingabebindungen
+: Bevor die Eingabe an ein Skript gesendet wird, werden die unverarbeiteten Eingaben des Geräts über die Tabelle der Eingabebindungen in sinnvolle *Aktionen* übersetzt.
+
+Aktionen
+: Aktionen werden anhand der (gehashten) Namen identifiziert, die du in der Datei für Eingabebindungen aufführst. Jede Aktion enthält außerdem relevante Daten zur Eingabe: ob eine Taste gedrückt oder losgelassen wird, die Koordinaten der Maus oder Berührung usw.
+
+Eingabeempfänger
+: Skriptkomponenten und GUI-Skripte können Eingabeaktionen empfangen, indem sie *den Eingabefokus anfordern*. Mehrere Empfänger können gleichzeitig aktiv sein.
+
+Eingabestapel
+: Die Liste der Eingabeempfänger, bei der der Empfänger, der den Fokus zuerst angefordert hat, ganz unten im Stapel steht und der letzte ganz oben.
+
+Eingaben abfangen
+: Ein Skript kann entscheiden, die empfangene Eingabe abzufangen, sodass Empfänger weiter unten im Stapel sie nicht erhalten.
+
+## Eingabebindungen einrichten {#setting-up-input-bindings}
+
+Die Eingabebindungen bilden eine projektweite Tabelle, mit der du festlegst, wie Geräteeingaben in benannte *Aktionen* übersetzt werden, bevor sie an deine Skriptkomponenten und GUI-Skripte weitergeleitet werden. Du kannst eine neue Datei für Eingabebindungen erstellen, indem du einen <kbd>Rechtsklick</kbd> auf einen Ort in der Ansicht *Assets* ausführst und <kbd>New... ▸ Input Binding</kbd> wählst. Damit die Engine die neue Datei verwendet, ändere den Eintrag *Game Binding* in *game.project*.
+
+![Einstellung für Eingabebindungen](images/input/setting.png)
+
+Bei allen neuen Projektvorlagen wird automatisch eine Standarddatei für Eingabebindungen erstellt, daher musst du normalerweise keine neue Bindungsdatei erstellen. Die Standarddatei heißt `game.input_binding` und befindet sich im Ordner `input` im Projektstammverzeichnis. <kbd>Doppelklicke</kbd> auf die Datei, um sie im Editor zu öffnen:
+
+![Eingabebindungen festlegen](images/input/input_binding.png)
+
+Um eine neue Bindung zu erstellen, klicke unten im Abschnitt des entsprechenden Auslösertyps auf die Schaltfläche <kbd>+</kbd>. Jeder Eintrag hat zwei Felder:
+
+*Input*
+: Die unverarbeitete Eingabe, auf die reagiert werden soll, ausgewählt aus einer scrollbaren Liste verfügbarer Eingaben.
+
+*Action*
+: Der Aktionsname, den Eingabeaktionen erhalten, wenn sie erstellt und an deine Skripte weitergeleitet werden. Derselbe Aktionsname kann mehreren Eingaben zugewiesen werden. Beispielsweise kannst du die Taste <kbd>Space</kbd> und die Gamepad-Taste `A` an die Aktion `jump` binden. Beachte, dass es einen bekannten Fehler gibt, durch den Berührungseingaben leider nicht dieselben Aktionsnamen wie andere Eingaben haben können.
+
+## Auslösertypen {#trigger-types}
+
+Du kannst fünf gerätespezifische Arten von Auslösern erstellen:
+
+Key Triggers
+: Eingabe einzelner Tastaturtasten. Jede Taste wird separat einer entsprechenden Aktion zugeordnet. Weitere Informationen findest du im [Handbuch zur Tasten- und Texteingabe](/manuals/input-key-and-text).
+
+Text Triggers
+: Textauslöser werden verwendet, um beliebige Texteingaben zu lesen. Weitere Informationen findest du im [Handbuch zur Tasten- und Texteingabe](/manuals/input-key-and-text)
+
+Mouse Triggers
+: Eingaben von Maustasten und Mausrädern. Weitere Informationen findest du im [Handbuch zur Maus- und Berührungseingabe](/manuals/input-mouse-and-touch).
+
+Touch Triggers
+: Auslöser für Berührungseingaben mit einer oder mehreren Berührungen sind auf iOS- und Android-Geräten in nativen Anwendungen und in HTML5-Bundles verfügbar. Weitere Informationen findest du im [Handbuch zur Maus- und Berührungseingabe](/manuals/input-mouse-and-touch).
+
+Gamepad Triggers
+: Gamepad-Auslöser ermöglichen es dir, Standard-Gamepad-Eingaben an Spielfunktionen zu binden. Weitere Informationen findest du im [Gamepad-Handbuch](/manuals/input-gamepads).
+
+### Eingabe des Beschleunigungssensors {#accelerometer-input}
+
+Zusätzlich zu den fünf oben aufgeführten Auslösertypen unterstützt Defold auch Eingaben des Beschleunigungssensors in nativen Android- und iOS-Anwendungen. Aktiviere das Kontrollkästchen *Use Accelerometer* im Abschnitt *Input* deiner Datei *game.project*.
+
+```lua
+function on_input(self, action_id, action)
+    if action.acc_x and action.acc_y and action.acc_z then
+        -- react to accelerometer data
+    end
+end
+```
+
+## Eingabefokus {#input-focus}
+
+Um in einer Skriptkomponente oder einem GUI-Skript auf Eingabeaktionen zu reagieren, sollte die Nachricht `acquire_input_focus` an das Spielobjekt gesendet werden, das die Komponente enthält:
+
+```lua
+-- tell the current game object (".") to acquire input focus
+msg.post(".", "acquire_input_focus")
+```
+
+Diese Nachricht weist die Engine an, eingabefähige Komponenten in den Spielobjekten zum *Eingabestapel* hinzuzufügen. Dazu gehören Skriptkomponenten, GUI-Komponenten und Sammlungs-Proxys (collection proxies). Die Komponenten der Spielobjekte werden oben auf den Eingabestapel gelegt; die zuletzt hinzugefügte Komponente steht ganz oben im Stapel. Beachte, dass alle Komponenten zum Stapel hinzugefügt werden, wenn das Spielobjekt mehr als eine eingabefähige Komponente enthält:
+
+![Eingabestapel](images/input/input_stack.png)
+
+Wenn ein Spielobjekt, das den Eingabefokus bereits angefordert hat, dies erneut tut, werden seine Komponenten an die oberste Stelle des Stapels verschoben.
+
+
+## Weiterleitung von Eingaben und on_input() {#input-dispatch-and-on_input}
+
+Eingabeaktionen werden entsprechend dem Eingabestapel von oben nach unten weitergeleitet.
+
+![Weiterleitung von Aktionen](images/input/actions.png)
+
+Bei jeder Komponente im Stapel, die eine Funktion `on_input()` enthält, wird diese Funktion einmal für jede Eingabeaktion während des Frames mit den folgenden Argumenten aufgerufen:
+
+`self`
+: Die aktuelle Skriptinstanz.
+
+`action_id`
+: Der gehashte Name der Aktion, wie in den Eingabebindungen festgelegt.
+
+`action`
+: Eine Tabelle mit den nützlichen Daten zur Aktion, etwa dem Eingabewert, ihrer Position (absolute Position und Positionsänderung), ob bei einer Tasteneingabe `pressed` gesetzt war usw. Einzelheiten zu den verfügbaren Aktionsfeldern findest du unter [on_input()](/ref/go#on_input).
+
+```lua
+function on_input(self, action_id, action)
+  if action_id == hash("left") and action.pressed then
+    -- move left
+    local pos = go.get_position()
+    pos.x = pos.x - 100
+    go.set_position(pos)
+  elseif action_id == hash("right") and action.pressed then
+    -- move right
+    local pos = go.get_position()
+    pos.x = pos.x + 100
+    go.set_position(pos)
+  end
+end
+```
+
+
+### Eingabefokus und Sammlungs-Proxy-Komponenten {#input-focus-and-collection-proxy-components}
+
+Jede Spielwelt, die dynamisch über einen Sammlungs-Proxy geladen wird, hat ihren eigenen Eingabestapel. Damit die Weiterleitung von Aktionen den Eingabestapel der geladenen Welt erreicht, muss sich die Proxy-Komponente im Eingabestapel der Hauptwelt befinden. Alle Komponenten im Stapel einer geladenen Welt werden verarbeitet, bevor die Weiterleitung im Hauptstapel nach unten fortgesetzt wird:
+
+![Weiterleitung von Aktionen an Proxys](images/input/proxy.png)
+
+::: important
+Ein häufiger Fehler besteht darin, das Senden von `acquire_input_focus` an das Spielobjekt zu vergessen, das die Sammlungs-Proxy-Komponente enthält. Wenn du diesen Schritt überspringst, erreichen Eingaben keine der Komponenten im Eingabestapel der geladenen Welt.
+:::
+
+
+### Eingabefokus freigeben {#releasing-input}
+
+Um nicht mehr auf Eingabeaktionen zu reagieren, sende eine Nachricht `release_input_focus` an das Spielobjekt. Diese Nachricht entfernt alle Komponenten des Spielobjekts aus dem Eingabestapel:
+
+```lua
+-- tell the current game object (".") to release input focus.
+msg.post(".", "release_input_focus")
+```
+
+
+## Eingaben abfangen {#consuming-input}
+
+Die Funktion `on_input()` einer Komponente kann aktiv steuern, ob Aktionen im Stapel weiter nach unten weitergegeben werden sollen:
+
+- Wenn `on_input()` den Wert `false` zurückgibt oder keine Rückgabe erfolgt (dies entspricht der Rückgabe von `nil`, das in Lua als falsch gilt), werden Eingabeaktionen an die nächste Komponente im Eingabestapel weitergegeben.
+- Wenn `on_input()` den Wert `true` zurückgibt, wird die Eingabe abgefangen. Keine Komponente weiter unten im Eingabestapel erhält die Eingabe. Beachte, dass dies für *alle* Eingabestapel gilt. Eine Komponente im Stapel einer über einen Proxy geladenen Welt kann Eingaben abfangen und dadurch verhindern, dass Komponenten im Hauptstapel Eingaben erhalten:
+
+![Eingaben abfangen](images/input/consuming.png)
+
+Es gibt viele gute Anwendungsfälle, in denen das Abfangen von Eingaben eine einfache und leistungsfähige Möglichkeit bietet, Eingaben zwischen verschiedenen Teilen eines Spiels umzuleiten. Das ist beispielsweise hilfreich, wenn du ein Pop-up-Menü benötigst, das vorübergehend als einziger Teil des Spiels auf Eingaben reagiert:
+
+![Eingaben abfangen](images/input/game.png)
+
+Das Pausenmenü ist anfangs ausgeblendet (deaktiviert) und wird aktiviert, wenn der Spieler das HUD-Element `PAUSE` berührt:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("mouse_press") and action.pressed then
+        -- Did the player press PAUSE?
+        local pausenode = gui.get_node("pause")
+        if gui.pick_node(pausenode, action.x, action.y) then
+            -- Tell the pause menu to take over.
+            msg.post("pause_menu", "show")
+        end
+    end
+end
+```
+
+![Pausenmenü](images/input/game_paused.png)
+
+Die GUI des Pausenmenüs fordert den Eingabefokus an und fängt Eingaben ab, sodass nur noch die für das Pop-up-Menü relevanten Eingaben verarbeitet werden:
+
+```lua
+function on_message(self, message_id, message, sender)
+  if message_id == hash("show") then
+    -- Show the pause menu.
+    local node = gui.get_node("pause_menu")
+    gui.set_enabled(node, true)
+
+    -- Acquire input.
+    msg.post(".", "acquire_input_focus")
+  end
+end
+
+function on_input(self, action_id, action)
+  if action_id == hash("mouse_press") and action.pressed then
+
+    -- do things...
+
+    local resumenode = gui.get_node("resume")
+    if gui.pick_node(resumenode, action.x, action.y) then
+        -- Hide the pause menu
+        local node = gui.get_node("pause_menu")
+        gui.set_enabled(node, false)
+
+        -- Release input.
+        msg.post(".", "release_input_focus")
+    end
+  end
+
+  -- Consume all input. Anything below us on the input stack
+  -- will never see input until we release input focus.
+  return true
+end
+```

--- a/docs/de/manuals/install.md
+++ b/docs/de/manuals/install.md
@@ -1,0 +1,10 @@
+---
+title: Defold installieren
+brief: Dieses Handbuch erklärt, wie du den Defold-Editor für dein Betriebssystem herunterlädst und installierst.
+---
+
+# Defold installieren {#installing-defold}
+
+Die Installation des Defold-Editors ist recht unkompliziert. Lade die für dein Betriebssystem erstellte Version herunter, entpacke sie und kopiere die Software an einen geeigneten Speicherort.
+
+:[install](../shared/install.md)

--- a/docs/de/manuals/instant-games.md
+++ b/docs/de/manuals/instant-games.md
@@ -1,0 +1,6 @@
+---
+title: Facebook Instant Games
+brief: Dieses Handbuch erklärt, wie du mit Defold Facebook Instant Games erstellst.
+---
+
+[Dieses Handbuch wurde verschoben](/extension-fbinstant)

--- a/docs/de/manuals/introduction.md
+++ b/docs/de/manuals/introduction.md
@@ -1,0 +1,74 @@
+---
+brief: Eine kurze Einführung in Defold. Hier kannst du dein Abenteuer mit der Spieleentwicklung und Defold beginnen.
+github: https://github.com/defold/doc
+layout: manual
+locale: de
+title: Einführung in Defold
+toc:
+- Willkommen bei Defold
+- Wo fängst du an?
+---
+
+## Willkommen bei Defold {#welcome-to-defold}
+
+Defold ist eine kostenlose, schlanke und leistungsstarke Komplettlösung für die Entwicklung von 2D- und 3D-Spielen. Sie vereint eine Game-Engine, einen Editor und ein Build-Ökosystem und bietet dir alles, was du brauchst, um Spiele zu entwerfen, zu erstellen und zu veröffentlichen. Die vollständige Liste der unterstützten Funktionen findest du in unserer [Produktübersicht](/product).
+
+Wir haben viel Zeit und Mühe darauf verwendet, bestimmte zentrale Schritte der Spieleentwicklung so reibungslos und mühelos wie möglich zu gestalten. Wir glauben, dass sich Defold dadurch von anderen Lösungen abhebt. Erfahre, [warum du unserer Meinung nach Defold verwenden solltest](/why).
+
+## Wo fängst du an? {#where-to-start}
+
+Unser [**Lernportal**](/learn) ist die Anlaufstelle für alle Lernmaterialien zu Defold. Dort findest du:
+
+- [**Handbücher**](/manuals) (wie dieses hier) - um ein bestimmtes Thema gründlich zu verstehen und dein Wissen zu erweitern
+- [**Tutorials**](/tutorials) - um mithilfe angeleiteter Schritt-für-Schritt-Anweisungen etwas zu erstellen
+- [**Beispiele**](/examples) - kurze Codeausschnitte sowie einfache, kleine, in sich abgeschlossene Funktionen und Beispiele
+- [**Kurse**](/courses) - ausführliche, umfassende und strukturierte Lektionen auf Zenva und Udemy sowie von der Community erstellte Kurse
+- [**Videos**](/videos) - wenn du lieber zuschaust, stehen dir viele Video-Tutorials und Übersichten zur Auswahl
+- [**API**](/ref/stable/overview_defoldlua) - um alle bereitgestellten Funktionen und Konstanten mithilfe unserer aktuellen und vollständigen Dokumentation zu verstehen
+- [**FAQ**](/faq/faq) - mit Antworten auf die am häufigsten gestellten Fragen - suche dort nach, ob dein Problem vielleicht schon gelöst wurde
+
+Wir ermutigen dich, zu experimentieren, Tutorials durchzuarbeiten, unsere Handbücher und die API-Dokumentation zu lesen und dich unseren [Community-Kanälen](/community) anzuschließen. Dort kannst du Fragen stellen, von anderen lernen und die Entwicklung von Defold verfolgen.
+
+Hier sind einige hilfreiche Hinweise für deinen Einstieg in die Spieleentwicklung oder in Defold:
+
+### Defold-Editor
+
+[![Übersicht des Editors](images/editor/editor_overview.png)](/manuals/editor)
+
+[Die Übersicht des Editors](/manuals/editor/) bietet eine gute Einführung und hilft dir, dich zurechtzufinden, die visuellen Werkzeuge zu verwenden und Code zu schreiben. Wenn du mit Editoren anderer Game-Engines, 3D-Modellierungsprogrammen und Programmier-IDEs vertraut bist, sollte es nicht viele Überraschungen geben. Manche Dinge werden sich aber immer von deiner bevorzugten Software unterscheiden.
+
+### Die Bausteine von Defold {#the-building-blocks-of-defold}
+
+[![Bausteine](images/building_blocks/building_blocks.png)](/manuals/building-blocks)
+
+Das Handbuch [Die Bausteine von Defold](/manuals/building-blocks/) bietet eine hilfreiche Einführung in die grundlegenden Konzepte der Spieleentwicklung in Defold. Zum Erstellen von Spielen verwendet Defold Spielobjekte (game objects) mit verschiedenen Arten von Komponenten (components). Die Spielobjekte werden wiederum in Sammlungen (collections) gruppiert. Diese Konzepte kommen dir vielleicht bekannt vor, wenn du bereits andere Engines verwendet hast. Einige Architekturentscheidungen machen die Bausteine von Defold besonders, und es dauert einen Moment, bis du dich an die Arbeit mit ihnen gewöhnt hast. Deshalb ist unser Handbuch zu den Bausteinen ein guter Einstieg, besonders wenn du verstehen möchtest, wie alles funktioniert.
+
+### Beispiele {#examples}
+
+[![Beispiele](images/introduction/examples.png)](/examples)
+
+Die Zusammenstellung von [Beispielen](/examples/) ist eine gute Einführung darin, wie du einzelne Teile zu etwas Funktionierendem zusammenfügst. Dort findest du minimale Beispiele für eine Vielzahl häufiger Aufgaben in Defold, Codeausschnitte zum Verwenden, Beispiele für einige gängige Funktionen und Vorführungen bestimmter Funktionen.
+
+### Tutorials
+
+[![Tutorials](images/introduction/tutorials.png)](/tutorials)
+
+[Tutorials](/tutorials) eignen sich hervorragend für deinen Einstieg in die Spieleentwicklung. Wir glauben, dass du am besten durch Ausprobieren lernst. Deshalb bieten wir eine Auswahl an Tutorials für verschiedene Kenntnisstände und mit unterschiedlicher Komplexität an, die direkt über [den Editor](/manuals/editor/) und in unserem Lernportal verfügbar sind. Starte den Editor und folge den Schritt-für-Schritt-Anweisungen, um zu lernen, wie du etwas erstellst und wie Defold funktioniert.
+
+### Die Sprache Lua {#the-lua-language}
+
+[![Übersicht zu Lua](images/introduction/lua.png)](/manuals/lua)
+
+[Lua](/manuals/lua/) ist die Sprache, die Defold für die gesamte Logiksteuerung verwendet. Intern arbeitet eine schnelle C++-Engine, die auf höherer Ebene durch Lua-Skripte gesteuert wird. Wenn du bereits in Python, GDScript, GML, JavaScript oder einer anderen höheren Programmiersprache programmiert hast, wird dir Lua recht leicht zugänglich sein, und du kannst wahrscheinlich problemlos einem Tutorial folgen. Andernfalls lies unser Lua-Handbuch und mache von dort aus weiter.
+
+### Das Defold-Forum {#the-defold-forum}
+
+[![Forum](images/introduction/forum.png)](//forum.defold.com/)
+
+[Das Defold-Forum](//forum.defold.com/) ist oft der beste Weg, um zu lernen. Du kannst von anderen lernen, das Forum durchsuchen, um herauszufinden, ob deine Frage schon einmal beantwortet wurde, oder direkt nachfragen. Unsere Community ist sehr freundlich, hilfsbereit und kennt sich mit der Spieleentwicklung im Allgemeinen und mit Defold im Besonderen bestens aus. Wenn du einmal nicht weiterkommst, zögere nicht und suche im Forum nach Hilfe!
+
+### Lernportal {#learning-hub}
+
+Denke daran: Ganz gleich, welchen Weg du beim Lernen von Defold einschlägst, du kannst jederzeit zu unserem [**Lernportal**](/learn) zurückkehren, um weitere Lernmaterialien zu finden und Handbücher mit ausführlichen Erklärungen zu den verschiedenen Funktionen und Konzepten von Defold zu lesen. Zögere auch nicht, auf Dinge hinzuweisen, die du nicht verstehst oder für falsch hältst. Diese Seiten sind für dich da, und wir möchten sie so gut wie möglich gestalten. Deshalb berücksichtigen wir das Feedback der Nutzer und verbessern die Materialien, um dir das Lernen so leicht wie möglich zu machen!
+
+Wir hoffen, dass du viel Freude daran hast, dein nächstes großartiges Spiel mit Defold zu erstellen!

--- a/docs/de/manuals/ios.md
+++ b/docs/de/manuals/ios.md
@@ -1,0 +1,273 @@
+---
+title: Entwicklung mit Defold für die iOS-Plattform
+brief: Dieses Handbuch erklärt, wie du in Defold Spiele und Apps für iOS-Geräte erstellst und ausführst.
+---
+
+# Entwicklung für iOS {#ios-development}
+
+::: sidenote
+Das Erstellen eines Bundles für iOS ist nur in der Mac-Version des Defold-Editors verfügbar.
+:::
+
+iOS verlangt, dass _jede_ App, die du erstellst und auf deinem Telefon oder Tablet ausführen möchtest, mit einem von Apple ausgestellten Zertifikat und Bereitstellungsprofil (provisioning profile) signiert werden _muss_. Dieses Handbuch erläutert die Schritte zur Erstellung eines Bundles deines Spiels für iOS. Während der Entwicklung ist es oft vorzuziehen, dein Spiel über die [Entwicklungs-App](/manuals/dev-app) auszuführen, da du damit Inhalte und Code per Hot Reload direkt auf dein Gerät laden kannst.
+
+## Apples Verfahren zur Codesignierung {#apples-code-signing-process}
+
+Die Sicherheit von iOS-Apps setzt sich aus mehreren Bestandteilen zusammen. Zugang zu den benötigten Werkzeugen erhältst du, indem du dich für das [iOS Developer Program von Apple](https://developer.apple.com/programs/) anmeldest. Rufe nach deiner Anmeldung das [Developer Member Center von Apple](https://developer.apple.com/membercenter/index.action) auf.
+
+![Apple Member Center](images/ios/apple_member_center.png)
+
+Der Bereich *Certificates, Identifiers & Profiles* enthält alle Werkzeuge, die du benötigst. Hier kannst du Folgendes erstellen, löschen und bearbeiten:
+
+Certificates
+: Von Apple ausgestellte kryptografische Zertifikate, die dich als Entwickler identifizieren. Du kannst Entwicklungs- oder Produktionszertifikate erstellen. Mit Entwicklungszertifikaten kannst du bestimmte Funktionen wie den Mechanismus für In-App-Käufe in einer Sandbox-Testumgebung testen. Produktionszertifikate werden verwendet, um die fertige App für das Hochladen in den App Store zu signieren. Du benötigst ein Zertifikat, um Apps zu signieren, bevor du sie zum Testen auf dein Gerät übertragen kannst.
+
+Identifiers
+: Kennungen für verschiedene Verwendungszwecke. Du kannst Kennungen mit Platzhaltern registrieren (z. B. `some.prefix.*`), die sich für mehrere Apps verwenden lassen. App-IDs können Informationen zu Anwendungsdiensten enthalten, etwa dazu, ob die App die Integration von Passbook, Game Center usw. aktiviert. Solche App-IDs können keine Kennungen mit Platzhaltern sein. Damit Anwendungsdienste funktionieren, muss die *Bundle-ID* deiner Anwendung mit der App-ID übereinstimmen.
+
+Devices
+: Jedes Entwicklungsgerät muss mit seiner UDID (Unique Device IDentifier, siehe unten) registriert werden.
+
+Provisioning Profiles
+: Bereitstellungsprofile verknüpfen Zertifikate mit App-IDs und einer Liste von Geräten. Sie legen fest, welche App von welchem Entwickler auf welchen Geräten vorhanden sein darf.
+
+Zum Signieren deiner Spiele und Apps in Defold benötigst du ein gültiges Zertifikat und ein gültiges Bereitstellungsprofil.
+
+::: sidenote
+Einige der Aktionen auf der Startseite des Member Center kannst du auch in der Entwicklungsumgebung Xcode ausführen---sofern du sie installiert hast.
+:::
+
+Gerätekennung (UDID)
+: Die UDID eines iOS-Geräts findest du, indem du das Gerät per WLAN oder Kabel mit einem Computer verbindest. Öffne Xcode und wähle <kbd>Window ▸ Devices and Simulators</kbd>. Wenn du dein Gerät auswählst, werden die Seriennummer und die Kennung angezeigt.
+
+  ![Geräte in Xcode](images/ios/xcode_devices.png)
+
+  Wenn du Xcode nicht installiert hast, kannst du die Kennung in iTunes finden. Klicke auf das Gerätesymbol und wähle dein Gerät aus.
+
+  ![Geräte in iTunes](images/ios/itunes_devices.png)
+
+  1. Suche auf der Seite *Summary* nach *Serial Number*.
+  2. Klicke einmal auf *Serial Number*, damit das Feld zu *UDID* wechselt. Wenn du wiederholt klickst, werden verschiedene Informationen zum Gerät angezeigt. Klicke einfach weiter, bis *UDID* erscheint.
+  3. Klicke mit der rechten Maustaste auf die lange UDID-Zeichenfolge und wähle <kbd>Copy</kbd>, um die Kennung in die Zwischenablage zu kopieren. So kannst du sie bei der Registrierung des Geräts im Developer Member Center von Apple bequem in das UDID-Feld einfügen.
+
+## Mit einem kostenlosen Apple-Entwicklerkonto entwickeln {#developing-using-a-free-apple-developer-account}
+
+Seit Xcode 7 kann jeder Xcode installieren und kostenlos direkt auf einem Gerät entwickeln. Du musst dich nicht für das iOS Developer Program anmelden. Stattdessen stellt Xcode automatisch ein Zertifikat für dich als Entwickler (1 Jahr gültig) und ein Bereitstellungsprofil für deine App (eine Woche gültig) auf deinem jeweiligen Gerät aus.
+
+1. Verbinde dein Gerät.
+2. Installiere Xcode.
+3. Füge Xcode ein neues Konto hinzu und melde dich mit deiner Apple-ID an.
+4. Erstelle ein neues Projekt. Die einfachste Vorlage `Single View App` eignet sich dafür.
+5. Wähle dein `Team` (wird automatisch für dich erstellt) und gib der App eine Bundle-ID.
+
+::: important
+Notiere dir die Bundle-ID, da du dieselbe Bundle-ID in deinem Defold-Projekt verwenden musst.
+:::
+
+6. Stelle sicher, dass Xcode ein *Provisioning Profile* und ein *Signing Certificate* für die App erstellt hat.
+
+   ![](images/ios/xcode_certificates.png)
+
+7. Erstelle den Build der App auf deinem Gerät. Beim ersten Mal fordert Xcode dich auf, den Entwicklermodus zu aktivieren, und bereitet das Gerät mit Debugger-Unterstützung vor. Dies kann eine Weile dauern.
+8. Wenn du geprüft hast, dass die App funktioniert, suche sie auf deinem Datenträger. Den Speicherort des Builds findest du im Build-Bericht im `Report Navigator`.
+
+   ![](images/ios/app_location.png)
+
+9. Suche die App, klicke mit der rechten Maustaste darauf und wähle <kbd>Show Package Contents</kbd>.
+
+   ![](images/ios/app_contents.png)
+
+10. Kopiere die Datei `embedded.mobileprovision` an einen Ort auf deinem Laufwerk, an dem du sie wiederfindest.
+
+   ![](images/ios/free_provisioning.png)
+
+Mit dieser Bereitstellungsdatei und deiner Identität für die Codesignierung kannst du eine Woche lang Apps in Defold signieren.
+
+Wenn die Gültigkeit des Bereitstellungsprofils abläuft, musst du den Build der App erneut in Xcode erstellen und dir wie oben beschrieben eine neue temporäre Bereitstellungsdatei beschaffen.
+
+## Ein iOS-Anwendungsbundle erstellen {#creating-an-ios-application-bundle}
+
+Sobald du die Identität für die Codesignierung und das Bereitstellungsprofil hast, kannst du im Editor ein eigenständiges Anwendungsbundle für dein Spiel erstellen. Wähle dazu im Menü <kbd>Project ▸ Bundle... ▸ iOS Application...</kbd>.
+
+![iOS-Bundle signieren](images/ios/sign_bundle.png)
+
+Wähle deine Identität für die Codesignierung, suche deine mobile Bereitstellungsdatei und wähle die Variante (Debug oder Release). Du kannst optional das Kontrollkästchen `Sign application` deaktivieren, um die Signierung zu überspringen und später manuell zu signieren. Aktiviere `Simulator`, um ein `arm64_sim-ios`-Bundle für den iOS-Simulator anstelle eines Gerätebundles zu erstellen.
+
+::: important
+Simulator-Bundles laufen nur im iOS-Simulator auf Macs mit Apple Silicon. Sie verwenden weder eine Signierungsidentität noch ein Bereitstellungsprofil. Deshalb sind die Optionen zum Signieren, Installieren und Starten deaktiviert, wenn `Simulator` aktiviert ist. Installiere das Bundle wie unten beschrieben mit `xcrun simctl`.
+:::
+
+Klicke auf *Create Bundle*. Anschließend wirst du aufgefordert, den Speicherort auf deinem Computer anzugeben, an dem das Bundle erstellt werden soll.
+
+![iOS-Anwendungsbundle im IPA-Format](images/ios/ipa_file.png){.left}
+
+Das Symbol für die App, das Storyboard für den Startbildschirm und weitere Angaben legst du in der Projekteinstellungsdatei *game.project* im [Abschnitt iOS](/manuals/project-settings/#ios) fest.
+
+### Benutzerdefinierte Info.plist und Erkennung lokaler Ziele {#custom-infoplist-and-local-target-discovery}
+
+Die integrierte iOS-Datei `Info.plist` enthält den Bonjour-Dienst und die Beschreibung der Nutzung des lokalen Netzwerks, die für die automatische Zielerkennung im Editor bei Builds erforderlich sind, die keine Release-Builds sind. Eine benutzerdefinierte `Info.plist` ersetzt dieses integrierte Basismanifest. Wenn du für einen Debug-Build ein benutzerdefiniertes Manifest verwendest und Zielerkennung, Profiling, Hot Reload oder die Übertragung von Protokollen über das lokale Netzwerk benötigst, füge diese Einträge hinzu:
+
+```xml
+{{^variant_release}}
+<key>NSBonjourServices</key>
+<array>
+    <string>_defold._tcp</string>
+</array>
+<key>NSLocalNetworkUsageDescription</key>
+<string>Discover Defold targets on the local network.</string>
+{{/variant_release}}
+```
+
+Die Mustache-Bedingung verhindert, dass die Einträge zur Erkennung in Release-Bundles enthalten sind. iOS zeigt den Text zur Beschreibung der Nutzung dem Benutzer an; du kannst ihn anpassen oder lokalisieren. Entferne die Bedingung nur, wenn die Release-Anwendung selbst denselben Bonjour-Dienst und dieselbe Funktionalität im lokalen Netzwerk verwendet.
+
+:[Build Variants](../shared/build-variants.md)
+
+## Ein Bundle auf einem verbundenen iPhone installieren und starten {#installing-and-launching-bundle-on-a-connected-iphone}
+
+Du kannst das erstellte Bundle mit den Kontrollkästchen `Install on connected device` und `Launch installed app` im Bundle-Dialogfeld des Editors installieren und starten:
+
+![iOS-Bundle installieren und starten](images/ios/install_and_launch.png)
+
+Damit diese Funktion verfügbar ist, muss das Kommandozeilenwerkzeug [ios-deploy](https://github.com/ios-control/ios-deploy) installiert sein. Am einfachsten installierst du es mit Homebrew:
+```
+$ brew install ios-deploy
+```
+
+Wenn der Editor den Installationsort des Werkzeugs ios-deploy nicht erkennen kann, musst du ihn in den [Editoreinstellungen](/manuals/editor-preferences/#tools) angeben. 
+
+### Ein Storyboard erstellen {#creating-a-storyboard}
+
+Eine Storyboard-Datei erstellst du mit Xcode. Starte Xcode und erstelle ein neues Projekt. Wähle iOS und Single View App:
+
+![Projekt erstellen](images/ios/xcode_create_project.png)
+
+Klicke auf Next und fahre mit der Konfiguration deines Projekts fort. Gib einen Product Name ein:
+
+![Projekteinstellungen](images/ios/xcode_storyboard_create_project_settings.png)
+
+Klicke auf Create, um den Vorgang abzuschließen. Dein Projekt ist nun erstellt, und wir können mit der Erstellung des Storyboards fortfahren:
+
+![Die Projektansicht](images/ios/xcode_storyboard_project_view.png)
+
+Ziehe ein Bild in das Projekt und lege es dort ab, um es zu importieren. Wähle anschließend `Assets.xcassets` und lege das Bild in `Assets.xcassets` ab:
+
+![Bild hinzufügen](images/ios/xcode_storyboard_add_image.png)
+
+Öffne `LaunchScreen.storyboard` und klicke auf die Plus-Schaltfläche (<kbd>+</kbd>). Gib `imageview` in das Dialogfeld ein, um die ImageView-Komponente zu finden.
+
+![Bildansicht hinzufügen](images/ios/xcode_storyboard_add_imageview.png)
+
+Ziehe die Komponente Image View auf das Storyboard:
+
+![Zum Storyboard hinzufügen](images/ios/xcode_storyboard_add_imageview_to_storyboard.png)
+
+Wähle aus der Auswahlliste Image das Bild aus, das du zuvor zu `Assets.xcassets` hinzugefügt hast:
+
+![](images/ios/xcode_storyboard_select_image.png)
+
+Positioniere das Bild und nimm alle weiteren gewünschten Anpassungen vor. Füge beispielsweise ein Label oder ein anderes UI-Element hinzu. Wenn du fertig bist, setze das aktive Schema auf **Any iOS Device (arm64)** (oder **Generic iOS Device**) und wähle **Product ▸ Build**. Defold unterstützt iOS 15.0 und neuer auf 64-Bit-Geräten. Belasse daher das Bereitstellungsziel bei 15.0 oder neuer. Warte, bis der Build-Vorgang abgeschlossen ist.
+
+Wenn du Bilder im Storyboard verwendest, werden sie nicht automatisch in deine `LaunchScreen.storyboardc` aufgenommen. Verwende das Feld `Bundle Resources` in *game.project*, um Ressourcen einzuschließen.
+Erstelle beispielsweise den Ordner `LaunchScreen` im Defold-Projekt und darin den Ordner `ios` (der Ordner `ios` ist erforderlich, damit diese Dateien nur in iOS-Bundles enthalten sind). Lege deine Dateien dann in `LaunchScreen/ios/` ab. Füge diesen Pfad in `Bundle Resources` hinzu.
+
+![](images/ios/bundle_res.png)
+
+Im letzten Schritt kopierst du die kompilierte Datei `LaunchScreen.storyboardc` in dein Defold-Projekt. Öffne im Finder den folgenden Speicherort und kopiere die Datei `LaunchScreen.storyboardc` in dein Defold-Projekt:
+
+    /Library/Developer/Xcode/DerivedData/YOUR-PRODUCT-NAME-cbqnwzfisotwygbybxohrhambkjy/Build/Intermediates.noindex/YOUR-PRODUCT-NAME.build/Debug-iphonesimulator/YOUR-PRODUCT-NAME.build/Base.lproj/LaunchScreen.storyboardc
+
+::: sidenote
+Der Forennutzer Sergey Lerg hat [ein Video-Tutorial zum Ablauf](https://www.youtube.com/watch?v=6jU8wGp3OwA&feature=emb_logo) zusammengestellt.
+:::
+
+Sobald du die Storyboard-Datei hast, kannst du in *game.project* darauf verweisen.
+
+
+### Einen Asset-Katalog für Symbole erstellen {#creating-an-icon-asset-catalog}
+
+Ein Asset-Katalog ist Apples bevorzugte Methode zur Verwaltung der Symbole deiner Anwendung. Tatsächlich ist dies die einzige Möglichkeit, das im App-Store-Eintrag verwendete Symbol bereitzustellen. Du erstellst einen Asset-Katalog genauso wie ein Storyboard mit Xcode. Starte Xcode und erstelle ein neues Projekt. Wähle iOS und Single View App:
+
+![Projekt erstellen](images/ios/xcode_create_project.png)
+
+Klicke auf Next und fahre mit der Konfiguration deines Projekts fort. Gib einen Product Name ein:
+
+![Projekteinstellungen](images/ios/xcode_icons_create_project_settings.png)
+
+Klicke auf Create, um den Vorgang abzuschließen. Dein Projekt ist nun erstellt, und wir können mit der Erstellung des Asset-Katalogs fortfahren:
+
+![Die Projektansicht](images/ios/xcode_icons_project_view.png)
+
+Ziehe Bilder in die leeren Felder für die verschiedenen unterstützten Symbolgrößen und lege sie dort ab:
+
+![Symbole hinzufügen](images/ios/xcode_icons_add_icons.png)
+
+::: sidenote
+Füge keine Symbole für Notifications, Settings oder Spotlight hinzu.
+:::
+
+Wenn du fertig bist, setze das aktive Schema auf `Build -> Any iOS Device (arm64)` (oder `Generic iOS Device`) und wähle <kbd>Product</kbd> -> <kbd>Build</kbd>. Warte, bis der Build-Vorgang abgeschlossen ist.
+
+::: sidenote
+Stelle sicher, dass du den Build für `Any iOS Device (arm64)` oder `Generic iOS Device` erstellst. Andernfalls erhältst du beim Hochladen deines Builds den Fehler `ERROR ITMS-90704`.
+:::
+
+![Projekt erstellen](images/ios/xcode_icons_build.png)
+
+Im letzten Schritt kopierst du die kompilierte Datei `Assets.car` in dein Defold-Projekt. Öffne im Finder den folgenden Speicherort und kopiere die Datei `Assets.car` in dein Defold-Projekt:
+
+    /Library/Developer/Xcode/DerivedData/YOUR-PRODUCT-NAME-cbqnwzfisotwygbybxohrhambkjy/Build/Products/Debug-iphoneos/Icons.app/Assets.car
+
+Sobald du die Asset-Katalogdatei hast, kannst du in *game.project* auf sie und die Symbole verweisen:
+
+![Symbol und Asset-Katalog zu game.project hinzufügen](images/ios/defold_icons_game_project.png)
+
+::: sidenote
+Auf das App-Store-Symbol muss in *game.project* nicht verwiesen werden. Es wird beim Hochladen in iTunes Connect automatisch aus der Datei `Assets.car` extrahiert.
+:::
+
+
+## Ein iOS-Anwendungsbundle installieren {#installing-an-ios-application-bundle}
+
+Der Editor schreibt eine Datei mit der Erweiterung *.ipa*, die ein iOS-Anwendungsbundle ist. Um die Datei auf deinem Gerät zu installieren, kannst du eines der folgenden Werkzeuge verwenden:
+
+* Xcode über das Fenster `Devices and Simulators`
+* das Kommandozeilenwerkzeug [`ios-deploy`](https://github.com/ios-control/ios-deploy)
+* [`Apple Configurator 2`](https://apps.apple.com/us/app/apple-configurator-2/) aus dem macOS App Store
+* iTunes
+
+Du kannst auch das Kommandozeilenwerkzeug `xcrun simctl` verwenden, um mit den über Xcode verfügbaren iOS-Simulatoren zu arbeiten:
+
+```
+# show a list of available devices
+xcrun simctl list
+
+# boot an iPhone X simulator
+xcrun simctl boot "iPhone X"
+
+# install your.app to a booted simulator
+xcrun simctl install booted your.app
+
+# launch the simulator
+open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
+```
+
+:[Apple Privacy Manifest](../shared/apple-privacy-manifest.md)
+
+
+## Angaben zur Einhaltung von Exportvorschriften {#export-compliance-information}
+
+Wenn du dein Spiel beim App Store einreichst, wirst du aufgefordert, Angaben zur Einhaltung von Exportvorschriften im Hinblick auf die Verwendung von Verschlüsselung in deinem Spiel zu machen. [Apple erklärt, warum dies erforderlich ist](https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations):
+
+„Wenn du deine App bei TestFlight oder dem App Store einreichst, lädst du sie auf einen Server in den Vereinigten Staaten hoch. Wenn du deine App außerhalb der USA oder Kanadas vertreibst, unterliegt sie den US-Exportgesetzen, unabhängig davon, wo deine juristische Person ihren Sitz hat. Wenn deine App Verschlüsselung verwendet, darauf zugreift, sie enthält, implementiert oder integriert, gilt dies als Export von Verschlüsselungssoftware. Damit unterliegt deine App den US-Exportvorschriften sowie den Einfuhrvorschriften der Länder, in denen du deine App vertreibst.“
+
+Die Defold-Game-Engine verwendet Verschlüsselung für die folgenden Zwecke:
+
+* Aufrufe über sichere Kanäle (z. B. HTTPS und SSL)
+* Urheberrechtlicher Schutz von Lua-Code (um eine Vervielfältigung zu verhindern)
+
+Diese Verwendungen von Verschlüsselung in der Defold-Engine sind nach dem Recht der Vereinigten Staaten und der Europäischen Union von der Pflicht zur Vorlage von Dokumenten zur Einhaltung von Exportvorschriften ausgenommen. Die meisten Defold-Projekte bleiben davon ausgenommen. Durch das Hinzufügen anderer kryptografischer Verfahren kann sich dieser Status jedoch ändern. Es liegt in deiner Verantwortung, sicherzustellen, dass dein Projekt die Anforderungen dieser Gesetze und die Regeln des App Store erfüllt. Weitere Informationen findest du in Apples [Übersicht zur Einhaltung von Exportvorschriften](https://help.apple.com/app-store-connect/#/dev88f5c7bf9).
+
+Wenn du davon ausgehst, dass dein Projekt ausgenommen ist, setze den Schlüssel [`ITSAppUsesNonExemptEncryption`](https://developer.apple.com/documentation/bundleresources/information-property-list/itsappusesnonexemptencryption) in der Datei `Info.plist` des Projekts auf `False`. Weitere Einzelheiten findest du unter [Anwendungsmanifeste](/manuals/extensions-manifest-merge-tool).
+
+## FAQ
+:[iOS FAQ](../shared/ios-faq.md)

--- a/docs/de/manuals/label.md
+++ b/docs/de/manuals/label.md
@@ -1,0 +1,140 @@
+---
+title: Beschriftungskomponenten in Defold
+brief: Dieses Handbuch erklärt, wie du mit Beschriftungskomponenten Text an Spielobjekten in der Spielwelt verwendest.
+---
+
+# Beschriftung {#label}
+
+Eine *Beschriftungskomponente* (Label component) rendert ein Stück Text im Spielraum auf dem Bildschirm. Standardmäßig wird sie zusammen mit allen Sprite- und Kachelgrafiken sortiert und gezeichnet. Die Komponente verfügt über eine Reihe von Eigenschaften, die bestimmen, wie der Text gerendert wird. Die GUI von Defold unterstützt Text, doch es kann schwierig sein, GUI-Elemente in der Spielwelt zu platzieren. Beschriftungen erleichtern dies.
+
+## Eine Beschriftung erstellen {#creating-a-label}
+
+Um eine Beschriftungskomponente zu erstellen, klicke <kbd>mit der rechten Maustaste</kbd> auf das Spielobjekt (game object) und wähle <kbd>Add Component ▸ Label</kbd>.
+
+![Beschriftung hinzufügen](images/label/add_label.png)
+
+(Wenn du mehrere Beschriftungen aus derselben Vorlage instanziieren möchtest, kannst du alternativ eine neue Datei für eine Beschriftungskomponente erstellen: Klicke <kbd>mit der rechten Maustaste</kbd> auf einen Ordner im Browser *Assets* und wähle <kbd>New... ▸ Label</kbd>. Füge die Datei anschließend als Komponente zu beliebigen Spielobjekten hinzu.)
+
+![Neue Beschriftung](images/label/label.png)
+
+Setze die Eigenschaft *Font* auf die Schriftart, die du verwenden möchtest, und stelle sicher, dass die Eigenschaft *Material* auf ein Material gesetzt ist, das zum Schrifttyp passt:
+
+![Schriftart und Material](images/label/font_material.png)
+
+## Eigenschaften der Beschriftung {#label-properties}
+
+Neben den Eigenschaften *Id*, *Position*, *Rotation* und *Scale* gibt es die folgenden komponentenspezifischen Eigenschaften:
+
+*Text*
+: Der Textinhalt der Beschriftung.
+
+*Size*
+: Die Größe des Begrenzungsrechtecks des Textes. Wenn *Line Break* aktiviert ist, legt die Breite fest, an welcher Stelle der Text umgebrochen werden soll.
+
+*Color*
+: Die Farbe des Textes.
+
+*Outline*
+: Die Farbe der Kontur.
+
+*Shadow*
+: Die Farbe des Schattens.
+
+::: sidenote
+Beachte, dass das Rendern von Schatten beim Standardmaterial aus Leistungsgründen deaktiviert ist.
+:::
+
+*Leading*
+: Ein Skalierungsfaktor für den Zeilenabstand. Ein Wert von 0 ergibt keinen Zeilenabstand. Der Standardwert ist 1.
+
+*Tracking*
+: Ein Skalierungsfaktor für den Zeichenabstand. Der Standardwert ist 0.
+
+*Pivot*
+: Der Bezugspunkt (pivot) des Textes. Verwende ihn, um die Textausrichtung zu ändern (siehe unten).
+
+*Blend Mode*
+: Der Mischmodus, der beim Rendern der Beschriftung verwendet wird.
+
+*Line Break*
+: Die Textausrichtung richtet sich nach der Einstellung des Bezugspunkts. Wenn du diese Eigenschaft aktivierst, kann sich der Text über mehrere Zeilen erstrecken. Die Breite der Komponente bestimmt, wo der Text umgebrochen wird. Beachte, dass der Text ein Leerzeichen enthalten muss, damit er umgebrochen werden kann.
+
+*Font*
+: Die Schriftressource, die für diese Beschriftung verwendet wird.
+
+*Material*
+: Das Material, das zum Rendern dieser Beschriftung verwendet wird. Achte darauf, ein Material auszuwählen, das für den verwendeten Schrifttyp erstellt wurde (Bitmap, Distanzfeld oder BMFont).
+
+### Mischmodi {#blend-modes}
+:[blend-modes](../shared/blend-modes.md)
+
+### Bezugspunkt und Ausrichtung {#pivot-and-alignment}
+
+Durch das Festlegen der Eigenschaft *Pivot* kannst du die Ausrichtung des Textes ändern.
+
+*Zentriert*
+: Wenn der Bezugspunkt auf `Center`, `North` oder `South` gesetzt ist, wird der Text zentriert.
+
+*Linksbündig*
+: Wenn der Bezugspunkt auf einen der `West`-Modi gesetzt ist, wird der Text linksbündig ausgerichtet.
+
+*Rechtsbündig*
+: Wenn der Bezugspunkt auf einen der `East`-Modi gesetzt ist, wird der Text rechtsbündig ausgerichtet.
+
+![Textausrichtung](images/label/align.png)
+
+## Änderungen zur Laufzeit {#runtime-manipulation}
+
+Du kannst Beschriftungen zur Laufzeit ändern, indem du den Beschriftungstext sowie die verschiedenen anderen Eigenschaften abfragst und festlegst.
+
+`text`
+: Der Textinhalt der Beschriftung (`string`). Seit Defold 1.13.2 über `go.get()` und `go.set()` verfügbar.
+
+`color`
+: Die Farbe der Beschriftung (`vector4`)
+
+`outline`
+: Die Konturfarbe der Beschriftung (`vector4`)
+
+`shadow`
+: Die Schattenfarbe der Beschriftung (`vector4`)
+
+`scale`
+: Die Skalierung der Beschriftung, entweder eine Zahl (`number`) für eine gleichmäßige Skalierung oder ein `vector3` für eine individuelle Skalierung entlang jeder Achse.
+
+`size`
+: Die Größe der Beschriftung (`vector3`)
+
+```lua
+function init(self)
+    -- Set the text of the "my_label" component in the same game object
+    -- as this script.
+    go.set("#my_label", "text", "New text")
+    local text = go.get("#my_label", "text")
+    print(text) -- New text
+end
+```
+
+::: sidenote
+Seit Defold 1.13.2 sind `label.set_text()` und `label.get_text()` zugunsten der Eigenschaft `text` veraltet und zur Ablösung vorgesehen. Die alten Funktionen bleiben aus Kompatibilitätsgründen verfügbar. Die alte Setter-Funktion stellt eine Nachricht in die Warteschlange, während `go.set()` den Text sofort aktualisiert.
+:::
+
+```lua
+function init(self)
+    -- Set the color of the "my_label" component in the same game object
+    -- as this script. Color is a RGBA value stored in a vector4.
+    local grey = vmath.vector4(0.5, 0.5, 0.5, 1.0)
+    go.set("#my_label", "color", grey)
+
+    -- ...and remove the outline, by setting its alpha to 0...
+    go.set("#my_label", "outline.w", 0)
+
+    -- ...and scale it x2 along x axis.
+    local scale_x = go.get("#my_label", "scale.x")
+    go.set("#my_label", "scale.x", scale_x * 2)
+end
+```
+
+## Projektkonfiguration {#project-configuration}
+
+Die Datei *game.project* enthält einige [Projekteinstellungen](/manuals/project-settings#label) für Beschriftungen.

--- a/docs/de/manuals/libraries.md
+++ b/docs/de/manuals/libraries.md
@@ -1,0 +1,128 @@
+---
+title: Mit Bibliotheksprojekten in Defold arbeiten
+brief: Mit der Bibliotheksfunktion kannst du Assets zwischen Projekten teilen. Dieses Handbuch erklärt, wie sie funktioniert.
+---
+
+# Bibliotheken {#libraries}
+
+Mit der Bibliotheksfunktion (Libraries) kannst du Assets zwischen Projekten teilen. Sie ist ein einfacher, aber sehr leistungsfähiger Mechanismus, den du auf verschiedene Weise in deinem Arbeitsablauf einsetzen kannst.
+
+Bibliotheken sind für folgende Zwecke nützlich:
+
+* Um Assets aus einem abgeschlossenen Projekt in ein neues zu kopieren. Wenn du eine Fortsetzung eines früheren Spiels entwickelst, erleichtert dir das den Einstieg.
+* Um eine Bibliothek mit Vorlagen aufzubauen, die du in deine Projekte kopieren und anschließend anpassen oder spezialisieren kannst.
+* Um eine oder mehrere Bibliotheken mit fertigen Objekten oder Skripten aufzubauen, die du direkt referenzieren kannst. Das ist sehr praktisch, um gemeinsam genutzte Skriptmodule zu speichern oder eine gemeinsame Bibliothek mit Grafik-, Audio- und Animations-Assets aufzubauen.
+
+## Die Freigabe einer Bibliothek einrichten {#setting-up-library-sharing}
+
+Angenommen, du möchtest eine Bibliothek mit gemeinsam genutzten Sprites und Kachelquellen (tile sources) aufbauen. Beginne damit, [ein neues Projekt einzurichten](/manuals/project-setup/). Entscheide, welche Ordner des Projekts du freigeben möchtest, und trage ihre Namen in der Eigenschaft *`include_dirs`* in den Projekteinstellungen ein. Wenn du mehrere Ordner auflisten möchtest, trenne ihre Namen durch Leerzeichen:
+
+![Einzubeziehende Verzeichnisse](images/libraries/libraries_include_dirs.png)
+
+Bevor wir diese Bibliothek einem anderen Projekt hinzufügen können, brauchen wir eine Möglichkeit, die Bibliothek zu finden.
+
+## Bibliotheks-URL {#library-url}
+
+Bibliotheken werden über eine normale URL referenziert. Bei einem auf GitHub gehosteten Projekt ist das die URL zu einer veröffentlichten Version des Projekts:
+
+![Bibliotheks-URL auf GitHub](images/libraries/libraries_library_url_github.png)
+
+::: important
+Es wird empfohlen, immer eine bestimmte veröffentlichte Version eines Bibliotheksprojekts als Abhängigkeit zu verwenden, statt den Branch `master`. So entscheidest du bei der Entwicklung selbst, wann du Änderungen aus einem Bibliotheksprojekt übernimmst, statt immer die neuesten Änderungen aus dessen Branch `master` zu erhalten, die möglicherweise die Kompatibilität beeinträchtigen.
+:::
+
+::: important
+Es wird empfohlen, Bibliotheken von Drittanbietern vor der Verwendung immer zu prüfen. Weitere Informationen findest du unter [Drittanbietersoftware sicher verwenden](https://defold.com/manuals/application-security/#securing-your-use-of-third-party-software).
+:::
+
+### Basisauthentifizierung {#basic-access-authentication}
+
+Du kannst der Bibliotheks-URL einen Benutzernamen und ein Passwort/Token hinzufügen, um bei Bibliotheken, die nicht öffentlich verfügbar sind, eine Basisauthentifizierung durchzuführen:
+
+```
+https://username:password@github.com/defold/private/archive/main.zip
+```
+
+Die Felder `username` und `password` werden ausgelesen und als Anfrageheader `Authorization` hinzugefügt. Das funktioniert mit jedem Server, der eine grundlegende Zugriffsautorisierung unterstützt.
+
+::: important
+Achte darauf, dein erzeugtes persönliches Zugriffstoken oder dein Passwort weder weiterzugeben noch versehentlich offenzulegen, denn es kann schwerwiegende Folgen haben, wenn diese Daten in die falschen Hände geraten!
+:::
+
+Damit du Zugangsdaten nicht versehentlich offenlegst, weil sie im Klartext in der Bibliotheks-URL stehen, kannst du auch ein Ersetzungsmuster für Zeichenfolgen verwenden und die Zugangsdaten als Umgebungsvariablen speichern:
+
+```
+https://__PRIVATE_USERNAME__:__PRIVATE_TOKEN__@github.com/defold/private/archive/main.zip
+```
+
+Im obigen Beispiel werden Benutzername und Token aus den Systemumgebungsvariablen `PRIVATE_USERNAME` und `PRIVATE_TOKEN` gelesen.
+
+#### Authentifizierung bei GitHub {#github-authentication}
+
+Um Inhalte aus einem privaten Repository auf GitHub abzurufen, musst du [ein persönliches Zugriffstoken erzeugen](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) und es als Passwort verwenden.
+
+```
+https://github-username:personal-access-token@github.com/defold/private/archive/main.zip
+```
+
+#### Authentifizierung bei GitLab {#gitlab-authentication}
+
+Um Inhalte aus einem privaten Repository auf GitLab abzurufen, musst du [ein persönliches Zugriffstoken erzeugen](https://docs.gitlab.com/ee/security/token_overview.html) und es als URL-Parameter senden.
+
+```
+https://gitlab.com/defold/private/-/archive/main/test-main.zip?private_token=personal-access-token
+```
+
+### Erweiterte Zugriffsauthentifizierung {#advanced-access-authentication}
+
+Bei der Basisauthentifizierung werden das Zugriffstoken und der Benutzername eines Benutzers über jedes für das Projekt verwendete Repository geteilt. Bei einem Team mit mehr als 1 Person kann das ein Problem sein. Um dieses Problem zu lösen, muss für den Bibliothekszugriff auf das Repository ein Benutzer mit ausschließlich lesendem Zugriff verwendet werden. Auf GitHub sind dafür eine Organisation, ein Team und ein Benutzer erforderlich, der das Repository nicht bearbeiten muss und deshalb nur lesenden Zugriff hat.
+
+Schritte auf GitHub:
+* [Erstelle eine Organisation](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/creating-a-new-organization-from-scratch)
+* [Erstelle ein Team innerhalb der Organisation](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/creating-a-team)
+* [Übertrage das gewünschte private Repository an deine Organisation](https://docs.github.com/en/github/administering-a-repository/transferring-a-repository)
+* [Gib dem Team ausschließlich lesenden Zugriff auf das Repository](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/managing-team-access-to-an-organization-repository)
+* [Erstelle oder wähle einen Benutzer als Mitglied dieses Teams](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/organizing-members-into-teams)
+* Verwende die oben beschriebene „Basisauthentifizierung“, um ein persönliches Zugriffstoken für diesen Benutzer zu erstellen
+
+Jetzt können die Authentifizierungsdaten des neuen Benutzers per Commit und Push in das Repository übernommen werden. So können alle, die mit deinem privaten Repository arbeiten, es als Bibliothek abrufen, ohne Bearbeitungsrechte für die Bibliothek selbst zu haben.
+
+::: important
+Das Token des Benutzers mit ausschließlich lesendem Zugriff ist für alle vollständig zugänglich, die auf die Spiel-Repositorys zugreifen können, die diese Bibliothek verwenden.
+:::
+
+Diese Lösung wurde im Defold-Forum vorgeschlagen und [in diesem Thema diskutiert](https://forum.defold.com/t/private-github-for-library-solved/67240).
+
+## Abhängigkeiten von Bibliotheken einrichten {#setting-up-library-dependencies}
+
+Öffne das Projekt, von dem aus du auf die Bibliothek zugreifen möchtest. Füge in den Projekteinstellungen die Bibliotheks-URL zur Eigenschaft *dependencies* hinzu. Du kannst bei Bedarf mehrere Projekte als Abhängigkeiten angeben. Füge sie einfach einzeln mit der Schaltfläche `+` hinzu und entferne sie mit der Schaltfläche `-`:
+
+![Abhängigkeiten](images/libraries/libraries_dependencies.png)
+
+Wähle nun <kbd>Project ▸ Fetch Libraries</kbd>, um die Abhängigkeiten von Bibliotheken zu aktualisieren. Das geschieht automatisch, wenn du ein Projekt öffnest. Du musst diesen Schritt daher nur ausführen, wenn sich die Abhängigkeiten ändern, ohne dass du das Projekt erneut öffnest. Das ist der Fall, wenn du Bibliotheken als Abhängigkeiten hinzufügst oder entfernst oder wenn jemand eines der als Abhängigkeit verwendeten Bibliotheksprojekte ändert und synchronisiert.
+
+![Fetch Libraries](images/libraries/libraries_fetch_libraries.png)
+
+Die freigegebenen Ordner erscheinen jetzt im Bereich *Assets*, und du kannst alle freigegebenen Inhalte verwenden. Alle synchronisierten Änderungen am Bibliotheksprojekt sind in deinem Projekt verfügbar.
+
+![Einrichtung der Bibliothek abgeschlossen](images/libraries/libraries_done.png)
+
+## Dateien in eingebundenen Bibliotheken bearbeiten {#editing-files-in-library-dependencies}
+
+Dateien in Bibliotheken können nicht gespeichert werden. Du kannst Änderungen vornehmen, und der Editor kann damit einen Build erstellen, was zum Testen nützlich ist. Die Datei selbst bleibt jedoch unverändert, und alle Änderungen werden verworfen, wenn du die Datei schließt.
+
+Wenn du Bibliotheksdateien ändern möchtest, erstelle einen eigenen Fork der Bibliothek und nimm die Änderungen dort vor. Alternativ kannst du den gesamten Bibliotheksordner in dein Projektverzeichnis kopieren und dort einfügen, um die lokale Kopie zu verwenden. In diesem Fall hat dein lokaler Ordner Vorrang vor der ursprünglichen Abhängigkeit, und die Verknüpfung zur Abhängigkeit sollte aus `game.project` entfernt werden. Vergiss nicht, anschließend <kbd>Project ▸ Fetch Libraries</kbd> zu wählen.
+
+`builtins` ist ebenfalls eine Bibliothek, die von der Engine bereitgestellt wird. Wenn du dort Dateien bearbeiten möchtest, kopiere sie in dein Projekt und verwende diese Kopien anstelle der ursprünglichen Dateien aus `builtins`. Um beispielsweise `default.render_script` zu ändern, kopiere sowohl `/builtins/render/default.render` als auch `/builtins/render/default.render_script` als `my_custom.render` und `my_custom.render_script` in deinen Projektordner. Aktualisiere anschließend deine lokale Datei `my_custom.render`, sodass sie auf `my_custom.render_script` statt auf das integrierte Skript verweist, und lege deine angepasste Datei `my_custom.render` in `game.project` unter der Einstellung Render fest.
+
+Wenn du ein Material kopierst und einfügst und es für alle Komponenten (components) eines bestimmten Typs verwenden möchtest, können [projektspezifische Vorlagen](/manuals/editor/#creating-new-project-files) hilfreich sein.
+
+## Ungültige Referenzen {#broken-references}
+
+Die Freigabe einer Bibliothek umfasst nur Dateien, die sich unterhalb der freigegebenen Ordner befinden. Wenn du etwas erstellst, das Assets außerhalb der freigegebenen Hierarchie referenziert, sind die Referenzpfade ungültig.
+
+## Namenskonflikte {#name-collisions}
+
+Da du in der Projekteinstellung *dependencies* mehrere Projekt-URLs angeben kannst, kann es zu einem Namenskonflikt kommen. Das passiert, wenn zwei oder mehr der als Abhängigkeit verwendeten Projekte in der Projekteinstellung *`include_dirs`* einen Ordner mit demselben Namen freigeben.
+
+Defold löst Namenskonflikte, indem es bei gleichnamigen Ordnern alle Referenzen bis auf die letzte ignoriert. Maßgeblich ist die Reihenfolge der Projekt-URLs in der Liste *dependencies*. Wenn du beispielsweise 3 Bibliotheksprojekt-URLs als Abhängigkeiten angibst und alle einen Ordner namens *items* freigeben, wird nur ein Ordner *items* angezeigt---derjenige aus dem Projekt, das in der URL-Liste an letzter Stelle steht.

--- a/docs/de/manuals/light.md
+++ b/docs/de/manuals/light.md
@@ -1,0 +1,248 @@
+---
+title: Lichtkomponente in Defold
+brief: Dieses Handbuch erklärt, wie du Umgebungslichter, gerichtete Lichter, Punktlichter und Spotlichter verwendest und in Shadern auf Lichtdaten zugreifst.
+---
+
+# Lichtkomponente {#light-component}
+
+Die Lichtkomponente (light component) stellt eine Lichtquelle in einer Sammlung (collection) dar. Defold unterstützt derzeit vier Typen von Lichtressourcen:
+
+- Umgebungslicht (ambient light) (`.ambient_light`)
+- Gerichtetes Licht (directional light) (`.directional_light`)
+- Punktlicht (point light) (`.point_light`)
+- Spotlicht (spot light) (`.spot_light`)
+
+Lichtressourcen werden Spielobjekten (game objects) wie andere Komponentenressourcen hinzugefügt. Du kannst Lichtkomponenten entweder direkt unter einem Spielobjekt erstellen oder eine Lichtressource im Browser *Assets* erstellen und sie anschließend einem Spielobjekt in der Ansicht *Outline* als Komponente hinzufügen.
+
+Defold wendet Beleuchtung nicht automatisch auf jedes Material an. Die Engine erfasst die Lichter und stellt sie Shadern über den integrierten Lichtpuffer zur Verfügung. Der Shader deines Materials entscheidet, wie er die Lichtdaten verwendet.
+
+Die folgenden Beispiele verwenden dieselbe Szene, um zu zeigen, wie sich die verschiedenen Lichttypen auf das Endergebnis auswirken:
+
+![Szene ohne Lichter](images/light/no_light.png)
+
+## Lichteigenschaften {#light-properties}
+
+Alle Lichtfarben sind RGB-Werte. Lichtressourcen verwenden den Alphakanal nicht.
+
+### Umgebungslicht {#ambient-light}
+
+Umgebungslichter fügen der Szene konstantes Licht hinzu. Position, Drehung und Skalierung des Spielobjekts wirken sich nicht auf sie aus. Sie können beispielsweise für eine allgemeine Hintergrundbeleuchtung verwendet werden oder um Objekte unbeleuchtet erscheinen zu lassen.
+
+Die Umgebungslichtkomponente wird im Editor durch ein Symbol mit zur Mitte gerichteten Pfeilen dargestellt. Die Farbe des Symbols entspricht seiner Eigenschaft `color`. 
+
+![Umgebungslicht mit geringerer Intensität](images/light/ambient_light_less_intensity.png)
+
+Eigenschaften:
+
+`color`
+: Die RGB-Farbe des Umgebungslichts.
+
+`intensity`
+: Multipliziert die Farbe des Umgebungslichts.
+
+![Umgebungslicht mit höherer Intensität](images/light/ambient_light_full_intensity.png)
+
+Umgebungslichter werden im Lichtpuffer des Shaders zu einer einzigen Umgebungslichtfarbe `light_info.xyz` aufsummiert. Sie belegen keine Einträge im Array `lights[]`. Mehrere Umgebungslichtkomponenten in der Szene ergeben nur eine Ausgabefarbe, die aus allen diesen Lichtern gemischt wird.
+
+### Gerichtetes Licht {#directional-light}
+
+Gerichtete Lichter stellen Licht dar, das aus einer Richtung kommt, etwa Sonnenlicht. Sie verwenden weder die Position noch die Skalierung des Spielobjekts. Die Lichtrichtung wird jedoch aus der Drehung des Spielobjekts im Weltkoordinatensystem abgeleitet, die auf die lokale Vorwärtsrichtung `(0, 0, -1)` angewendet wird.
+
+Die Komponente für gerichtetes Licht wird im Editor durch ein farbiges Sonnensymbol mit einem 3D-Pfeil dargestellt, der ihre Richtung angibt.
+
+![Gerichtetes Licht](images/light/directional_light.png)
+
+Eigenschaften:
+
+`color`
+: Die RGB-Farbe des gerichteten Lichts.
+
+`intensity`
+: Multipliziert die Farbe des gerichteten Lichts.
+
+
+Gerichtete Lichter werden oft mit Umgebungslicht kombiniert, damit Oberflächen, die vom gerichteten Licht abgewandt sind, nicht vollständig dunkel werden.
+
+![Gerichtetes Licht und Umgebungslicht](images/light/directional_and_ambient_light.png)
+
+### Punktlicht {#point-light}
+
+Punktlichter strahlen von der Position des Spielobjekts im Weltkoordinatensystem nach außen. Die Position des Punktlichts ergibt sich aus der Position des Spielobjekts im Weltkoordinatensystem.
+
+Die Punktlichtkomponente wird im Editor durch einen Punkt mit nach außen verlaufenden Strahlen dargestellt. Seine Farbe entspricht der Eigenschaft `color`, und ein Kreis stellt die Reichweite `range` dar.
+
+![Punktlicht](images/light/point_light.png)
+
+Eigenschaften:
+
+`color`
+: Die RGB-Farbe des Punktlichts.
+
+`intensity`
+: Multipliziert die Farbe des Punktlichts.
+
+`range`
+: Der Lichtradius in Welteinheiten.
+
+Die wirksame Reichweite wird mit dem kleinsten Betrag der Achsenskalierungsfaktoren des Spielobjekts im Weltkoordinatensystem multipliziert.
+
+![Reichweite des Punktlichts](images/light/point_light_range.png)
+
+Eine Änderung der Lichtfarbe färbt den Beleuchtungsbeitrag des Punktlichts ein, während die Reichweite steuert, wie weit das Licht von der Quelle aus reicht.
+
+![Reichweite des Punktlichts mit grüner Farbe](images/light/point_ight_range_green_color.png)
+
+### Spotlicht {#spot-light}
+
+Spotlichter strahlen von der Position des Spielobjekts im Weltkoordinatensystem in einem Kegel ab. Die Richtung wird aus der Drehung des Spielobjekts im Weltkoordinatensystem abgeleitet, die auf `(0, 0, -1)` angewendet wird.
+
+Die Spotlichtkomponente wird im Editor durch ein farbiges Lampensymbol und Hilfslinien dargestellt, die den äußeren und inneren Kegel zeigen.
+
+![Spotlicht](images/light/spot_light.png)
+
+Eigenschaften:
+
+`color`
+: Die RGB-Farbe des Spotlichts.
+
+`intensity`
+: Multipliziert die Farbe des Spotlichts.
+
+`range`
+: Der Lichtradius in Welteinheiten.
+
+`inner_cone_angle`
+: Der innere Kegelwinkel in Grad im Editor. Pixel innerhalb dieses Kegels erhalten den vollen Beleuchtungsbeitrag des Spotlichts.
+
+`outer_cone_angle`
+: Der äußere Kegelwinkel in Grad im Editor. Das Licht nimmt zwischen dem inneren und dem äußeren Kegel ab.
+
+Die wirksame Reichweite wird mit dem kleinsten Betrag der Achsenskalierungsfaktoren des Spielobjekts im Weltkoordinatensystem multipliziert. Kegelwinkel werden in Grad bearbeitet und in der kompilierten Lichtressource ins Bogenmaß umgerechnet.
+
+![Bearbeitungshilfen für Spotlichter](images/light/spot_light_gizmos.png)
+
+## Validierung {#validation}
+
+Die Build-Pipeline validiert und normalisiert die Daten der Lichtressourcen:
+
+- `color` muss genau drei Zahlen enthalten.
+- `intensity` wird auf mindestens `0` begrenzt.
+- `range` wird für Punktlichter und Spotlichter auf mindestens `0` begrenzt.
+- Die Kegelwinkel von Spotlichtern werden auf `0..180` Grad begrenzt.
+- `inner_cone_angle` wird so begrenzt, dass der Wert niemals `outer_cone_angle` überschreitet.
+
+## Projektgrenze {#project-limit}
+
+Die maximale Anzahl der Lichtkomponenten wird durch die Projekteinstellung `light.max_count` gesteuert. Der Standardwert ist `64`.
+
+Umgebungslichter belegen keine Einträge im Shader-Array `lights[]`, sind aber weiterhin Lichtkomponenten und zählen für `light.max_count` mit. Gerichtete Lichter, Punktlichter und Spotlichter belegen Einträge in `lights[]`, solange sie aktiv sind.
+
+Wenn die Anzahl der Lichtkomponenten `light.max_count` überschreitet, meldet die Engine einen Fehler wegen eines vollen Komponentenpuffers.
+
+## Lichtpuffer in Shadern {#light-buffer-in-shaders}
+
+Ein Shader kann auf aktive Lichter zugreifen, indem er einen Uniform-Block namens `LightBuffer` mit dem integrierten Layout deklariert. Die Engine erkennt diesen Block und bindet die Lichtdaten automatisch für Materialien und Compute-Programme, die ihn verwenden.
+
+![Shader mit Lichtpuffer](images/light/light-buffer-shader.png)
+
+```glsl
+#version 140
+
+#define MAX_LIGHT_COUNT 32
+
+struct Light
+{
+    vec4 position;        // xyz: world position, w: unused
+    vec4 color;           // rgb: color, a: unused
+    vec4 direction_range; // xyz: normalized world direction, w: range
+    vec4 params;          // x: type, y: intensity, z: inner cone, w: outer cone
+};
+
+uniform LightBuffer
+{
+    // xyz: accumulated ambient color, w: active non-ambient light count
+    vec4 light_info;
+    Light lights[MAX_LIGHT_COUNT];
+};
+```
+
+Der Lichttyp wird in `lights[i].params.x` gespeichert:
+
+| Typ | Wert |
+|------|-------|
+| Gerichtetes Licht | `0` |
+| Punktlicht | `1` |
+| Spotlicht | `2` |
+
+Der Shader darf ein kleineres Array `lights[]` als `light.max_count` deklarieren, aber kein größeres. Begrenze Schleifen über Lichter immer auf die deklarierte Arraygröße:
+
+```glsl
+vec3 apply_lights(vec3 normal)
+{
+    vec3 result = light_info.xyz;
+    int active_light_count = int(light_info.w);
+
+    for (int i = 0; i < MAX_LIGHT_COUNT; ++i)
+    {
+        if (i >= active_light_count)
+        {
+            break;
+        }
+
+        int type = int(lights[i].params.x);
+        vec3 light_color = lights[i].color.rgb * lights[i].params.y;
+
+        if (type == 0) // Directional
+        {
+            vec3 light_dir = normalize(-lights[i].direction_range.xyz);
+            result += light_color * max(dot(normal, light_dir), 0.0);
+        }
+        else if (type == 1) // Point
+        {
+            result += light_color;
+        }
+        else if (type == 2) // Spot
+        {
+            result += light_color;
+        }
+    }
+
+    return result;
+}
+```
+
+Das obige Beispiel zeigt das Muster für den Pufferzugriff. Ein tatsächlicher Shader für Punktlichter oder Spotlichter sollte außerdem den Vektor vom zu schattierenden Punkt zu `lights[i].position.xyz` berechnen, mithilfe von `lights[i].direction_range.w` eine entfernungsabhängige Abschwächung anwenden und für Spotlichter `lights[i].params.z` und `lights[i].params.w` als Kegelwinkel im Bogenmaß verwenden.
+
+## Integrierte Beleuchtungshilfe {#built-in-lighting-helper}
+
+Defold enthält unter `/builtins/materials/lighting.glsl` eine Shader-Hilfsdatei. Definiere `MAX_LIGHT_COUNT`, stelle die von der Hilfsdatei erwarteten Varyings bereit und binde sie dann aus deinem Fragment-Shader ein:
+
+```glsl
+#version 140
+
+#define MAX_LIGHT_COUNT 32
+
+in vec3 var_normal;
+in vec4 var_position;
+in mat4 var_view;
+
+out vec4 color_out;
+
+#include "/builtins/materials/lighting.glsl"
+
+void main()
+{
+    vec3 normal = normalize(var_normal);
+    vec3 ambient = ambient_light();
+    vec3 diffuse = diffuse_lambert(normal, var_position.xyz);
+    color_out = vec4(ambient + diffuse, 1.0);
+}
+```
+
+Die Hilfsdatei definiert die Konstanten `LIGHT_DIRECTIONAL`, `LIGHT_POINT` und `LIGHT_SPOT`, stellt `ambient_light()` bereit und bietet Funktionen für die diffuse Beleuchtung nach Lambert für die Lichter im Puffer.
+
+## Siehe auch {#see-also}
+
+- [Shader-Handbuch](/manuals/shader)
+- [Material-Handbuch](/manuals/material)
+- [Rendering-Handbuch](/manuals/render)

--- a/docs/de/manuals/linux.md
+++ b/docs/de/manuals/linux.md
@@ -1,0 +1,11 @@
+---
+title: Defold-Entwicklung für die Linux-Plattform
+brief: Dieses Handbuch beschreibt, wie du Builds von Defold-Anwendungen für Linux erstellst und die Anwendungen unter Linux ausführst
+---
+
+# Entwicklung für Linux {#linux-development}
+
+Die Entwicklung von Defold-Anwendungen für die Linux-Plattform ist unkompliziert, und du musst dabei nur wenige Dinge beachten.
+
+## FAQ
+:[Linux FAQ](../shared/linux-faq.md)

--- a/docs/de/manuals/live-update-aws.md
+++ b/docs/de/manuals/live-update-aws.md
@@ -1,0 +1,127 @@
+---
+title: Inhalte für Live Update auf AWS hochladen
+brief: Dieser Abschnitt erklärt, wie du bei Amazon Web Services einen neuen Benutzer mit eingeschränktem Zugriff erstellst, mit dem der Defold-Editor beim Erstellen eines Bundles für dein Spiel automatisch Ressourcen für Live Update hochladen kann.
+---
+
+# Amazon Web Services einrichten {#setting-up-amazon-web-service}
+
+Um die Funktion Live Update von Defold zusammen mit den Diensten von Amazon zu verwenden, benötigst du ein Konto bei Amazon Web Services. Falls du noch kein Konto hast, kannst du hier eines erstellen: https://aws.amazon.com/.
+
+Dieser Abschnitt erklärt, wie du bei Amazon Web Services einen neuen Benutzer mit eingeschränktem Zugriff erstellst, mit dem der Defold-Editor beim Erstellen eines Bundles für dein Spiel automatisch Ressourcen für Live Update hochladen kann. Außerdem erfährst du, wie du Amazon S3 so konfigurierst, dass Spielclients Ressourcen abrufen können. Weitere Informationen zur Konfiguration von Amazon S3 findest du in der [Dokumentation zu Amazon S3](http://docs.aws.amazon.com/AmazonS3/latest/dev/Welcome.html).
+
+1. Einen Bucket für Ressourcen für Live Update erstellen
+
+    Öffne das Menü `Services` und wähle `S3` in der Kategorie _Storage_ ([Amazon S3-Konsole](https://console.aws.amazon.com/s3)). Du siehst alle vorhandenen Buckets sowie die Möglichkeit, einen neuen Bucket zu erstellen. Du kannst zwar einen vorhandenen Bucket verwenden, wir empfehlen jedoch, einen neuen Bucket für Ressourcen für Live Update zu erstellen, damit du den Zugriff leicht einschränken kannst.
+
+    ![Einen Bucket erstellen](images/live-update/01-create-bucket.png)
+
+2. Deinem Bucket eine Bucket-Richtlinie hinzufügen
+
+    Wähle den Bucket aus, den du verwenden möchtest, öffne den Bereich *Properties* und klappe darin die Option *Permissions* auf. Öffne die Bucket-Richtlinie, indem du auf die Schaltfläche *Add bucket policy* klickst. Die Bucket-Richtlinie in diesem Beispiel erlaubt einem anonymen Benutzer, Dateien aus dem Bucket abzurufen. Dadurch kann ein Spielclient die Ressourcen für Live Update herunterladen, die das Spiel benötigt. Weitere Informationen zu Bucket-Richtlinien findest du in der [Dokumentation von Amazon](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html).
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AddPerm",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::defold-liveupdate-example/*"
+            }
+        ]
+    }
+    ```
+
+    ![Bucket-Richtlinie](images/live-update/02-bucket-policy.png)
+
+3. Deinem Bucket eine CORS-Konfiguration hinzufügen (optional)
+
+    [Ursprungsübergreifende Ressourcenfreigabe (Cross-Origin Resource Sharing, CORS)](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) ist ein Mechanismus, mit dem eine Website mithilfe von JavaScript eine Ressource von einer anderen Domain abrufen kann. Wenn du dein Spiel als HTML5-Client veröffentlichen möchtest, musst du deinem Bucket eine CORS-Konfiguration hinzufügen.
+
+    Wähle den Bucket aus, den du verwenden möchtest, öffne den Bereich *Properties* und klappe darin die Option *Permissions* auf. Öffne die Bucket-Richtlinie, indem du auf die Schaltfläche *Add CORS Configuration* klickst. Die Konfiguration in diesem Beispiel erlaubt durch die Angabe eines Platzhalters für die Domain den Zugriff von jeder Website. Du kannst diesen Zugriff jedoch weiter einschränken, wenn du weißt, auf welchen Domains du dein Spiel bereitstellen wirst. Weitere Informationen zur CORS-Konfiguration bei Amazon findest du in der [Dokumentation von Amazon](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
+
+    ```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <CORSRule>
+            <AllowedOrigin>*</AllowedOrigin>
+            <AllowedMethod>GET</AllowedMethod>
+        </CORSRule>
+    </CORSConfiguration>
+    ```
+
+    ![CORS-Konfiguration](images/live-update/03-cors-configuration.png)
+
+4. Eine IAM-Richtlinie erstellen
+
+    Öffne das Menü *Services* und wähle *IAM* in der Kategorie _Security, Identity & Compliance_ ([Amazon IAM-Konsole](https://console.aws.amazon.com/iam)). Wähle im Menü links *Policies* aus. Du siehst alle vorhandenen Richtlinien sowie die Möglichkeit, eine neue Richtlinie zu erstellen.
+
+    Klicke auf die Schaltfläche *Create Policy* und wähle anschließend _Create Your Own Policy_. Die Richtlinie in diesem Beispiel erlaubt einem Benutzer, alle Buckets aufzulisten. Das ist nur erforderlich, wenn du ein Defold-Projekt für Live Update konfigurierst. Außerdem erlaubt sie dem Benutzer, die Zugriffssteuerungsliste (Access Control List, ACL) des für Ressourcen für Live Update verwendeten Buckets abzurufen und Ressourcen in diesen Bucket hochzuladen. Weitere Informationen zu Amazon Identity and Access Management (IAM) findest du in der [Dokumentation von Amazon](http://docs.aws.amazon.com/IAM/latest/UserGuide/access.html).
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListAllMyBuckets"
+                ],
+                "Resource": "arn:aws:s3:::*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetBucketAcl"
+                ],
+                "Resource": "arn:aws:s3:::defold-liveupdate-example"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:PutObject"
+                ],
+                "Resource": "arn:aws:s3:::defold-liveupdate-example/*"
+            }
+        ]
+    }
+    ```
+
+    ![IAM-Richtlinie](images/live-update/04-create-policy.png)
+
+5. Einen Benutzer für den programmgesteuerten Zugriff erstellen
+
+    Öffne das Menü *Services* und wähle *IAM* in der Kategorie _Security, Identity & Compliance_ ([Amazon IAM-Konsole](https://console.aws.amazon.com/iam)). Wähle im Menü links *Users* aus. Du siehst alle vorhandenen Benutzer sowie die Möglichkeit, einen neuen Benutzer hinzuzufügen. Du kannst zwar einen vorhandenen Benutzer verwenden, wir empfehlen jedoch, einen neuen Benutzer für Ressourcen für Live Update hinzuzufügen, damit du den Zugriff leicht einschränken kannst.
+
+    Klicke auf die Schaltfläche *Add User*, gib einen Benutzernamen ein und wähle *Programmatic access* als *Access type*. Klicke dann auf *Next: Permissions*. Wähle *Attach existing policies directly* und anschließend die Richtlinie aus, die du in Schritt 4 erstellt hast.
+
+    Wenn du den Vorgang abgeschlossen hast, erhältst du eine *Access key ID* und einen *Secret access key*.
+
+    ::: important
+    Es ist *sehr wichtig*, dass du diese Schlüssel speicherst, da du sie nicht mehr bei Amazon abrufen kannst, nachdem du die Seite verlassen hast.
+    :::
+
+6. Eine Profildatei mit Zugangsdaten erstellen
+
+    Zu diesem Zeitpunkt solltest du einen Bucket erstellt, eine Bucket-Richtlinie konfiguriert, eine CORS-Konfiguration hinzugefügt, eine Benutzerrichtlinie erstellt und einen neuen Benutzer angelegt haben. Jetzt musst du nur noch eine [Profildatei mit Zugangsdaten](https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks) erstellen, damit der Defold-Editor in deinem Namen auf den Bucket zugreifen kann.
+
+    Erstelle in deinem persönlichen Ordner ein neues Verzeichnis namens *.aws* und darin eine Datei namens *credentials*.
+
+    ```bash
+    $ mkdir ~/.aws
+    $ touch ~/.aws/credentials
+    ```
+
+    Die Datei *~/.aws/credentials* enthält deine Zugangsdaten für den programmgesteuerten Zugriff auf Amazon Web Services und ist eine standardisierte Möglichkeit, AWS-Zugangsdaten zu verwalten. Öffne die Datei in einem Texteditor und trage deine *Access key ID* und deinen *Secret access key* im unten gezeigten Format ein.
+
+    ```ini
+    [defold-liveupdate-example]
+    aws_access_key_id = <Access key ID>
+    aws_secret_access_key = <Secret access key>
+    ```
+
+    Die Kennung in den eckigen Klammern, in diesem Beispiel _defold-liveupdate-example_, ist dieselbe Kennung, die du beim Konfigurieren der Einstellungen für Live Update deines Projekts im Defold-Editor angeben solltest.
+
+    ![Einstellungen für Live Update](images/live-update/05-liveupdate-settings.png)

--- a/docs/de/manuals/live-update-scripting.md
+++ b/docs/de/manuals/live-update-scripting.md
@@ -1,0 +1,188 @@
+---
+title: Live-Update-Inhalte per Skript verwenden
+brief: Um Live-Update-Inhalte zu verwenden, musst du die Daten herunterladen und in dein Spiel einbinden. In diesem Handbuch erfährst du, wie du Live Update in Skripten verwendest.
+---
+
+# Live Update per Skript verwenden {#scripting-live-update}
+
+Der grundlegende Arbeitsablauf für Einbindungen (mounts) verwendet `liveupdate.add_mount()`, `liveupdate.remove_mount()` und `liveupdate.get_mounts()`. Alle verfügbaren Funktionen findest du in der vollständigen [API-Referenz zu `liveupdate`](/ref/liveupdate/).
+
+Verwende `liveupdate.is_built_with_excluded_files()`, wenn dein Code ein Bundle erkennen muss, dessen Build-Manifest ausgeschlossene Live-Update-Inhalte erwartet:
+
+```lua
+if liveupdate.is_built_with_excluded_files() then
+    print("The bundle expects excluded Live Update content")
+end
+```
+
+Dies gibt nur Metadaten des Build-Manifests zurück. Es bedeutet nicht, dass derzeit ein Archiv eingebunden ist oder eine bestimmte Ressource verfügbar ist. Verwende `liveupdate.get_mounts()`, um aktive Einbindungen zu untersuchen, und [`collectionproxy.get_resources()`](/ref/collectionproxy/#collectionproxy.get_resources), um die im Manifest verzeichneten Ressourcen-Hashwerte für einen Sammlungs-Proxy (collection proxy) zu untersuchen.
+
+Der empfohlene Arbeitsablauf besteht darin, ein vollständiges ZIP-Archiv herunterzuladen und über eine URI mit `zip:` einzubinden.
+
+## Einbindungen abrufen {#get-mounts}
+
+`liveupdate.get_mounts()` gibt die Einbindungen zurück, die in der aktuellen Sitzung aktiv sind. Jeder Eintrag hat eine Zeichenfolge `uri`, einen numerischen Wert `priority` und einen Hashwert `name`. Die Liste enthält auch die Basiseinbindungen der Engine, deren Prioritäten unter null liegen und die nicht entfernt werden können.
+
+Die Engine stellt Einbindungen nach einem Neustart nicht wieder her. Wenn die Anwendung zuvor heruntergeladene Inhalte in einer späteren Sitzung benötigt, muss sie die URI, den Namen und die Priorität des Pakets in ihren eigenen Speicherdaten dauerhaft speichern und beim Start erneut `liveupdate.add_mount()` aufrufen.
+
+Wenn mehrere Pakete eingebunden sind, ist es sinnvoll, ihre von der Anwendung definierten Metadaten zu validieren. Da `mount.name` ein Hashwert ist, verwende ihn als Tabellenschlüssel oder vergleiche ihn mit `hash("mount-name")`; füge ihn nicht durch Verkettung in einen Ressourcenpfad ein. Das folgende Beispiel ordnet jedem Namens-Hashwert einen eindeutigen Pfad zu einer Metadatenressource zu:
+
+```lua
+local function remove_old_mounts()
+	local mounts = liveupdate.get_mounts() -- table with mounts
+	local version_resources = {
+		[hash("level-pack")] = "/version_level_pack.json",
+		[hash("season-pack")] = "/version_season_pack.json",
+	}
+
+	for _, mount in ipairs(mounts) do
+		local version_resource = version_resources[mount.name]
+		local version_data = version_resource and sys.load_resource(version_resource)
+
+		if version_data then
+			version_data = json.decode(version_data)
+		elseif mount.priority >= 0 then
+			version_data = {version = 0} -- if it has no version file, it's likely an old/invalid archive
+		end
+
+		-- Ignore the engine's base mounts, which have negative priorities.
+		if version_data and version_data.version < sys.get_config_int("game.minimum_lu_version") then
+			liveupdate.remove_mount(mount.name)
+		end
+	end
+end
+```
+
+Verwende für verschiedene Pakete eindeutige Metadatenpfade. Die Ressourcensuche folgt der Priorität der Einbindungen. Wenn du denselben Pfad in mehreren Paketen verwendest, wird daher die Kopie aus der Einbindung mit der höchsten Priorität gelesen.
+
+## Skripte mit ausgeschlossenen Sammlungs-Proxys {#scripting-with-excluded-collection-proxies}
+
+Ein Sammlungs-Proxy, der von der Bundle-Erstellung ausgeschlossen wurde, funktioniert wie ein normaler Sammlungs-Proxy, mit einem wichtigen Unterschied. Wenn du ihm eine `load`-Nachricht sendest, während noch Ressourcen im Bundle-Speicher fehlen, schlägt das Laden fehl.
+
+Beim Arbeitsablauf mit Archiven legst du in der Regel im Voraus fest, welche Archive ein Proxy benötigt, und bindest sie vor dem Laden ein. Um die im Manifest verzeichneten Ressourcen-Hashwerte für einen bekannten ausgeschlossenen Proxy zu untersuchen, verwende `collectionproxy.get_resources()`.
+
+Nachdem ein Paket eingebunden wurde, kann ein ausgeschlossener und entladener Proxy mit `collectionproxy.set_collection()` auch auf eine andere kompilierte Sammlung (collection) umgeleitet werden. Die Einschränkungen und die Ladereihenfolge findest du unter [Die Sammlung eines ausgeschlossenen Proxys ändern](/manuals/collection-proxy/#changing-an-excluded-proxys-collection).
+
+Bei einem Archiv-Build, der Live-Update-Inhalte veröffentlicht, lässt das im Bundle enthaltene Hauptmanifest ausgeschlossene Live-Update-Einträge aus, während das veröffentlichte Paketmanifest sie beibehält. `collectionproxy.get_resources()` liest die Abhängigkeitsmetadaten des Manifests; es überprüft nicht, ob jeder referenzierte Datenblock verfügbar ist:
+
+* Bevor ein Paketmanifest mit den ausgeschlossenen Einträgen des Proxys eingebunden wird, gibt `collectionproxy.get_resources("#proxy")` eine leere Tabelle `{}` zurück.
+* Nachdem das entsprechende Paket eingebunden wurde, gibt die Funktion eine nicht leere Tabelle mit Ressourcen-Hashwerten für diesen Proxy zurück, zum Beispiel:
+
+```lua
+{
+    "a1b2c3...",
+    "d4e5f6...",
+    "7890ab...",
+    ...
+}
+```
+
+ Der folgende Beispielcode setzt voraus, dass die Ressourcen über die URL verfügbar sind, die in der Einstellung `game.http_url` angegeben ist.
+
+```lua
+
+-- You'll need to track which archive contains which content
+-- In this example, we only use a single liveupdate archive, containing all missing resource.
+-- If you are using multiple archive, you need to structure the downloads accordingly
+local lu_infos = {
+    liveupdate = {
+        name = "liveupdate",
+        priority = 10,
+    }
+}
+
+local function get_lu_info_for_level(level_name)
+    if level_name == "level1" then
+        return lu_infos['liveupdate']
+    end
+end
+
+local function mount_zip(self, name, priority, path, callback)
+    liveupdate.add_mount(name, "zip:" .. path, priority, function(_self, _name, _uri, _result) -- <1>
+        callback(_name, _uri, _result)
+    end)
+end
+
+local function has_mount(name)
+    local name_hash = hash(name)
+    for _, mount in ipairs(liveupdate.get_mounts()) do
+        if mount.name == name_hash then
+            return true
+        end
+    end
+    return false
+end
+
+function init(self)
+    self.http_url = sys.get_config_string("game.http_url", nil) -- <2>
+
+    local level_name = "level1"
+
+    local info = get_lu_info_for_level(level_name) -- <3>
+
+    msg.post("#", "load_level", {level = "level1", info = info }) -- <4>
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("load_level") then
+        local proxy_resources = collectionproxy.get_resources("#" .. message.level) -- <5>
+
+        -- A build that publishes Live Update content omits excluded entries from the
+        -- bundled manifest, so this table is empty until the relevant package manifest
+        -- is mounted. After mounting, it contains the resource hashes for the proxy.
+        if message.info and #proxy_resources == 0 and not has_mount(message.info.name) then
+            msg.post("#", "download_archive", message) -- <6>
+        else
+            msg.post("#" .. message.level, "load")
+        end
+
+    elseif message_id == hash("download_archive") then
+        local zip_filename = message.info.name .. ".zip"
+        local download_path = sys.get_save_file("mygame", zip_filename)
+        local url = self.http_url .. "/" .. zip_filename
+
+        -- Check if the archive already exists. If it does, try to mount it!
+        if sys.exists(download_path) then
+            mount_zip(self, message.info.name, message.info.priority, download_path, function(name, uri, result) -- <8>
+                if result == liveupdate.LIVEUPDATE_OK then
+                    msg.post("#", "load_level", message) -- try to load the level again
+                else
+                    os.remove(download_path)             -- remove and try to
+                    msg.post("#", "load_level", message) -- download again
+                end
+            end)
+        else
+            -- Make the request. You can use credentials
+            http.request(url, "GET", function(self, id, response) -- <7>
+                if response.status == 200 or response.status == 304 then
+                    mount_zip(self, message.info.name, message.info.priority, download_path, function(name, uri, result) -- <8>
+                        if result == liveupdate.LIVEUPDATE_OK then
+                            msg.post("#", "load_level", message) -- try to load the level again
+                        else
+                            print("Failed to mount archive", download_path, ":", result)
+                        end
+                    end)
+                else
+                    print("Failed to download archive", download_path, "from", url, ":", response.status)
+                end
+            end, nil, nil, {path=download_path})
+        end
+
+    elseif message_id == hash("proxy_loaded") then -- the level is loaded, and we can enable it
+        msg.post(sender, "init")
+        msg.post(sender, "enable")
+    end
+end
+```
+
+1. `liveupdate.add_mount()` bindet ein einzelnes Archiv mit einem angegebenen Namen, einer Priorität und einer ZIP-Datei ein. Die Daten stehen dann sofort zum Laden bereit (die Engine muss nicht neu gestartet werden). Die Einbindung ist nur für die aktuelle Sitzung aktiv. Speichere den Pfad des heruntergeladenen Pakets und die gewünschten Einstellungen für die Einbindung dauerhaft in deinen eigenen Speicherdaten und rufe nach jedem Neustart erneut `liveupdate.add_mount()` auf.
+2. Du musst das Archiv online speichern (z. B. auf S3), damit du es von dort herunterladen kannst.
+3. Ausgehend vom Namen eines Sammlungs-Proxys musst du ermitteln, welche Archive heruntergeladen werden müssen und wie sie einzubinden sind.
+4. Beim Start versuchen wir, das Level zu laden.
+5. Verwende in diesem Arbeitsablauf zur Veröffentlichung von Archiven `collectionproxy.get_resources()`, um die Metadaten zu den ausgeschlossenen Inhalten des Proxys zu untersuchen. Die Funktion gibt `{}` zurück, bis das entsprechende Paketmanifest eingebunden ist, und danach eine nicht leere Tabelle mit Ressourcen-Hashwerten. Diese Hashwerte beschreiben Abhängigkeiten; das Ergebnis selbst bestätigt nicht, dass jeder Datenblock verfügbar ist.
+6. Wenn der Proxy Live-Update-Inhalte verwendet und das passende Archiv noch nicht eingebunden ist, laden wir es herunter und binden es ein, bevor wir den Proxy laden.
+7. Sende eine HTTP-Anfrage und lade das Archiv nach `download_path` herunter.
+8. Die Daten sind heruntergeladen, und jetzt können wir sie in die laufende Engine einbinden.
+
+
+Mit dem Code zum Laden können wir die Anwendung testen. Wenn du sie aus dem Editor heraus ausführst, wird allerdings nichts heruntergeladen. Der Grund dafür ist, dass Live Update eine Bundle-Funktion ist. Bei der Ausführung in der Editorumgebung werden niemals Ressourcen ausgeschlossen. Um sicherzustellen, dass alles richtig funktioniert, müssen wir ein Bundle erstellen.

--- a/docs/de/manuals/live-update.md
+++ b/docs/de/manuals/live-update.md
@@ -1,0 +1,152 @@
+---
+title: Live-Update-Inhalte in Defold
+brief: Live Update bietet einen Mechanismus, mit dem die Laufzeitumgebung Ressourcen abrufen und im Anwendungs-Bundle speichern kann, die beim Build absichtlich aus dem Bundle ausgelassen wurden. Dieses Handbuch erklärt, wie das funktioniert.
+---
+
+# Live Update
+
+Wenn du ein Bundle für ein Spiel erstellst, packt Defold alle Spielressourcen in das entstehende plattformspezifische Paket. In den meisten Fällen ist dies erwünscht, da die laufende Engine sofort auf alle Ressourcen zugreifen und sie schnell vom Datenträger laden kann. Es gibt jedoch Fälle, in denen du das Laden von Ressourcen auf einen späteren Zeitpunkt verschieben möchtest. Zum Beispiel:
+
+- Dein Spiel besteht aus einer Reihe von Episoden, und du möchtest nur die erste mitliefern, damit die Spieler sie ausprobieren können, bevor sie entscheiden, ob sie mit dem Rest des Spiels fortfahren möchten.
+- Dein Spiel ist für HTML5 vorgesehen. Im Browser bedeutet das Laden einer Anwendung vom Datenträger, dass das gesamte Anwendungspaket vor dem Start heruntergeladen werden muss. Auf einer solchen Plattform möchtest du möglicherweise ein minimales Startpaket bereitstellen und die Anwendung schnell starten, bevor du die restlichen Spielressourcen herunterlädst.
+- Dein Spiel enthält sehr große Ressourcen (Bilder, Videos usw.), deren Download du aufschieben möchtest, bis sie im Spiel angezeigt werden sollen. So bleibt die Installationsgröße gering.
+
+Live Update erweitert das Konzept des Sammlungs-Proxys (collection proxy) um einen Mechanismus, mit dem die Laufzeitumgebung Ressourcen abrufen und im Anwendungs-Bundle speichern kann, die beim Build absichtlich aus dem Bundle ausgelassen wurden.
+
+Damit kannst du deine Inhalte auf mehrere Archive aufteilen:
+
+* _Basisarchiv_
+* Gemeinsame Leveldateien
+* Levelpaket 1
+* Levelpaket 2
+* ...
+
+## Inhalte für Live Update vorbereiten {#preparing-content-for-live-update}
+
+Angenommen, wir erstellen ein Spiel mit großen, hochauflösenden Bildressourcen. Das Spiel hält diese Bilder in Sammlungen (collections) mit jeweils einem Spielobjekt (game object) und einem Sprite mit dem Bild:
+
+![Mona-Lisa-Sammlung](images/live-update/mona-lisa.png)
+
+Damit die Engine eine solche Sammlung dynamisch lädt, können wir einfach eine Komponente (component) vom Typ Sammlungs-Proxy hinzufügen und auf *`monalisa.collection`* verweisen lassen. Das Spiel kann nun entscheiden, wann es die Inhalte der Sammlung vom Datenträger in den Arbeitsspeicher lädt, indem es eine `load`-Nachricht an den Sammlungs-Proxy sendet. Wir möchten jedoch noch weiter gehen und das Laden der in der Sammlung enthaltenen Ressourcen selbst steuern.
+
+Dazu aktivieren wir einfach das Kontrollkästchen *Exclude* in den Eigenschaften des Sammlungs-Proxys. Damit weisen wir Defold an, beim Erstellen eines Anwendungs-Bundles sämtliche Inhalte von *`monalisa.collection`* auszulassen.
+
+::: important
+Ressourcen, auf die das Basispaket des Spiels verweist, werden nicht ausgeschlossen.
+:::
+
+![Ausgeschlossener Sammlungs-Proxy](images/live-update/proxy-excluded.png)
+
+## Einstellungen für Live Update {#live-update-settings}
+
+Wenn Defold ein Anwendungs-Bundle erstellt, muss es die ausgeschlossenen Ressourcen an einem anderen Ort speichern. Die Projekteinstellungen für Live Update bestimmen den Speicherort dieser Ressourcen. Du findest die Einstellungen unter <kbd>Project ▸ Live update Settings...</kbd>. Dabei wird eine Einstellungsdatei erstellt, falls noch keine vorhanden ist. Wähle in *game.project* aus, welche Einstellungsdatei für Live Update bei der Bundle-Erstellung verwendet werden soll. So kannst du unterschiedliche Einstellungen für verschiedene Umgebungen verwenden, zum Beispiel für den Produktivbetrieb, die Qualitätssicherung (QA), die Entwicklung usw.
+
+![Einstellungen für Live Update](images/live-update/05-liveupdate-settings-zip.png)
+
+Derzeit gibt es drei Möglichkeiten, wie Defold die Ressourcen speichern kann. Wähle die Methode im Dropdown-Menü *Mode* des Einstellungsfensters:
+
+`Zip`
+: Diese Option weist Defold an, eine Zip-Archivdatei mit allen ausgeschlossenen Ressourcen zu erstellen. Das Archiv wird am Speicherort abgelegt, der in der Einstellung *Export path* angegeben ist, und kann zur Laufzeit mit einer `zip:`-URI und `liveupdate.add_mount()` eingebunden werden.
+
+`Folder`  
+: Diese Option weist Defold an, einen Ordner mit allen ausgeschlossenen Ressourcen zu erstellen. Das ist nützlich, wenn du Dateien vor dem Hochladen oder Verpacken nachbearbeiten musst. Ein Ordner mit einzelnen kompilierten Dateien, die unter ihren erwarteten Ressourcenpfaden abgelegt sind, kann zur Laufzeit mit einer `file:`-URI eingebunden werden.
+
+`Amazon`
+: Diese Option weist Defold an, ausgeschlossene Ressourcen automatisch in einen S3-Bucket von Amazon Web Service (AWS) hochzuladen. Gib den Namen deines AWS-*Credential profile* ein, wähle den passenden *Bucket* aus und gib einen Namen für *Prefix* an.  Mehr zur Einrichtung eines AWS-Kontos erfährst du in dieser [AWS-Anleitung](/manuals/live-update-aws)
+
+## Bundles mit Live Update erstellen {#bundling-with-live-update}
+
+::: important
+Das Erstellen eines Builds und dessen Ausführung im Editor (<kbd>Project ▸ Build</kbd>) unterstützt Live Update nicht. Um Live Update zu testen, musst du ein Bundle des Projekts erstellen.
+:::
+
+Ein Bundle mit Live Update zu erstellen ist einfach. Wähle <kbd>Project ▸ Bundle ▸ ...</kbd> und anschließend die Plattform aus, für die du ein Anwendungs-Bundle erstellen möchtest. Dadurch öffnet sich der Dialog zur Bundle-Erstellung:
+
+![Anwendungs-Bundle mit Live Update erstellen](images/live-update/bundle-app.png)
+
+Bei der Bundle-Erstellung werden alle ausgeschlossenen Ressourcen aus dem Anwendungs-Bundle ausgelassen. Wenn du das Kontrollkästchen *Publish Live update content* aktivierst, weist du Defold an, die ausgeschlossenen Ressourcen entweder zu Amazon hochzuladen oder ein Zip-Archiv zu erstellen, je nachdem, wie du deine Einstellungen für Live Update festgelegt hast (siehe oben). Die veröffentlichten Live-Update-Inhalte enthalten weiterhin `liveupdate.game.dmanifest`, das die vollständige Ressourcenliste für die Bereitstellung über das Netzwerk enthält.
+
+Beim Veröffentlichen von Live-Update-Inhalten entfernt Defold automatisch die Einträge, die ausschließlich zu Live Update gehören, aus dem im Bundle enthaltenen `game.dmanifest`, während das veröffentlichte `liveupdate.game.dmanifest` die vollständige Ressourcenliste behält. Dadurch werden die Bundle-Größe und der Speicherverbrauch zur Laufzeit verringert. Die frühere Einstellung `liveupdate.exclude_entries_from_main_manifest` wurde entfernt; ein eventuell noch vorhandener Eintrag im Projekt wird ignoriert.
+
+Beim Arbeiten mit Archiven gibt `collectionproxy.get_resources()` so lange `{}` zurück, bis das betreffende Archiv eingebunden wurde. Nach dem Einbinden gibt die Funktion die Ressourcen-Hashes für diesen Proxy zurück.
+
+Klicke auf *Package* und wähle einen Speicherort für das Anwendungs-Bundle aus. Nun kannst du die Anwendung starten und prüfen, ob alles wie erwartet funktioniert.
+
+## Die .zip-Archive {#the-zip-archives}
+
+Eine .zip-Datei für Live Update enthält Dateien, die aus dem Basispaket des Spiels ausgeschlossen wurden.
+
+Unsere aktuelle Pipeline unterstützt zwar nur das Erstellen einer einzigen .zip-Datei, du kannst diese Zip-Datei jedoch in kleinere .zip-Dateien aufteilen. Dadurch sind kleinere Downloads für ein Spiel möglich: Levelpakete, saisonale Inhalte usw. Jede .zip-Datei enthält außerdem eine Manifestdatei, die die Metadaten jeder im .zip-Archiv enthaltenen Ressource beschreibt.
+
+## .zip-Archive aufteilen {#splitting-zip-archives}
+
+Oft ist es sinnvoll, die ausgeschlossenen Inhalte auf mehrere kleinere Archive aufzuteilen, um die Ressourcennutzung genauer steuern zu können. Ein Beispiel ist die Aufteilung eines Spiels mit mehreren Levels in mehrere Levelpakete. Ein weiteres Beispiel sind Dekorationen der Benutzeroberfläche für verschiedene Feiertage, die du in getrennten Archiven ablegst. So kannst du nur das zum aktuellen Kalenderdatum passende Thema laden und einbinden.
+
+Der Ressourcengraph wird in `build/default/game.graph.json` gespeichert und bei jeder Bundle-Erstellung des Projekts automatisch erzeugt. Die erzeugte Datei enthält eine Liste aller Ressourcen des Projekts und die Abhängigkeiten jeder Ressource. Beispieleintrag:
+
+```json
+{
+  "path" : "/game/player.goc",
+  "hexDigest" : "caa342ec99794de45b63735b203e83ba60d7e5a1",
+  "children" : [ "/game/ship.spritec", "/game/player.scriptc" ]
+}
+```
+
+Jeder Eintrag hat einen `path`, der den eindeutigen Pfad der Ressource innerhalb des Projekts angibt. Der `hexDigest` ist der kryptografische Fingerabdruck der Ressource und wird als Dateiname im .zip-Archiv für Live Update verwendet. Das Feld `children` schließlich ist eine Liste weiterer Abhängigkeiten, von denen diese Ressource abhängt. Im obigen Beispiel hat `/game/player.goc` eine Abhängigkeit von einem Sprite und einer Skriptkomponente.
+
+Du kannst die Datei `game.graph.json` auswerten und diese Informationen nutzen, um Gruppen von Einträgen im Ressourcengraphen zu identifizieren und ihre zugehörigen Ressourcen zusammen mit der ursprünglichen Manifestdatei in separaten Archiven zu speichern (die Manifestdatei wird zur Laufzeit so gekürzt, dass sie nur die Dateien des jeweiligen Archivs enthält).
+
+## Live Update auf Android {#live-update-on-android}
+
+Du kannst Play Asset Delivery verwenden, um Live-Update-Inhalte herunterzuladen und einzubinden. Mehr dazu erfährst du [im offiziellen Handbuch](https://defold.com/extension-pad/).
+
+## Inhaltsprüfung {#content-verification}
+
+Eine der wichtigsten Funktionen des Live-Update-Systems ist, dass du nun viele Inhaltsarchive verwenden kannst, möglicherweise aus vielen verschiedenen Defold-Versionen.
+
+Standardmäßig führt `liveupdate.add_mount()` beim Hinzufügen einer Einbindung (mount) eine Prüfung der Engine-Version durch.
+Das bedeutet, dass sowohl das Basisarchiv des Spiels als auch die Live-Update-Archive zur selben Zeit mit derselben Engine-Version über die Bundle-Option erstellt werden müssen. Dadurch werden alle zuvor vom Client heruntergeladenen Archive ungültig, sodass die Inhalte erneut heruntergeladen werden müssen.
+
+Dieses Verhalten lässt sich über ein Options-Flag deaktivieren.
+Wenn es deaktiviert ist, liegt die Verantwortung für die Inhaltsprüfung vollständig bei dir als Entwickler. Du musst sicherstellen, dass jedes Live-Update-Archiv mit der laufenden Engine funktioniert.
+
+Wir empfehlen, Metadaten für jede Einbindung zu speichern, damit die Anwendung entscheiden kann, ob das Paket eingebunden bleiben soll. Führe die Prüfung nach dem Hinzufügen der Einbindung durch, auch wenn die Anwendung beim Start ihre benötigten Einbindungen erneut hinzufügt.
+Eine Möglichkeit dazu ist, nach der Bundle-Erstellung des Spiels eine zusätzliche Datei in das Zip-Archiv einzufügen. Füge beispielsweise eine `metadata.json` mit allen Informationen ein, die das Spiel benötigt, und rufe sie nach dem Einbinden mit `sys.load_resource("/metadata.json")` ab. _Verwende für die benutzerdefinierten Daten jeder Einbindung einen eindeutigen Ressourcenpfad, sonst gibt die Ressourcensuche die Datei aus der Einbindung mit der höchsten Priorität zurück._
+
+Wenn du das nicht tust, kann es passieren, dass die Inhalte überhaupt nicht mit der Engine kompatibel sind und diese sich deshalb beenden muss.
+
+## Einbindungen {#mounts}
+
+Das Live-Update-System kann mehrere Inhaltsarchive gleichzeitig verwenden.
+Jedes Archiv wird mit einem Namen und einer Priorität in das Ressourcensystem der Engine „eingebunden“.
+
+Wenn zwei Archive dieselbe Datei `sprite.texturec` enthalten, lädt die Engine die Datei aus der Einbindung mit der höchsten Priorität.
+
+Die Engine hält keine Referenz auf eine Ressource in einer Einbindung. Sobald eine Ressource in den Arbeitsspeicher geladen wurde, kann die Einbindung des Archivs aufgehoben werden. Die Ressource bleibt im Arbeitsspeicher, bis sie entladen wird.
+
+Einbindungen sind nur für die aktuelle Engine-Sitzung aktiv. Nach einem Neustart muss die Anwendung für jedes benötigte Paket erneut `liveupdate.add_mount()` aufrufen. Speichere den Speicherort des Pakets, den Namen der Einbindung und ihre Priorität in persistenten Daten, die von der Anwendung verwaltet werden, wenn diese Angaben zwischen Sitzungen erhalten bleiben müssen.
+
+::: sidenote
+Ein Zip-Archiv oder ein Ordner wird beim Einbinden weder kopiert noch verschoben. Die eingebundenen Inhalte müssen so lange am angegebenen Speicherort bleiben, wie die Einbindung verwendet wird.
+:::
+
+## Skripting mit Live Update {#scripting-with-live-update}
+
+Um Live-Update-Inhalte tatsächlich zu verwenden, musst du die Daten herunterladen und in dein Spiel einbinden.
+Mehr zum [Skripting mit Live Update erfährst du hier](/manuals/live-update-scripting).
+
+## Hinweise für die Entwicklung {#development-caveats}
+
+Debugging
+: Wenn du eine als Bundle erstellte Version deines Spiels ausführst, hast du keinen direkten Zugriff auf eine Konsole. Das erschwert die Fehlersuche. Du kannst die Anwendung jedoch über die Befehlszeile oder durch einen direkten Doppelklick auf die ausführbare Datei im Bundle starten:
+
+  ![Eine Anwendung aus einem Bundle ausführen](images/live-update/run-bundle.png)
+
+  Das Spiel startet nun mit einem Shell-Fenster, das die Ausgabe aller `print()`-Anweisungen anzeigt:
+
+  ![Konsolenausgabe](images/live-update/run-bundle-console.png)
+
+Erneuten Download von Ressourcen erzwingen
+: Als Entwickler kannst du die Inhalte in eine beliebige Datei oder einen beliebigen Ordner herunterladen. Häufig befinden sie sich jedoch unter dem Anwendungspfad. Der Speicherort des Ordners für Anwendungsdaten hängt vom Betriebssystem ab. Du kannst ihn mit `print(sys.get_save_file("", ""))` ermitteln. Um einen Download zu erzwingen, entferne das heruntergeladene Paket und den zugehörigen Eintrag aus allen von der Anwendung verwalteten Zustandsdaten. Es gibt keine von der Engine verwaltete Liste von Einbindungen, die gelöscht werden müsste; Einbindungen bleiben über Neustarts hinweg nicht erhalten.
+
+  ![Lokaler Speicher](images/live-update/local-storage.png)

--- a/docs/de/manuals/lua.md
+++ b/docs/de/manuals/lua.md
@@ -1,0 +1,670 @@
+---
+title: Lua-Programmierung in Defold
+brief: Dieses Handbuch bietet eine kurze Einführung in die Grundlagen der Lua-Programmierung und erklärt, was du bei der Arbeit mit Lua in Defold beachten solltest.
+---
+
+# Lua in Defold
+
+In die Defold-Engine ist die Sprache Lua für die Skriptprogrammierung eingebettet. Lua ist eine schlanke dynamische Sprache, die leistungsfähig, schnell und leicht einzubetten ist. Sie wird häufig als Skriptsprache für Videospiele eingesetzt. Lua-Programme werden in einer einfachen prozeduralen Syntax geschrieben. Die Sprache ist dynamisch typisiert und wird von einem Bytecode-Interpreter ausgeführt. Sie bietet eine automatische Speicherverwaltung mit inkrementeller automatischer Speicherbereinigung (Garbage Collection).
+
+Dieses Handbuch bietet eine kurze Einführung in die Grundlagen der Lua-Programmierung und erklärt, was du bei der Arbeit mit Lua in Defold beachten solltest. Wenn du bereits Erfahrung mit Python, Perl, Ruby, JavaScript oder einer ähnlichen dynamischen Sprache hast, wirst du dich schnell zurechtfinden. Wenn du noch keine Programmiererfahrung hast, kannst du mit einem Lua-Buch für den Einstieg beginnen. Es gibt eine große Auswahl.
+
+## Lua-Versionen {#lua-versions}
+
+Defold verwendet [LuaJIT](https://luajit.org/), eine stark optimierte Version von Lua, die sich für Spiele und andere Software mit hohen Leistungsanforderungen eignet. LuaJIT ist vollständig aufwärtskompatibel mit Lua 5.1 und unterstützt alle Funktionen der Lua-Standardbibliotheken sowie sämtliche Funktionen der Lua/C-API.
+
+LuaJIT bietet außerdem mehrere [Spracherweiterungen](https://luajit.org/extensions.html) und einige Funktionen aus Lua 5.2 und 5.3.
+
+Das Defold-Team strebt an, Defold auf allen Plattformen einheitlich zu halten. Derzeit gibt es jedoch einige kleinere Unterschiede zwischen den Plattformen bei der verwendeten Lua-Sprachversion:
+* iOS erlaubt keine JIT-Kompilierung.
+* Nintendo Switch erlaubt keine JIT-Kompilierung.
+* HTML5 verwendet Lua 5.1.4 anstelle von LuaJIT.
+
+::: important
+Damit dein Spiel auf allen unterstützten Plattformen funktioniert, empfehlen wir dringend, NUR Sprachfunktionen aus Lua 5.1 zu verwenden.
+:::
+
+### Standardbibliotheken und Erweiterungen {#standard-libraries-and-extensions}
+Defold enthält alle [Lua-5.1-Standardbibliotheken](http://www.lua.org/manual/5.1/manual.html#5) sowie eine Socket-Bibliothek und eine Bibliothek für Bitoperationen:
+
+  - base (`assert()`, `error()`, `print()`, `ipairs()`, `require()` usw.)
+  - coroutine
+  - package
+  - string
+  - table
+  - math
+  - io
+  - os
+  - debug
+  - socket (aus [LuaSocket](https://github.com/diegonehab/luasocket))
+  - bitop (aus [BitOp](http://bitop.luajit.org/api.html))
+
+Alle Bibliotheken sind in der [API-Referenzdokumentation](/ref/go) dokumentiert.
+
+## Bücher und Ressourcen zu Lua {#lua-books-and-resources}
+
+### Online-Ressourcen {#online-resources}
+* [Programming in Lua (erste Ausgabe)](http://www.lua.org/pil/contents.html) Spätere Ausgaben sind in gedruckter Form erhältlich.
+* [Lua-5.1-Referenzhandbuch](http://www.lua.org/manual/5.1/)
+* [Lua in 15 Minuten lernen](http://tylerneylon.com/a/learn-lua/)
+* [Awesome Lua – Abschnitt mit Tutorials](https://github.com/LewisJEllis/awesome-lua#tutorials)
+
+### Bücher {#books}
+* [Programming in Lua](https://www.amazon.com/gp/product/8590379868/ref=dbs_a_def_rwt_hsch_vapi_taft_p1_i0) - Programming in Lua ist das offizielle Buch zur Sprache und bietet allen, die mit Lua programmieren möchten, eine solide Grundlage. Geschrieben wurde es von Roberto Ierusalimschy, dem Hauptarchitekten der Sprache.
+* [Lua programming gems](https://www.amazon.com/Programming-Gems-Luiz-Henrique-Figueiredo/dp/8590379841) - Diese Artikelsammlung hält einen Teil des vorhandenen Wissens und bewährter Verfahren für gutes Programmieren in Lua fest.
+* [Lua-5.1-Referenzhandbuch](https://www.amazon.com/gp/product/8590379833/ref=dbs_a_def_rwt_hsch_vapi_taft_p1_i4) - Auch online verfügbar (siehe oben)
+* [Beginning Lua Programming](https://www.amazon.com/Beginning-Lua-Programming-Kurt-Jung/dp/0470069171)
+
+### Videos
+* [Lua in einem Video lernen](https://www.youtube.com/watch?v=iMacxZQMPXs)
+
+## Syntax
+
+Programme haben eine einfache, gut lesbare Syntax. Anweisungen werden jeweils in eine eigene Zeile geschrieben, und ihr Ende muss nicht gekennzeichnet werden. Optional kannst du Semikolons `;` verwenden, um Anweisungen zu trennen. Codeblöcke werden durch Schlüsselwörter begrenzt und enden mit dem Schlüsselwort `end`. Kommentare können als Block oder bis zum Ende einer Zeile geschrieben werden:
+
+```lua
+--[[
+Here is a block of comments that can run
+over several lines in the source file.
+--]]
+
+a = 10
+b = 20 ; c = 30 -- two statements on one line
+
+if my_variable == 3 then
+    call_some_function(true) -- Here is a line comment
+else
+    call_another_function(false)
+end
+```
+
+## Variablen und Datentypen {#variables-and-data-types}
+
+Lua ist dynamisch typisiert. Das bedeutet, dass Variablen keinen Typ haben, Werte hingegen schon. 
+Anders als in statisch typisierten Sprachen kannst du jeder Variablen einen beliebigen Wert zuweisen. 
+
+Lua hat acht grundlegende Typen:
+
+`nil`
+: Dieser Typ hat nur den Wert `nil`. Er steht gewöhnlich für das Fehlen eines sinnvollen Werts, beispielsweise bei Variablen, denen noch kein Wert zugewiesen wurde.
+
+  ```lua
+  print(my_var) -- will print 'nil' since 'my_var' is not yet assigned a value
+  ```
+
+boolean
+: Hat entweder den Wert `true` oder `false`. Bedingungen mit dem Wert `false` oder `nil` werden als falsch ausgewertet. Jeder andere Wert wird als wahr ausgewertet.
+
+  ```lua
+  flag = true
+  if flag then
+      print("flag is true")
+  else
+      print("flag is false")
+  end
+
+  if my_var then
+      print("my_var is not nil nor false!")
+  end
+
+  if not my_var then
+      print("my_var is either nil or false!")
+  end
+  ```
+
+number
+: Zahlen werden intern entweder als _Ganzzahlen_ mit 64 Bit oder als _Gleitkommazahlen_ mit 64 Bit dargestellt. Lua wandelt diese Darstellungen bei Bedarf automatisch ineinander um, sodass du dich in der Regel nicht darum kümmern musst.
+
+  ```lua
+  print(10) --> prints '10'
+  print(10.0) --> '10'
+  print(10.000000000001) --> '10.000000000001'
+
+  a = 5 -- integer
+  b = 7/3 -- float
+  print(a - b) --> '2.6666666666667'
+  ```
+
+string
+: Zeichenfolgen sind unveränderliche Folgen von Bytes, die jeden beliebigen 8-Bit-Wert enthalten können, einschließlich eingebetteter Nullbytes (`\0`). Lua trifft keine Annahmen über den Inhalt einer Zeichenfolge, sodass du beliebige Daten darin speichern kannst. Zeichenfolgenliterale werden in einfache oder doppelte Anführungszeichen eingeschlossen. Lua wandelt Zahlen und Zeichenfolgen zur Laufzeit ineinander um. Zeichenfolgen lassen sich mit dem Operator `..` verketten.
+
+  Zeichenfolgen können die folgenden Escape-Sequenzen im Stil von C enthalten:
+
+  | Sequenz | Zeichen |
+  | -------- | --------- |
+  | `\a`     | Signalton       |
+  | `\b`     | Rückschritt |
+  | `\f`     | Seitenvorschub  |
+  | `\n`     | Zeilenumbruch    |
+  | `\r`     | Wagenrücklauf |
+  | `\t`     | horizontaler Tabulator |
+  | `\v`     | vertikaler Tabulator   |
+  | `\\`     | umgekehrter Schrägstrich      |
+  | `\"`     | doppeltes Anführungszeichen   |
+  | `\'`     | einfaches Anführungszeichen   |
+  | `\[`     | öffnende eckige Klammer    |
+  | `\]`     | schließende eckige Klammer   |
+  | `\ddd`   | durch seinen Zahlenwert angegebenes Zeichen, wobei `ddd` eine Folge aus bis zu drei _Dezimalziffern_ ist |
+
+  ```lua
+  my_string = "hello"
+  another_string = 'world'
+  print(my_string .. another_string) --> "helloworld"
+
+  print("10.2" + 1) --> 11.2
+  print(my_string + 1) -- error, can't convert "hello"
+  print(my_string .. 1) --> "hello1"
+
+  print("one\nstring") --> one
+                       --> string
+
+  print("\097bc") --> "abc"
+
+  multi_line_string = [[
+  Here is a chunk of text that runs over several lines. This is all
+  put into the string and is sometimes very handy.
+  ]]
+  ```
+
+function
+: Funktionen sind in Lua vollwertige Werte. Das bedeutet, dass du sie als Parameter an Funktionen übergeben und als Werte zurückgeben kannst. Variablen, denen eine Funktion zugewiesen ist, enthalten eine Referenz auf diese Funktion. Du kannst Variablen anonyme Funktionen zuweisen, aber Lua bietet zur Vereinfachung syntaktischen Zucker (`function name(param1, param2) ... end`).
+
+  ```lua
+  -- Assign 'my_plus' to function
+  my_plus = function(p, q)
+      return p + q
+  end
+
+  print(my_plus(4, 5)) --> 9
+
+  -- Convenient syntax to assign function to variable 'my_mult'
+  function my_mult(p, q)
+      return p * q
+  end
+
+  print(my_mult(4, 5)) --> 20
+
+  -- Takes a function as parameter 'func'
+  function operate(func, p, q)
+      return func(p, q) -- Calls the provided function with parameters 'p' and 'q'
+  end
+
+  print(operate(my_plus, 4, 5)) --> 9
+  print(operate(my_mult, 4, 5)) --> 20
+
+  -- Create an adder function and return it
+  function create_adder(n)
+      return function(a)
+          return a + n
+      end
+  end
+
+  adder = create_adder(2)
+  print(adder(3)) --> 5
+  print(adder(10)) --> 12
+  ```
+
+table
+: Tabellen sind der einzige Typ in Lua zur Strukturierung von Daten. Es sind _Objekte_ in Form assoziativer Arrays, mit denen Listen, Arrays, Sequenzen, Symboltabellen, Mengen, Datensätze, Graphen, Bäume usw. dargestellt werden. Tabellen sind immer anonym. Variablen, denen du eine Tabelle zuweist, enthalten nicht die Tabelle selbst, sondern eine Referenz darauf. Wenn du eine Tabelle als Sequenz initialisierst, ist der erste Index `1`, nicht `0`.
+
+  ```lua
+  -- Initialize a table as a sequence
+  weekdays = {"Sunday", "Monday", "Tuesday", "Wednesday",
+              "Thursday", "Friday", "Saturday"}
+  print(weekdays[1]) --> "Sunday"
+  print(weekdays[5]) --> "Thursday"
+
+  -- Initialize a table as a record with sequence values
+  moons = { Earth = { "Moon" },
+            Uranus = { "Puck", "Miranda", "Ariel", "Umbriel", "Titania", "Oberon" } }
+  print(moons.Uranus[3]) --> "Ariel"
+
+  -- Build a table from an empty constructor {}
+  a = 1
+  t = {}
+  t[1] = "first"
+  t[a + 1] = "second"
+  t.x = 1 -- same as t["x"] = 1
+
+  -- Iterate over the table key, value pairs
+  for key, value in pairs(t) do
+      print(key, value)
+  end
+  --> 1   first
+  --> 2   second
+  --> x   1
+
+  u = t -- u now refers to the same table as t
+  u[1] = "changed"
+
+  for key, value in pairs(t) do -- still iterating over t!
+      print(key, value)
+  end
+  --> 1   changed
+  --> 2   second
+  --> x   1
+  ```
+
+userdata
+: `userdata` ermöglicht es, beliebige C-Daten in Lua-Variablen zu speichern. Defold verwendet Lua-Objekte vom Typ `userdata`, um Hash-Werte (hash), URL-Objekte (url), mathematische Objekte (vector3, vector4, matrix4, quaternion), Spielobjekte (game objects), GUI-Knoten (node), Render-Prädikate (predicate), Renderziele (render_target) und Render-Konstantenpuffer (constant_buffer) zu speichern
+
+thread
+: Threads stellen unabhängige Ausführungsstränge dar und werden zur Implementierung von Koroutinen verwendet. Einzelheiten findest du weiter unten.
+
+## Operatoren {#operators}
+
+Arithmetische Operatoren
+: Die mathematischen Operatoren `+`, `-`, `*`, `/`, das unäre `-` (Negation) und der Potenzoperator `^`.
+
+  ```lua
+  a = -1
+  print(a * 2 + 3 / 4^5) --> -1.9970703125
+  ```
+
+  Lua wandelt Zahlen und Zeichenfolgen zur Laufzeit automatisch ineinander um. Bei jeder numerischen Operation auf einer Zeichenfolge wird versucht, die Zeichenfolge in eine Zahl umzuwandeln:
+
+  ```lua
+  print("10" + 1) --> 11
+  ```
+
+Relations- und Vergleichsoperatoren
+: `<` (kleiner als), `>` (größer als), `<=` (kleiner oder gleich), `>=` (größer oder gleich), `==` (gleich), `~=` (ungleich). Diese Operatoren geben immer `true` oder `false` zurück. Werte unterschiedlicher Typen gelten als verschieden. Bei gleichem Typ werden sie anhand ihres Werts verglichen. Lua vergleicht Tabellen, `userdata` und Funktionen anhand ihrer Referenz. Zwei solche Werte gelten nur dann als gleich, wenn sie auf dasselbe Objekt verweisen.
+
+  ```lua
+  a = 5
+  b = 6
+
+  if a <= b then
+      print("a is less than or equal to b")
+  end
+
+  print("A" < "a") --> true
+  print("aa" < "ab") --> true
+  print(10 == "10") --> false
+  print(tostring(10) == "10") --> true
+  ```
+
+Logische Operatoren
+: `and`, `or` und `not`. `and` gibt sein erstes Argument zurück, wenn es `false` ist, andernfalls sein zweites Argument. `or` gibt sein erstes Argument zurück, wenn es nicht `false` ist, andernfalls sein zweites Argument.
+
+  ```lua
+  print(true or false) --> true
+  print(true and false) --> false
+  print(not false) --> true
+
+  if a == 5 and b == 6 then
+      print("a is 5 and b is 6")
+  end
+  ```
+
+Verkettung
+: Zeichenfolgen lassen sich mit dem Operator `..` verketten. Zahlen werden bei der Verkettung in Zeichenfolgen umgewandelt.
+
+  ```lua
+  print("donkey" .. "kong") --> "donkeykong"
+  print(1 .. 2) --> "12"
+  ```
+
+Länge
+: Der unäre Längenoperator `#`. Die Länge einer Zeichenfolge ist ihre Anzahl an Bytes. Die Länge einer Tabelle ist ihre Sequenzlänge, also die Anzahl der ab `1` aufwärts nummerierten Indizes, deren Wert nicht `nil` ist. Hinweis: Wenn die Sequenz „Lücken“ mit dem Wert `nil` enthält, kann die Länge jeder Index sein, der einem Wert `nil` vorausgeht.
+
+  ```lua
+  s = "donkey"
+  print(#s) --> 6
+
+  t = { "a", "b", "c", "d" }
+  print(#t) --> 4
+
+  u = { a = 1, b = 2, c = 3 }
+  print(#u) --> 0
+
+  v = { "a", "b", nil }
+  print(#v) --> 2
+  ```
+
+## Ablaufsteuerung {#flow-control}
+
+Lua bietet die üblichen Konstrukte zur Ablaufsteuerung.
+
+if---then---else
+: Prüft eine Bedingung und führt den Teil `then` aus, wenn die Bedingung wahr ist, andernfalls den (optionalen) Teil `else`. Statt `if`-Anweisungen zu verschachteln, kannst du `elseif` verwenden. Dies ersetzt eine switch-Anweisung, die Lua nicht hat.
+
+  ```lua
+  a = 5
+  b = 4
+
+  if a < b then
+      print("a is smaller than b")
+  end
+
+  if a == '1' then
+      print("a is 1")
+  elseif a == '2' then
+      print("a is 2")
+  elseif a == '3' then
+      print("a is 3")
+  else
+      print("I have no idea what a is...")
+  end
+  ```
+
+while
+: Prüft eine Bedingung und führt den Block aus, solange sie wahr ist.
+
+  ```lua
+  weekdays = {"Sunday", "Monday", "Tuesday", "Wednesday",
+              "Thursday", "Friday", "Saturday"}
+
+  -- Print each weekday
+  i = 1
+  while weekdays[i] do
+      print(weekdays[i])
+      i = i + 1
+  end
+  ```
+
+repeat---until
+: Wiederholt den Block, bis eine Bedingung wahr ist. Die Bedingung wird nach dem Block geprüft, sodass dieser mindestens einmal ausgeführt wird.
+
+  ```lua
+  weekdays = {"Sunday", "Monday", "Tuesday", "Wednesday",
+              "Thursday", "Friday", "Saturday"}
+
+  -- Print each weekday
+  i = 0
+  repeat
+      i = i + 1
+      print(weekdays[i])
+  until weekdays[i] == "Saturday"
+  ```
+
+for
+: Lua hat zwei Arten von `for`-Schleifen: numerische und generische. Die numerische `for`-Schleife nimmt 2 oder 3 Zahlenwerte entgegen, während die generische `for`-Schleife über alle Werte iteriert, die eine _Iteratorfunktion_ zurückgibt.
+
+  ```lua
+  -- Print the numbers 1 to 10
+  for i = 1, 10 do
+      print(i)
+  end
+
+  -- Print the numbers 1 to 10 and increment with 2 each time
+  for i = 1, 10, 2 do
+      print(i)
+  end
+
+  -- Print the numbers 10 to 1
+  for i=10, 1, -1 do
+      print(i)
+  end
+
+  t = { "a", "b", "c", "d" }
+  -- Iterate over the sequence and print the values
+  for i, v in ipairs(t) do
+      print(v)
+  end
+  ```
+
+break und return
+: Verwende die Anweisung `break`, um aus einem inneren Block einer `for`-, `while`- oder `repeat`-Schleife auszubrechen. Verwende `return`, um einen Wert aus einer Funktion zurückzugeben oder die Ausführung einer Funktion zu beenden und zum Aufrufer zurückzukehren. `break` oder `return` darf nur als letzte Anweisung eines Blocks stehen.
+
+  ```lua
+  a = 1
+  while true do
+      a = a + 1
+      if a >= 100 then
+          break
+      end
+  end
+
+  function my_add(a, b)
+      return a + b
+  end
+
+  print(my_add(10, 12)) --> 22
+  ```
+
+## Lokale und globale Variablen sowie lexikalische Gültigkeitsbereiche {#locals-globals-and-lexical-scoping}
+
+Alle Variablen, die du deklarierst, sind standardmäßig global. Das bedeutet, dass sie in allen Teilen des Lua-Laufzeitkontexts verfügbar sind. Du kannst Variablen ausdrücklich als `local` deklarieren. Dann existiert die Variable nur innerhalb des aktuellen Gültigkeitsbereichs.
+
+Jede Lua-Quelldatei definiert einen eigenen Gültigkeitsbereich. Deklarationen mit `local` auf der obersten Ebene einer Datei bedeuten, dass die Variable lokal zur Lua-Skriptdatei ist. Jede Funktion erzeugt einen weiteren verschachtelten Gültigkeitsbereich, und jeder Block einer Kontrollstruktur erzeugt zusätzliche Gültigkeitsbereiche. Mit den Schlüsselwörtern `do` und `end` kannst du ausdrücklich einen Gültigkeitsbereich erstellen. Lua hat lexikalische Gültigkeitsbereiche. Das bedeutet, dass ein Gültigkeitsbereich vollen Zugriff auf _lokale_ Variablen des umgebenden Gültigkeitsbereichs hat. Beachte, dass lokale Variablen vor ihrer Verwendung deklariert werden müssen.
+
+```lua
+function my_func(a, b)
+    -- 'a' and 'b' are local to this function and available through its scope
+
+    do
+        local x = 1
+    end
+
+    print(x) --> nil. 'x' is not available outside the do-end scope
+    print(foo) --> nil. 'foo' is declared after 'my_func'
+    print(foo_global) --> "value 2"
+end
+
+local foo = "value 1"
+foo_global = "value 2"
+
+print(foo) --> "value 1". 'foo' is available in the topmost scope after declaration.
+```
+
+Wenn du Funktionen in einer Skriptdatei als `local` deklarierst, was in der Regel sinnvoll ist, musst du auf die Reihenfolge des Codes achten. Wenn sich Funktionen gegenseitig aufrufen, kannst du Vorwärtsdeklarationen verwenden.
+
+```lua
+local func2 -- Forward declare 'func2'
+
+local function func1(a)
+    print("func1")
+    func2(a)
+end
+
+function func2(a) -- or func2 = function(a)
+    print("func2")
+    if a < 10 then
+        func1(a + 1)
+    end
+end
+
+function init(self)
+    func1(1)
+end
+```
+
+Wenn du eine Funktion innerhalb einer anderen Funktion schreibst, hat auch sie vollen Zugriff auf die lokalen Variablen der umgebenden Funktion. Dies ist ein sehr leistungsfähiges Konstrukt.
+
+```lua
+function create_counter(x)
+    -- 'x' is a local variable in 'create_counter'
+    return function()
+        x = x + 1
+        return x
+    end
+end
+
+count1 = create_counter(10)
+count2 = create_counter(20)
+print(count1()) --> 11
+print(count2()) --> 21
+print(count1()) --> 12
+```
+
+## Überschattung von Variablen {#variable-shadowing}
+
+Lokale Variablen, die in einem Block deklariert werden, überschatten gleichnamige Variablen aus einem umgebenden Block.
+
+```lua
+my_global = "global"
+print(my_global) -->"global"
+
+local v = "local"
+print(v) --> "local"
+
+local function test(v)
+    print(v)
+end
+
+function init(self)
+    v = "apple"
+    print(v) --> "apple"
+    test("banana") --> "banana"
+end
+```
+
+## Koroutinen {#coroutines}
+
+Funktionen werden vom Anfang bis zum Ende ausgeführt und können nicht mittendrin angehalten werden. Koroutinen ermöglichen genau das, was in manchen Fällen sehr praktisch sein kann. Angenommen, wir möchten eine ganz bestimmte Animation Bild für Bild erstellen, bei der wir ein Spielobjekt von der y-Position `0` aus in den Frames 1 bis 5 zu bestimmten y-Positionen bewegen. Wir könnten dies mit einem Zähler in der Funktion `update()` (siehe unten) und einer Liste der Positionen lösen. Mit einer Koroutine erhalten wir jedoch eine sehr übersichtliche Implementierung, die sich leicht erweitern und bearbeiten lässt. Der gesamte Zustand ist in der Koroutine selbst enthalten.
+
+Wenn eine Koroutine pausiert, gibt sie die Steuerung an den Aufrufer zurück, merkt sich aber ihre Ausführungsposition, sodass sie später dort fortfahren kann.
+
+```lua
+-- This is our coroutine
+local function sequence(self)
+    coroutine.yield(120)
+    coroutine.yield(320)
+    coroutine.yield(510)
+    coroutine.yield(240)
+    return 440 -- return the final value
+end
+
+function init(self)
+    self.co = coroutine.create(sequence) -- Create the coroutine. 'self.co' is a thread object
+    go.set_position(vmath.vector3(100, 0, 0)) -- Set initial position
+end
+
+function update(self, dt)
+    local status, y_pos = coroutine.resume(self.co, self) -- Continue execution of coroutine.
+    if status then
+        -- If the coroutine is still not terminated/dead, use its yielded return value as a new position
+        go.set_position(vmath.vector3(100, y_pos, 0))
+    end
+end
+```
+
+
+## Lua-Kontexte in Defold {#lua-contexts-in-defold}
+
+Alle Variablen, die du deklarierst, sind standardmäßig global. Das bedeutet, dass sie in allen Teilen des Lua-Laufzeitkontexts verfügbar sind. Defold hat in *game.project* die Einstellung *shared_state*, die diesen Kontext steuert. Wenn die Option aktiviert ist, werden alle Skripte, GUI-Skripte und das Render-Skript im selben Lua-Kontext ausgewertet, und globale Variablen sind überall sichtbar. Wenn die Option deaktiviert ist, führt die Engine Skripte, GUI-Skripte und das Render-Skript in getrennten Kontexten aus.
+
+![Kontexte](images/lua/lua_contexts.png)
+
+In Defold kannst du dieselbe Skriptdatei in mehreren separaten Komponenten (components) von Spielobjekten verwenden. Alle lokal deklarierten Variablen werden von den Komponenten gemeinsam genutzt, die dieselbe Skriptdatei ausführen.
+
+```lua
+-- 'my_global_value' will be available from all scripts, gui_scripts, render script and modules (Lua files)
+my_global_value = "global scope"
+
+-- this value will be shared through all component instances that use this particular script file
+local script_value = "script scope"
+
+function init(self, dt)
+    -- This value will be available on this script component instance
+    self.foo = "self scope"
+
+    -- this value will be available inside init() and after it's declaration
+    local local_foo = "local scope"
+    print(local_foo)
+end
+
+function update(self, dt)
+    print(self.foo)
+    print(my_global_value)
+    print(script_value)
+    print(local_foo) -- will print nil, since local_foo is only visible in init()
+end
+```
+
+## Überlegungen zur Leistung {#performance-considerations}
+
+In einem leistungsintensiven Spiel, das mit flüssigen 60 FPS laufen soll, können kleine Fehler bei der Leistung große Auswirkungen auf das Spielerlebnis haben. Es gibt einige einfache allgemeine Punkte zu beachten und einige Dinge, die zunächst unproblematisch erscheinen können.
+
+Beginnen wir mit den einfachen Dingen. Im Allgemeinen ist es sinnvoll, übersichtlichen Code ohne unnötige Schleifen zu schreiben. Manchmal musst du über Listen von Elementen iterieren, aber sei vorsichtig, wenn die Liste entsprechend groß ist. Dieses Beispiel benötigt auf einem recht leistungsfähigen Laptop etwas mehr als 1 Millisekunde. Das kann entscheidend sein, wenn jeder Frame nur 16 Millisekunden dauert (bei 60 FPS) und die Engine, das Render-Skript, die Physiksimulation usw. bereits einen Teil davon beanspruchen.
+
+```lua
+local t = socket.gettime()
+local table = {}
+for i=1,2000 do
+    table[i] = vmath.vector3(i, i, i)
+end
+print((socket.gettime() - t) * 1000)
+
+-- DEBUG:SCRIPT: 0.40388
+```
+
+Verwende den von `socket.gettime()` zurückgegebenen Wert (Sekunden seit der Systemepoche), um die Ausführungszeit von verdächtigem Code zu messen.
+
+## Speicher und automatische Speicherbereinigung {#memory-and-garbage-collection}
+
+Die automatische Speicherbereinigung von Lua läuft standardmäßig im Hintergrund und gibt Speicher frei, den die Lua-Laufzeitumgebung zugewiesen hat. Die Bereinigung großer Mengen nicht mehr benötigter Daten kann viel Zeit beanspruchen. Daher ist es sinnvoll, die Anzahl der Objekte, die bereinigt werden müssen, gering zu halten:
+
+* Lokale Variablen selbst verursachen keine Kosten und erzeugen keine zu bereinigenden Daten. (z. B. `local v = 42`)
+* Jede _neue, eindeutige_ Zeichenfolge erzeugt ein neues Objekt. Mit `local s = "some_string"` wird ein neues Objekt erstellt und `s` darauf gesetzt. Die lokale Variable `s` selbst erzeugt keine zu bereinigenden Daten, das Zeichenfolgenobjekt jedoch schon. Die mehrfache Verwendung derselben Zeichenfolge verursacht keinen zusätzlichen Speicherbedarf.
+* Jedes Mal, wenn ein Tabellenkonstruktor (`{ ... }`) ausgeführt wird, entsteht eine neue Tabelle.
+* Die Ausführung einer _Funktionsanweisung_ erzeugt ein Closure-Objekt. (Gemeint ist die Ausführung der Anweisung `function () ... end`, nicht der Aufruf einer definierten Funktion.)
+* Funktionen mit variabler Argumentzahl (`function(v, ...) end`) erzeugen bei jedem _Aufruf_ eine Tabelle für die Auslassungspunkte (in Lua vor Version 5.2 oder wenn LuaJIT nicht verwendet wird).
+* `dofile()` und `dostring()`
+* Userdata-Objekte
+
+In vielen Fällen kannst du das Erstellen neuer Objekte vermeiden und stattdessen bereits vorhandene wiederverwenden. Beispielsweise steht häufig Folgendes am Ende jedes Aufrufs von `update()`:
+
+```lua
+-- Reset velocity
+self.velocity = vmath.vector3()
+```
+
+Es wird leicht vergessen, dass jeder Aufruf von `vmath.vector3()` ein neues Objekt erzeugt. Sehen wir uns an, wie viel Speicher ein `vector3` benötigt:
+
+```lua
+print(collectgarbage("count") * 1024)       -- 88634
+local v = vmath.vector3()
+print(collectgarbage("count") * 1024)       -- 88704. 70 bytes in total has been allocated
+```
+
+Zwischen den Aufrufen von `collectgarbage()` sind 70 Byte hinzugekommen. Darin sind jedoch auch Speicherzuweisungen enthalten, die über das Objekt `vector3` hinausgehen. Jede Ausgabe des Ergebnisses von `collectgarbage()` erzeugt eine Zeichenfolge, die selbst 22 Byte an zu bereinigenden Daten hinzufügt:
+
+```lua
+print(collectgarbage("count") * 1024)       -- 88611
+print(collectgarbage("count") * 1024)       -- 88633. 22 bytes allocated
+```
+
+Ein `vector3` benötigt also 70-22=48 Byte. Das ist nicht viel, aber wenn du in einem Spiel mit 60 FPS in jedem Frame _eines_ erstellst, entstehen plötzlich 2,8 kB an zu bereinigenden Daten pro Sekunde. Bei 360 Skriptkomponenten, die in jedem Frame jeweils ein `vector3` erstellen, entsteht 1 MB an zu bereinigenden Daten pro Sekunde. Die Zahlen können sich sehr schnell summieren. Wenn die Lua-Laufzeitumgebung den Speicher bereinigt, kann das viele kostbare Millisekunden beanspruchen---besonders auf mobilen Plattformen.
+
+Eine Möglichkeit, Speicherzuweisungen zu vermeiden, besteht darin, ein `vector3` zu erstellen und dann mit demselben Objekt weiterzuarbeiten. Um beispielsweise ein `vector3` zurückzusetzen, können wir folgendes Konstrukt verwenden:
+
+```lua
+-- Instead of doing self.velocity = vmath.vector3() which creates a new object
+-- we zero an existing velocity vector object's components
+self.velocity.x = 0
+self.velocity.y = 0
+self.velocity.z = 0
+```
+
+Das standardmäßige Verfahren zur automatischen Speicherbereinigung ist für manche zeitkritischen Anwendungen möglicherweise nicht optimal. Wenn dein Spiel oder deine App ruckelt, kannst du das Verhalten der Speicherbereinigung in Lua über die Lua-Funktion [`collectgarbage()`](/ref/base/#collectgarbage) anpassen. Beispielsweise kannst du die Speicherbereinigung in jedem Frame mit einem niedrigen Wert für `step` kurz ausführen lassen. Um eine Vorstellung davon zu bekommen, wie viel Speicher dein Spiel oder deine App benötigt, kannst du die aktuelle Menge an zu bereinigenden Bytes so ausgeben:
+
+```lua
+print(collectgarbage("count") * 1024)
+```
+
+## Bewährte Verfahren {#best-practices}
+
+Eine häufige Überlegung beim Entwurf einer Implementierung ist, wie Code für gemeinsam genutzte Verhaltensweisen strukturiert werden sollte. Dafür gibt es mehrere Ansätze.
+
+Verhaltensweisen in einem Modul
+: Wenn du eine Verhaltensweise in einem Modul kapselst, kannst du Code leicht zwischen den Skriptkomponenten verschiedener Spielobjekte (und GUI-Skripten) gemeinsam nutzen. Beim Schreiben von Modulfunktionen ist es in der Regel am besten, streng funktionalen Code zu schreiben. Es gibt Fälle, in denen ein gespeicherter Zustand oder Seiteneffekte erforderlich sind oder zu einem übersichtlicheren Entwurf führen. Wenn du den internen Zustand im Modul speichern musst, beachte, dass Komponenten Lua-Kontexte gemeinsam nutzen. Einzelheiten findest du in der [Dokumentation zu Modulen](/manuals/modules).
+
+  ![Modul](images/lua/lua_module.png)
+
+  Auch wenn Modulcode das Innere eines Spielobjekts direkt ändern kann, indem du `self` an eine Modulfunktion übergibst, raten wir dringend davon ab, da dadurch eine sehr enge Kopplung entsteht.
+
+Ein Hilfsspielobjekt mit gekapseltem Verhalten
+: So wie du Skriptcode in einem Lua-Modul kapseln kannst, kannst du ihn auch in einem Spielobjekt mit einer Skriptkomponente kapseln. Der Unterschied besteht darin, dass du bei der Kapselung in einem Spielobjekt ausschließlich über Nachrichten mit ihm kommunizieren kannst.
+
+  ![Hilfsspielobjekt](images/lua/lua_helper.png)
+
+Spielobjekt und Hilfsobjekt für das Verhalten in einer Sammlung gruppieren
+: Bei diesem Entwurf kannst du ein Spielobjekt für eine Verhaltensweise erstellen, das automatisch auf ein anderes Zielspielobjekt einwirkt. Dies geschieht entweder über einen vordefinierten Namen, an den der Name des Zielspielobjekts angepasst werden muss, oder über eine URL in `go.property()`, die auf das Zielspielobjekt verweist.
+
+  ![Sammlung](images/lua/lua_collection.png)
+
+  Der Vorteil dieses Aufbaus ist, dass du ein Spielobjekt mit einer Verhaltensweise in einer Sammlung (collection) ablegen kannst, die das Zielobjekt enthält. Es ist kein zusätzlicher Code erforderlich.
+
+  In Situationen, in denen du große Mengen von Spielobjekten verwalten musst, ist dieser Entwurf nicht vorzuziehen. Das Verhaltensobjekt wird für jede Instanz dupliziert, und jedes Objekt benötigt Speicher.

--- a/docs/de/manuals/macos.md
+++ b/docs/de/manuals/macos.md
@@ -1,0 +1,124 @@
+---
+title: Defold-Entwicklung für die macOS-Plattform
+brief: Dieses Handbuch beschreibt, wie du Defold-Anwendungen für macOS erstellst und ausführst
+---
+
+# Entwicklung für macOS {#macos-development}
+
+Die Entwicklung von Defold-Anwendungen für die macOS-Plattform ist unkompliziert und erfordert nur wenige besondere Überlegungen.
+
+## Projekteinstellungen {#project-settings}
+
+Die macOS-spezifische Konfiguration der Anwendung erfolgt im [Abschnitt macOS](/manuals/project-settings/#macos) der Einstellungsdatei *game.project*.
+
+## Anwendungssymbol {#application-icon}
+
+Das Anwendungssymbol für ein macOS-Spiel muss im Format .`icns` vorliegen. Du kannst eine `.icns`-Datei ganz einfach aus mehreren `.png`-Dateien erstellen, die als `.iconset` zusammengefasst sind. Befolge die [offizielle Anleitung zum Erstellen einer `.icns`-Datei](https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html). Hier ist eine kurze Zusammenfassung der erforderlichen Schritte:
+
+* Erstelle einen Ordner für die Symbole, z. B. `game.iconset`
+* Kopiere die Symboldateien in den erstellten Ordner:
+
+    * `icon_16x16.png`
+    * `icon_16x16@2x.png`
+    * `icon_32x32.png`
+    * `icon_32x32@2x.png`
+    * `icon_128x128.png`
+    * `icon_128x128@2x.png`
+    * `icon_256x256.png`
+    * `icon_256x256@2x.png`
+    * `icon_512x512.png`
+    * `icon_512x512@2x.png`
+
+* Konvertiere den `.iconset`-Ordner in eine `.icns`-Datei. Verwende dazu das Kommandozeilenwerkzeug `iconutil`:
+
+```
+iconutil -c icns -o game.icns game.iconset
+```
+
+## Deine Anwendung veröffentlichen {#publishing-your-application}
+Du kannst deine Anwendung im Mac App Store, über einen Store oder ein Portal eines Drittanbieters wie Steam oder itch.io oder selbst über eine Website veröffentlichen. Vor der Veröffentlichung musst du deine Anwendung für die Einreichung vorbereiten. Die folgenden Schritte sind unabhängig davon erforderlich, wie du die Anwendung verteilen möchtest:
+
+1. Stelle sicher, dass alle dein Spiel ausführen können, indem du die Ausführungsberechtigungen hinzufügst (standardmäßig hat nur der Dateieigentümer Ausführungsberechtigungen):
+
+```
+$ chmod +x Game.app/Contents/MacOS/Game
+```
+
+2. Erstelle eine Berechtigungsdatei, die die von deinem Spiel benötigten Berechtigungen festlegt. Für die meisten Spiele reichen die folgenden Berechtigungen aus:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>
+```
+
+  * `com.apple.security.cs.allow-jit` - Gibt an, ob die Anwendung mit dem Flag MAP_JIT beschreibbaren und ausführbaren Speicher erstellen darf
+  * `com.apple.security.cs.allow-unsigned-executable-memory` - Gibt an, ob die Anwendung beschreibbaren und ausführbaren Speicher ohne die Einschränkungen erstellen darf, die durch die Verwendung des Flags MAP_JIT auferlegt werden
+  * `com.apple.security.cs.allow-dyld-environment-variables` - Gibt an, ob die Anwendung von Umgebungsvariablen des dynamischen Linkers beeinflusst werden darf, mit denen du Code in den Prozess deiner Anwendung einschleusen kannst
+
+Einige Anwendungen benötigen möglicherweise zusätzliche Berechtigungen. Die Steamworks-Erweiterung benötigt diese zusätzliche Berechtigung:
+
+```
+<key>com.apple.security.cs.disable-library-validation</key>
+<true/>
+```
+
+  * `com.apple.security.cs.disable-library-validation` - Gibt an, ob die Anwendung beliebige Plug-ins oder Frameworks laden darf, ohne dass eine Codesignierung erforderlich ist.
+
+Alle Berechtigungen, die einer Anwendung erteilt werden können, sind in der offiziellen [Entwicklerdokumentation von Apple](https://developer.apple.com/documentation/bundleresources/entitlements) aufgeführt.
+
+3. Signiere dein Spiel mit `codesign`:
+
+```
+$ codesign --force --sign "Developer ID Application: Company Name" --options runtime --deep --timestamp --entitlements entitlement.plist Game.app
+```
+
+## Außerhalb des Mac App Store veröffentlichen {#publishing-outside-the-mac-app-store}
+Apple verlangt, dass sämtliche Software, die außerhalb des Mac App Store verteilt wird, von Apple notarisiert wird, damit sie unter macOS Catalina standardmäßig ausgeführt werden kann. In der [offiziellen Dokumentation](https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow) erfährst du, wie du die Notarisierung in eine skriptgesteuerte Build-Umgebung außerhalb von Xcode integrierst. Hier ist eine kurze Zusammenfassung der erforderlichen Schritte:
+
+1. Befolge die obigen Schritte zum Hinzufügen von Berechtigungen und zum Signieren der Anwendung.
+
+2. Verpacke dein Spiel als ZIP-Datei und lade es mit `altool` zur Notarisierung hoch.
+
+```
+$ xcrun altool --notarize-app
+               --primary-bundle-id "com.acme.foobar"
+               --username "AC_USERNAME"
+               --password "@keychain:AC_PASSWORD"
+               --asc-provider <ProviderShortname>
+               --file Game.zip
+
+altool[16765:378423] No errors uploading 'Game.zip'.
+RequestUUID = 2EFE2717-52EF-43A5-96DC-0797E4CA1041
+```
+
+3. Prüfe den Status deiner Einreichung mithilfe der Anfrage-UUID, die vom Aufruf von `altool --notarize-app` zurückgegeben wurde:
+
+```
+$ xcrun altool --notarization-info 2EFE2717-52EF-43A5-96DC-0797E4CA1041
+               -u "AC_USERNAME"
+```
+
+4. Warte, bis der Status `success` lautet, und füge dem Spiel das Notarisierungsticket hinzu:
+
+```
+$ xcrun stapler staple "Game.app"
+```
+
+5. Dein Spiel ist jetzt bereit zur Verteilung.
+
+## Im Mac App Store veröffentlichen {#publishing-to-the-mac-app-store}
+Der Ablauf zur Veröffentlichung im Mac App Store ist in der [Entwicklerdokumentation von Apple](https://developer.apple.com/macos/submit/) gut dokumentiert. Stelle sicher, dass du vor der Einreichung wie oben beschrieben Berechtigungen hinzufügst und die Anwendung mit `codesign` signierst.
+
+Hinweis: Bei der Veröffentlichung im Mac App Store muss das Spiel nicht notarisiert werden.
+
+:[Apple Privacy Manifest](../shared/apple-privacy-manifest.md)

--- a/docs/de/manuals/material.md
+++ b/docs/de/manuals/material.md
@@ -1,0 +1,440 @@
+---
+title: Handbuch zu Materialien in Defold
+brief: Dieses Handbuch erklärt die Arbeit mit Materialien, Shader-Konstanten und Samplern.
+---
+
+# Materialien {#materials}
+
+Materialien legen fest, wie eine grafische Komponente (component), etwa ein Sprite, eine Kachelkarte (tile map), eine Schriftart, ein GUI-Knoten oder ein Modell, gerendert werden soll.
+
+Ein Material enthält _Tags_, also Informationen, mit denen die Rendering-Pipeline die zu rendernden Objekte auswählt. Es enthält außerdem Referenzen auf _Shader-Programme_, die über den verfügbaren Grafiktreiber kompiliert und auf die Grafikhardware hochgeladen werden. Sie werden in jedem Frame ausgeführt, wenn die Komponente gerendert wird.
+
+* Weitere Informationen zur Rendering-Pipeline findest du in der [Rendering-Dokumentation](/manuals/render).
+* Eine ausführliche Erklärung von Shader-Programmen findest du in der [Shader-Dokumentation](/manuals/shader).
+
+## Ein Material erstellen {#creating-a-material}
+
+Um ein Material zu erstellen, führe im Browser *Assets* einen <kbd>Rechtsklick</kbd> auf einen Zielordner aus und wähle <kbd>New... ▸ Material</kbd>. (Du kannst auch im Menü <kbd>File ▸ New...</kbd> und anschließend <kbd>Material</kbd> wählen.) Benenne die neue Materialdatei und drücke <kbd>Ok</kbd>.
+
+![Materialdatei](images/materials/material_file.png)
+
+Das neue Material wird im *Material Editor* geöffnet.
+
+![Materialeditor](images/materials/material.png)
+
+Die Materialdatei enthält die folgenden Informationen:
+
+Name
+: Die Kennung des Materials. Mit diesem Namen wird das Material in der Ressource *Render* aufgeführt, um es in den Build aufzunehmen. Der Name wird auch in der Render-API-Funktion `render.enable_material()` verwendet. Der Name sollte eindeutig sein.
+
+Vertex Program
+: Die Datei des Vertex-Shader-Programms (*`.vp`*), die beim Rendern mit diesem Material verwendet wird. Das Vertex-Shader-Programm wird auf der GPU für jeden Vertex der Primitive einer Komponente ausgeführt. Es berechnet die Bildschirmposition jedes Vertex und gibt optional auch „varying“-Variablen aus, die interpoliert und an das Fragment-Programm übergeben werden.
+
+Fragment Program
+: Die Datei des Fragment-Shader-Programms (*`.fp`*), die beim Rendern mit diesem Material verwendet wird. Das Programm läuft auf der GPU für jedes Fragment (Pixel) eines Primitivs und bestimmt die Farbe jedes Fragments. Dies geschieht üblicherweise durch Texturabfragen und Berechnungen anhand von Eingabevariablen (Varying-Variablen oder Konstanten).
+
+Vertex Constants
+: Uniforms, die an das Vertex-Shader-Programm übergeben werden. Weiter unten findest du eine Liste der verfügbaren Konstanten.
+
+Fragment Constants
+: Uniforms, die an das Fragment-Shader-Programm übergeben werden. Weiter unten findest du eine Liste der verfügbaren Konstanten.
+
+Samplers
+: Du kannst in der Materialdatei optional bestimmte Sampler konfigurieren. Füge einen Sampler hinzu, gib ihm den im Shader-Programm verwendeten Namen und lege die Einstellungen für Texturadressierung und Filterung nach deinen Anforderungen fest.
+
+Tags
+: Die dem Material zugeordneten Tags. Die Engine stellt Tags als _Bitmaske_ dar, die [`render.predicate()`](/ref/render#render.predicate) verwendet, um Komponenten zusammenzufassen, die gemeinsam gezeichnet werden sollen. Wie das geht, erfährst du in der [Rendering-Dokumentation](/manuals/render). In einem Projekt kannst du höchstens 32 Tags verwenden.
+
+## Attribute {#attributes}
+
+Shader-Attribute (auch Vertex-Datenströme oder Vertex-Attribute genannt) legen fest, wie die GPU Vertices aus dem Speicher abruft, um Geometrie zu rendern. Der Vertex-Shader gibt mit dem Schlüsselwort `attribute` eine Menge von Datenströmen an. In den meisten Fällen erzeugt und bindet Defold die Daten im Hintergrund automatisch anhand der Namen dieser Datenströme. In manchen Fällen möchtest du jedoch zusätzliche Daten pro Vertex übergeben, um einen bestimmten Effekt zu erzielen, dessen Daten die Engine nicht erzeugt. Ein Vertex-Attribut kann mit den folgenden Feldern konfiguriert werden:
+
+Name
+: Der Attributname. Ähnlich wie bei Shader-Konstanten wird die Attributkonfiguration nur verwendet, wenn der Name mit einem im Vertex-Programm angegebenen Attribut übereinstimmt.
+
+Semantic type
+: Ein semantischer Typ gibt die Bedeutung des Attributs an, also *was* das Attribut darstellt und/oder *wie* es im Editor angezeigt werden soll. Wenn du beispielsweise für ein Attribut `SEMANTIC_TYPE_COLOR` angibst, zeigt der Editor eine Farbauswahl an. Die Engine übergibt die Daten dabei weiterhin unverändert an den Shader.
+
+  - `SEMANTIC_TYPE_NONE` Der standardmäßige semantische Typ. Hat keinen weiteren Einfluss auf das Attribut, außer die Materialdaten für das Attribut direkt an den Vertex-Puffer zu übergeben (Standard)
+  - `SEMANTIC_TYPE_POSITION` Erzeugt Positionsdaten pro Vertex für das Attribut. Kann zusammen mit dem Koordinatensystem verwendet werden, um der Engine vorzugeben, wie die Positionen berechnet werden
+  - `SEMANTIC_TYPE_TEXCOORD` Erzeugt Texturkoordinaten pro Vertex für das Attribut
+  - `SEMANTIC_TYPE_PAGE_INDEX` Erzeugt Seitenindizes pro Vertex für das Attribut
+  - `SEMANTIC_TYPE_COLOR` Beeinflusst, wie der Editor das Attribut interpretiert. Wenn ein Attribut mit Farbsemantik konfiguriert ist, wird im Inspektor ein Farbauswahlfeld angezeigt
+  - `SEMANTIC_TYPE_NORMAL` Erzeugt Normalendaten pro Vertex für das Attribut
+  - `SEMANTIC_TYPE_TANGENT` Erzeugt Tangentendaten pro Vertex für das Attribut
+  - `SEMANTIC_TYPE_WORLD_MATRIX` Erzeugt Weltmatrixdaten pro Vertex für das Attribut
+  - `SEMANTIC_TYPE_NORMAL_MATRIX` Erzeugt Normalenmatrixdaten pro Vertex für das Attribut
+  - `SEMANTIC_TYPE_TEXTURE_TRANSFORM_2D` Erzeugt eine 3x3-Texturtransformationsmatrix pro Vertex für das Attribut. Für Partikelkomponenten stellt die Engine eine Matrix bereit, die Koordinaten für die Bildeigenschaft der Komponente in das Atlas-Koordinatensystem transformiert. Für Sprite-Komponenten stellt die Engine für jedes von der Komponente verwendete Bild eine Matrix bereit (bei Verwendung mehrerer Texturen). Für Modellkomponenten wird eine Einheitsmatrix bereitgestellt.
+
+Data type
+: Der Datentyp der zugrunde liegenden Daten des Attributs.
+
+  - `TYPE_BYTE` Vorzeichenbehaftete 8-Bit-Byte-Werte
+  - `TYPE_UNSIGNED_BYTE` Vorzeichenlose 8-Bit-Byte-Werte
+  - `TYPE_SHORT` Vorzeichenbehaftete 16-Bit-Short-Werte
+  - `TYPE_UNSIGNED_SHORT` Vorzeichenlose 16-Bit-Short-Werte
+  - `TYPE_INT` Vorzeichenbehaftete Ganzzahlwerte
+  - `TYPE_UNSIGNED_INT` Vorzeichenlose Ganzzahlwerte
+  - `TYPE_FLOAT` Gleitkommawerte (Standard)
+
+Normalize
+: Wenn diese Einstellung aktiviert ist, normalisiert der GPU-Treiber die Attributwerte. Das kann nützlich sein, wenn du nicht die volle Genauigkeit benötigst, aber Berechnungen durchführen möchtest, ohne die jeweiligen Grenzwerte zu kennen. Ein Farbvektor benötigt beispielsweise meist nur Byte-Werte von 0..255, wird im Shader aber trotzdem als Wert von 0..1 behandelt.
+
+Coordinate space
+: Einige semantische Typen unterstützen die Bereitstellung von Daten in unterschiedlichen Koordinatensystemen. Um einen Billboarding-Effekt mit Sprites umzusetzen, benötigst du üblicherweise ein Positionsattribut im lokalen Koordinatensystem sowie eine vollständig transformierte Position im Weltkoordinatensystem, damit Zeichenoperationen möglichst effektiv gebündelt werden können (Batching).
+
+Vector type
+: Der Vektortyp des Attributs.
+
+  - `VECTOR_TYPE_SCALAR` Einzelner Skalarwert
+  - `VECTOR_TYPE_VEC2` 2D-Vektor
+  - `VECTOR_TYPE_VEC3` 3D-Vektor
+  - `VECTOR_TYPE_VEC4` 4D-Vektor (Standard)
+  - `VECTOR_TYPE_MAT2` 2D-Matrix
+  - `VECTOR_TYPE_MAT3` 3D-Matrix
+  - `VECTOR_TYPE_MAT4` 4D-Matrix
+
+Step function
+: Gibt an, wie die Attributdaten an die Vertex-Funktion übergeben werden sollen. Dies ist nur für Instancing relevant.
+
+  - `Vertex` Einmal pro Vertex; ein Positionsattribut wird beispielsweise üblicherweise für jeden Vertex im Mesh an die Vertex-Funktion übergeben (Standard)
+  - `Instance` Einmal pro Instanz; ein Weltmatrixattribut wird beispielsweise üblicherweise einmal pro Instanz an die Vertex-Funktion übergeben
+
+Value
+: Der Wert des Attributs. Attributwerte können für jede Komponente einzeln überschrieben werden; andernfalls dient dieser Wert als Standardwert des Vertex-Attributs. Hinweis: Bei *Standardattributen* (Position, Texturkoordinaten und Seitenindizes) wird der Wert ignoriert.
+
+::: sidenote
+Mit benutzerdefinierten Attributen kannst du auch den Speicherbedarf sowohl auf der CPU als auch auf der GPU verringern, indem du die Datenströme für einen kleineren Datentyp oder eine andere Elementanzahl konfigurierst.
+:::
+
+### Standardsemantik von Attributen {#default-attribute-semantics}
+
+Das Materialsystem weist zur Laufzeit für eine bestimmte Menge von Attributnamen automatisch einen standardmäßigen semantischen Typ anhand des Namens zu:
+
+  - `position` - semantischer Typ: `SEMANTIC_TYPE_POSITION`
+  - `texcoord0` - semantischer Typ: `SEMANTIC_TYPE_TEXCOORD`
+  - `texcoord1` - semantischer Typ: `SEMANTIC_TYPE_TEXCOORD`
+  - `page_index` - semantischer Typ: `SEMANTIC_TYPE_PAGE_INDEX`
+  - `color` - semantischer Typ: `SEMANTIC_TYPE_COLOR`
+  - `normal` - semantischer Typ: `SEMANTIC_TYPE_NORMAL`
+  - `tangent` - semantischer Typ: `SEMANTIC_TYPE_TANGENT`
+  - `mtx_world` - semantischer Typ: `SEMANTIC_TYPE_WORLD_MATRIX`
+  - `mtx_normal` - semantischer Typ: `SEMANTIC_TYPE_NORMAL_MATRIX`
+  - `mtx_texture_transform_2d` - semantischer Typ: `SEMANTIC_TYPE_TEXTURE_TRANSFORM_2D`
+
+Wenn du im Material Einträge für diese Attribute anlegst, wird der standardmäßige semantische Typ durch den im Materialeditor konfigurierten Typ überschrieben.
+
+### Daten benutzerdefinierter Vertex-Attribute setzen {#setting-custom-vertex-attribute-data}
+
+Ähnlich wie benutzerdefinierte Shader-Konstanten kannst du auch Vertex-Attribute zur Laufzeit aktualisieren, indem du `go.get`, `go.set` und `go.animate` aufrufst:
+
+![Benutzerdefiniertes Materialattribut](images/materials/set_custom_attribute.png)
+
+```lua
+go.set("#sprite", "tint", vmath.vector4(1,0,0,1))
+
+go.animate("#sprite", "tint", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,0,0,1), go.EASING_LINEAR, 2)
+```
+
+Beim Aktualisieren von Vertex-Attributen gibt es jedoch einige Einschränkungen: Ob eine Komponente den Wert verwenden kann, hängt vom semantischen Typ des Attributs ab. Eine Sprite-Komponente unterstützt beispielsweise `SEMANTIC_TYPE_POSITION`. Wenn du ein Attribut mit diesem semantischen Typ aktualisierst, ignoriert die Komponente den überschriebenen Wert, da der semantische Typ vorgibt, dass die Daten immer aus der Position des Sprites erzeugt werden sollen.
+
+Modellkomponenten stellen benutzerdefinierte Materialattribute ebenfalls über `go.get()`, `go.set()` und `go.animate()` bereit. Nachdem du beispielsweise ein Attribut namens `my_attribute` im Modellmaterial definiert hast:
+
+```lua
+go.set("#model", "my_attribute", vmath.vector4(1, 0, 0, 1))
+go.animate("#model", "my_attribute", go.PLAYBACK_LOOP_PINGPONG,
+    vmath.vector4(0, 1, 0, 1), go.EASING_LINEAR, 2)
+```
+
+Bei einem Modell mit mehreren Meshes kann derzeit nur das erste Mesh auf diese Weise angesprochen werden. Das Aktualisieren eines nicht instanzierten Attributs pro Vertex kann außerdem dazu führen, dass Vertex-Daten in einem zur Mesh-Größe proportionalen Umfang neu erstellt und hochgeladen werden. Häufige Aktualisierungen können daher bei großen Meshes aufwendig sein.
+
+Wenn ein Vertex-Attribut ein Skalar oder ein anderer Vektortyp als `Vec4` ist, kannst du die Daten trotzdem mit `go.set` setzen:
+
+```lua
+-- The last two components in the vec4 will not be used!
+go.set("#sprite", "sprite_position_2d", vmath.vector4(my_x,my_y,0,0))
+go.animate("#sprite", "sprite_position_2d", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,2,0,0), go.EASING_LINEAR, 2)
+```
+
+Dasselbe gilt für Matrixattribute: Wenn das Attribut einen anderen Matrixtyp als `Mat4` hat, kannst du die Daten trotzdem mit `go.set` setzen.
+
+### Beispiele für benutzerdefinierte Vertex-Attribute {#examples-of-using-custom-vertex-attributes}
+
+Ein Texturtransformationsattribut verwenden, um UV-Koordinaten in das Atlas-Koordinatensystem umzuwandeln:
+
+```glsl
+#version 140
+
+in vec3 position;
+in vec4 texcoord0;
+in mat3 texture_transform_2d;
+
+out vec2 var_texcoord0;
+
+void main()
+{
+  // Extract position from the transform
+  vec2 atlas_pos = texture_transform_2d[2].xy;
+  // Extract the scale from the transform
+  vec2 atlas_size = vec2(
+      length(texture_transform_2d[0].xy),
+      length(texture_transform_2d[1].xy)
+  );
+  // convert to local UV (0..1)
+  vec2 localUV = (texcoord0 - atlas_pos) / atlas_size;
+
+  // Alternatively, if the UV coordinates already are in the 0..1 range,
+  // you can transform into atlas space directly by multiplying the transform:
+  vec2 transformedUv = texture_transform_2d * texcoord0;
+
+  // Pass the value into the fragment shader
+  var_texcoord0 = localUV;
+
+  // ... rest of vertex shader
+}
+```
+
+### Instancing
+
+Instancing ist eine Technik, mit der mehrere Kopien desselben Objekts in einer Szene effizient gezeichnet werden. Anstatt bei jeder Verwendung eine separate Kopie des Objekts zu erzeugen, kann die Grafik-Engine mit Instancing ein einzelnes Objekt erstellen und es mehrfach wiederverwenden. In einem Spiel mit einem großen Wald kannst du beispielsweise ein einziges Baummodell erstellen und es dann hunderte oder tausende Male mit unterschiedlichen Positionen und Skalierungen platzieren, anstatt für jeden Baum ein eigenes Modell anzulegen. Der Wald kann nun mit einem einzigen Zeichenaufruf (draw call) gerendert werden statt mit einzelnen Zeichenaufrufen für jeden Baum.
+
+::: sidenote
+Instancing ist derzeit nur für Modellkomponenten verfügbar.
+:::
+
+Instancing wird automatisch aktiviert, wenn es möglich ist. Defold setzt stark darauf, Zeichenoperationen mit gleichem Zustand möglichst weitgehend zu bündeln. Damit Instancing funktioniert, müssen einige Voraussetzungen erfüllt sein:
+
+- Für alle Instanzen muss dasselbe Material verwendet werden. Instancing funktioniert auch dann, wenn ein benutzerdefiniertes Material mit `render.enable_material` gesetzt wurde
+- Das Material muss für den Vertex-Koordinatenraum 'local' konfiguriert sein
+- Das Material muss mindestens ein Vertex-Attribut haben, das pro Instanz wiederholt wird
+- Konstantenwerte müssen für alle Instanzen gleich sein. Stattdessen können Konstantenwerte in benutzerdefinierten Vertex-Attributen oder auf andere Weise gespeichert werden (z. B. in einer Textur)
+- Shader-Ressourcen wie Texturen oder Speicherpuffer müssen für alle Instanzen gleich sein
+
+Damit ein Vertex-Attribut pro Instanz wiederholt wird, muss `Step function` auf `Instance` gesetzt sein. Bei bestimmten semantischen Typen geschieht dies automatisch anhand des Namens (siehe die Tabelle `Standardsemantik von Attributen` weiter oben). Du kannst dies aber auch im Materialeditor manuell einstellen, indem du `Step function` auf `Instance` setzt.
+
+Als einfaches Beispiel enthält die folgende Szene vier Spielobjekte (game objects) mit jeweils einer Modellkomponente:
+
+![Einrichtung von Instancing](images/materials/instancing-setup.png)
+
+Das Material ist wie folgt konfiguriert, mit einem einzelnen benutzerdefinierten Vertex-Attribut, das pro Instanz wiederholt wird:
+
+![Material für Instancing](images/materials/instancing-material.png)
+
+Im Vertex-Shader sind mehrere Attribute pro Instanz angegeben:
+
+```glsl
+// Per vertex attributes
+attribute highp vec4 position;
+attribute mediump vec2 texcoord0;
+attribute mediump vec3 normal;
+
+// Per instance attributes
+attribute mediump mat4 mtx_world;
+attribute mediump mat4 mtx_normal;
+attribute mediump vec4 instance_color;
+```
+
+Beachte, dass `mtx_world` und `mtx_normal` standardmäßig mit der Schritt-Funktion `Instance` konfiguriert werden. Du kannst dies im Materialeditor ändern, indem du für sie einen Eintrag hinzufügst und `Step function` auf `Vertex` setzt. Dadurch wird das Attribut pro Vertex statt pro Instanz wiederholt.
+
+Um zu überprüfen, ob Instancing in diesem Fall funktioniert, kannst du den Web-Profiler verwenden. Da sich die Instanzen des Quaders in diesem Fall nur durch die Attribute pro Instanz unterscheiden, kann er mit einem einzigen Zeichenaufruf gerendert werden:
+
+![Zeichenaufrufe beim Instancing](images/materials/instancing-draw-calls.png)
+
+#### Abwärtskompatibilität {#backwards-compatibility}
+
+OpenGL 3.1 auf Desktop-Geräten und OpenGL ES 3.0 auf Mobilgeräten bieten Instancing als Kernfunktion. Ältere OpenGL-ES- und WebGL-Kontexte können es weiterhin über eine Erweiterung wie `ANGLE_instanced_arrays` unterstützen; andere ältere Adapter unterstützen es nicht. Wenn Instancing nicht verfügbar ist, funktioniert das Rendering standardmäßig weiterhin, kann jedoch weniger leistungsfähig sein.
+
+Verwende `graphics.get_adapter_info()`, um die Unterstützung zu erkennen und bei Bedarf ein weniger aufwendiges Material zu wählen oder Inhalte mit vielen Instanzen auszulassen. Das Feld `features` ist ein Array der unterstützten Funktionskonstanten, keine Tabelle mit diesen Konstanten als Schlüsseln:
+
+```lua
+local function has_context_feature(feature)
+    local adapter_info = graphics.get_adapter_info()
+    for _, supported_feature in ipairs(adapter_info.features) do
+        if supported_feature == feature then
+            return true
+        end
+    end
+    return false
+end
+
+local instancing_supported = has_context_feature(
+    graphics.CONTEXT_FEATURE_INSTANCING
+)
+```
+
+## Vertex- und Fragment-Konstanten {#vertex-and-fragment-constants}
+
+Shader-Konstanten oder „Uniforms“ sind Werte, die die Engine an Vertex- und Fragment-Shader-Programme übergibt. Um eine Konstante zu verwenden, definierst du sie in der Materialdatei entweder als Eigenschaft *Vertex Constant* oder als Eigenschaft *Fragment Constant*. Entsprechende `uniform`-Variablen müssen im Shader-Programm definiert werden. Die folgenden Konstanten können in einem Material gesetzt werden:
+
+`CONSTANT_TYPE_WORLD`
+: Die Weltmatrix. Verwende sie, um Vertices in das Weltkoordinatensystem zu transformieren. Bei einigen Komponententypen liegen die Vertices bereits im Weltkoordinatensystem vor, wenn sie an das Vertex-Programm übergeben werden (aufgrund der Bündelung von Zeichenoperationen). In diesen Fällen liefert die Multiplikation mit der Weltmatrix im Shader falsche Ergebnisse.
+
+`CONSTANT_TYPE_VIEW`
+: Die Ansichtsmatrix. Verwende sie, um Vertices in das Ansichtskoordinatensystem (Kamerakoordinatensystem) zu transformieren.
+
+`CONSTANT_TYPE_PROJECTION`
+: Die Projektionsmatrix. Verwende sie, um Vertices in das Bildschirmkoordinatensystem zu transformieren.
+
+`CONSTANT_TYPE_VIEWPROJ`
+: Eine Matrix, in der die Ansichts- und Projektionsmatrix bereits miteinander multipliziert wurden.
+
+`CONSTANT_TYPE_WORLDVIEW`
+: Eine Matrix, in der die Welt- und Ansichtsmatrix bereits miteinander multipliziert wurden.
+
+`CONSTANT_TYPE_WORLDVIEWPROJ`
+: Eine Matrix, in der die Welt-, Ansichts- und Projektionsmatrix bereits miteinander multipliziert wurden.
+
+`CONSTANT_TYPE_WORLD_INVERSE`
+: Die Inverse der Weltmatrix. Verwende sie, um vom Weltkoordinatensystem zurück in das lokale Koordinatensystem des Objekts zu transformieren.
+
+`CONSTANT_TYPE_VIEW_INVERSE`
+: Die Inverse der Ansichtsmatrix. Verwende sie, um vom Kamerakoordinatensystem zurück in das Weltkoordinatensystem zu transformieren.
+
+`CONSTANT_TYPE_PROJECTION_INVERSE`
+: Die Inverse der Projektionsmatrix. Verwende sie, um vom Clip-Koordinatensystem zurück in das Kamerakoordinatensystem zu transformieren.
+
+`CONSTANT_TYPE_VIEWPROJ_INVERSE`
+: Die Inverse der kombinierten Ansichts- und Projektionsmatrix. Verwende sie, um vom Clip-Koordinatensystem zurück in das Weltkoordinatensystem zu transformieren.
+
+`CONSTANT_TYPE_WORLDVIEW_INVERSE`
+: Die Inverse der kombinierten Welt- und Ansichtsmatrix. Verwende sie, um vom Kamerakoordinatensystem zurück in das lokale Koordinatensystem des Objekts zu transformieren.
+
+`CONSTANT_TYPE_WORLDVIEWPROJ_INVERSE`
+: Die Inverse der kombinierten Welt-, Ansichts- und Projektionsmatrix. Verwende sie, um vom Clip-Koordinatensystem zurück in das lokale Koordinatensystem des Objekts zu transformieren. Diese inversen Konstanten ersparen die Berechnung einer inversen Matrix im Shader.
+
+`CONSTANT_TYPE_NORMAL`
+: Eine Matrix zur Berechnung der Normalenausrichtung. Die Welttransformation kann eine ungleichmäßige Skalierung enthalten, die die Orthogonalität der kombinierten Welt-Ansichts-Transformation aufhebt. Die Normalenmatrix verhindert Richtungsprobleme beim Transformieren von Normalen. (Die Normalenmatrix ist die transponierte Inverse der Welt-Ansichts-Matrix.)
+
+`CONSTANT_TYPE_TIME`
+: Ein von der Engine bereitgestellter `vector4`, bei dem `.x` die seit dem Start der Engine verstrichene Zeit und `.y` die Zeitdifferenz zum vorherigen Frame enthält. `.z` und `.w` sind derzeit null. Die Engine aktualisiert diesen Wert automatisch; er muss nicht mit `go.set()` aktualisiert werden. Ein Beispiel findest du im [Shadertoy-Tutorial](/tutorials/shadertoy/#animation).
+
+  Deklariere eine Time-Konstante namens `time` in einem modernen GLSL-Uniform-Block:
+
+  ```glsl
+  uniform fragment_inputs
+  {
+      vec4 time;
+  };
+  ```
+
+`CONSTANT_TYPE_USER`
+: Eine vector4-Konstante, die du für beliebige benutzerdefinierte Daten verwenden kannst, die du an deine Shader-Programme übergeben möchtest. Du kannst den Anfangswert der Konstante in ihrer Definition setzen und ihn anschließend über die Funktionen [go.set()](/ref/stable/go/#go.set) / [go.animate()](/ref/stable/go/#go.animate) ändern. Mit [go.get()](/ref/stable/go/#go.get) kannst du den Wert auch abrufen. Wenn du eine Materialkonstante einer einzelnen Komponenteninstanz änderst, [wird die Bündelung von Zeichenoperationen unterbrochen und es entstehen zusätzliche Zeichenaufrufe](/manuals/render/#draw-calls-and-batching).
+
+Beispiel:
+
+```lua
+go.set("#sprite", "tint", vmath.vector4(1,0,0,1))
+
+go.animate("#sprite", "tint", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,0,0,1), go.EASING_LINEAR, 2)
+```
+
+`CONSTANT_TYPE_USER_MATRIX4`
+: Eine matrix4-Konstante, die du für beliebige benutzerdefinierte Daten verwenden kannst, die du an deine Shader-Programme übergeben möchtest. Du kannst den Anfangswert der Konstante in ihrer Definition setzen und ihn anschließend über die Funktionen [go.set()](/ref/stable/go/#go.set) / [go.animate()](/ref/stable/go/#go.animate) ändern. Mit [go.get()](/ref/stable/go/#go.get) kannst du den Wert auch abrufen. Wenn du eine Materialkonstante einer einzelnen Komponenteninstanz änderst, [wird die Bündelung von Zeichenoperationen unterbrochen und es entstehen zusätzliche Zeichenaufrufe](/manuals/render/#draw-calls-and-batching).
+
+Beispiel:
+
+```lua
+go.set("#sprite", "m", vmath.matrix4())
+```
+
+### Materialkonstanten von GUI-Knoten {#gui-node-material-constants}
+
+Lies und schreibe die Materialkonstanten eines Knotens innerhalb eines GUI-Skripts mit `gui.get()` und `gui.set()` statt mit den `go`-Funktionen. Vektorkomponenten, Matrixkonstanten und Konstantenarrays werden unterstützt. Array-Indizes in der Optionstabelle beginnen bei 1:
+
+```lua
+local node = gui.get_node("button")
+
+local tint = gui.get(node, "tint")
+gui.set(node, "tint.x", 0.5)
+gui.set(node, "light_matrix", vmath.matrix4())
+gui.set(node, "tint_array", vmath.vector4(1, 0, 0, 1), { index = 1 })
+```
+
+::: sidenote
+Damit eine Materialkonstante vom Typ `CONSTANT_TYPE_USER` oder `CONSTANT_TYPE_USER_MATRIX4` über `go.get()` und `go.set()` oder `gui.get()` und `gui.set()` verfügbar ist, muss sie im Shader-Programm verwendet werden. Wenn die Konstante im Material definiert ist, aber im Programm nicht verwendet wird, wird sie aus dem Material entfernt und ist zur Laufzeit nicht verfügbar.
+:::
+
+## Sampler {#samplers}
+
+Sampler dienen dazu, Farbinformationen aus einer Textur (einer Kachelquelle oder einem Atlas) abzutasten. Die Farbinformationen können anschließend für Berechnungen im Shader-Programm verwendet werden.
+
+Sprite-, Kachelkarten-, GUI- und Partikeleffektkomponenten binden ihre Bildtextur automatisch an den zuerst deklarierten `sampler2D`. Sprite-Komponenten unterstützen außerdem mehrere Texturen: Jeder im Material deklarierte Sampler wird zu einem benannten Bildplatz in der Sprite-Komponente. Die erste Textur liefert die Animationsdaten des Sprites und steuert die Einzelbildfolge. Für jedes Einzelbild wird anhand seiner Bild-ID das entsprechende Bild in jeder zusätzlichen Textur gesucht, die jeweils ihre eigenen UV-Koordinaten liefert. Die zugewiesenen Atlanten oder Kachelquellen sollten daher übereinstimmende Einzelbild-IDs und ähnlich geformte Bilder enthalten; unterschiedliche polygonal gepackte Formen können zum Übergreifen benachbarter Texturpixel (texture bleeding) führen. Weitere Informationen findest du unter [Sprites mit mehreren Texturen](/manuals/sprite/#multi-textured-sprites).
+
+Bei einer Komponente oder einem Rendering-Arbeitsablauf, der keinen zusätzlichen Texturplatz bereitstellt, kannst du mit [`render.enable_texture()`](/ref/render/#render.enable_texture) zusätzliche Textur-Sampler aus dem Render-Skript binden.
+
+![Sprite-Sampler](images/materials/sprite_sampler.png)
+
+```glsl
+-- mysprite.fp
+varying mediump vec2 var_texcoord0;
+uniform lowp sampler2D MY_SAMPLER;
+void main()
+{
+    gl_FragColor = texture2D(MY_SAMPLER, var_texcoord0.xy);
+}
+```
+
+Du kannst die Sampler-Einstellungen einer Komponente festlegen, indem du den Sampler mit seinem Namen in der Materialdatei hinzufügst. Wenn du deinen Sampler nicht in der Materialdatei konfigurierst, werden die globalen Projekteinstellungen unter *graphics* verwendet.
+
+![Sampler-Einstellungen](images/materials/my_sampler.png)
+
+Für Modellkomponenten musst du deine Sampler mit den gewünschten Einstellungen in der Materialdatei angeben. Anschließend kannst du im Editor Texturen für jede Modellkomponente setzen, die das Material verwendet:
+
+![Modell-Sampler](images/materials/model_samplers.png)
+
+```glsl
+-- mymodel.fp
+varying mediump vec2 var_texcoord0;
+uniform lowp sampler2D TEXTURE_1;
+uniform lowp sampler2D TEXTURE_2;
+void main()
+{
+    lowp vec4 color1 = texture2D(TEXTURE_1, var_texcoord0.xy);
+    lowp vec4 color2 = texture2D(TEXTURE_2, var_texcoord0.xy);
+    gl_FragColor = color1 * color2;
+}
+```
+
+![Modell](images/materials/model.png)
+
+## Sampler-Einstellungen {#sampler-settings}
+
+Name
+: Der Name des Samplers. Dieser Name sollte mit dem im Fragment-Shader deklarierten `sampler2D` übereinstimmen.
+
+Wrap U/W
+: Der Texturadressierungsmodus für die U- und V-Achse:
+
+  - `WRAP_MODE_REPEAT` wiederholt Texturdaten außerhalb des Bereichs [0,1].
+  - `WRAP_MODE_MIRRORED_REPEAT` wiederholt Texturdaten außerhalb des Bereichs [0,1], wobei jede zweite Wiederholung gespiegelt wird.
+  - `WRAP_MODE_CLAMP_TO_EDGE` begrenzt Texturdaten für Werte größer als 1.0 auf 1.0 und setzt alle Werte kleiner als 0.0 auf 0.0---das heißt, die Randpixel werden bis zum Rand wiederholt.
+
+Filter Min/Mag
+: Die Filterung beim Vergrößern und Verkleinern. Nächster-Nachbar-Filterung erfordert weniger Berechnungen als lineare Interpolation, kann jedoch zu Aliasing-Artefakten führen. Lineare Interpolation liefert oft glattere Ergebnisse:
+
+  - `Default` verwendet die Standardfilteroption, die in der Datei `game.project` unter `Graphics` als `Default Texture Min Filter` und `Default Texture Mag Filter` angegeben ist.
+  - `FILTER_MODE_NEAREST` verwendet das Texel, dessen Koordinaten dem Mittelpunkt des Pixels am nächsten liegen.
+  - `FILTER_MODE_LINEAR` berechnet einen gewichteten linearen Mittelwert des 2x2-Arrays der Texel, die dem Mittelpunkt des Pixels am nächsten liegen.
+  - `FILTER_MODE_NEAREST_MIPMAP_NEAREST` wählt den nächstgelegenen Texelwert innerhalb einer einzelnen Mipmap.
+  - `FILTER_MODE_NEAREST_MIPMAP_LINEAR` wählt das nächstgelegene Texel in den beiden am besten passenden Mipmaps und interpoliert anschließend linear zwischen diesen beiden Werten.
+  - `FILTER_MODE_LINEAR_MIPMAP_NEAREST` interpoliert linear innerhalb einer einzelnen Mipmap.
+  - `FILTER_MODE_LINEAR_MIPMAP_LINEAR` berechnet den Wert in jeder von zwei Mipmaps durch lineare Interpolation und interpoliert anschließend linear zwischen diesen beiden Werten.
+
+Max Anisotropy
+: Anisotrope Filterung ist eine fortgeschrittene Filtertechnik, die mehrere Abtastwerte nimmt und die Ergebnisse miteinander mischt. Diese Einstellung steuert den Anisotropiegrad für die Textur-Sampler. Wenn die GPU anisotrope Filterung nicht unterstützt, hat der Parameter keine Wirkung und wird standardmäßig auf 1 gesetzt.
+
+## Konstantenpuffer {#constants-buffers}
+
+Beim Zeichnen ruft die Rendering-Pipeline Konstantenwerte aus einem standardmäßigen Systemkonstantenpuffer ab. Du kannst einen benutzerdefinierten Konstantenpuffer erstellen, um die Standardkonstanten zu überschreiben und die Uniforms des Shader-Programms stattdessen im Render-Skript programmatisch zu setzen:
+
+```lua
+self.constants = render.constant_buffer() -- <1>
+self.constants.tint = vmath.vector4(1, 0, 0, 1) -- <2>
+...
+render.draw(self.my_pred, {constants = self.constants}) -- <3>
+```
+1. Erstelle einen neuen Konstantenpuffer
+2. Setze die Konstante `tint` auf leuchtendes Rot
+3. Zeichne das Prädikat mit unseren benutzerdefinierten Konstanten
+
+Beachte, dass du die Konstantenelemente des Puffers wie die Einträge einer gewöhnlichen Lua-Tabelle ansprichst, den Puffer jedoch nicht mit `pairs()` oder `ipairs()` durchlaufen kannst.

--- a/docs/de/manuals/mesh.md
+++ b/docs/de/manuals/mesh.md
@@ -1,0 +1,107 @@
+---
+title: 3D-Meshes in Defold
+brief: Dieses Handbuch beschreibt, wie du in deinem Spiel zur Laufzeit 3D-Meshes erstellst.
+---
+
+# Mesh-Komponente {#mesh-component}
+
+Defold ist im Kern eine 3D-Engine. Auch wenn du ausschließlich mit 2D-Material arbeitest, erfolgt das gesamte Rendering in 3D, wird aber orthografisch auf den Bildschirm projiziert. Defold ermöglicht dir, vollständige 3D-Inhalte zu nutzen, indem du zur Laufzeit 3D-Meshes in deinen Sammlungen (collections) hinzufügst und erstellst. Du kannst reine 3D-Spiele mit ausschließlich 3D-Assets entwickeln oder 3D- und 2D-Inhalte nach Belieben kombinieren.
+
+## Eine Mesh-Komponente erstellen {#creating-a-mesh-component}
+
+Mesh-Komponenten erstellst du wie jede andere Komponente (component) eines Spielobjekts (game object). Dafür gibt es zwei Möglichkeiten:
+
+- Erstelle eine *Mesh-Datei*, indem du im Browser *Assets* an einer Stelle <kbd>mit der rechten Maustaste klickst</kbd> und <kbd>New... ▸ Mesh</kbd> auswählst.
+- Erstelle die Komponente direkt in ein Spielobjekt eingebettet, indem du in der Ansicht *Outline* auf ein Spielobjekt <kbd>mit der rechten Maustaste klickst</kbd> und <kbd>Add Component ▸ Mesh</kbd> auswählst.
+
+![Mesh in einem Spielobjekt](images/mesh/mesh.png)
+
+Nachdem du das Mesh erstellt hast, musst du einige Eigenschaften festlegen:
+
+### Mesh-Eigenschaften {#mesh-properties}
+
+Neben den Eigenschaften *Id*, *Position* und *Rotation* gibt es die folgenden komponentenspezifischen Eigenschaften:
+
+*Material*
+: Das Material, mit dem das Mesh gerendert wird.
+
+*Vertices*
+: Eine Pufferdatei, die die Mesh-Daten für jeden Datenstrom beschreibt.
+
+*Primitive Type*
+: Lines, Triangles oder Triangle Strip.
+
+*Position Stream*
+: Diese Eigenschaft sollte den Namen des Datenstroms *position* enthalten. Der Datenstrom wird dem Vertex-Shader automatisch als Eingabe bereitgestellt.
+
+*Normal Stream*
+: Diese Eigenschaft sollte den Namen des Datenstroms *normal* enthalten. Der Datenstrom wird dem Vertex-Shader automatisch als Eingabe bereitgestellt.
+
+*tex0*
+: Lege hier die Textur fest, die für das Mesh verwendet werden soll.
+
+## Bearbeitung im Editor {#editor-manipulation}
+
+Sobald die Mesh-Komponente vorhanden ist, kannst du die Komponente und/oder das Spielobjekt, das sie enthält, mit den üblichen Werkzeugen des *Scene Editor* bearbeiten und verändern, um das Mesh nach deinen Wünschen zu verschieben, zu drehen und zu skalieren.
+
+## Bearbeitung zur Laufzeit {#runtime-manipulation}
+
+Du kannst Meshes zur Laufzeit mithilfe von Defold-Puffern verändern. Beispiel für das Erstellen eines Würfels aus Dreiecksstreifen:
+
+```Lua
+
+-- cube
+local vertices = {
+	0, 0, 0,
+	0, 1, 0,
+	1, 0, 0,
+	1, 1, 0,
+	1, 1, 1,
+	0, 1, 0,
+	0, 1, 1,
+	0, 0, 1,
+	1, 1, 1,
+	1, 0, 1,
+	1, 0, 0,
+	0, 0, 1,
+	0, 0, 0,
+	0, 1, 0
+}
+
+-- create a buffer with a position stream
+local buf = buffer.create(#vertices / 3, {
+	{ name = hash("position"), type=buffer.VALUE_TYPE_FLOAT32, count = 3 }
+})
+
+-- get the position stream and write the vertices
+local positions = buffer.get_stream(buf, "position")
+for i, value in ipairs(vertices) do
+	positions[i] = vertices[i]
+end
+
+-- set the buffer with the vertices on the mesh
+local res = go.get("#mesh", "vertices")
+resource.set_buffer(res, buf)
+```
+
+Im [Ankündigungsbeitrag im Forum findest du weitere Informationen](https://forum.defold.com/t/mesh-component-in-defold-1-2-169-beta/65137) zur Verwendung der Mesh-Komponente, einschließlich Beispielprojekten und Codeausschnitten.
+
+## Aussondern von Geometrie außerhalb des Sichtvolumens {#frustum-culling}
+
+Mesh-Komponenten werden außerhalb des Sichtvolumens nicht automatisch ausgesondert (Frustum Culling), weil sie dynamisch sind und nicht sicher bekannt ist, wie die Positionsdaten codiert sind. Damit ein Mesh ausgesondert werden kann, muss sein achsenparalleler Begrenzungsquader als Metadaten im Puffer mit 6 Gleitkommazahlen (AABB min/max) festgelegt werden:
+
+```lua
+buffer.set_metadata(buf, hash("AABB"), { 0, 0, 0, 1, 1, 1 }, buffer.VALUE_TYPE_FLOAT32)
+```
+
+## Materialkonstanten {#material-constants}
+
+{% include shared/material-constants.md component='mesh' variable='tint' %}
+
+`tint`
+: Die Einfärbung des Meshes (`vector4`). Der `vector4` stellt die Einfärbung dar, wobei x, y, z und w den Rot-, Grün-, Blau- und Alphaanteilen entsprechen.
+
+## Vertices im lokalen Koordinatensystem und im Weltkoordinatensystem {#vertex-local-vs-world-space}
+Wenn die Einstellung Vertex Space des Mesh-Materials auf Local Space gesetzt ist, werden dir die Daten im Shader unverändert bereitgestellt. Du musst die Vertices und Normalen wie üblich auf der GPU transformieren.
+
+Wenn die Einstellung Vertex Space des Mesh-Materials auf World Space gesetzt ist, musst du entweder Datenströme mit den Standardnamen `position` und `normal` bereitstellen oder sie beim Bearbeiten des Meshes aus der Auswahlliste auswählen. Dadurch kann die Engine die Daten in das Weltkoordinatensystem transformieren, um Zeichenoperationen mit anderen Objekten zu bündeln (Batching).

--- a/docs/de/manuals/message-passing.md
+++ b/docs/de/manuals/message-passing.md
@@ -1,0 +1,254 @@
+---
+title: Nachrichtenübermittlung in Defold
+brief: Die Nachrichtenübermittlung ist der Mechanismus, mit dem Defold die Kommunikation zwischen lose gekoppelten Objekten ermöglicht. Dieses Handbuch beschreibt diesen Mechanismus ausführlich.
+---
+
+# Nachrichtenübermittlung {#message-passing}
+
+Die Nachrichtenübermittlung (message passing) ist ein Mechanismus, über den Spielobjekte (game objects) in Defold miteinander kommunizieren. Dieses Handbuch setzt voraus, dass du ein grundlegendes Verständnis von Defolds [Adressierungsmechanismus](/manuals/addressing) und [grundlegenden Bausteinen](/manuals/building-blocks) hast.
+
+Defold verwendet keine Objektorientierung in dem Sinne, dass du deine Anwendung durch Klassenhierarchien mit Vererbung und Memberfunktionen in deinen Objekten definierst (wie in Java, C++ oder C#). Stattdessen erweitert Defold Lua um einen einfachen und leistungsfähigen objektorientierten Entwurf, bei dem der Objektzustand intern in Skriptkomponenten (script components) gespeichert wird und über die Referenz `self` zugänglich ist. Außerdem lassen sich Objekte vollständig voneinander entkoppeln, indem sie über asynchrone Nachrichtenübermittlung miteinander kommunizieren.
+
+
+## Anwendungsbeispiele {#usage-examples}
+
+Sehen wir uns zunächst einige einfache Anwendungsbeispiele an. Angenommen, du entwickelst ein Spiel, das aus Folgendem besteht:
+
+1. Einer Startsammlung (bootstrap collection) als Hauptsammlung, die ein Spielobjekt mit einer GUI-Komponente enthält (die GUI besteht aus einer Minikarte und einem Punktezähler). Außerdem gibt es eine Sammlung (collection) mit dem Bezeichner "level".
+2. Die Sammlung namens "level" enthält zwei Spielobjekte: eine vom Spieler gesteuerte Heldenfigur und einen Gegner.
+
+![Struktur der Nachrichtenübermittlung](images/message_passing/message_passing_structure.png)
+
+::: sidenote
+Der Inhalt dieses Beispiels befindet sich in zwei getrennten Dateien. Es gibt eine Datei für die Startsammlung und eine für die Sammlung mit dem Bezeichner "level". Dateinamen _spielen in Defold jedoch keine Rolle_. Entscheidend ist die Identität, die du den Instanzen zuweist.
+:::
+
+Das Spiel enthält einige einfache Mechaniken, die Kommunikation zwischen den Objekten erfordern:
+
+![Nachrichtenübermittlung](images/message_passing/message_passing.png)
+
+① Der Held schlägt den Gegner
+: Als Teil dieser Mechanik wird eine Nachricht `"punch"` von der Skriptkomponente "hero" an die Skriptkomponente "enemy" gesendet. Da sich beide Objekte an derselben Stelle in der Sammlungshierarchie befinden, ist relative Adressierung vorzuziehen:
+
+  ```lua
+  -- Send "punch" from the "hero" script to "enemy" script
+  msg.post("enemy#controller", "punch")
+  ```
+
+  Im Spiel gibt es nur einen Schlag mit einer festen Stärke, daher muss die Nachricht außer ihrem Namen "punch" keine weiteren Informationen enthalten.
+
+  In der Skriptkomponente des Gegners erstellst du eine Funktion, um die Nachricht zu empfangen:
+
+  ```lua
+  function on_message(self, message_id, message, sender)
+    if message_id == hash("punch") then
+      self.health = self.health - 100
+    end
+  end
+  ```
+
+  In diesem Fall prüft der Code nur den Namen der Nachricht (der als gehashte Zeichenfolge im Parameter `message_id` gesendet wird). Der Code berücksichtigt weder die Nachrichtendaten noch den Absender---*jeder*, der die Nachricht "punch" sendet, fügt dem armen Gegner Schaden zu.
+
+② Der Held erhält Punkte
+: Immer wenn der Spieler einen Gegner besiegt, erhöht sich sein Punktestand. Außerdem wird eine Nachricht `"update_score"` von der Skriptkomponente des Spielobjekts "hero" an die Komponente "gui" des Spielobjekts "interface" gesendet.
+
+  ```lua
+  -- Enemy defeated. Increase score counter by 100.
+  self.score = self.score + 100
+  msg.post("/interface#gui", "update_score", { score = self.score })
+  ```
+
+  In diesem Fall lässt sich keine relative Adresse angeben, da sich "interface" an der Wurzel der Namenshierarchie befindet und "hero" nicht. Die Nachricht wird an die GUI-Komponente gesendet, der ein Skript zugewiesen ist, sodass sie entsprechend auf die Nachricht reagieren kann. Nachrichten können frei zwischen Skripten, GUI-Skripten und Render-Skripten gesendet werden.
+
+  Die Nachricht `"update_score"` enthält Daten zum Punktestand. Diese Daten werden als Lua-Tabelle im Parameter `message` übergeben:
+
+  ```lua
+  function on_message(self, message_id, message, sender)
+    if message_id == hash("update_score") then
+      -- set the score counter to new score
+      local score_node = gui.get_node("score")
+      gui.set_text(score_node, "SCORE: " .. message.score)
+    end
+  end
+  ```
+
+③ Die Position des Gegners auf der Minikarte
+: Dem Spieler steht eine Minikarte auf dem Bildschirm zur Verfügung, um Gegner zu finden und zu verfolgen. Jeder Gegner ist dafür verantwortlich, seine Position zu melden, indem er eine Nachricht `"update_minimap"` an die Komponente "gui" im Spielobjekt "interface" sendet:
+
+  ```lua
+  -- Send the current position to update the interface minimap
+  local pos = go.get_position()
+  msg.post("/interface#gui", "update_minimap", { position = pos })
+  ```
+
+  Der Code des GUI-Skripts muss die Position jedes Gegners verfolgen. Sendet derselbe Gegner eine neue Position, sollte sie die alte ersetzen. Der Absender der Nachricht (der im Parameter `sender` übergeben wird) kann als Schlüssel einer Lua-Tabelle mit Positionen verwendet werden:
+
+  ```lua
+  function init(self)
+    self.minimap_positions = {}
+  end
+
+  local function update_minimap(self)
+    for url, pos in pairs(self.minimap_positions) do
+      -- update position on map
+      ...
+    end
+  end
+
+  function on_message(self, message_id, message, sender)
+    if message_id == hash("update_score") then
+      -- set the score counter to new score
+      local score_node = gui.get_node("score")
+      gui.set_text(score_node, "SCORE: " .. message.score)
+    elseif message_id == hash("update_minimap") then
+      -- update the minimap with new positions
+      self.minimap_positions[sender] = message.position
+      update_minimap(self)
+    end
+  end
+  ```
+
+## Nachrichten senden {#sending-messages}
+
+Eine Nachricht zu senden ist, wie wir oben gesehen haben, sehr einfach. Du rufst die Funktion `msg.post()` auf, die deine Nachricht in die Nachrichtenwarteschlange einreiht. Die Engine durchläuft dann in jedem Frame die Warteschlange und stellt jede Nachricht an ihrer Zieladresse zu. Bei einigen Systemnachrichten (wie `"enable"`, `"disable"`, `"set_parent"` usw.) verarbeitet der Engine-Code die Nachricht. Die Engine erzeugt auch selbst einige Systemnachrichten (wie `"collision_response"` bei physikalischen Kollisionen), die deinen Objekten zugestellt werden. Bei benutzerdefinierten Nachrichten an Skriptkomponenten ruft die Engine lediglich eine spezielle Lua-Funktion von Defold namens `on_message()` auf.
+
+Du kannst beliebige Nachrichten an jedes vorhandene Objekt oder jede vorhandene Komponente senden. Es liegt am Code auf der Empfängerseite, auf die Nachricht zu reagieren. Wenn du eine Nachricht an eine Skriptkomponente sendest und der Skriptcode sie ignoriert, ist das in Ordnung. Die Verantwortung für den Umgang mit Nachrichten liegt vollständig beim Empfänger.
+
+Die Engine prüft die Zieladresse der Nachricht. Wenn du versuchst, eine Nachricht an einen unbekannten Empfänger zu senden, meldet Defold einen Fehler in der Konsole:
+
+```lua
+-- Try to post to a non existing object
+msg.post("dont_exist#script", "hello")
+```
+
+```txt
+ERROR:GAMEOBJECT: Instance '/dont_exists' could not be found when dispatching message 'hello' sent from main:/my_object#script
+```
+
+Die vollständige Signatur des Aufrufs `msg.post()` lautet:
+
+`msg.post(receiver, message_id, [message])`
+
+receiver
+: Der Bezeichner der Zielkomponente oder des Zielspielobjekts. Beachte, dass die Nachricht an alle Komponenten im Spielobjekt gesendet wird, wenn du ein Spielobjekt als Ziel angibst.
+
+message_id
+: Eine Zeichenfolge oder gehashte Zeichenfolge mit dem Namen der Nachricht.
+
+[message]
+: Eine optionale Lua-Tabelle mit Schlüssel-Wert-Paaren für die Nachrichtendaten. Die Lua-Tabelle der Nachricht kann nahezu jeden Datentyp enthalten. Du kannst Zahlen, Zeichenfolgen, boolesche Werte, URLs, Hashwerte und verschachtelte Tabellen übergeben. Funktionen kannst du nicht übergeben.
+
+  ```lua
+  -- Send table data containing a nested table
+  local inventory_table = { sword = true, shield = true, bow = true, arrows = 9 }
+  local stats = { score = 100, stars = 2, health = 4, inventory = inventory_table }
+  msg.post("other_object#script", "set_stats", stats)
+  ```
+
+::: sidenote
+Für die Größe der Tabelle im Parameter `message` gibt es eine feste Obergrenze. Diese beträgt 2 Kilobyte. Derzeit gibt es keine einfache Möglichkeit, den genauen Speicherbedarf einer Tabelle zu bestimmen. Du kannst aber vor und nach dem Einfügen der Tabelle `collectgarbage("count")` verwenden, um den Speicherverbrauch zu beobachten.
+:::
+
+### Kurzformen {#shorthands}
+
+Defold bietet zwei praktische Kurzformen, mit denen du Nachrichten senden kannst, ohne eine vollständige URL anzugeben:
+
+:[Shorthands](../shared/url-shorthands.md)
+
+
+## Nachrichten empfangen {#receiving-messages}
+
+Um Nachrichten zu empfangen, musst du sicherstellen, dass die Zielskriptkomponente eine Funktion namens `on_message()` enthält. Die Funktion nimmt vier Parameter entgegen:
+
+`function on_message(self, message_id, message, sender)`
+
+`self`
+: Eine Referenz auf die Skriptkomponente selbst.
+
+`message_id`
+: Enthält den Namen der Nachricht. Der Name ist _gehasht_.
+
+`message`
+: Enthält die Nachrichtendaten. Dies ist eine Lua-Tabelle. Wenn es keine Daten gibt, ist die Tabelle leer.
+
+`sender`
+: Enthält die vollständige URL des Absenders.
+
+```lua
+function on_message(self, message_id, message, sender)
+    print(message_id) --> hash: [my_message_name]
+
+    pprint(message) --> {
+                    -->   score = 100,
+                    -->   value = "some string"
+                    --> }
+
+    print(sender) --> url: [main:/my_object#script]
+end
+```
+
+## Nachrichten zwischen Spielwelten {#messaging-between-game-worlds}
+
+Wenn du eine Sammlungs-Proxy-Komponente (collection proxy component) verwendest, um eine neue Spielwelt in die Laufzeitumgebung zu laden, wirst du Nachrichten zwischen den Spielwelten übermitteln wollen. Angenommen, du hast eine Sammlung über einen Proxy geladen und ihre Eigenschaft *Name* ist auf "level" gesetzt:
+
+![Name der Sammlung](images/message_passing/collection_name.png)
+
+Sobald die Sammlung geladen, initialisiert und aktiviert wurde, kannst du Nachrichten an jede Komponente oder jedes Objekt in der neuen Welt senden, indem du den Namen der Spielwelt im Feld "socket" der Empfängeradresse angibst:
+
+```lua
+-- Send a message to the player in the new game world
+msg.post("level:/player#controller", "wake_up")
+```
+Eine ausführlichere Beschreibung der Funktionsweise von Proxys findest du in der Dokumentation zu [Sammlungs-Proxys](/manuals/collection-proxy).
+
+## Nachrichtenketten {#message-chains}
+
+Wenn eine gesendete Nachricht schließlich zugestellt wird, wird `on_message()` beim Empfänger aufgerufen. Häufig sendet der Code als Reaktion neue Nachrichten, die der Nachrichtenwarteschlange hinzugefügt werden.
+
+Wenn die Engine mit der Zustellung beginnt, arbeitet sie die Nachrichtenwarteschlange ab, ruft die Funktion `on_message()` jedes Nachrichtenempfängers auf und fährt fort, bis die Nachrichtenwarteschlange leer ist. Werden während dieses Durchlaufs neue Nachrichten zur Warteschlange hinzugefügt, führt sie einen weiteren Durchlauf aus. Es gibt jedoch eine feste Obergrenze dafür, wie oft die Engine versucht, die Warteschlange zu leeren. Dadurch ist die Länge der Nachrichtenketten begrenzt, deren vollständige Zustellung du innerhalb eines Frames erwarten kannst. Mit dem folgenden Skript kannst du leicht testen, wie viele Durchläufe der Nachrichtenverarbeitung die Engine zwischen den einzelnen Aufrufen von `update()` ausführt:
+
+```lua
+function init(self)
+    -- We’re starting a long message chain during object init
+    -- and keeps it running through a number of update() steps.
+    print("INIT")
+    msg.post("#", "msg")
+    self.updates = 0
+    self.count = 0
+end
+
+function update(self, dt)
+    if self.updates < 5 then
+        self.updates = self.updates + 1
+        print("UPDATE " .. self.updates)
+        print(self.count .. " dispatch passes before this update.")
+        self.count = 0
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("msg") then
+        self.count = self.count + 1
+        msg.post("#", "msg")
+    end
+end
+```
+
+Wenn du dieses Skript ausführst, erhältst du eine Ausgabe wie die folgende:
+
+```txt
+DEBUG:SCRIPT: INIT
+INFO:ENGINE: Defold Engine 1.2.36 (5b5af21)
+DEBUG:SCRIPT: UPDATE 1
+DEBUG:SCRIPT: 10 dispatch passes before this update.
+DEBUG:SCRIPT: UPDATE 2
+DEBUG:SCRIPT: 75 dispatch passes before this update.
+DEBUG:SCRIPT: UPDATE 3
+DEBUG:SCRIPT: 75 dispatch passes before this update.
+DEBUG:SCRIPT: UPDATE 4
+DEBUG:SCRIPT: 75 dispatch passes before this update.
+DEBUG:SCRIPT: UPDATE 5
+DEBUG:SCRIPT: 75 dispatch passes before this update.
+```
+
+Wir sehen, dass diese bestimmte Version der Defold-Engine zwischen `init()` und dem ersten Aufruf von `update()` die Nachrichtenwarteschlange in 10 Durchläufen abarbeitet. Anschließend führt sie bei jeder weiteren Aktualisierungsschleife 75 Durchläufe aus.

--- a/docs/de/manuals/microsoft-xbox.md
+++ b/docs/de/manuals/microsoft-xbox.md
@@ -1,0 +1,8 @@
+---
+title: Entwicklung mit Defold für Microsoft Xbox
+brief: Dieses Handbuch beschreibt, wie du Zugang zu Microsoft Xbox erhältst
+---
+
+# Xbox-Unterstützung {#xbox-support}
+
+Defold unterstützt Microsoft Xbox noch nicht. Die Defold Foundation arbeitet aktiv daran, ein Middleware-Anbieter für Xbox zu werden. Wenn du als Xbox-Entwickler zugelassen bist, ermutigen wir dich, deine Kontaktperson im Xbox-Entwicklerprogramm zu kontaktieren und Unterstützung für Microsoft Xbox durch Defold anzufragen.

--- a/docs/de/manuals/model-animation.md
+++ b/docs/de/manuals/model-animation.md
@@ -1,0 +1,222 @@
+---
+title: Handbuch zur 3D-Modellanimation in Defold
+brief: Dieses Handbuch beschreibt, wie du 3D-Modellanimationen in Defold verwendest.
+---
+
+# 3D-Modellanimation {#3d-model-animation}
+
+Modellkomponenten (model components) können Skelettanimationen und Morph-Ziel-Animationen abspielen, die aus glTF-Dateien importiert wurden. Die Skelettanimation (skeletal animation) nutzt die Knochen des Modells, um dessen Vertices zu verformen. Die Morph-Ziel-Animation (morph target animation), auch als Blend-Shape-Animation bekannt, verändert die Form des Modells, indem sie Gewichtungen für alternative Vertex-Positionen animiert.
+
+Einzelheiten dazu, wie du 3D-Daten für die Animation in ein Modell importierst, findest du in der [Modelldokumentation](/manuals/model).
+
+  ![Blender-Animation](images/animation/blender_animation.png)
+  ![Wackelanimation in einer Schleife](images/animation/suzanne.gif)
+
+
+## Animationen abspielen {#playing-animations}
+
+Modelle werden mit der Funktion [`model.play_anim()`](/ref/model#model.play_anim) animiert:
+
+```lua
+function init(self)
+    -- Start the "wiggle" animation back and forth on #model
+    model.play_anim("#model", "wiggle", go.PLAYBACK_LOOP_PINGPONG)
+end
+```
+
+::: important
+Defold unterstützt derzeit nur vorab berechnete Skelettanimationen. Skelettanimationen müssen in jedem Schlüsselbild (keyframe) für jeden animierten Knochen Matrizen enthalten, anstelle separater Schlüssel für Position, Drehung und Skalierung.
+
+Animationen werden außerdem linear interpoliert. Wenn du eine komplexere Kurveninterpolation verwendest, müssen die Animationen beim Export vorab berechnet werden.
+:::
+
+### Morph-Ziele {#morph-targets}
+
+Morph-Ziele (morph targets) sind alternative Formen desselben Meshes. Jedes Ziel speichert Differenzen für Position, Normale und Tangente und besitzt eine Mischgewichtung, die steuert, wie stark diese Form angewendet wird. Eine Gewichtung von `0` bedeutet, dass das Ziel keine Auswirkung hat, während eine Gewichtung von `1` die vollständige Zielform anwendet. Werte außerhalb dieses Bereichs können ebenfalls für überzeichnete Effekte nützlich sein, wenn der Shader und das Asset dafür ausgelegt sind.
+
+Defold importiert Morph-Ziele und anfängliche Morph-Gewichtungen aus glTF-Modelldaten. glTF-Animationen, die Morph-Gewichtungen animieren, werden in den Animationssatz des Modells importiert und können genau wie Skelettanimationen mit [`model.play_anim()`](/ref/model#model.play_anim) abgespielt werden:
+
+```lua
+function init(self)
+    model.play_anim("#model", "smile", go.PLAYBACK_LOOP_FORWARD)
+end
+```
+
+Morph-Ziel-Daten können allein oder zusammen mit einer Skelettanimation verwendet werden, aber eine Modellkomponente kann jeweils nur eine Modellanimation abspielen. Das bedeutet, dass du mit `model.play_anim()` eine Skelettanimation und eine separate Morph-Ziel-Animation nicht gleichzeitig abspielen kannst. Wenn ein Modell Animationsdaten, aber kein Skelett besitzt, werden nur die Animationsdaten der Morph-Ziele verwendet.
+
+Du kannst die Wiedergabe einer Skelettanimation dennoch mit Änderungen an Morph-Zielen aus anderen Quellen kombinieren, beispielsweise indem du die Gewichtungen der Morph-Ziele per Skript mit `model.set_blend_weights()` festlegst.
+
+Du kannst die Gewichtungen der Morph-Ziele auch per Skript auslesen und überschreiben. [`model.get_blend_weights()`](/ref/model#model.get_blend_weights) gibt die aktuellen Gewichtungen für das erste Mesh im Modell zurück, das Morph-Ziele besitzt. [`model.set_blend_weights()`](/ref/model#model.set_blend_weights) überschreibt die Werte per Skript für jedes durch Morph-Ziele verformte Mesh im Modell:
+
+```lua
+function init(self)
+    local weights = model.get_blend_weights("#model")
+    weights[1] = 0.75
+    weights[2] = 0.25
+    model.set_blend_weights("#model", weights)
+end
+```
+
+Die Gewichtungstabelle verwendet bei eins beginnende Lua-Indizes in derselben Reihenfolge wie die Morph-Ziele im Mesh. Zusätzliche Werte werden ignoriert. Bei Meshes mit mehr Morph-Zielen als Einträgen in der Tabelle werden fehlende Werte als null behandelt. Die Überschreibung per Skript wird in jedem Frame nach der Animation angewendet, bis sie aufgehoben wird:
+
+```lua
+model.set_blend_weights("#model")     -- clear the override
+model.set_blend_weights("#model", nil) -- also clears the override
+```
+
+### Shader-Unterstützung {#shader-support}
+
+Um Morph-Ziele zu rendern, muss der Vertex-Shader des Modellmaterials die erzeugte Textur `morph_targets` abtasten und die gewichteten Differenzen auf die Vertex-Daten anwenden. Die Morph-Ziel-Textur ist eine 2D-Array-Textur, in der jedes Morph-Ziel drei Array-Ebenen verwendet: die Differenz für die Position, die Normale und die Tangente.
+
+Die Engine stellt die aktuellen Morph-Gewichtungen über eine Vertex-Shader-Uniform namens `morph_targets_weights` bereit. Jeder `vec4` speichert vier Gewichtungen, sodass `morph_targets_weights[2]` Platz für acht Morph-Ziele bietet.
+
+Das folgende Beispiel zeigt die relevanten Teile des Vertex-Shaders für ein Modellmaterial ohne Instancing:
+
+```glsl
+#version 140
+
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec3 normal;
+in mediump vec4 tangent;
+
+out mediump vec2 var_texcoord0;
+out mediump vec3 var_normal;
+out mediump vec4 var_tangent;
+
+uniform vs_uniforms
+{
+    mediump mat4 mtx_worldview;
+    mediump mat4 mtx_proj;
+    mediump mat4 mtx_normal;
+    // Each vec4 stores four blend weights. Use morph_targets_weights[1]
+    // for up to 4 morph targets, [2] for up to 8, [3] for up to 12, etc.
+    mediump vec4 morph_targets_weights[2];
+};
+
+uniform sampler2DArray morph_targets;
+
+vec2 get_morph_uv(int vertex_index, int width, int height)
+{
+    int x = vertex_index % width;
+    int y = vertex_index / width;
+    return vec2(
+        (float(x) + 0.5) / float(width),
+        (float(y) + 0.5) / float(height)
+    );
+}
+
+void apply_morph_target(vec2 uv, float weight, int target,
+    inout vec3 position_delta, inout vec3 normal_delta, inout vec3 tangent_delta)
+{
+    if (weight == 0.0) {
+        return;
+    }
+
+    int position_layer = target * 3 + 0;
+    int normal_layer = target * 3 + 1;
+    int tangent_layer = target * 3 + 2;
+
+    position_delta += weight * texture(morph_targets, vec3(uv, position_layer)).xyz;
+    normal_delta += weight * texture(morph_targets, vec3(uv, normal_layer)).xyz;
+    tangent_delta += weight * texture(morph_targets, vec3(uv, tangent_layer)).xyz;
+}
+
+void get_morph_target_data(int vertex_index,
+    out vec3 position_delta, out vec3 normal_delta, out vec3 tangent_delta)
+{
+    position_delta = vec3(0.0);
+    normal_delta = vec3(0.0);
+    tangent_delta = vec3(0.0);
+
+#ifndef EDITOR
+    ivec3 texture_size = textureSize(morph_targets, 0);
+    vec2 uv = get_morph_uv(vertex_index, texture_size.x, texture_size.y);
+
+    apply_morph_target(uv, morph_targets_weights[0].x, 0, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[0].y, 1, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[0].z, 2, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[0].w, 3, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[1].x, 4, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[1].y, 5, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[1].z, 6, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[1].w, 7, position_delta, normal_delta, tangent_delta);
+#endif
+}
+
+void main()
+{
+    vec3 position_delta;
+    vec3 normal_delta;
+    vec3 tangent_delta;
+    get_morph_target_data(gl_VertexIndex, position_delta, normal_delta, tangent_delta);
+
+    vec3 morphed_position = position.xyz + position_delta;
+    vec3 morphed_normal = normalize(normal + normal_delta);
+    vec3 morphed_tangent = normalize(tangent.xyz + tangent_delta);
+
+    var_texcoord0 = texcoord0;
+    var_normal = normalize((mtx_normal * vec4(morphed_normal, 0.0)).xyz);
+    var_tangent = vec4(normalize((mtx_normal * vec4(morphed_tangent, 0.0)).xyz), tangent.w);
+
+    gl_Position = mtx_proj * mtx_worldview * vec4(morphed_position, 1.0);
+}
+```
+
+Die Umschließung mit `#ifndef EDITOR` ist erforderlich, da der Editor noch keine Vorschau von Modellanimationen unterstützt und die erzeugten Morph-Ziel-Texturdaten deshalb nur zur Laufzeit verfügbar sind. Vergrößere das Array `morph_targets_weights` und füge weitere Aufrufe von `apply_morph_target()` hinzu, wenn das Mesh mehr Morph-Ziele besitzt.
+
+::: important
+Das obige Shader-Beispiel verwendet `textureSize()` und funktioniert nicht mit OpenGL ES 2.0.
+:::
+
+### Die Knochenhierarchie {#the-bone-hierarchy}
+
+Die Knochen im Skelett des Modells werden intern als Spielobjekte (game objects) dargestellt.
+
+Du kannst den Instanzbezeichner des Knochen-Spielobjekts zur Laufzeit abrufen. Die Funktion [`model.get_go()`](/ref/model#model.get_go) gibt den Bezeichner des Spielobjekts für den angegebenen Knochen zurück.
+
+```lua
+-- Get the middle bone go of our wiggler model
+local bone_go = model.get_go("#wiggler", "Bone_002")
+
+-- Now do something useful with the game object...
+```
+
+### Cursor-Animation
+
+Neben der Möglichkeit, eine Modellanimation mit `model.play_anim()` voranzutreiben, stellen *Modellkomponenten* eine Eigenschaft `cursor` bereit, die du mit `go.animate()` verändern kannst (mehr über [Eigenschaftsanimationen](/manuals/property-animation)):
+
+```lua
+-- Set the animation on #model but don't start it
+model.play_anim("#model", "wiggle", go.PLAYBACK_NONE)
+-- Set the cursor to the beginning of the animation
+go.set("#model", "cursor", 0)
+-- Tween the cursor between 0 and 1 pingpong with in-out quad easing.
+go.animate("#model", "cursor", go.PLAYBACK_LOOP_PINGPONG, 1, go.EASING_INOUTQUAD, 3)
+```
+
+## Callbacks beim Abschluss {#completion-callbacks}
+
+Die Modellanimationsfunktion `model.play_anim()` unterstützt eine optionale Lua-Callback-Funktion als letztes Argument. Diese Funktion wird aufgerufen, wenn die Animation bis zum Ende abgespielt wurde. Die Funktion wird weder bei wiederholten Animationen noch beim manuellen Abbrechen einer Animation über `go.cancel_animations()` aufgerufen. Mit dem Callback kannst du beim Abschluss einer Animation Ereignisse auslösen oder mehrere Animationen miteinander verketten.
+
+```lua
+local function wiggle_done(self, message_id, message, sender)
+    -- Done animating
+end
+
+function init(self)
+    model.play_anim("#model", "wiggle", go.PLAYBACK_ONCE_FORWARD, nil, wiggle_done)
+end
+```
+
+## Wiedergabemodi {#playback-modes}
+
+Animationen können entweder einmalig oder in einer Schleife abgespielt werden. Der Wiedergabemodus bestimmt, wie die Animation abgespielt wird:
+
+* `go.PLAYBACK_NONE`
+* `go.PLAYBACK_ONCE_FORWARD`
+* `go.PLAYBACK_ONCE_BACKWARD`
+* `go.PLAYBACK_ONCE_PINGPONG`
+* `go.PLAYBACK_LOOP_FORWARD`
+* `go.PLAYBACK_LOOP_BACKWARD`
+* `go.PLAYBACK_LOOP_PINGPONG`

--- a/docs/de/manuals/model.md
+++ b/docs/de/manuals/model.md
@@ -1,0 +1,157 @@
+---
+title: 3D-Modelle in Defold
+brief: Dieses Handbuch beschreibt, wie du 3D-Modelle, Skelette und Animationen in dein Spiel einbindest.
+---
+
+# Modellkomponente {#model-component}
+
+Defold ist im Kern eine 3D-Engine. Selbst wenn du ausschließlich mit 2D-Material arbeitest, erfolgt das gesamte Rendering in 3D, wird aber orthografisch auf den Bildschirm projiziert. Defold ermöglicht dir, vollständige 3D-Inhalte zu nutzen, indem du 3D-Assets oder _Modelle_ (models) in deine Sammlungen (collections) einbindest. Du kannst reine 3D-Spiele ausschließlich mit 3D-Assets erstellen oder 3D- und 2D-Inhalte nach Belieben mischen.
+
+## Eine Modellkomponente erstellen {#creating-a-model-component}
+
+Modellkomponenten werden genauso erstellt wie jede andere Komponente (component) eines Spielobjekts (game object). Dafür gibt es zwei Möglichkeiten:
+
+- Erstelle eine *Modelldatei*, indem du im Browser *Assets* einen <kbd>Rechtsklick</kbd> auf einen Speicherort ausführst und <kbd>New... ▸ Model</kbd> auswählst.
+- Erstelle die Komponente direkt in ein Spielobjekt eingebettet, indem du in der Ansicht *Outline* einen <kbd>Rechtsklick</kbd> auf ein Spielobjekt ausführst und <kbd>Add Component ▸ Model</kbd> auswählst.
+
+![Modell in einem Spielobjekt](images/model/model_gltf.png)
+
+Nachdem du das Modell erstellt hast, musst du einige Eigenschaften festlegen:
+
+### Modelleigenschaften {#model-properties}
+
+Neben den Eigenschaften *Id*, *Position* und *Rotation* gibt es die folgenden komponentenspezifischen Eigenschaften:
+
+*Scene*
+: Die glTF-Datei mit der Erweiterung *.gltf* oder *.glb*, die die Geometrie des Modells enthält. Wenn die Datei Morph-Ziele (morph targets) enthält, werden sie zusammen mit der Szene importiert. Vor Defold 1.13.2 hieß diese Eigenschaft *Mesh*.
+
+*Mesh*
+: Ein optionales benanntes Mesh aus der ausgewählten *Scene*, verfügbar seit Defold 1.13.2. Lasse dieses Feld leer, um die gesamte Szene mit ihren importierten Transformationen zu rendern. Wähle ein Mesh aus, um dieses Mesh einmal in seinen lokalen Koordinaten ohne die glTF-Knotentransformationen zu rendern. Positioniere, drehe und skaliere die Modellkomponente oder ihr Spielobjekt, um das ausgewählte Mesh zu platzieren.
+
+*Create GO Bones*
+: Aktiviere diese Option, um für jeden Knochen des Modells ein Spielobjekt zu erstellen. Du kannst diese Spielobjekte verwenden, um andere Spielobjekte anzuhängen, beispielsweise Waffen an Handknochen und so weiter. 
+
+*Skeleton*
+: Diese Eigenschaft sollte auf die glTF-Datei mit der Erweiterung *.gltf* oder *.glb* verweisen, die das für die Animation zu verwendende Skelett enthält. Beachte, dass Defold einen einzigen Wurzelknochen in deiner Hierarchie voraussetzt.
+
+*Animations*
+: Setze diese Eigenschaft auf die *Animationssatzdatei*, die die Animationen enthält, die du für das Modell verwenden möchtest.
+
+*Default Animation*
+: Dies ist die Animation (aus dem Animationssatz), die automatisch auf dem Modell abgespielt wird.
+
+Zusätzlich zu den oben genannten Eigenschaften gibt es für jedes Mesh des Modells ein Feld, in dem du ein Material zuweisen kannst:
+
+*Material*
+: Setze diese Eigenschaft auf ein von dir erstelltes Material, das für ein texturiertes 3D-Objekt geeignet ist. Es gibt einige integrierte Materialien, die du als Ausgangspunkt verwenden kannst:
+
+  * Verwende *model.material* für statische Modelle ohne Instanziierung
+  * Verwende *model_instanced.material* für statische instanziierte Modelle
+  * Verwende *model_skinned.material* für Modelle mit Skinning (animiert) ohne Instanziierung
+  * Verwende *model_skinned_instanced.material* für instanziierte Modelle mit Skinning (animiert)
+
+Je nach Material gibt es eine oder mehrere Textureigenschaften:
+
+*Texture*
+: Diese Eigenschaft sollte auf die Texturbilddatei verweisen, die du auf das Objekt anwenden möchtest.
+
+
+## Bearbeitung im Editor {#editor-manipulation}
+
+Sobald die Modellkomponente vorhanden ist, kannst du die Komponente und/oder das Spielobjekt, das sie enthält, mit den üblichen Werkzeugen des *Scene Editor* bearbeiten und verändern, um das Modell nach deinen Wünschen zu verschieben, zu drehen und zu skalieren.
+
+## Änderungen zur Laufzeit {#runtime-manipulation}
+
+Du kannst Modelle zur Laufzeit über verschiedene Funktionen und Eigenschaften verändern (Hinweise zur Verwendung findest du in der [API-Dokumentation](/ref/model/)).
+
+![Wiggler im Spiel](images/model/runtime.png)
+
+### Animation zur Laufzeit {#runtime-animation}
+
+Defold bietet umfangreiche Unterstützung für die Steuerung von Animationen zur Laufzeit. Mehr dazu findest du im [Handbuch zu Modellanimationen](/manuals/model-animation):
+
+```lua
+local play_properties = { blend_duration = 0.1 }
+model.play_anim("#model", "jump", go.PLAYBACK_ONCE_FORWARD, play_properties)
+```
+
+Der Wiedergabecursor der Animation kann entweder von Hand oder über das System für Eigenschaftsanimationen animiert werden:
+
+```lua
+-- set the run animation
+model.play_anim("#model", "run", go.PLAYBACK_NONE)
+-- animate the cursor
+go.animate("#model", "cursor", go.PLAYBACK_LOOP_PINGPONG, 1, go.EASING_LINEAR, 10)
+```
+
+Modelle können auch glTF-Animationen mit Morph-Zielen verwenden. Die Gewichtungen der Morph-Ziele werden wie andere Modellanimationen mit `model.play_anim()` animiert und können zur Laufzeit mit [`model.get_blend_weights()`](/ref/model#model.get_blend_weights) und [`model.set_blend_weights()`](/ref/model#model.set_blend_weights) gelesen oder überschrieben werden. Einzelheiten findest du im [Abschnitt zu Morph-Zielen](/manuals/model-animation#morph-targets) im Handbuch zu Modellanimationen.
+
+### Eigenschaften ändern {#changing-properties}
+
+Ein Modell hat außerdem verschiedene Eigenschaften, die mit `go.get()` und `go.set()` verändert werden können:
+
+`animation`
+: Die aktuelle Modellanimation (`hash`) (NUR LESBAR). Du änderst die Animation mit `model.play_anim()` (siehe oben).
+
+`cursor`
+: Der normalisierte Animationscursor (`number`).
+
+`material`
+: Das Material des Modells (`hash`). Du kannst es mit einer Materialressourceneigenschaft und `go.set()` ändern. Ein Beispiel findest du in der [API-Referenz](/ref/model/#material).
+
+`playback_rate`
+: Die Wiedergabegeschwindigkeit der Animation (`number`).
+
+`textureN`
+: Die Texturen des Modells, wobei N den Bereich 0-15 abdeckt (`hash`). Du kannst diese Eigenschaften mit `go.get()` lesen und mit einer Texturressourceneigenschaft und `go.set()` ändern. Defold unterstützt höchstens 16 Texturen pro Zeichenaufruf (draw call). Die Anzahl der von einem Shader nutzbaren Texturen kann auf Grafikadaptern mit einer niedrigeren Grenze für Textur-Sampler jedoch geringer sein.
+
+
+## Material
+
+In 3D-Software kannst du üblicherweise Eigenschaften an den Vertices deiner Objekte festlegen, etwa zur Farbgebung und Texturierung. Diese Informationen werden in der glTF-Datei mit der Erweiterung *.gltf* oder *.glb* gespeichert, die du aus deiner 3D-Software exportierst. Je nach den Anforderungen deines Spiels musst du geeignete und _leistungsfähige_ Materialien für deine Objekte auswählen und/oder erstellen. Ein Material kombiniert _Shader-Programme_ mit einem Satz von Parametern für das Rendering des Objekts.
+
+Es gibt einige integrierte Materialien, die du als Ausgangspunkt verwenden kannst:
+
+  * Verwende *model.material* für statische Modelle ohne Instanziierung
+  * Verwende *model_instanced.material* für statische instanziierte Modelle
+  * Verwende *model_skinned.material* für Modelle mit Skinning (animiert) ohne Instanziierung
+  * Verwende *model_skinned_instanced.material* für instanziierte Modelle mit Skinning (animiert)
+
+Die integrierten Modellmaterialien verwenden ein lokales Koordinatensystem für Vertices. Bei Modellen mit Skinning ermöglicht dieses lokale Koordinatensystem dem Vertex-Shader, das Skinning auf der GPU mithilfe einer Knochenmatrix-Textur durchzuführen. Das lokale Koordinatensystem für Vertices ist auch für die Instanziierung von Modellen erforderlich. Ein benutzerdefiniertes Material für Modelle mit GPU-Skinning oder instanziierte Modelle sollte daher die Einstellung *Local* für das Vertex-Koordinatensystem verwenden.
+
+Der Knochenmatrix-Cache verwendet eine `RGBA32F`-Textur. Wenn der aktive Grafikadapter dieses Texturformat nicht unterstützt, kann Defold keine animierte Modellkomponente erstellen, die ein Material mit lokalem Koordinatensystem verwendet. Bei OpenGL ES 2.0 und WebGL 1.0 hängt die Unterstützung daher von der Erweiterung des Adapters für Gleitkommatexturen ab. Für die Kompatibilität mit einem Adapter, dem diese Erweiterung fehlt, verwende ein benutzerdefiniertes Material mit Weltkoordinatensystem. Dieses verwendet CPU-Skinning und kann keine Modellinstanziierung nutzen. Die Abmessungen des Caches kannst du über die [Projekteinstellungen für Model](/manuals/project-settings/#model) anpassen.
+
+Wenn du benutzerdefinierte Materialien für deine Modelle erstellen musst, findest du Informationen dazu in der [Materialdokumentation](/manuals/material). Das [Shader-Handbuch](/manuals/shader) enthält Informationen zur Funktionsweise von Shader-Programmen.
+
+
+### Materialkonstanten {#material-constants}
+
+{% include shared/material-constants.md component='model' variable='tint' %}
+
+`tint`
+: Die Einfärbung des Modells (`vector4`). Der `vector4` stellt die Einfärbung dar, wobei x, y, z und w den Rot-, Grün-, Blau- und Alpha-Anteilen der Einfärbung entsprechen.
+
+
+## Rendering
+
+Das standardmäßige Render-Skript ist auf 2D-Spiele zugeschnitten und funktioniert nicht mit 3D-Modellen. Indem du das standardmäßige Render-Skript kopierst und einige Codezeilen zum Render-Skript hinzufügst, kannst du jedoch das Rendering deiner Modelle aktivieren. Zum Beispiel:
+
+  ```lua
+
+  function init(self)
+    self.model_pred = render.predicate({"model"})
+    ...
+  end
+
+  function update()
+    ...
+    render.set_depth_mask(true)
+    render.enable_state(graphics.STATE_DEPTH_TEST)
+    render.set_projection(stretch_projection(-1000, 1000))  -- orthographic
+    render.draw(self.model_pred)
+    render.set_depth_mask(false)
+    ...
+  end
+  ```
+
+Einzelheiten zur Funktionsweise von Render-Skripten findest du in der [Render-Dokumentation](/manuals/render).

--- a/docs/de/manuals/models.md
+++ b/docs/de/manuals/models.md
@@ -1,0 +1,12 @@
+---
+title: Veraltete Dokumentation zu 3D-Modellen
+brief: Dieses Dokument wurde ersetzt
+---
+
+# Modelle {#models}
+
+Dieses Dokument wurde durch die folgenden Handbücher ersetzt:
+
+* [Überblick über 3D-Grafik](/manuals/3dgraphics)
+* [Handbuch zur 3D-Modellkomponente](/manuals/model)
+* [Handbuch zur 3D-Modellanimation](/manuals/model-animation)

--- a/docs/de/manuals/modules.md
+++ b/docs/de/manuals/modules.md
@@ -1,0 +1,239 @@
+---
+title: Lua-Module in Defold
+brief: Mit Lua-Modulen kannst du dein Projekt strukturieren und wiederverwendbaren Bibliothekscode erstellen. Dieses Handbuch erklärt, wie das in Defold funktioniert.
+---
+
+# Lua-Module {#lua-modules}
+
+Mit Lua-Modulen kannst du dein Projekt strukturieren und wiederverwendbaren Bibliothekscode erstellen. Im Allgemeinen ist es sinnvoll, Duplizierungen in deinen Projekten zu vermeiden. Defold ermöglicht es dir, mit der Modulfunktionalität von Lua Skriptdateien in andere Skriptdateien einzubinden. So kannst du Funktionalität (und Daten) in einer externen Skriptdatei kapseln und sie in Skriptdateien für Spielobjekte (game objects) und GUIs wiederverwenden.
+
+## Lua-Dateien mit require laden {#requiring-lua-files}
+
+Lua-Code, der in Dateien mit der Dateierweiterung `.lua` an beliebiger Stelle in der Struktur deines Spielprojekts gespeichert ist, kann mit `require` in Skript- und GUI-Skriptdateien geladen werden. Um eine neue Lua-Moduldatei zu erstellen, klicke in der Ansicht *Assets* mit der rechten Maustaste auf den Ordner, in dem du sie erstellen möchtest, und wähle dann <kbd>New... ▸ Lua Module</kbd>. Gib der Datei einen eindeutigen Namen und drücke <kbd>Ok</kbd>:
+
+![Neue Datei](images/modules/new_name.png)
+
+Angenommen, du fügst der Datei „`main/anim.lua`“ den folgenden Code hinzu:
+
+```lua
+function direction_animation(direction, char)
+    local d = ""
+    if direction.x > 0 then
+        d = "right"
+    elseif direction.x < 0 then
+        d = "left"
+    elseif direction.y > 0 then
+        d = "up"
+    elseif direction.y < 0 then
+        d = "down"
+    end
+    return hash(char .. "-" .. d)
+end
+```
+
+Dann kann jedes Skript diese Datei mit `require` laden und die Funktion verwenden:
+
+```lua
+require "main.anim"
+
+function update(self, dt)
+    -- update position, set direction etc
+    ...
+
+    -- set animation
+    local anim = direction_animation(self.dir, "player")
+    if anim ~= self.current_anim then
+        sprite.play_flipbook("#sprite", anim)
+        self.current_anim = anim
+    end
+end
+```
+
+Die Funktion `require` lädt das angegebene Modul. Zuerst prüft sie anhand der Tabelle `package.loaded`, ob das Modul bereits geladen ist. Falls ja, gibt `require` den unter `package.loaded[module_name]` gespeicherten Wert zurück. Andernfalls lädt sie die Datei über eine Ladefunktion und wertet sie aus.
+
+Die Syntax der Dateinamenzeichenfolge, die du an `require` übergibst, hat eine Besonderheit. Lua ersetzt die Zeichen `.` in der Dateinamenzeichenfolge durch Pfadtrennzeichen: `/` unter macOS und Linux und `\\` unter Windows.
+
+Beachte, dass es in der Regel keine gute Idee ist, wie oben den globalen Gültigkeitsbereich zum Speichern von Zustand und Definieren von Funktionen zu verwenden. Du riskierst Namenskonflikte, legst den Zustand des Moduls offen oder erzeugst eine Kopplung zwischen den Stellen, die das Modul verwenden.
+
+## Module {#modules}
+
+Um Daten und Funktionen zu kapseln, verwendet Lua _Module_. Ein Lua-Modul ist eine gewöhnliche Lua-Tabelle, die Funktionen und Daten enthält. Die Tabelle wird lokal deklariert, um den globalen Gültigkeitsbereich nicht mit zusätzlichen Namen zu belegen:
+
+```lua
+local M = {}
+
+-- private
+local message = "Hello world!"
+
+function M.hello()
+    print(message)
+end
+
+return M
+```
+
+Anschließend kannst du das Modul verwenden. Auch hier solltest du es vorzugsweise einer lokalen Variablen zuweisen:
+
+```lua
+local m = require "mymodule"
+m.hello() --> "Hello world!"
+```
+
+## Module mit Hot Reload neu laden {#hot-reloading-modules}
+
+Betrachte ein einfaches Modul:
+
+```lua
+-- module.lua
+local M = {} -- creates a new table in the local scope
+M.value = 4711
+return M
+```
+
+Und Code, der dieses Modul verwendet: 
+
+```lua
+local m = require "module"
+print(m.value) --> "4711" (even if "module.lua" is changed and hot reloaded)
+```
+
+Wenn du die Moduldatei mit Hot Reload neu lädst, wird der Code erneut ausgeführt, aber `m.value` bleibt unverändert. Woran liegt das?
+
+Erstens wird die Tabelle in `module.lua` im lokalen Gültigkeitsbereich erstellt, und eine _Referenz_ auf diese Tabelle wird an den aufrufenden Code zurückgegeben. Beim erneuten Laden von `module.lua` wird der Modulcode erneut ausgewertet. Dabei entsteht jedoch eine neue Tabelle im lokalen Gültigkeitsbereich, anstatt die Tabelle zu aktualisieren, auf die `m` verweist.
+
+Zweitens speichert Lua Dateien, die mit `require` geladen werden, im Cache. Beim ersten Laden einer Datei wird sie in der Tabelle [`package.loaded`](/ref/package/#package.loaded) abgelegt, damit sie bei nachfolgenden Aufrufen von `require` schneller gelesen werden kann. Du kannst das erneute Einlesen einer Datei vom Datenträger erzwingen, indem du den Eintrag der Datei auf `nil` setzt: `package.loaded["my_module"] = nil`.
+
+Damit Hot Reload bei einem Modul korrekt funktioniert, musst du das Modul neu laden, den Cache zurücksetzen und dann alle Dateien neu laden, die das Modul verwenden. Das ist alles andere als optimal.
+
+Stattdessen kannst du _während der Entwicklung_ eine Behelfslösung verwenden: Lege die Modultabelle im globalen Gültigkeitsbereich ab und lasse `M` auf die globale Tabelle verweisen, anstatt bei jeder Auswertung der Datei eine neue Tabelle zu erstellen. Das erneute Laden des Moduls ändert dann den Inhalt der globalen Tabelle:
+
+```lua
+--- module.lua
+
+-- Replace with local M = {} when done
+uniquevariable12345 = uniquevariable12345 or {}
+local M = uniquevariable12345
+
+M.value = 4711
+return M
+```
+
+## Module und Zustand {#modules-and-state}
+
+Zustandsbehaftete Module speichern einen internen Zustand, den sich alle Stellen teilen, die das Modul verwenden. Sie lassen sich mit Singletons vergleichen:
+
+```lua
+local M = {}
+
+-- all users of the module will share this table
+local state = {}
+
+function M.do_something(foobar)
+    table.insert(state, foobar)
+end
+
+return M
+```
+
+Ein zustandsloses Modul speichert dagegen keinen internen Zustand. Stattdessen bietet es einen Mechanismus, um den Zustand in eine separate Tabelle auszulagern, die beim aufrufenden Code lokal ist. Dafür gibt es verschiedene Umsetzungsmöglichkeiten:
+
+Eine Zustandstabelle verwenden
+: Der vielleicht einfachste Ansatz ist eine Konstruktorfunktion, die eine neue Tabelle zurückgibt, die nur den Zustand enthält. Der Zustand wird dem Modul explizit als erster Parameter jeder Funktion übergeben, die die Zustandstabelle verändert.
+
+  ```lua
+  local M = {}
+  
+  function M.alter_state(the_state, v)
+      the_state.value = the_state.value + v
+  end
+  
+  function M.get_state(the_state)
+      return the_state.value
+  end
+  
+  function M.new(v)
+      local state = {
+          value = v
+      }
+      return state
+  end
+  
+  return M
+  ```
+  
+  Verwende das Modul so:
+  
+  ```lua
+  local m = require "main.mymodule"
+  local my_state = m.new(42)
+  m.alter_state(my_state, 1)
+  print(m.get_state(my_state)) --> 43
+  ```
+
+Metatabellen verwenden
+: Ein weiterer Ansatz ist eine Konstruktorfunktion, die bei jedem Aufruf eine neue Tabelle mit dem Zustand und den öffentlichen Funktionen des Moduls zurückgibt:
+
+  ```lua
+  local M = {}
+  
+  function M:alter_state(v)
+      -- self is added as first argument when using : notation
+      self.value = self.value + v
+  end
+  
+  function M:get_state()
+      return self.value
+  end
+  
+  function M.new(v)
+      local state = {
+          value = v
+      }
+      return setmetatable(state, { __index = M })
+  end
+  
+  return M
+  ```
+
+  Verwende das Modul so:
+
+  ```lua
+  local m = require "main.mymodule"
+  local my_state = m.new(42)
+  my_state:alter_state(1) -- "my_state" is added as first argument when using : notation
+  print(my_state:get_state()) --> 43
+  ```
+
+Closures verwenden
+:  Eine dritte Möglichkeit besteht darin, eine Closure zurückzugeben, die den gesamten Zustand und alle Funktionen enthält. Du musst die Instanz nicht wie bei Metatabellen als Argument übergeben (weder explizit noch implizit mit dem Doppelpunktoperator). Diese Methode ist außerdem etwas schneller als die Verwendung von Metatabellen, da Funktionsaufrufe nicht über die Metamethoden `__index` laufen müssen. Allerdings enthält jede Closure eine eigene Kopie der Methoden, weshalb der Speicherverbrauch höher ist.
+
+  ```lua
+  local M = {}
+  
+  function M.new(v)
+      local state = {
+          value = v
+      }
+  
+      state.alter_state = function(v)
+          state.value = state.value + v
+      end
+  
+      state.get_state = function()
+          return state.value
+      end
+  
+      return state
+  end
+  
+  return M
+  ```
+
+  Verwende das Modul so:
+
+  ```lua
+  local m = require "main.mymodule"
+  local my_state = m.new(42)
+  my_state.alter_state(1)
+  print(my_state.get_state()) 
+  ```

--- a/docs/de/manuals/networking.md
+++ b/docs/de/manuals/networking.md
@@ -1,0 +1,28 @@
+---
+title: Netzwerkverbindungen in Defold
+brief: Dieses Handbuch erklärt, wie du dich mit entfernten Servern verbindest und andere Arten von Netzwerkverbindungen herstellst.
+---
+
+# Netzwerkverbindungen {#networking}
+
+Spiele verfügen häufig über eine Verbindung zu einem Backend-Dienst, etwa um Punktestände zu übermitteln, die Spielersuche abzuwickeln oder Spielstände in der Cloud zu speichern. Viele Spiele nutzen außerdem Peer-to-Peer-Verbindungen, bei denen die Spielclients direkt miteinander kommunizieren, ohne dass ein zentraler Server beteiligt ist. Für Netzwerkverbindungen und den Datenaustausch können verschiedene Protokolle und Standards verwendet werden. Erfahre mehr über die verschiedenen Möglichkeiten, Netzwerkverbindungen in Defold zu nutzen:
+
+* [HTTP-Anfragen](/manuals/http-requests)
+* [Socket-Verbindungen](/manuals/socket-connections)
+* [WebSocket-Verbindungen](/manuals/websocket-connections)
+* [Online-Dienste](/manuals/online-services)
+
+
+## Technische Details {#technical-details}
+
+### IPv4 und IPv6 {#ipv4-and-ipv6}
+
+Defold unterstützt IPv4- und IPv6-Verbindungen für Sockets und HTTP-Anfragen.
+
+### Sichere Verbindungen {#secure-connections}
+
+Defold unterstützt sichere SSL-Verbindungen für Sockets und HTTP-Anfragen.
+
+Defold kann optional auch das SSL-Zertifikat jeder sicheren Verbindung überprüfen. Die SSL-Überprüfung wird aktiviert, wenn du im Feld der [Einstellung SSL Certificates](/manuals/project-settings/#network)) im Abschnitt Network von *game.project* eine PEM-Datei angibst, die öffentliche Schlüssel von CA-Stammzertifikaten oder den öffentlichen Schlüssel eines selbstsignierten Zertifikats enthält. Eine Liste von CA-Stammzertifikaten ist in `builtins/ca-certificates` enthalten. Es wird jedoch empfohlen, eine neue PEM-Datei zu erstellen und die benötigten CA-Stammzertifikate per Kopieren und Einfügen zu übernehmen, abhängig davon, mit welchen Servern sich das Spiel verbindet.
+
+

--- a/docs/de/manuals/nintendo-switch.md
+++ b/docs/de/manuals/nintendo-switch.md
@@ -1,0 +1,31 @@
+---
+title: Entwicklung mit Defold für Nintendo Switch
+brief: Dieses Handbuch beschreibt, wie du Zugang zur Nintendo Switch-Unterstützung erhältst
+---
+
+# Entwicklung für Nintendo Switch {#nintendo-switch-development}
+
+Aufgrund der Lizenzbeschränkungen von Nintendo ist der Zugang zu Defold-Versionen mit Unterstützung für die Plattform Nintendo Switch nicht in der Standardversion von Defold enthalten. Um Zugang zu Defold-Versionen mit Nintendo Switch-Unterstützung zu erhalten, musst du als Spieleentwickler für Nintendo Switch zugelassen sein.
+
+
+## Registrierung als Nintendo Switch-Entwickler {#registering-as-a-nintendo-switch-developer}
+
+Du kannst dich im [Nintendo Developer Portal](https://developer.nintendo.com/register) als Spieleentwickler für Nintendo Switch registrieren:
+
+![](images/nintendo-switch/register-nintendo.png)
+
+Sobald Nintendo dich zugelassen hat, erhältst du Zugang zur Seite Tools and Middleware im Nintendo Developer Portal, auf der du den Zugang zu Defold beantragen kannst. Wenn du den Zugang zu Defold beantragst, erhält das Defold-Team eine E-Mail von Nintendo, die bestätigt, dass du als Nintendo-Entwickler registriert bist.
+
+
+## Zugang zur Nintendo Switch-Unterstützung in Defold {#nintendo-switch-access-in-defold}
+
+Sobald das Defold-Team deinen Status als zugelassener Nintendo Switch-Entwickler bestätigt hat, erhältst du Zugang zu Folgendem:
+
+* Zugriff auf den Quellcode der Nintendo Switch-Erweiterung (extension) mit konsolenspezifischen API-Integrationen.
+* Zugriff auf den Quellcode der Version der Defold-Game-Engine mit Nintendo Switch-Unterstützung. Beachte, dass der Zugriff auf den Quellcode nicht erforderlich ist, um Builds von Spielen für Nintendo Switch zu erstellen. Das Defold-Team stellt den Zugriff bereit, falls du zum Quellcode des Engine-Kerns beitragen möchtest.
+* [Kommandozeilenwerkzeug](/manuals/bob) mit Unterstützung für die Bundle-Erstellung für die Plattform Nintendo Switch. Die Bundle-Erstellung im Defold-Editor wird nicht unterstützt.
+* Forum, in dem du spezifische Unterstützung für Nintendo Switch erhalten kannst.
+
+
+## Häufig gestellte Fragen (FAQ) {#faq}
+:[Consoles FAQ](../shared/consoles-faq.md)

--- a/docs/de/manuals/online-services.md
+++ b/docs/de/manuals/online-services.md
@@ -1,0 +1,26 @@
+---
+title: Onlinedienste
+brief: Dieses Handbuch erklärt, wie du eine Verbindung zu verschiedenen Spiel- und Backend-Diensten herstellst.
+---
+# Spieldienste {#game-services}
+
+Mit HTTP-Anfragen und Socket-Verbindungen kannst du dich mit Tausenden verschiedener Dienste im Internet verbinden und mit ihnen interagieren. In den meisten Fällen gehört jedoch mehr dazu, als nur eine HTTP-Anfrage zu senden. Üblicherweise musst du eine Form der Authentifizierung verwenden, die Anfragedaten müssen möglicherweise auf eine bestimmte Weise formatiert und die Antwort muss gegebenenfalls geparst werden, bevor sie verwendet werden kann. Das kannst du natürlich selbst manuell erledigen, aber es gibt auch Erweiterungen und Bibliotheken, die solche Aufgaben für dich übernehmen. Nachfolgend findest du eine Liste einiger Erweiterungen, mit denen du leichter mit bestimmten Backend-Diensten interagieren kannst:
+
+## Vielseitig einsetzbar {#general-purpose}
+* [Colyseus](https://defold.com/assets/colyseus/) - Client für Mehrspielerspiele
+* [Nakama](https://defold.com/assets/nakama/) - Ergänze dein Spiel um Authentifizierung, Spielersuche, Analysefunktionen, Speichern in der Cloud, Mehrspielerfunktionen, Chat und mehr
+* [Photon Realtime](https://defold.com/assets/photon-realtime/) - Photon Realtime bietet skalierbare Lösungen für grundlegende Funktionen wie Authentifizierung, Spielersuche und schnelle, zuverlässige Kommunikation.
+* [PlayFab](https://defold.com/assets/playfabsdk/) - Ergänze dein Spiel um Authentifizierung, Spielersuche, Analysefunktionen, Speichern in der Cloud und mehr
+* [AWS SDK](https://github.com/britzl/aws-sdk-lua) - Nutze Amazon Web Services aus deinem Spiel heraus
+
+## Authentifizierung, Bestenlisten, Erfolge {#authentication-leaderboards-achievements}
+* [Google Play Game Services](https://defold.com/assets/googleplaygameservices/) - Nutze Google Play Game Services zur Authentifizierung und zum Speichern in der Cloud in deinem Spiel
+* [Steamworks](https://defold.com/assets/steamworks/) - Ergänze dein Spiel um Steam-Unterstützung
+* [Apple GameKit Game Center](https://defold.com/assets/gamekit/)
+
+## Analyse {#analytics}
+* [Firebase Analytics](https://defold.com/assets/googleanalyticsforfirebase/) - Ergänze dein Spiel um Firebase Analytics
+* [Game Analytics](https://gameanalytics.com/docs/item/defold-sdk) - Ergänze dein Spiel um GameAnalytics
+* [Google Analytics](https://defold.com/assets/gameanalytics/) - Ergänze dein Spiel um Google Analytics
+
+Im [Asset Portal](https://www.defold.com/assets/) findest du noch mehr Erweiterungen!

--- a/docs/de/manuals/optimization-battery.md
+++ b/docs/de/manuals/optimization-battery.md
@@ -1,0 +1,18 @@
+---
+title: Den Akkuverbrauch eines Defold-Spiels optimieren
+brief: Dieses Handbuch beschreibt, wie du den Akkuverbrauch eines Defold-Spiels optimierst.
+---
+
+# Den Akkuverbrauch optimieren {#optimize-battery-usage}
+Der Akkuverbrauch ist vor allem dann relevant, wenn du Mobilgeräte oder Handhelds als Zielplattform verwendest. Eine hohe CPU- oder GPU-Auslastung entlädt den Akku schnell und lässt das Gerät überhitzen.
+
+In den Handbüchern dazu, wie du die [Leistung eines Spiels zur Laufzeit optimierst](/manuals/optimization-speed), erfährst du, wie du die CPU- und GPU-Auslastung reduzierst.
+
+## Den Beschleunigungssensor deaktivieren {#disable-accelerometer}
+Wenn du ein mobiles Spiel entwickelst, das den Beschleunigungssensor des Geräts nicht verwendet, solltest du [ihn in *game.project* deaktivieren](/manuals/project-settings/#use-accelerometer), um die Anzahl der erzeugten Eingabeereignisse zu reduzieren.
+
+# Plattformspezifische Optimierungen {#platform-specific-optimizations}
+
+## Android Device Performance Framework
+
+Das Android Dynamic Performance Framework umfasst eine Reihe von APIs, über die Spiele direkter mit den Systemen für Energie- und Wärmeverwaltung von Android-Geräten interagieren können. Du kannst das dynamische Verhalten von Android-Systemen überwachen und die Spielleistung auf ein dauerhaft aufrechterhaltbares Niveau optimieren, bei dem die Geräte nicht überhitzen. Verwende die [Erweiterung für das Android Dynamic Performance Framework](https://defold.com/extension-adpf/), um die Leistung deines Defold-Spiels für Android-Geräte zu überwachen und zu optimieren.

--- a/docs/de/manuals/optimization-memory.md
+++ b/docs/de/manuals/optimization-memory.md
@@ -1,0 +1,28 @@
+---
+title: Den Speicherverbrauch eines Defold-Spiels optimieren
+brief: Dieses Handbuch beschreibt, wie du den Speicherverbrauch eines Defold-Spiels optimierst.
+---
+
+# Den Speicherverbrauch optimieren {#optimizing-memory-usage}
+
+## Texturkomprimierung {#texture-compression}
+Texturkomprimierung verringert nicht nur die Größe der Ressourcen im Archiv deines Spiels. Komprimierte Texturen können auch den benötigten GPU-Speicher reduzieren.
+
+## Dynamisches Laden {#dynamic-loading}
+Die meisten Spiele haben zumindest einige Inhalte, die nur selten verwendet werden. Aus Sicht des Speicherverbrauchs ist es nicht sinnvoll, solche Inhalte ständig im Speicher zu halten. Stattdessen solltest du sie bei Bedarf laden und wieder entladen, wenn sie nicht mehr benötigt werden. Dabei musst du natürlich abwägen: Du kannst Inhalte sofort verfügbar halten, was zur Laufzeit Speicher kostet, oder sie bei Bedarf laden, was Ladezeit kostet.
+
+Defold bietet mehrere Möglichkeiten, Inhalte dynamisch zu laden:
+
+* [Sammlungs-Proxys (collection proxies)](/manuals/collection-proxy/)
+* [Dynamische Sammlungsfabriken (collection factories)](/manuals/collection-factory/#dynamic-loading-of-factory-resources)
+* [Dynamische Fabriken (factories)](/manuals/factory/#dynamic-loading-of-factory-resources)
+* [Live Update](/manuals/live-update/)
+
+## Komponentenzähler optimieren {#optimize-component-counters}
+Defold reserviert den Speicher für Komponenten (components) und Ressourcen einmalig beim Erstellen einer Sammlung (collection), um die Speicherfragmentierung zu verringern. Die reservierte Speichermenge hängt von der Konfiguration verschiedener Komponentenzähler in *game.project* ab. Verwende den [Profiler](/manuals/profiling/), um die genaue Nutzung von Komponenten und Ressourcen zu ermitteln, und konfiguriere dein Spiel mit Maximalwerten, die näher an der tatsächlichen Anzahl der Komponenten und Ressourcen liegen. Dadurch verringert sich der Speicherverbrauch deines Spiels (siehe die Informationen zur [Optimierung der maximalen Komponentenanzahl](/manuals/project-settings/#component-max-count-optimizations)).
+
+## Anzahl der GUI-Knoten optimieren {#optimize-gui-node-count}
+Optimiere die Anzahl der GUI-Knoten (GUI nodes), indem du die maximale Knotenanzahl in der GUI-Datei auf die tatsächlich benötigte Anzahl setzt. Das Feld `Current Nodes` in den [Eigenschaften der GUI-Komponente](https://defold.com/manuals/gui/#gui-properties) zeigt die Anzahl der von der GUI-Komponente verwendeten Knoten an.
+
+:[HTML5 Optimizations](../shared/optimization-memory-html5.md)
+

--- a/docs/de/manuals/optimization-size.md
+++ b/docs/de/manuals/optimization-size.md
@@ -1,0 +1,104 @@
+---
+title: Die Größe eines Defold-Spiels optimieren
+brief: Dieses Handbuch beschreibt, wie du die Größe eines Defold-Spiels optimierst.
+---
+
+# Die Spielgröße optimieren {#optimizing-game-size}
+
+Die Größe deines Spiels kann auf Plattformen wie dem Web und Mobilgeräten ein entscheidender Erfolgsfaktor sein. Auf Desktopcomputern und Konsolen ist sie dagegen weniger wichtig, da Speicherplatz dort günstig und oft reichlich vorhanden ist.
+
+### iOS und Android {#ios-and-android}
+Apple und Google haben Größenbeschränkungen für Anwendungen festgelegt, die über Mobilfunknetze heruntergeladen werden (im Gegensatz zum Download über WLAN). Unter Android liegt diese Grenze bei 200 MB für Apps, die als [App Bundles](https://developer.android.com/guide/app-bundle#size_restrictions) veröffentlicht werden. Unter iOS erhalten Nutzer eine Warnung, wenn die Anwendung größer als 200 MB ist, können den Download aber trotzdem fortsetzen.
+
+::: sidenote
+Eine Studie aus dem Jahr 2017 zeigte: „Für jede Zunahme der APK-Größe um 6 MB beobachten wir einen Rückgang der Installationskonversionsrate um 1 %.“ ([Quelle](https://medium.com/googleplaydev/shrinking-apks-growing-installs-5d3fcba23ce2))
+:::
+
+### HTML5
+Poki und viele andere Plattformen für Webspiele empfehlen, dass der anfängliche Download nicht größer als 5 MB sein sollte.
+
+Facebook empfiehlt, dass ein Facebook Instant Game in weniger als 5 Sekunden und vorzugsweise in weniger als 3 Sekunden starten sollte. Was das für die tatsächliche Anwendungsgröße bedeutet, ist nicht klar definiert, aber gemeint sind Größen im Bereich von bis zu 20 MB.
+
+Spielbare Werbeanzeigen sind je nach Werbenetzwerk üblicherweise auf 2 bis 5 MB begrenzt.
+
+## Strategien zur Größenoptimierung {#size-optimization-strategies}
+Du kannst die Anwendungsgröße auf zwei Arten optimieren: indem du die Größe der Engine und/oder die Größe der Spiel-Assets reduzierst.
+
+Um besser zu verstehen, woraus sich die Größe deiner Anwendung zusammensetzt, kannst du bei der Bundle-Erstellung [einen Build-Bericht erzeugen](/manuals/bundling/#build-reports). Häufig machen Audiodateien und Grafiken den größten Teil der Größe eines Spiels aus.
+
+::: important
+Defold erstellt beim Erstellen von Builds und Bundles deiner Anwendung einen Abhängigkeitsbaum. Das Build-System beginnt bei der Startsammlung (bootstrap collection), die in der Datei *game.project* angegeben ist, und untersucht jede referenzierte Sammlung (collection), jedes Spielobjekt (game object) und jede Komponente (component), um eine Liste der verwendeten Assets zu erstellen. Nur diese Assets werden in das endgültige Anwendungsbundle aufgenommen. Alles, was nicht direkt referenziert wird, wird ausgeschlossen. Es ist zwar gut zu wissen, dass ungenutzte Assets nicht aufgenommen werden, dennoch musst du bei der Entwicklung berücksichtigen, was in die endgültige Anwendung gelangt, wie groß die einzelnen Assets sind und wie groß das Anwendungsbundle insgesamt ist. 
+:::
+
+## Die Größe der Engine optimieren {#optimize-engine-size}
+Eine schnelle Möglichkeit, die Größe der Engine zu reduzieren, besteht darin, nicht verwendete Funktionen aus der Engine zu entfernen. Dazu dient die [Anwendungsmanifestdatei](https://defold.com/manuals/app-manifest/), über die du nicht benötigte Engine-Komponenten entfernen kannst. Beispiele:
+
+* Physik - Wenn dein Spiel weder Box2D- noch Bullet3D-Physik verwendet, wird dringend empfohlen, die Physik-Engines zu entfernen.
+* GUI, Partikeleffekte und Kachelkarten (tile maps) - Diese Komponenten lassen sich mit den [Komponentenschaltern im Anwendungsmanifest](/manuals/app-manifest/#exclude-gui) einzeln ausschließen. Entferne Komponentenreferenzen und API-Aufrufe für jede Funktion, die du ausschließt. Wenn du Partikeleffekte ausschließt, entfällt auch die Unterstützung für Partikelknoten in GUI-Szenen.
+* Formatierter Text (rich text) - Deaktiviere [Use Rich Text](/manuals/app-manifest/#use-rich-text), wenn Beschriftungen (labels) und GUI-Texte nur unformatierten Text benötigen. Dadurch entfallen die Verarbeitung von formatiertem Text und Stileffekte, während das gewöhnliche Rendern von Text erhalten bleibt.
+* Live Update - Wenn dein Spiel Live Update nicht verwendet, kannst du es entfernen.
+* Laden von Bildern - Wenn dein Spiel Bilder nicht manuell mit `image.load()` lädt und dekodiert.
+* BasisU - Wenn dein Spiel nur wenige Texturen enthält, vergleiche die Build-Größe ohne BasisU (über das Anwendungsmanifest entfernt) und ohne Texturkomprimierung mit einem Build mit BasisU und komprimierten Texturen. Bei Spielen mit wenigen Texturen kann es vorteilhafter sein, die Größe der Binärdatei zu reduzieren und auf Texturkomprimierung zu verzichten. Außerdem kann der Verzicht auf den Transcoder den zum Ausführen deines Spiels benötigten Speicher reduzieren.
+
+## Die Größe der Assets optimieren {#optimize-asset-size}
+Die größten Einsparungen bei der Größenoptimierung von Assets erreichst du meist, indem du die Größe von Audiodateien und Texturen reduzierst.
+
+### Audiodateien optimieren {#optimize-sounds}
+Defold unterstützt diese Formate:
+* .wav
+* .ogg
+* .opus
+
+Defold unterstützt PCM-Wave-Dateien mit 8 Bit und 16 Bit. Ogg Vorbis und Ogg Opus verwenden ihre jeweiligen komprimierten Formate und setzen keine bestimmte PCM-Bittiefe voraus. Der Opus-Decoder ist standardmäßig nicht enthalten. Aktiviere **Include Sound Decoder: Opus** im [Anwendungsmanifest](/manuals/app-manifest/#sound), bevor du `.opus`-Ressourcen verwendest.
+Die Audiodecoder von Defold erhöhen oder verringern die Abtastraten nach Bedarf für das aktuelle Audiogerät.
+
+Kürzere Audiodateien wie Soundeffekte werden häufig stärker komprimiert, während Musikdateien weniger stark komprimiert werden.
+Defold führt keine Komprimierung durch. Du musst dich daher bei der Entwicklung für jedes Audioformat gesondert darum kümmern.
+
+Du kannst die Audiodateien in einem externen Audiobearbeitungsprogramm bearbeiten (oder über die Kommandozeile, beispielsweise mit [ffmpeg](https://ffmpeg.org)), um die Qualität zu reduzieren oder zwischen Formaten zu konvertieren. Ziehe auch in Betracht, Audiodateien von Stereo in Mono umzuwandeln, um die Größe der Inhalte weiter zu reduzieren.
+
+### Texturen optimieren {#optimize-textures}
+Du hast mehrere Möglichkeiten, die von deinem Spiel verwendeten Texturen zu optimieren. Zunächst solltest du jedoch die Größe der Bilder prüfen, die einem Atlas hinzugefügt oder als Kachelquelle (tile source) verwendet werden. Du solltest niemals größere Bilder verwenden, als dein Spiel tatsächlich benötigt. Große Bilder zu importieren und sie dann auf die passende Größe zu verkleinern, verschwendet Texturspeicher und sollte vermieden werden. Passe die Bilder zunächst mit einem externen Bildbearbeitungsprogramm an die tatsächlich im Spiel benötigte Größe an. Für Dinge wie Hintergrundbilder kann es auch ausreichen, ein kleines Bild zu verwenden und es auf die gewünschte Größe zu vergrößern. Sobald deine Bilder die richtige Größe haben und Atlanten hinzugefügt wurden oder in Kachelquellen verwendet werden, musst du auch die Größe der Atlanten selbst berücksichtigen. Die maximal nutzbare Atlasgröße hängt von der Plattform und der Grafikhardware ab.
+
+::: sidenote
+[Dieser Forenbeitrag](https://forum.defold.com/t/texture-management-in-defold/8921/17?u=britzl) enthält mehrere Tipps dazu, wie du die Größe mehrerer Bilder mithilfe von Skripten oder Software von Drittanbietern ändern kannst.
+:::
+
+* Maximale Texturgröße unter HTML5 laut den Meldungen an das [Web3D-Survey-Projekt](https://web3dsurvey.com/webgl/parameters/MAX_TEXTURE_SIZE)
+* Maximale Texturgröße unter iOS:
+  * iPad: 2048x2048
+  * iPhone 4: 2048x2048
+  * iPad 2, 3, Mini, Air, Pro: 4096x4096
+  * iPhone 4s, 5, 6+, 6s: 4096x4096
+* Die maximale Texturgröße unter Android variiert stark, aber im Allgemeinen unterstützen alle einigermaßen neuen Geräte mindestens 4096x4096.
+
+Wenn ein Atlas zu groß ist, musst du ihn entweder in mehrere kleinere Atlanten aufteilen, mehrseitige Atlanten verwenden oder den gesamten Atlas mithilfe eines Texturprofils skalieren. Das Texturprofilsystem von Defold ermöglicht dir, sowohl ganze Atlanten zu skalieren als auch Komprimierungsalgorithmen anzuwenden, um die Größe des Atlas auf dem Datenträger zu reduzieren. Du kannst [im Handbuch mehr über Texturprofile lesen](/manuals/texture-profiles/). Wenn du nicht weißt, was du verwenden sollst, probiere diese Einstellungen als Ausgangspunkt für weitere Anpassungen aus:
+
+* mipmaps: false
+* premultiply_alpha: true
+* format: TEXTURE_FORMAT_RGBA
+* compression_level: NORMAL
+* compression_type: COMPRESSION_TYPE_BASIS_UASTC
+
+::: sidenote
+Mehr zum Optimieren und Verwalten von Texturen erfährst du in [diesem Forenbeitrag](https://forum.defold.com/t/texture-management-in-defold/8921).
+:::
+
+### Schriftarten optimieren {#optimize-fonts}
+Deine Schriftarten werden kleiner, wenn du die verwendeten Zeichen festlegst und sie unter [Characters](/manuals/font/#properties) angibst, anstatt das Kontrollkästchen All Chars zu verwenden.
+
+### Inhalte für den Download bei Bedarf ausschließen {#exclude-content-for-download-on-demand}
+Eine weitere Möglichkeit, die anfängliche Anwendungsgröße zu reduzieren, besteht darin, Teile der Spielinhalte aus dem Anwendungsbundle auszuschließen und sie bei Bedarf herunterzuladen. Defold bietet ein System namens Live Update, mit dem sich Inhalte für den Download bei Bedarf ausschließen lassen.
+
+Ausgeschlossene Inhalte können von ganzen Levels bis zu freischaltbaren Charakteren, Skins, Waffen oder Fahrzeugen reichen. Wenn dein Spiel viele Inhalte hat, organisiere den Ladevorgang so, dass die Startsammlung und die Sammlung des ersten Levels nur die für dieses Level unbedingt erforderlichen Ressourcen enthalten. Das erreichst du mit Sammlungs-Proxys (collection proxies) oder Fabriken (factories), bei denen das Kontrollkästchen „Exclude“ aktiviert ist. Teile die Ressourcen entsprechend dem Spielfortschritt auf. Dieser Ansatz sorgt für ein effizientes Laden der Ressourcen und hält den anfänglichen Speicherverbrauch niedrig. Erfahre mehr im [Handbuch zu Live Update](/manuals/live-update/).
+
+## Android-spezifische Größenoptimierungen {#android-specific-size-optimizations}
+Android-Builds müssen sowohl 32-Bit- als auch 64-Bit-CPU-Architekturen unterstützen. Wenn du [ein Bundle für Android erstellst](/manuals/android), kannst du angeben, welche CPU-Architekturen enthalten sein sollen:
+
+![Ein Android-Bundle signieren](images/android/sign_bundle.png)
+
+Standardmäßig enthält ein Bundle die Architekturen `armv7-android` und `arm64-android`. Eine dritte Architektur, `x86_64-android`, ist verfügbar, aber standardmäßig nicht enthalten, da sie hauptsächlich für Android-Emulatoren, ChromeOS und Windows Subsystem for Android und weniger für physische Geräte nützlich ist. Lass sie deaktiviert, um die Bundle-Größe gering zu halten, sofern du nicht gezielt eine dieser Umgebungen unterstützen musst.
+
+Google Play unterstützt [mehrere APKs](https://developer.android.com/google/play/publishing/multiple-apks) pro Veröffentlichung eines Spiels. Das bedeutet, dass du die Anwendungsgröße reduzieren kannst, indem du zwei APKs erzeugst, eines pro CPU-Architektur, und beide bei Google Play hochlädst.
+
+Du kannst auch eine Kombination aus [APK Expansion Files](https://developer.android.com/google/play/expansion-files) und [Live-Update-Inhalten](/manuals/live-update) verwenden, die dir die [APKX-Erweiterung im Asset Portal](https://defold.com/assets/apkx/) ermöglicht.

--- a/docs/de/manuals/optimization-speed.md
+++ b/docs/de/manuals/optimization-speed.md
@@ -1,0 +1,89 @@
+---
+title: Laufzeitleistung eines Defold-Spiels optimieren
+brief: Dieses Handbuch beschreibt, wie du ein Defold-Spiel so optimierst, dass es mit einer stabil hohen Bildrate läuft.
+---
+
+# Ausführungsgeschwindigkeit optimieren {#optimizing-runtime-speed}
+Bevor du versuchst, ein Spiel für eine stabil hohe Bildrate (Bilder pro Sekunde, FPS) zu optimieren, musst du wissen, wo die Engpässe liegen. Was beansprucht in einem Frame deines Spiels tatsächlich die meiste Zeit? Ist es das Rendering? Ist es deine Spiellogik? Ist es der Szenengraph (scene graph)? Um das herauszufinden, empfiehlt sich die Verwendung der integrierten Profiling-Werkzeuge. Verwende den [Bildschirm- oder Web-Profiler](/manuals/profiling/), um die Leistung deines Spiels zu messen und dann zu entscheiden, ob und was du optimieren solltest. Sobald du besser verstehst, was Zeit beansprucht, kannst du die Probleme angehen.
+
+## Ausführungszeit von Skripten verringern {#reduce-script-execution-time}
+Du musst die Ausführungszeit von Skripten verringern, wenn der Profiler hohe Werte für den Messbereich `Script` anzeigt. Als allgemeine Faustregel solltest du natürlich versuchen, in jedem Frame möglichst wenig Code auszuführen. Viel Code in `update()` und `on_input()` in jedem Frame auszuführen, wirkt sich wahrscheinlich auf die Leistung deines Spiels aus, insbesondere auf weniger leistungsfähigen Geräten. Hier sind einige Richtlinien:
+
+### Reaktive Codemuster verwenden {#use-reactive-code-patterns}
+Frage Änderungen nicht wiederholt ab, wenn du einen Callback erhalten kannst. Animiere nichts manuell und führe keine Aufgabe selbst aus, die du der Engine überlassen kannst (z. B. `go.animate)()` statt einer manuellen Animation).
+
+### Automatische Speicherbereinigung reduzieren {#reduce-garbage-collection}
+Wenn du in jedem Frame viele kurzlebige Objekte wie Lua-Tabellen erstellst, löst das irgendwann die automatische Speicherbereinigung (Garbage Collection) von Lua aus. Das kann sich als kurze Ruckler oder Spitzen in der Frame-Dauer bemerkbar machen. Verwende Tabellen nach Möglichkeit wieder und versuche wirklich, Lua-Tabellen möglichst nicht innerhalb von Schleifen und ähnlichen Konstrukten zu erstellen.
+
+### Hashwerte von Nachrichten- und Aktionsbezeichnern vorab berechnen {#prehash-message-and-action-ids}
+Wenn du viele Nachrichten verarbeitest oder viele Eingabeereignisse behandeln musst, empfiehlt es sich, die Hashwerte der Zeichenfolgen vorab zu berechnen. Betrachte diesen Code:
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("message1") then
+        msg.post(sender, hash("message3"))
+    elseif message_id == hash("message2") then
+        msg.post(sender, hash("message4"))
+    end
+end
+```
+
+Im obigen Beispiel würde der Hashwert der Zeichenfolge jedes Mal neu berechnet, wenn eine Nachricht empfangen wird. Du kannst das verbessern, indem du die Hashwerte der Zeichenfolgen einmal berechnest und sie dann bei der Verarbeitung von Nachrichten verwendest:
+
+```lua
+local MESSAGE1 = hash("message1")
+local MESSAGE2 = hash("message2")
+local MESSAGE3 = hash("message3")
+local MESSAGE4 = hash("message4")
+
+function on_message(self, message_id, message, sender)
+    if message_id == MESSAGE1 then
+        msg.post(sender, MESSAGE3)
+    elseif message_id == MESSAGE2 then
+        msg.post(sender, MESSAGE4)
+    end
+end
+```
+
+### URLs bevorzugen und zwischenspeichern {#prefer-and-cache-urls}
+Beim Übermitteln von Nachrichten oder beim anderweitigen Adressieren eines Spielobjekts (game object) oder einer Komponente (component) kannst du einen Bezeichner als Zeichenfolge oder Hashwert oder eine URL angeben. Wenn du eine Zeichenfolge oder einen Hashwert verwendest, wird diese Angabe intern in eine URL umgewandelt. Deshalb empfiehlt es sich, häufig verwendete URLs zwischenzuspeichern, um die bestmögliche Leistung aus dem System herauszuholen. Betrachte Folgendes:
+
+```lua
+    local pos = go.get_position("enemy")
+    local pos = go.get_position(hash("enemy"))
+    local pos = go.get_position(msg.url("enemy"))
+    -- do something with pos
+```
+
+In allen drei Fällen würde die Position eines Spielobjekts mit dem Bezeichner `enemy` abgerufen. Im ersten und zweiten Fall würde der Bezeichner (Zeichenfolge oder Hashwert) vor der Verwendung in eine URL umgewandelt. Daraus ergibt sich, dass es für die bestmögliche Leistung besser ist, URLs zwischenzuspeichern und die zwischengespeicherte Version zu verwenden:
+
+```lua
+    function init(self)
+        self.enemy_url = msg.url("enemy")
+    end
+
+    function update(self, dt)
+        local pos = go.get_position(self.enemy_url)
+        -- do something with pos
+    end
+```
+
+## Zeit zum Rendern eines Frames verringern {#reduce-time-it-takes-to-render-a-frame}
+Du musst die Zeit zum Rendern eines Frames verringern, wenn der Profiler hohe Werte in den Messbereichen `Render` und `Render Script` anzeigt. Wenn du diese Zeit verringern möchtest, solltest du mehrere Dinge berücksichtigen:
+
+* Zeichenaufrufe (draw calls) reduzieren - Lies mehr über das Reduzieren von Zeichenaufrufen in [diesem Forumsbeitrag](https://forum.defold.com/t/draw-calls-and-defold/4674)
+* Mehrfaches Zeichnen derselben Pixel (Overdraw) reduzieren
+* Shader-Komplexität verringern - Informiere dich über GLSL-Optimierungen in [diesem Khronos-Artikel](https://www.khronos.org/opengl/wiki/GLSL_Optimizations). Du kannst auch die von Defold verwendeten Standard-Shader (unter `builtins/materials`) ändern und eine geringere Genauigkeit wählen, wenn der Shader kein `highp` benötigt. Crosskompilierte GLSL-ES-Shader verwenden standardmäßig `mediump` für Gleitkommawerte und `highp` für Ganzzahlen. Diese Standardwerte lassen sich in den Projekteinstellungen unter Shader ändern. Explizite Qualifizierer für einzelne Variablen haben Vorrang. Siehe die [Dokumentation zur Shader-Genauigkeit](/manuals/shader/#precision).
+
+## Komplexität des Szenengraphen verringern {#reduce-scene-graph-complexity}
+Du musst die Komplexität des Szenengraphen verringern, wenn der Profiler hohe Werte im Messbereich `GameObject` und insbesondere für den Messwert `UpdateTransform` anzeigt. Mögliche Maßnahmen:
+
+* Aussondern von Geometrie (Culling) - Deaktiviere Spielobjekte (und ihre Komponenten), wenn sie gerade nicht sichtbar sind. Wie du das feststellst, hängt stark von der Art des Spiels ab. Bei einem 2D-Spiel kann es so einfach sein, immer alle Spielobjekte außerhalb eines rechteckigen Bereichs zu deaktivieren. Du kannst das mit einem Physik-Trigger erkennen oder deine Objekte in Gruppen aufteilen. Sobald du weißt, welche Objekte du deaktivieren oder aktivieren möchtest, sendest du dazu eine Nachricht `disable` oder `enable` an jedes Spielobjekt.
+
+## Aussondern von Geometrie außerhalb des Sichtvolumens {#frustum-culling}
+Das Render-Skript kann Komponenten von Spielobjekten, die sich außerhalb einer festgelegten Begrenzungsbox (Sichtvolumen, frustum) befinden, automatisch vom Rendering ausschließen. Erfahre mehr über das Aussondern von Geometrie außerhalb des Sichtvolumens (Frustum Culling) im [Handbuch zur Rendering-Pipeline](/manuals/render/#frustum-culling).
+
+# Plattformspezifische Optimierungen {#platform-specific-optimizations}
+
+## Android Device Performance Framework
+Das Android Dynamic Performance Framework ist eine Sammlung von APIs, mit denen Spiele direkter mit den Systemen für Energie- und Temperaturverwaltung von Android-Geräten interagieren können. Damit lässt sich das dynamische Verhalten auf Android-Systemen überwachen und die Spielleistung auf einem dauerhaft tragbaren Niveau optimieren, ohne dass Geräte überhitzen. Verwende die [Erweiterung Android Dynamic Performance Framework](https://defold.com/extension-adpf/), um die Leistung deines Defold-Spiels auf Android-Geräten zu überwachen und zu optimieren.

--- a/docs/de/manuals/optimization.md
+++ b/docs/de/manuals/optimization.md
@@ -1,0 +1,12 @@
+---
+title: Ein Defold-Spiel optimieren
+brief: Dieses Handbuch beschreibt, wie du die Größe und Leistung eines Defold-Spiels optimierst.
+---
+
+# Ein Defold-Spiel optimieren {#optimizing-a-defold-game}
+Es ist wichtig, die technischen Einschränkungen deiner Zielplattformen zu verstehen und dein Spiel so zu entwerfen, zu implementieren und zu optimieren, dass es diese Anforderungen erfüllt. Bei den meisten Plattformen gibt es mehrere Aspekte zu berücksichtigen:
+
+* [Spielgröße](/manuals/optimization-size) - Wie groß darf das Spiel-Bundle höchstens sein, und wie kannst du das Spiel möglichst klein halten, ohne bei der Qualität Abstriche zu machen?
+* [Ausführungsgeschwindigkeit](/manuals/optimization-speed) - Welche Leistung bietet die Zielplattform, und wie kannst du dafür sorgen, dass das Spiel bei minimaler CPU- und/oder GPU-Auslastung mit einer stabilen Bildrate läuft?
+* [Speicherverbrauch](/manuals/optimization-memory) - Welche Speicherbeschränkungen hat die Zielplattform, und wie kannst du den Speicherverbrauch verringern?
+* [Akkuverbrauch](/manuals/optimization-battery) - Dieser Aspekt ist vor allem dann wichtig, wenn du Mobilgeräte oder Handhelds als Zielplattformen verwendest.

--- a/docs/de/manuals/particlefx.md
+++ b/docs/de/manuals/particlefx.md
@@ -1,0 +1,246 @@
+---
+title: Partikeleffekte in Defold
+brief: Dieses Handbuch erklärt, wie die Partikeleffektkomponente funktioniert und wie du sie bearbeitest, um visuelle Partikeleffekte zu erstellen.
+---
+
+# Partikeleffekte {#particle-fx}
+
+Partikeleffekte (particle effects) werden verwendet, um Spiele visuell aufzuwerten. Du kannst damit Explosionen, Blutspritzer, Spuren, Wetter oder beliebige andere Effekte erzeugen.
+
+![Partikeleffekt-Editor](images/particlefx/editor.png)
+
+Partikeleffekte bestehen aus mehreren Emittern und optionalen Modifikatoren (modifiers):
+
+Emitter
+: Ein Emitter ist eine positionierte Form, die gleichmäßig über die Form verteilte Partikel erzeugt. Der Emitter enthält Eigenschaften, die die Partikelerzeugung sowie das Bild oder die Animation, die Lebensdauer, Farbe, Form und Geschwindigkeit der einzelnen Partikel steuern.
+
+Modifikator
+: Ein Modifikator beeinflusst die Geschwindigkeit erzeugter Partikel, sodass sie in eine bestimmte Richtung beschleunigen oder langsamer werden, sich radial bewegen oder um einen Punkt wirbeln. Modifikatoren können die Partikel eines einzelnen Emitters oder einen bestimmten Emitter beeinflussen.
+
+## Einen Effekt erstellen {#creating-an-effect}
+
+Wähle <kbd>New... ▸ Particle FX</kbd> im Kontextmenü des Browsers *Assets*. Gib der neuen Partikeleffektdatei einen Namen. Der Editor öffnet die Datei nun im [Szeneneditor](/manuals/editor/#the-scene-editor).
+
+Der Bereich *Outline* zeigt den standardmäßig angelegten Emitter. Wähle den Emitter aus, um seine Eigenschaften im darunterliegenden Bereich *Properties* anzuzeigen.
+
+![Standardpartikel](images/particlefx/default.png)
+
+Um dem Effekt einen neuen Emitter hinzuzufügen, <kbd>klicke mit der rechten Maustaste</kbd> auf die Wurzel in *Outline* und wähle <kbd>Add Emitter ▸ [type]</kbd> im Kontextmenü. Beachte, dass du den Typ des Emitters in den Emittereigenschaften ändern kannst.
+
+Um einen neuen Modifikator hinzuzufügen, <kbd>klicke mit der rechten Maustaste</kbd> auf die Position des Modifikators in *Outline* (die Effektwurzel oder einen bestimmten Emitter) und wähle <kbd>Add Modifier</kbd>. Wähle anschließend den Modifikatortyp.
+
+![Modifikator hinzufügen](images/particlefx/add_modifier.png)
+
+![Modifikator zum Hinzufügen auswählen](images/particlefx/add_modifier_select.png)
+
+Ein Modifikator an der Effektwurzel (der keinem Emitter untergeordnet ist) beeinflusst alle Partikel des Effekts.
+
+Ein Modifikator, der einem Emitter als untergeordnetes Objekt hinzugefügt wird, beeinflusst nur diesen Emitter.
+
+## Vorschau eines Effekts {#previewing-an-effect}
+
+* Wähle <kbd>View ▸ Play</kbd> im Menü, um eine Vorschau des Effekts anzuzeigen. Möglicherweise musst du mit der Kamera herauszoomen, um den Effekt richtig zu sehen.
+* Wähle erneut <kbd>View ▸ Play</kbd>, um den Effekt anzuhalten.
+* Wähle <kbd>View ▸ Stop</kbd>, um den Effekt zu stoppen. Wenn du ihn erneut abspielst, beginnt er wieder in seinem Ausgangszustand.
+
+Wenn du einen Emitter oder Modifikator bearbeitest, ist das Ergebnis sofort im Editor sichtbar, auch wenn der Effekt angehalten ist:
+
+![Partikel bearbeiten](images/particlefx/rotate.gif)
+
+## Emittereigenschaften {#emitter-properties}
+
+Id
+: Bezeichner des Emitters (wird beim Setzen von Renderkonstanten für bestimmte Emitter verwendet).
+
+Position/Rotation
+: Transformation des Emitters relativ zur Partikeleffektkomponente (component).
+
+Play Mode
+: Steuert, wie der Emitter abgespielt wird:
+  - `Once` stoppt den Emitter nach Ablauf seiner Dauer.
+  - `Loop` startet den Emitter nach Ablauf seiner Dauer neu.
+
+Size Mode
+: Steuert, wie die Größe von Flipbook-Animationen festgelegt wird:
+  - `Auto` behält für jedes Einzelbild der Flipbook-Animation die Größe des Quellbilds bei.
+  - `Manual` legt die Partikelgröße anhand der Größeneigenschaft fest.
+
+Emission Space
+: Das geometrische Koordinatensystem, in dem die erzeugten Partikel existieren:
+  - `World` bewegt die Partikel unabhängig vom Emitter.
+  - `Emitter` bewegt die Partikel relativ zum Emitter.
+
+Duration
+: Die Anzahl der Sekunden, für die der Emitter Partikel erzeugen soll.
+
+Start Delay
+: Die Anzahl der Sekunden, die der Emitter warten soll, bevor er Partikel erzeugt.
+
+Start Offset
+: Die Anzahl der Sekunden innerhalb der Partikelsimulation, bei der der Emitter starten soll. Anders ausgedrückt: wie lange der Emitter den Effekt im Voraus simulieren soll.
+
+Image
+: Die Bilddatei (Kachelquelle oder Atlas), die zum Texturieren und Animieren der Partikel verwendet wird.
+
+Animation
+: Die Animation aus der Datei unter *Image*, die für die Partikel verwendet wird.
+
+Material
+: Das Material für das Shading der Partikel.
+
+Blend Mode
+: Die verfügbaren Mischmodi sind `Alpha`, `Add` und `Multiply`.
+
+Max Particle Count
+: Wie viele Partikel dieses Emitters gleichzeitig existieren können.
+
+Emitter Type
+: Die Form des Emitters
+  - `Circle` erzeugt Partikel an einer zufälligen Position innerhalb eines Kreises. Die Partikel sind vom Mittelpunkt nach außen gerichtet. Der Kreisdurchmesser wird durch *Emitter Size X* festgelegt.
+
+  - `2D Cone` erzeugt Partikel an einer zufälligen Position innerhalb eines flachen Kegels (eines Dreiecks). Die Partikel sind durch die Oberseite des Kegels nach außen gerichtet. *Emitter Size X* legt die Breite der Oberseite fest und *Y* die Höhe.
+
+  - `Box` erzeugt Partikel an einer zufälligen Position innerhalb eines Quaders. Die Partikel sind entlang der lokalen Y-Achse des Quaders nach oben gerichtet. *Emitter Size X*, *Y* und *Z* legen jeweils Breite, Höhe und Tiefe fest. Für ein 2D-Rechteck lässt du die Z-Größe auf null.
+
+  - `Sphere` erzeugt Partikel an einer zufälligen Position innerhalb einer Kugel. Die Partikel sind vom Mittelpunkt nach außen gerichtet. Der Kugeldurchmesser wird durch *Emitter Size X* festgelegt.
+
+  - `Cone` erzeugt Partikel an einer zufälligen Position innerhalb eines 3D-Kegels. Die Partikel sind durch die obere Kreisscheibe des Kegels nach außen gerichtet. *Emitter Size X* legt den Durchmesser der oberen Kreisscheibe fest und *Y* die Höhe des Kegels.
+
+  ![Emittertypen](images/particlefx/emitter_types.png)
+
+Particle Orientation
+: Die Ausrichtung der erzeugten Partikel:
+  - `Default` setzt die Ausrichtung auf die Einheitsausrichtung
+  - `Initial Direction` behält die anfängliche Ausrichtung der erzeugten Partikel bei.
+  - `Movement Direction` passt die Ausrichtung der Partikel an ihre Geschwindigkeit an.
+
+Inherit Velocity
+: Ein Skalierungsfaktor, der angibt, wie viel von der Geschwindigkeit des Emitters die Partikel übernehmen sollen. Dieser Wert ist nur verfügbar, wenn *Space* auf `World` gesetzt ist. Die Geschwindigkeit des Emitters wird in jedem Frame geschätzt.
+
+Stretch With Velocity
+: Aktiviere diese Option, um jede Partikelstreckung in Bewegungsrichtung zu skalieren.
+
+### Mischmodi {#blend-modes}
+:[blend-modes](../shared/blend-modes.md)
+
+## Über Kurven animierbare Emittereigenschaften {#keyable-emitter-properties}
+
+Diese Eigenschaften haben zwei Felder: einen Wert und eine Streuung. Die Streuung ist eine Variation, die für jeden erzeugten Partikel zufällig angewendet wird. Wenn der Wert beispielsweise 50 und die Streuung 3 beträgt, erhält jeder erzeugte Partikel einen Wert zwischen 47 und 53 (50 +/- 3).
+
+![Eigenschaft](images/particlefx/property.png)
+
+Wenn du die Schaltfläche mit dem Schlüsselsymbol aktivierst, wird der Eigenschaftswert über die Dauer des Emitters durch eine Kurve gesteuert. Um eine über eine Kurve gesteuerte Eigenschaft zurückzusetzen, deaktiviere die Schaltfläche mit dem Schlüsselsymbol.
+
+![Eigenschaft mit Kurvensteuerung](images/particlefx/key.png)
+
+Der *Curve Editor* (verfügbar unter den Registerkarten in der unteren Ansicht) dient zum Bearbeiten der Kurve. Eigenschaften mit Kurvensteuerung können nicht in der Ansicht *Properties* bearbeitet werden, sondern nur im *Curve Editor*. Verändere die Form der Kurve, indem du die Punkte und Tangenten <kbd>anklickst und ziehst</kbd>. Füge durch <kbd>Doppelklicken</kbd> auf die Kurve Kontrollpunkte hinzu. Um einen Kontrollpunkt zu entfernen, <kbd>doppelklicke</kbd> darauf.
+
+![Kurveneditor für Partikeleffekte](images/particlefx/curve_editor.png)
+
+Um den Zoom im Curve Editor automatisch so anzupassen, dass alle Kurven angezeigt werden, drücke <kbd>F</kbd>.
+
+Die folgenden Eigenschaften können über die Wiedergabedauer des Emitters durch Kurven gesteuert werden:
+
+Spawn Rate
+: Die Anzahl der Partikel, die pro Sekunde erzeugt werden sollen.
+
+Emitter Size X/Y/Z
+: Die Abmessungen der Emitterform, siehe *Emitter Type* oben.
+
+Particle Life Time
+: Die Lebensdauer jedes erzeugten Partikels in Sekunden.
+
+Initial Speed
+: Die Anfangsgeschwindigkeit jedes erzeugten Partikels.
+
+Initial Size
+: Die Anfangsgröße jedes erzeugten Partikels. Wenn du *Size Mode* auf `Automatic` setzt und eine Flipbook-Animation als Bildquelle verwendest, wird diese Eigenschaft ignoriert.
+
+Initial Red/Green/Blue/Alpha
+: Die anfänglichen Werte der Farbkomponenten zur Einfärbung der Partikel.
+
+Initial Rotation
+: Die anfänglichen Drehungswerte (in Grad) der Partikel.
+
+Initial Stretch X/Y
+: Die anfänglichen Streckungswerte (in Einheiten) der Partikel.
+
+Initial Angular Velocity
+: Die anfängliche Winkelgeschwindigkeit (in Grad/Sekunde) jedes erzeugten Partikels.
+
+Die folgenden Eigenschaften können über die Lebensdauer der Partikel durch Kurven gesteuert werden:
+
+Life Scale
+: Der Skalierungsfaktor über die Lebensdauer jedes Partikels.
+
+Life Red/Green/Blue/Alpha
+: Der Wert der Farbkomponente zur Einfärbung über die Lebensdauer jedes Partikels.
+
+Life Rotation
+: Der Drehungswert (in Grad) über die Lebensdauer jedes Partikels.
+
+Life Stretch X/Y
+: Der Streckungswert (in Einheiten) über die Lebensdauer jedes Partikels.
+
+Life Angular Velocity
+: Die Winkelgeschwindigkeit (in Grad/Sekunde) über die Lebensdauer jedes Partikels.
+
+## Modifikatoren {#modifiers}
+
+Es stehen vier Arten von Modifikatoren zur Verfügung, die die Geschwindigkeit der Partikel beeinflussen:
+
+`Acceleration`
+: Beschleunigung in eine allgemeine Richtung.
+
+`Drag`
+: Verringert die Beschleunigung der Partikel proportional zur Partikelgeschwindigkeit.
+
+`Radial`
+: Zieht Partikel entweder zu einer Position hin oder stößt sie von ihr ab.
+
+`Vortex`
+: Beeinflusst Partikel in einer kreisförmigen oder spiralförmigen Richtung um seine Position.
+
+  ![Modifikatoren](images/particlefx/modifiers.png)
+
+## Modifikatoreigenschaften {#modifier-properties}
+
+Position/Rotation
+: Die Transformation des Modifikators relativ zu seinem übergeordneten Objekt.
+
+Magnitude
+: Die Stärke des Einflusses, den der Modifikator auf die Partikel hat.
+
+Max Distance
+: Die maximale Entfernung, innerhalb derer dieser Modifikator Partikel überhaupt beeinflusst. Wird nur für Radial und Vortex verwendet.
+
+## Einen Partikeleffekt steuern {#controlling-a-particle-effect}
+
+So startest und stoppst du einen Partikeleffekt aus einem Skript:
+
+```lua
+-- start the effect component "particles" in the current game object
+particlefx.play("#particles")
+
+-- stop the effect component "particles" in the current game object
+particlefx.stop("#particles")
+```
+
+Weitere Informationen zum Starten und Stoppen eines Partikeleffekts aus einem GUI-Skript findest du im [Handbuch zu GUI-Partikeleffekten](/manuals/gui-particlefx#controlling-the-effect).
+
+::: sidenote
+Ein Partikeleffekt erzeugt weiterhin Partikel, auch wenn das Spielobjekt (game object), zu dem die Partikeleffektkomponente gehörte, gelöscht wird.
+:::
+Weitere Informationen findest du in der [Referenzdokumentation zu Partikeleffekten](/ref/particlefx).
+
+## Materialkonstanten {#material-constants}
+
+Das Standardmaterial für Partikeleffekte hat die folgenden Konstanten, die du mit `particlefx.set_constant()` ändern und mit `particlefx.reset_constant()` zurücksetzen kannst (weitere Einzelheiten findest du im [Handbuch zu Materialien](/manuals/material/#vertex-and-fragment-constants)):
+
+`tint`
+: Die Einfärbung des Partikeleffekts (`vector4`). Der vector4 stellt die Einfärbung dar, wobei x, y, z und w den Rot-, Grün-, Blau- und Alphaanteilen der Einfärbung entsprechen. Ein Beispiel findest du in der [API-Referenz](/ref/particlefx/#particlefx.set_constant:url-constant-value).
+
+
+## Projektkonfiguration {#project-configuration}
+
+Die Datei *game.project* enthält einige [Projekteinstellungen](/manuals/project-settings#particle-fx) für Partikel.

--- a/docs/de/manuals/physically-based-rendering.md
+++ b/docs/de/manuals/physically-based-rendering.md
@@ -1,0 +1,392 @@
+---
+title: Physikalisch basiertes Rendering in Defold
+brief: Dieses Handbuch erklärt die Grundlagen des Zugriffs auf Materialdaten für physikalisch basiertes Rendering in Defold.
+---
+
+# Physikalisch basiertes Rendering (PBR) {#physically-based-rendering-pbr}
+
+Physikalisch basiertes Rendering (Physically Based Rendering, PBR) ist ein Shading-Verfahren, das anhand realer physikalischer Prinzipien modelliert, wie Licht mit Oberflächen interagiert. Es erzeugt eine konsistente, realistische Beleuchtung in unterschiedlichen Umgebungen und ermöglicht es, Assets unter verschiedensten Lichtbedingungen korrekt darzustellen.
+
+Die PBR-Implementierung von Defold folgt der Materialspezifikation von glTF 2.0 und den zugehörigen Khronos-Erweiterungen. Wenn du glTF-Assets in Defold importierst, werden Materialeigenschaften automatisch eingelesen und als strukturierte Materialdaten gespeichert, auf die Shader zur Laufzeit zugreifen können.
+
+PBR-Materialien können Effekte wie metallische Reflexionen, Oberflächenrauheit, Transmission, Klarlack, Streuung unter der Oberfläche, Irideszenz und weitere Effekte enthalten.
+
+::: sidenote
+Defold stellt Shadern derzeit PBR-Materialdaten zur Verfügung, bietet aber kein integriertes PBR-Beleuchtungsmodell. Du kannst diese Daten in deinen eigenen Beleuchtungs- und Reflexions-Shadern verwenden, um physikalisch basiertes Rendering zu erreichen. Ein standardmäßiges PBR-Beleuchtungsmodell wird Defold zu einem späteren Zeitpunkt hinzugefügt.
+:::
+
+::: sidenote
+Eingebettete Texturen aus glTF-Dateien werden in Defold derzeit nicht automatisch zugewiesen. Nur Materialparameter werden Shadern zur Verfügung gestellt. Du kannst Texturen weiterhin manuell Modellkomponenten (model components) zuweisen und sie in deinem Shader abtasten.
+:::
+
+## Übersicht der Materialeigenschaften {#material-properties-overview}
+
+Die Materialeigenschaften werden aus den glTF-2.0-Quelldateien eingelesen, die einer Modellkomponente zugewiesen sind. Nicht alle Eigenschaften gehören zum Standard. Einige werden durch optionale glTF-Erweiterungen bereitgestellt, die das zum Exportieren der glTF-Datei verwendete Werkzeug möglicherweise einbezieht. Die jeweilige Erweiterung steht unten in Klammern hinter dem Namen der Eigenschaft.
+
+Metallizität und Rauheit
+: Beschreibt, wie Licht mit dem Material interagiert. Das standardmäßige PBR-Modell.
+
+Glanzreflexion und Glätte (KHR_materials_pbrSpecularGlossiness)
+: Eine Alternative zu Metallizität und Rauheit. Wird häufig in älteren Assets verwendet.
+
+Klarlack (KHR_materials_clearcoat)
+: Fügt eine transparente Beschichtung mit eigener Rauheit und Normalen-Map hinzu.
+
+Brechungsindex (Ior) (KHR_materials_ior)
+: Fügt einen Brechungsindex hinzu.
+
+Glanzreflexion (KHR_materials_specular)
+: Fügt einen eigenen Intensitäts- und Farbkanal für Glanzreflexionen hinzu.
+
+Irideszenz (KHR_materials_iridescence)
+: Simuliert Dünnschichtinterferenz für Materialien wie Seifenblasen oder Perlen.
+
+Schimmer (KHR_materials_sheen)
+: Modelliert stoffähnliche Reflexionen an Mikrooberflächen.
+
+Transmission (KHR_materials_transmission)
+: Modelliert die Lichtdurchlässigkeit transparenter oder glasähnlicher Materialien.
+
+Volumen (KHR_materials_volume)
+: Unterstützt volumetrische Effekte wie Dicke und Abschwächung.
+
+Emissionsstärke (KHR_materials_emissive_strength)
+: Steuert die Helligkeit der Eigenemission unabhängig von der Grundfarbe.
+
+Normalen-Map
+: Normalen-Map für Oberflächendetails.
+
+Okklusions-Map
+: Map für Umgebungsverdeckung (Ambient Occlusion).
+
+Emissions-Map
+: Selbstleuchtende Textur für leuchtende Oberflächen.
+
+Emissionsfaktor
+: RGB-Multiplikator für die Emissionsintensität
+
+Alpha-Schwellenwert
+: Schwellenwert für maskierte Transparenz.
+
+Alphamodus
+: Transparenzmodi Opaque, Masked oder Blended.
+
+Doppelseitig
+: Wenn der Wert true ist, werden beide Seiten der Oberfläche gerendert.
+
+Unbeleuchtet
+: Wenn der Wert true ist, umgeht das Material die Beleuchtungsberechnungen.
+
+::: sidenote
+Einige dieser Eigenschaften geben Hinweise darauf, wie das Material gerendert werden sollte. Die Daten für diese Eigenschaften (Alpha-Schwellenwert, Alphamodus, doppelseitig und unbeleuchtet) stehen in den Shadern zur Verfügung, beeinflussen aber nicht, wie das Material in Defold gerendert wird.
+:::
+
+## Shader-Integration
+
+Die PBR-Materialdaten werden den Shadern anhand von Typen und Namenskonventionen zur Verfügung gestellt. Das PBR-Materialsystem stellt Shadern alle eingelesenen Materialparameter über einen strukturierten Uniform-Block namens `PbrMaterial` bereit. Jede unterstützte glTF-Erweiterung entspricht einer Struktur innerhalb dieses Blocks, die mithilfe von `#define`-Flags bedingt kompiliert werden kann.
+
+```glsl
+uniform PbrMaterial
+{
+	// Material properties
+};
+```
+
+Die verschiedenen Merkmale des Materials werden im Shader als festgelegte Strukturen angegeben. Die Daten wurden so weit wie möglich in `vec4`-Vektoren zusammengefasst, da Konstanten in Defold intern auf diese Weise gesetzt werden. Wo Daten zusammengefasst wurden, wird dies in den Kommentaren der folgenden Shader-Ausschnitte für jedes Merkmal angegeben:
+
+```glsl
+struct PbrMetallicRoughness
+{
+    vec4 baseColorFactor;
+    // R: metallic (Default=1.0), G: roughness (Default=1.0)
+    vec4 metallicAndRoughnessFactor;
+    // R: use baseColorTexture, G: use metallicRoughnessTexture
+    vec4 metallicRoughnessTextures;
+};
+
+struct PbrSpecularGlossiness
+{
+	vec4 diffuseFactor;
+	// RGB: specular (Default=1.0), A: glossiness (Default=1.0)
+	vec4 specularAndSpecularGlossinessFactor;
+	// R: use diffuseTexture, G: use specularGlossinessTexture
+	vec4 specularGlossinessTextures;
+};
+
+struct PbrClearCoat
+{
+	// R: clearCoat (Default=0.0), G: clearCoatRoughness (Default=0.0)
+	vec4 clearCoatAndClearCoatRoughnessFactor;
+	// R: use clearCoatTexture, G: use clearCoatRoughnessTexture, B: use clearCoatNormalTexture
+	vec4 clearCoatTextures;
+};
+
+struct PbrTransmission
+{
+	// R: transmission (Default=0.0)
+	vec4 transmissionFactor;
+	// R: use transmissionTexture
+	vec4 transmissionTextures;
+};
+
+struct PbrIor
+{
+	// R: ior (Default=0.0)
+	vec4 ior;
+};
+
+struct PbrSpecular
+{
+	// RGB: specularColor, A: specularFactor (Default=1.0);
+	vec4 specularColorAndSpecularFactor;
+	// R: use specularTexture, G: use specularColorTexture
+	vec4 specularTextures;
+};
+
+struct PbrVolume
+{
+	// R: thicknessFactor (Default=0.0), RGB: attenuationColor
+	vec4 thicknessFactorAndAttenuationColor;
+	// R: attentuationDistance (Default=-1.0)
+	vec4 attenuationDistance;
+	// R: use thicknessTexture
+	vec4 volumeTextures;
+};
+
+struct PbrSheen
+{
+	// RGB: sheenColor, A: sheenRoughnessFactor (Default=0.0)
+	vec4 sheenColorAndRoughnessFactor;
+	// R: use sheenColorTexture, G: use sheenRoughnessTexture
+	vec4 sheenTextures;
+};
+
+struct PbrEmissiveStrength
+{
+	// R: emissiveStrength (Default=1.0)
+	vec4 emissiveStrength;
+};
+
+struct PbrIridescence
+{
+	// R: iridescenceFactor (Default=0.0), G: iridescenceIor (Default=1.3), B: iridescenceThicknessMin (Default=100.0), A: iridescenceThicknessMax (Default=400.0)
+	vec4 iridescenceFactorAndIorAndThicknessMinMax;
+	// R: use iridescenceTexture, G: use iridescenceThicknessTexture
+	vec4 iridescenceTextures;
+};
+```
+
+Die gemeinsamen Eigenschaften werden direkt in der Material-Uniform gesetzt (beachte auch hier die Zusammenfassung der Daten in `vec4`).
+
+```glsl
+// Common textures
+uniform sampler2D PbrMaterial_normalTexture;
+uniform sampler2D PbrMaterial_occlusionTexture;
+uniform sampler2D PbrMaterial_emissiveTexture;
+
+uniform PbrMaterial
+{
+	// Common properties:
+
+	// R: alphaCutoff (Default=0.5), G: doubleSided (Default=false), B: unlit (Default=false)
+	vec4 pbrAlphaCutoffAndDoubleSidedAndIsUnlit;
+	// R: use normalTexture, G: use occlusionTexture, B: use emissiveTexture
+	vec4 pbrCommonTextures;
+
+	// Other properties...
+};
+```
+
+### Beispiel-Shader {#example-shader}
+
+Hier siehst du einen Beispiel-Shader, der alle Merkmale enthält und ein Namensschema für Texturbindungen vorschlägt (auch dies musst du manuell handhaben). Beachte, dass du Merkmale einfach deaktivieren kannst, indem du `#define`-Anweisungen um die einzelnen Felder von `PbrMaterial` selbst setzt, wie im folgenden Beispiel gezeigt:
+
+```glsl
+// Feature flags, comment or remove these to slim down the shader.
+#define PBR_METALLIC_ROUGHNESS
+#define PBR_SPECULAR_GLOSSINESS
+#define PBR_CLEARCOAT
+#define PBR_TRANSMISSION
+#define PBR_IOR
+#define PBR_SPECULAR
+#define PBR_VOLUME
+#define PBR_SHEEN
+#define PBR_EMISSIVE_STRENGTH
+#define PBR_IRIDESCENCE
+
+// Common
+uniform sampler2D PbrMaterial_normalTexture;
+uniform sampler2D PbrMaterial_occlusionTexture;
+uniform sampler2D PbrMaterial_emissiveTexture;
+
+// PbrMetallicRoughness
+uniform sampler2D PbrMetallicRoughness_baseColorTexture;
+uniform sampler2D PbrMetallicRoughness_metallicRoughnessTexture;
+
+struct PbrMetallicRoughness
+{
+    vec4 baseColorFactor;
+    // R: metallic (Default=1.0), G: roughness (Default=1.0)
+    vec4 metallicAndRoughnessFactor;
+    // R: use baseColorTexture, G: use metallicRoughnessTexture
+    vec4 metallicRoughnessTextures;
+};
+
+// PbrSpecularGlossiness
+uniform sampler2D PbrSpecularGlossiness_diffuseTexture;
+uniform sampler2D PbrSpecularGlossiness_specularGlossinessTexture;
+
+struct PbrSpecularGlossiness
+{
+	vec4 diffuseFactor;
+	// RGB: specular (Default=1.0), A: glossiness (Default=1.0)
+	vec4 specularAndSpecularGlossinessFactor;
+	// R: use diffuseTexture, G: use specularGlossinessTexture
+	vec4 specularGlossinessTextures;
+};
+
+// PbrClearCoat
+uniform sampler2D PbrClearCoat_clearcoatTexture;
+uniform sampler2D PbrClearCoat_clearcoatRoughnessTexture;
+uniform sampler2D PbrClearCoat_clearcoatNormalTexture;
+
+struct PbrClearCoat
+{
+	// R: clearCoat (Default=0.0), G: clearCoatRoughness (Default=0.0)
+	vec4 clearCoatAndClearCoatRoughnessFactor;
+	// R: use clearCoatTexture, G: use clearCoatRoughnessTexture, B: use clearCoatNormalTexture
+	vec4 clearCoatTextures;
+};
+
+// PbrTransmission
+uniform sampler2D PbrTransmission_transmissionTexture;
+
+struct PbrTransmission
+{
+	// R: transmission (Default=0.0)
+	vec4 transmissionFactor;
+	// R: use transmissionTexture
+	vec4 transmissionTextures;
+};
+
+struct PbrIor
+{
+	// R: ior (Default=0.0)
+	vec4 ior;
+};
+
+// PbrSpecular
+uniform sampler2D PbrSpecular_specularTexture;
+uniform sampler2D PbrSpecular_specularColorTexture;
+
+struct PbrSpecular
+{
+	// RGB: specularColor, A: specularFactor (Default=1.0);
+	vec4 specularColorAndSpecularFactor;
+	// R: use specularTexture, G: use specularColorTexture
+	vec4 specularTextures;
+};
+
+// PbrVolume
+uniform sampler2D PbrVolume_thicknessTexture;
+
+struct PbrVolume
+{
+	// R: thicknessFactor (Default=0.0), RGB: attenuationColor
+	vec4 thicknessFactorAndAttenuationColor;
+	// R: attentuationDistance (Default=-1.0)
+	vec4 attenuationDistance;
+	// R: use thicknessTexture
+	vec4 volumeTextures;
+};
+
+// PbrSheen
+uniform sampler2D PbrSheen_sheenColorTexture;
+uniform sampler2D PbrSheen_sheenRoughnessTexture;
+
+struct PbrSheen
+{
+	// RGB: sheenColor, A: sheenRoughnessFactor (Default=0.0)
+	vec4 sheenColorAndRoughnessFactor;
+	// R: use sheenColorTexture, G: use sheenRoughnessTexture
+	vec4 sheenTextures;
+};
+
+struct PbrEmissiveStrength
+{
+	// R: emissiveStrength (Default=1.0)
+	vec4 emissiveStrength;
+};
+
+// PbrIridescence
+uniform sampler2D PbrEmissive_iridescenceTexture;
+uniform sampler2D PbrEmissive_iridescenceThicknessTexture;
+
+struct PbrIridescence
+{
+	// R: iridescenceFactor (Default=0.0), G: iridescenceIor (Default=1.3), B: iridescenceThicknessMin (Default=100.0), A: iridescenceThicknessMax (Default=400.0)
+	vec4 iridescenceFactorAndIorAndThicknessMinMax;
+	// R: use iridescenceTexture, G: use iridescenceThicknessTexture
+	vec4 iridescenceTextures;
+};
+
+uniform PbrMaterial
+{
+	// Common properties
+	// R: alphaCutoff (Default=0.5), G: doubleSided (Default=false), B: unlit (Default=false)
+	vec4 pbrAlphaCutoffAndDoubleSidedAndIsUnlit;
+	// R: use normalTexture, G: use occlusionTexture, B: use emissiveTexture
+	vec4 pbrCommonTextures;
+
+	// Features
+#ifdef PBR_METALLIC_ROUGHNESS
+	PbrMetallicRoughness  pbrMetallicRoughness;
+#endif
+#ifdef PBR_SPECULAR_GLOSSINESS
+	PbrSpecularGlossiness pbrSpecularGlossiness;
+#endif
+#ifdef PBR_CLEARCOAT
+	PbrClearCoat pbrClearCoat;
+#endif
+#ifdef PBR_TRANSMISSION
+	PbrTransmission pbrTransmission;
+#endif
+#ifdef PBR_IOR
+	PbrIor pbrIor;
+#endif
+#ifdef PBR_SPECULAR
+	PbrSpecular pbrSpecular;
+#endif
+#ifdef PBR_VOLUME
+	PbrVolume pbrVolume;
+#endif
+#ifdef PBR_SHEEN
+	PbrSheen pbrSheen;
+#endif
+#ifdef PBR_EMISSIVE_STRENGTH
+	PbrEmissiveStrength pbrEmissiveStrength;
+#endif
+#ifdef PBR_IRIDESCENCE
+	PbrIridescence pbrIridescence;
+#endif
+};
+```
+
+::: sidenote
+Wenn bestimmte Datenfelder in der Materialstruktur nicht gefunden werden, werden die Daten für diese Merkmale nicht gesetzt. Wenn beispielsweise `pbrClearCoat` in der Materialstruktur fehlt, werden keine Klarlackdaten gesetzt. Wenn der Uniform-Block nicht gefunden wird, werden beim Rendern überhaupt keine Daten gesetzt.
+:::
+
+### Konstanten {#constants}
+
+Jede Materialeigenschaft entspricht einer internen Render-Konstante in Defold. Du kannst Standardwerte überschreiben, indem du direkt in der Materialressource Konstanten nach dem Namensmuster `pbrFeature.structMember` definierst. Diese Werte werden automatisch angewendet, wenn die entsprechenden Daten im glTF-Material fehlen.
+
+![Materialkonstanten](images/physically-based-rendering/material-constants.png)
+
+## Nächste Schritte {#next-steps}
+
+Um die Materialdaten für physikalisch basierte Beleuchtung zu verwenden, implementiere eine BRDF in deinem Fragment-Shader mit den Parametern aus dem Block `PbrMaterial`.
+Siehe auch:
+
+* [Shader-Handbuch](/manuals/shader)
+* [Rendering-Handbuch](/manuals/render)
+* [glTF-2.0-Spezifikation](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html)

--- a/docs/de/manuals/physics-events.md
+++ b/docs/de/manuals/physics-events.md
@@ -1,0 +1,143 @@
+---
+title: Kollisionsereignisse in Defold
+brief: Die Verarbeitung von Kollisionsereignissen lässt sich mit `physics.set_event_listener()` zentralisieren, indem alle Kollisions- und Interaktionsnachrichten an eine einzelne festgelegte Funktion geleitet werden.
+---
+
+# Verarbeitung von Physikereignissen in Defold {#defold-physics-event-handling}
+
+Defold bietet mit der Funktion `physics.set_event_listener()` eine zentrale Verarbeitung von Physikereignissen. Mit dieser Funktion kannst du einen benutzerdefinierten Listener festlegen, der alle Ereignisse physikalischer Interaktionen an einer Stelle verarbeitet. Dadurch wird dein Code übersichtlicher und effizienter.
+
+## Den Listener für die Physikwelt festlegen {#setting-the-physics-world-listener}
+
+In Defold erstellt jeder Sammlungs-Proxy (collection proxy) seine eigene separate Physikwelt. Wenn du mit mehreren Sammlungs-Proxys arbeitest, musst du daher die verschiedenen Physikwelten verwalten, die ihnen jeweils zugeordnet sind. Damit Physikereignisse in jeder Welt korrekt verarbeitet werden, musst du für die Welt jedes Sammlungs-Proxys einen eigenen Listener für die Physikwelt festlegen.
+
+Das bedeutet, dass der Listener für Physikereignisse innerhalb des Kontexts der Sammlung (collection) festgelegt werden muss, die der Proxy repräsentiert. Dadurch ordnest du den Listener direkt der entsprechenden Physikwelt zu, sodass er Physikereignisse korrekt verarbeiten kann.
+
+Hier ist ein Beispiel dafür, wie du einen Listener für die Physikwelt innerhalb eines Sammlungs-Proxys festlegst:
+
+```lua
+function init(self)
+    -- Assuming this script is attached to a game object within the collection loaded by the proxy
+    -- Set the physics world listener for the physics world of this collection proxy
+    physics.set_event_listener(physics_world_listener)
+end
+```
+
+Mit dieser Methode stellst du sicher, dass jede von einem Sammlungs-Proxy erzeugte Physikwelt ihren eigenen Listener hat. Das ist entscheidend, um Physikereignisse in Projekten mit mehreren Sammlungs-Proxys effektiv zu verarbeiten.
+
+::: important
+Wenn ein Listener festgelegt ist, werden für die Physikwelt, in der dieser Listener festgelegt ist, keine [Physiknachrichten](/manuals/physics-messages) mehr gesendet.
+:::
+
+## Datenstruktur der Ereignisse {#event-data-structure}
+
+Der Listener wird mit `self` und einer Tabelle namens `events` aufgerufen. Die Tabelle `events` ist ein Array, das alle für den Callback gesammelten Physikereignisse enthält. Jeder Eintrag ist eine Ereignistabelle mit einem Feld namens `type`, das den Hashwert des Ereignisnamens enthält, sowie zusätzlichen Feldern, die für den jeweiligen Ereignistyp spezifisch sind.
+
+Die Ereignistabellen enthalten die folgenden Daten:
+
+1. **Kontaktpunktereignis (`contact_point_event`):**
+Dieses Ereignis meldet einen Kontaktpunkt zwischen zwei Kollisionsobjekten (collision object). Es eignet sich für eine detaillierte Kollisionsverarbeitung, beispielsweise zur Berechnung von Aufprallkräften oder benutzerdefinierten Kollisionsreaktionen.
+
+   - `applied_impulse`: Der aus dem Kontakt resultierende Impuls.
+   - `distance`: Die Eindringtiefe zwischen den Objekten.
+   - `a` und `b`: Objekte, die die kollidierenden Entitäten repräsentieren und jeweils Folgendes enthalten:
+     - `position`: Weltposition des Kontaktpunkts (vector3).
+     - `instance_position`: Weltposition der Instanz eines Spielobjekts (game object) (vector3).
+     - `id`: Instanz-ID (hash).
+     - `group`: Kollisionsgruppe (hash).
+     - `relative_velocity`: Geschwindigkeit relativ zum anderen Objekt (vector3).
+     - `mass`: Masse in Kilogramm (number).
+     - `normal`: Kontaktnormale, die vom anderen Objekt weg zeigt (vector3).
+
+2. **Kollisionsereignis (`collision_event`):**
+Dieses Ereignis zeigt an, dass eine Kollision zwischen zwei Objekten stattgefunden hat. Es ist allgemeiner als das Kontaktpunktereignis und eignet sich ideal zum Erkennen von Kollisionen, wenn keine detaillierten Informationen zu den Kontaktpunkten benötigt werden.
+
+   - `a` und `b`: Objekte, die die kollidierenden Entitäten repräsentieren und jeweils Folgendes enthalten:
+     - `position`: Weltposition (vector3).
+     - `id`: Instanz-ID (hash).
+     - `group`: Kollisionsgruppe (hash).
+
+3. **Trigger-Ereignis (`trigger_event`):** 
+Dieses Ereignis wird gesendet, wenn ein Objekt mit einem Trigger-Objekt interagiert. Es eignet sich dazu, Bereiche in deinem Spiel zu erstellen, die etwas auslösen, wenn ein Objekt sie betritt oder verlässt.
+
+   - `enter`: Gibt an, ob es sich bei der Interaktion um einen Eintritt (true) oder einen Austritt (false) handelt.
+   - `a` und `b`: Am Trigger-Ereignis beteiligte Objekte, die jeweils Folgendes enthalten:
+     - `id`: Instanz-ID (hash).
+     - `group`: Kollisionsgruppe (hash).
+
+4. **Antwort auf eine Strahlabfrage (`ray_cast_response`):**
+Dieses Ereignis wird als Antwort auf eine Strahlabfrage (raycast) gesendet und liefert Informationen über das vom Strahl getroffene Objekt.
+
+   - `group`: Kollisionsgruppe des getroffenen Objekts (hash).
+   - `request_id`: Kennung der Strahlabfrage (number).
+   - `position`: Trefferposition (vector3).
+   - `fraction`: Der Anteil der Strahllänge, an dem der Treffer auftrat (number).
+   - `normal`: Normale an der Trefferposition (vector3).
+   - `id`: Instanz-ID des getroffenen Objekts (hash).
+
+5. **Strahlabfrage ohne Treffer (`ray_cast_missed`):**
+Dieses Ereignis wird gesendet, wenn eine Strahlabfrage kein Objekt trifft.
+
+   - `request_id`: Kennung der Strahlabfrage, die kein Objekt getroffen hat (number).
+
+## Anwendungsbeispiel {#example-usage}
+
+```lua
+local function physics_world_listener(self, events)
+    for _,event in ipairs(events) do
+        if event.type == hash("contact_point_event") then
+            -- Handle detailed contact point data
+            pprint(event)
+        elseif event.type == hash("collision_event") then
+            -- Handle general collision data
+            pprint(event)
+        elseif event.type == hash("trigger_event") then
+            -- Handle trigger interaction data
+            pprint(event)
+        elseif event.type == hash("ray_cast_response") then
+            -- Handle raycast hit data
+            pprint(event)
+        elseif event.type == hash("ray_cast_missed") then
+            -- Handle raycast miss data
+            pprint(event)
+        end
+    end
+end
+
+function init(self)
+    physics.set_event_listener(physics_world_listener)
+end
+```
+
+## Einschränkungen {#limitations}
+
+Der Listener wird synchron zum Zeitpunkt des Ereignisses aufgerufen. Das geschieht mitten in einem Zeitschritt, weshalb die Physikwelt gesperrt ist. Dadurch ist es nicht möglich, Funktionen zu verwenden, die die Simulationen der Physikwelt beeinflussen könnten, beispielsweise `physics.create_joint()`.
+
+Hier ist ein kurzes Beispiel dafür, wie du diese Einschränkungen umgehen kannst:
+```lua
+local function physics_world_listener(self, events)
+    for _,event in ipairs(events) do
+        if event.type == hash("contact_point_event") then
+            local position_a = event.a.normal * SIZE
+            local position_b =  event.b.normal * SIZE
+            local url_a = msg.url(nil, event.a.id, "collisionobject")
+            local url_b = msg.url(nil, event.b.id, "collisionobject")
+            -- fill the message in the same way arguments should be passed to `physics.create_joint()`
+            local message = {physics.JOINT_TYPE_FIXED, url_a, "joind_id", position_a, url_b, position_b, {max_length = SIZE}}
+            -- send message to the object itself
+            msg.post(".", "create_joint", message)
+        end
+    end
+end
+
+function on_message(self, message_id, message)
+    if message_id == hash("create_joint") then
+        -- unpack message with function arguments
+        physics.create_joint(unpack(message))
+    end
+end
+
+function init(self)
+    physics.set_event_listener(physics_world_listener)
+end
+```

--- a/docs/de/manuals/physics-groups.md
+++ b/docs/de/manuals/physics-groups.md
@@ -1,0 +1,17 @@
+---
+title: Kollisionsgruppen in Defold
+brief: Die Physik-Engine ermöglicht dir, deine Physikobjekte zu gruppieren und durch Filter festzulegen, wie sie miteinander kollidieren sollen.
+---
+
+# Gruppe und Maske {#group-and-mask}
+
+Die Physik-Engine ermöglicht dir, deine Physikobjekte zu gruppieren und durch Filter festzulegen, wie sie miteinander kollidieren sollen. Dafür werden benannte _Kollisionsgruppen_ (collision groups) verwendet. Bei jedem Kollisionsobjekt (collision object), das du erstellst, steuern zwei Eigenschaften, wie das Objekt mit anderen Objekten kollidiert: *Group* und *Mask*.
+
+Damit eine Kollision zwischen zwei Objekten registriert wird, müssen beide Objekte im Feld *Mask* jeweils die Gruppe des anderen Objekts angeben.
+
+![Kollisionsgruppe der Physik-Engine](images/physics/collision_group.png)
+
+Das Feld *Mask* kann mehrere Gruppennamen enthalten und ermöglicht dadurch komplexe Interaktionsszenarien.
+
+## Kollisionen erkennen {#detecting-collisions}
+Wenn zwei Kollisionsobjekte mit zueinander passenden Gruppen und Masken kollidieren, erzeugt die Physik-Engine [Kollisionsnachrichten](/manuals/physics-messages), die du in Spielen verwenden kannst, um auf Kollisionen zu reagieren.

--- a/docs/de/manuals/physics-joints.md
+++ b/docs/de/manuals/physics-joints.md
@@ -1,0 +1,61 @@
+---
+title: Physikgelenke in Defold
+brief: Defold unterstützt Gelenke für die 2D-Physik. Dieses Handbuch erklärt, wie du Gelenke erstellst und mit ihnen arbeitest.
+---
+
+# Gelenke {#joints}
+
+Ein Gelenk (joint) verbindet zwei Kollisionsobjekte (collision objects) durch eine Zwangsbedingung (constraint). Defold unterstützt Gelenke sowohl in der 2D- als auch in der 3D-Physik über unterschiedliche APIs.
+
+Dieses Handbuch beschreibt die 2D-Gelenke, die das Modul `physics` bereitstellt. Seit Defold 1.13.2 können 3D-Projekte über [`bullet3d.constraint`](/ref/beta/bullet3d.constraint/) Zwangsbedingungen erstellen und steuern, darunter Scharniere, Schieber und Federn. Verwende diese API mit starren Körpern (rigid bodies), die du über [`bullet3d.get_rigid_body()`](/ref/beta/bullet3d/#bullet3d.get_rigid_body) erhältst.
+
+Die 2D-API `physics` unterstützt folgende Gelenktypen:
+
+* **Festes Gelenk (Fixed, physics.JOINT_TYPE_FIXED)** - Ein Seilgelenk, das den maximalen Abstand zwischen zwei Punkten begrenzt. In Box2D wird es als Rope joint bezeichnet.
+* **Scharniergelenk (Hinge, physics.JOINT_TYPE_HINGE)** - Ein Scharniergelenk legt einen Ankerpunkt an zwei Kollisionsobjekten fest und bewegt sie so, dass sich die beiden Kollisionsobjekte immer an derselben Stelle befinden. Die relative Drehung der Kollisionsobjekte ist dabei nicht eingeschränkt. Beim Scharniergelenk kann ein Motor mit einem festgelegten maximalen Motordrehmoment und einer festgelegten Drehzahl aktiviert werden. In Box2D wird es als [Drehgelenk (Revolute joint)](https://box2d.org/documentation/group__revolute__joint.html#details) bezeichnet.
+* **Schweißgelenk (Weld, physics.JOINT_TYPE_WELD)** - Ein Schweißgelenk versucht, jede relative Bewegung zwischen zwei Kollisionsobjekten zu unterbinden. Das Schweißgelenk kann durch eine Frequenz und ein Dämpfungsverhältnis nachgiebig wie eine Feder eingestellt werden. In Box2D wird es als [Schweißgelenk (Weld joint)](https://box2d.org/documentation/group__weld__joint.html#details) bezeichnet.
+* **Federgelenk (Spring, physics.JOINT_TYPE_SPRING)** - Ein Federgelenk hält zwei Kollisionsobjekte in einem konstanten Abstand zueinander. Das Federgelenk kann durch eine Frequenz und ein Dämpfungsverhältnis nachgiebig wie eine Feder eingestellt werden. In Box2D wird es als [Abstandsgelenk (Distance joint)](https://box2d.org/documentation/group__distance__joint.html#details) bezeichnet.
+* **Schiebegelenk (Slider, physics.JOINT_TYPE_SLIDER)** - Ein Schiebegelenk ermöglicht die relative Verschiebung zweier Kollisionsobjekte entlang einer festgelegten Achse und verhindert ihre relative Drehung. In Box2D wird es als [prismatisches Gelenk (Prismatic joint)](https://box2d.org/documentation/group__prismatic__joint.html#details) bezeichnet.
+* **Radgelenk (Wheel, physics.JOINT_TYPE_WHEEL)** - Ein Radgelenk beschränkt einen Punkt auf `bodyB` auf eine Linie auf `bodyA`. Das Radgelenk stellt außerdem eine Feder für die Aufhängung bereit. In Box2D wird es als  [Radgelenk (Wheel joint)](https://box2d.org/documentation/group__wheel__joint.html#details) bezeichnet.
+
+## Gelenke erstellen {#creating-joints}
+
+Die hier beschriebenen 2D-Gelenke werden per Code mit [`physics.create_joint()`](/ref/physics/#physics.create_joint:joint_type-collisionobject_a-joint_id-position_a-collisionobject_b-position_b-[properties]) erstellt:
+::: sidenote
+Die Unterstützung für das Erstellen von Gelenken im Editor ist geplant, ein Veröffentlichungsdatum steht jedoch noch nicht fest.
+:::
+
+```lua
+-- connect two collision objects with a fixed joint constraint (rope)
+physics.create_joint(physics.JOINT_TYPE_FIXED, "obj_a#collisionobject", "my_test_joint", vmath.vector3(10, 0, 0), "obj_b#collisionobject", vmath.vector3(0, 20, 0), { max_length = 20 })
+```
+
+Das obige Beispiel erstellt ein festes Gelenk mit der ID `my_test_joint`, das die beiden Kollisionsobjekte `obj_a#collisionobject` und `obj_b#collisionobject` verbindet. Das Gelenk ist 10 Pixel rechts vom Mittelpunkt des Kollisionsobjekts `obj_a#collisionobject` und 20 Pixel oberhalb des Mittelpunkts des Kollisionsobjekts `obj_b#collisionobject` befestigt. Die maximale Länge des Gelenks beträgt 20 Pixel.
+
+## Gelenke zerstören {#destroying-joints}
+
+Du kannst ein Gelenk mit [`physics.destroy_joint()`](/ref/physics/#physics.destroy_joint:collisionobject-joint_id) zerstören:
+
+```lua
+-- destroy a joint previously connected to the first collision object
+physics.destroy_joint("obj_a#collisionobject", "my_test_joint")
+```
+
+## Gelenke auslesen und aktualisieren {#reading-from-and-updating-joints}
+
+Du kannst die Eigenschaften eines Gelenks mit [`physics.get_joint_properties()`](/ref/physics/#physics.get_joint_properties:collisionobject-joint_id) auslesen und mit [`physics.set_joint_properties()`](/ref/physics/#physics.set_joint_properties:collisionobject-joint_id-properties) setzen:
+
+```lua
+function update(self, dt)
+    if self.accelerating then
+        local hinge_props = physics.get_joint_properties("obj_a#collisionobject", "my_hinge")
+        -- increase motor speed by 100 revolutions per second
+        hinge_props.motor_speed = hinge_props.motor_speed + 100 * 2 * math.pi * dt
+        physics.set_joint_properties("obj_a#collisionobject", "my_hinge", hinge_props)
+    end
+end
+```
+
+## Reaktionskraft und Drehmoment eines Gelenks auslesen {#get-joint-reaction-force-and-torque}
+
+Du kannst die auf ein Gelenk wirkende Reaktionskraft und das Drehmoment mit [`physics.get_joint_reaction_force()`](/ref/physics/#physics.get_joint_reaction_force:collisionobject-joint_id) und [`physics.get_joint_reaction_torque()`](/ref/physics/#physics.get_joint_reaction_torque:collisionobject-joint_id) auslesen.

--- a/docs/de/manuals/physics-messages.md
+++ b/docs/de/manuals/physics-messages.md
@@ -1,0 +1,152 @@
+---
+title: Kollisionsnachrichten in Defold
+brief: Wenn zwei Objekte kollidieren, ruft die Engine den Ereignis-Callback auf oder sendet Nachrichten an alle betreffenden Empfänger.
+---
+
+# Kollisionsnachrichten {#collision-messages}
+
+Wenn zwei Objekte kollidieren, sendet die Engine ein Ereignis an den Ereignis-Callback oder Nachrichten an beide Objekte.
+
+## Ereignisfilterung {#event-filtering}
+
+Die Arten der erzeugten Ereignisse lassen sich über die Optionen für jedes Objekt steuern:
+
+* "Generate Collision Events"
+* "Generate Contact Events"
+* "Generate Trigger Events"
+
+Diese sind standardmäßig alle `true`.
+Wenn zwei Kollisionsobjekte (collision objects) miteinander interagieren, prüft die Engine anhand dieser Kontrollkästchen, ob sie dir eine Nachricht senden soll.
+
+Am Beispiel der Kontrollkästchen "Generate Contact Events":
+
+Bei Verwendung von `physics.set_event_listener()`:
+
+| Komponente (component) A | Komponente B | Nachricht senden |
+|-------------|-------------|--------------|
+| ✅︎          | ✅︎          | Ja           |
+| ❌          | ✅︎          | Ja           |
+| ✅︎          | ❌          | Ja           |
+| ❌          | ❌          | Nein         |
+
+Bei Verwendung des standardmäßigen Nachrichtenhandlers:
+
+| Komponente A | Komponente B | Nachricht(en) senden |
+|-------------|-------------|-------------------|
+| ✅︎          | ✅︎          | Ja (A,B) + (B,A)  |
+| ❌          | ✅︎          | Ja (B,A)          |
+| ✅︎          | ❌          | Ja (A,B)          |
+| ❌          | ❌          | Nein              |
+
+## Kollisionsreaktion {#collision-response}
+
+Die Nachricht `"collision_response"` wird gesendet, wenn eines der kollidierenden Objekte vom Typ "dynamic", "kinematic" oder "static" ist. Dabei sind die folgenden Felder gesetzt:
+
+`other_id`
+: der Bezeichner der Instanz, mit der das Kollisionsobjekt kollidiert ist (`hash`)
+
+`other_position`
+: die Weltposition der Instanz, mit der das Kollisionsobjekt kollidiert ist (`vector3`)
+
+`other_group`
+: die Kollisionsgruppe des anderen Kollisionsobjekts (`hash`)
+
+`own_group`
+: die Kollisionsgruppe des Kollisionsobjekts (`hash`)
+
+Die Nachricht `collision_response` eignet sich nur zum Auflösen von Kollisionen, bei denen du keine Einzelheiten zur tatsächlichen Überschneidung der Objekte benötigst, zum Beispiel wenn du erkennen möchtest, ob ein Geschoss einen Gegner trifft. Für jedes kollidierende Objektpaar wird pro Frame nur eine dieser Nachrichten gesendet.
+
+```Lua
+function on_message(self, message_id, message, sender)
+    -- check for the message
+    if message_id == hash("collision_response") then
+        -- take action
+        print("I collided with", message.other_id)
+    end
+end
+```
+
+## Kontaktpunktreaktion {#contact-point-response}
+
+Die Nachricht `"contact_point_response"` wird gesendet, wenn eines der kollidierenden Objekte vom Typ "dynamic" oder "kinematic" und das andere vom Typ "dynamic", "kinematic" oder "static" ist. Dabei sind die folgenden Felder gesetzt:
+
+`position`
+: die Weltposition des Kontaktpunkts (`vector3`).
+
+`normal`
+: die Normale des Kontaktpunkts in Weltkoordinaten, die vom anderen Objekt zum aktuellen Objekt zeigt (`vector3`).
+
+`relative_velocity`
+: die relative Geschwindigkeit des Kollisionsobjekts aus Sicht des anderen Objekts (`vector3`).
+
+`distance`
+: die Eindringtiefe zwischen den Objekten -- nicht negativ (`number`).
+
+`applied_impulse`
+: der Impuls, der sich aus dem Kontakt ergeben hat (`number`).
+
+`life_time`
+: (*wird derzeit nicht verwendet!*) die Lebensdauer des Kontakts (`number`).
+
+`mass`
+: die Masse des aktuellen Kollisionsobjekts in kg (`number`).
+
+`other_mass`
+: die Masse des anderen Kollisionsobjekts in kg (`number`).
+
+`other_id`
+: der Bezeichner der Instanz, mit der das Kollisionsobjekt in Kontakt steht (`hash`).
+
+`other_position`
+: die Weltposition des anderen Kollisionsobjekts (`vector3`).
+
+`other_group`
+: die Kollisionsgruppe des anderen Kollisionsobjekts (`hash`).
+
+`own_group`
+: die Kollisionsgruppe des Kollisionsobjekts (`hash`).
+
+Für ein Spiel oder eine Anwendung, in der du Objekte exakt voneinander trennen musst, liefert dir die Nachricht `"contact_point_response"` alle benötigten Informationen. Beachte jedoch, dass für ein bestimmtes kollidierendes Objektpaar je nach Art der Kollision mehrere Nachrichten vom Typ `"contact_point_response"` pro Frame empfangen werden können. Weitere Informationen findest du unter [Kollisionen auflösen](/manuals/physics-resolving-collisions).
+
+```Lua
+function on_message(self, message_id, message, sender)
+    -- check for the message
+    if message_id == hash("contact_point_response") then
+        -- take action
+        if message.other_mass > 10 then
+            print("I collided with something weighing more than 10 kilos!")
+        end
+    end
+end
+```
+
+## Triggerreaktion {#trigger-response}
+
+Die Nachricht `"trigger_response"` wird gesendet, wenn eines der kollidierenden Objekte vom Typ "trigger" ist. Die Nachricht wird einmal gesendet, wenn die Kollision erstmals erkannt wird, und ein weiteres Mal, wenn die Objekte nicht mehr kollidieren. Sie enthält die folgenden Felder:
+
+`other_id`
+: der Bezeichner der Instanz, mit der das Kollisionsobjekt kollidiert ist (`hash`).
+
+`enter`
+: `true`, wenn die Interaktion ein Eintritt in den Trigger war, und `false`, wenn es ein Austritt war. (`boolean`).
+
+`other_group`
+: die Kollisionsgruppe des anderen Kollisionsobjekts (`hash`).
+
+`own_group`
+: die Kollisionsgruppe des Kollisionsobjekts (`hash`).
+
+```Lua
+function on_message(self, message_id, message, sender)
+    -- check for the message
+    if message_id == hash("trigger_response") then
+        if message.enter then
+            -- take action for entry
+            print("I am now inside", message.other_id)
+        else
+            -- take action for exit
+            print("I am now outside", message.other_id)
+        end
+    end
+end
+```

--- a/docs/de/manuals/physics-objects.md
+++ b/docs/de/manuals/physics-objects.md
@@ -1,0 +1,122 @@
+---
+title: Kollisionsobjekte in Defold
+brief: Ein Kollisionsobjekt ist eine Komponente, mit der du einem Spielobjekt physikalisches Verhalten gibst. Ein Kollisionsobjekt hat physikalische Eigenschaften und eine räumliche Form.
+---
+
+# Kollisionsobjekte {#collision-objects}
+
+Ein Kollisionsobjekt (collision object) ist eine Komponente (component), mit der du einem Spielobjekt (game object) physikalisches Verhalten gibst. Ein Kollisionsobjekt hat physikalische Eigenschaften wie Gewicht, Rückprallkoeffizient und Reibung. Seine räumliche Ausdehnung wird durch eine oder mehrere _Formen_ bestimmt, die du der Komponente hinzufügst. Defold unterstützt die folgenden Arten von Kollisionsobjekten:
+
+Statische Objekte
+: Statische Objekte (static objects) bewegen sich nie, aber ein dynamisches Objekt, das mit einem statischen Objekt kollidiert, reagiert durch Abprallen und/oder Gleiten. Statische Objekte eignen sich sehr gut zum Aufbau unbeweglicher Levelgeometrie (z. B. Boden und Wände). Sie benötigen außerdem weniger Rechenleistung als dynamische Objekte. Du kannst statische Objekte weder bewegen noch anderweitig verändern.
+
+Dynamische Objekte
+: Dynamische Objekte (dynamic objects) werden von der Physik-Engine simuliert. Die Engine löst alle Kollisionen auf und wendet die daraus resultierenden Kräfte an. Dynamische Objekte eignen sich für Objekte, die sich realistisch verhalten sollen. Meist beeinflusst du sie indirekt, indem du [Kräfte anwendest](/ref/physics/#apply_force) oder die [Winkeldämpfung](/ref/stable/physics/#angular_damping) und [Winkelgeschwindigkeit](/ref/stable/physics/#linear_velocity) sowie die [lineare Dämpfung](/ref/stable/physics/#linear_damping) und [lineare Geschwindigkeit](/ref/stable/physics/#angular_velocity) änderst. Du kannst die Position und Ausrichtung eines dynamischen Objekts auch direkt verändern, wenn die [Einstellung Allow Dynamic Transforms](/manuals/project-settings/#allow-dynamic-transforms) in *game.project* aktiviert ist.
+
+Kinematische Objekte
+: Kinematische Objekte (kinematic objects) registrieren Kollisionen mit anderen Physikobjekten, aber die Physik-Engine führt keine automatische Simulation durch. Die Aufgabe, Kollisionen aufzulösen oder zu ignorieren, bleibt dir überlassen ([mehr erfahren](/manuals/physics-resolving-collisions)). Kinematische Objekte eignen sich sehr gut für vom Spieler oder durch Skripte gesteuerte Objekte, deren physikalische Reaktionen genau kontrolliert werden müssen, etwa eine Spielfigur.
+
+Trigger
+: Trigger sind Objekte, die einfache Kollisionen registrieren. Trigger sind Kollisionsobjekte mit geringem Rechenaufwand. Sie ähneln [Strahlabfragen (raycast)](/manuals/physics-ray-casts), da sie die Physikwelt abfragen, statt mit ihr zu interagieren. Sie eignen sich für Objekte, die lediglich einen Treffer registrieren müssen (etwa ein Geschoss), oder als Teil der Spiellogik, wenn du bestimmte Aktionen auslösen möchtest, sobald ein Objekt einen bestimmten Punkt erreicht. Trigger benötigen weniger Rechenleistung als kinematische Objekte und sollten daher möglichst an deren Stelle verwendet werden.
+
+
+## Eine Kollisionsobjekt-Komponente hinzufügen {#adding-a-collision-object-component}
+
+Eine Kollisionsobjekt-Komponente hat eine Reihe von *Properties*, die ihren Typ und ihre physikalischen Eigenschaften festlegen. Außerdem enthält sie eine oder mehrere *Shapes*, die zusammen die gesamte Form des Physikobjekts bestimmen.
+
+So fügst du einem Spielobjekt eine Kollisionsobjekt-Komponente hinzu:
+
+1. Klicke in der Ansicht *Outline* <kbd>mit der rechten Maustaste</kbd> auf das Spielobjekt und wähle im Kontextmenü <kbd>Add Component ▸ Collision Object</kbd>. Dadurch wird eine neue Komponente ohne Formen erstellt.
+2. Klicke <kbd>mit der rechten Maustaste</kbd> auf die neue Komponente und wähle <kbd>Add Shape</kbd>. Wähle anschließend eine Form: <kbd>Box</kbd>, <kbd>Capsule</kbd>, <kbd>Sphere</kbd>, <kbd>Hull</kbd> oder <kbd>Mesh</kbd> in Projekten mit 3D-Physik, <kbd>Box</kbd> oder <kbd>Circle</kbd> in Projekten mit 2D-Physik. Die Formen Hull und Mesh sind seit Defold 1.13.2 verfügbar und verwenden ein benanntes Mesh aus einer glTF- oder GLB-Szene. Du kannst der Komponente mehrere Formen hinzufügen. Über die Eigenschaft *Collision Shape* kannst du auch eine Kachelkarte (tile map) oder eine `.convexshape`-Ressource verwenden.
+3. Verwende die Werkzeuge zum Verschieben, Drehen und Skalieren, um die Formen zu bearbeiten.
+4. Wähle die Komponente in *Outline* aus und bearbeite die *Properties* des Kollisionsobjekts.
+
+![Physikalisches Kollisionsobjekt](images/physics/collision_object.png)
+
+
+## Eine Kollisionsform hinzufügen {#adding-a-collision-shape}
+
+Eine Kollisionskomponente kann mehrere eingebettete Formen enthalten, darunter Hüllen und Dreiecks-Meshes bei 3D-Physik, oder eine Kachelkarte beziehungsweise eine Ressource für eine konvexe Form verwenden. Mehr über die verschiedenen Formen und wie du sie einer Kollisionskomponente hinzufügst, erfährst du im [Handbuch zu Kollisionsformen](/manuals/physics-shapes).
+
+
+## Eigenschaften von Kollisionsobjekten {#collision-object-properties}
+
+Id
+: Die Kennung der Komponente.
+
+Collision Shape
+: Eine Kachelkarte oder eine `.convexshape`-Ressource. Um ein glTF- oder GLB-Mesh zu verwenden, füge der Komponente eine Form vom Typ Hull oder Mesh hinzu und lege stattdessen die Eigenschaften *Scene* und *Mesh* dieser Form fest. Weitere Informationen findest du unter [Kollisionsformen](/manuals/physics-shapes).
+
+Type
+: Der Typ des Kollisionsobjekts: `Dynamic`, `Kinematic`, `Static` oder `Trigger`. Wenn du das Objekt auf `Dynamic` setzt, _musst_ du die Eigenschaft *Mass* auf einen Wert ungleich null setzen. Bei Objekten vom Typ `Dynamic` oder `Static` solltest du außerdem prüfen, ob die Werte von *Friction* und *Restitution* für deinen Anwendungsfall geeignet sind.
+
+Friction
+: Reibung ermöglicht es Objekten, realistisch aneinander entlangzugleiten. Der Reibungswert liegt normalerweise zwischen `0` (keine Reibung---ein sehr rutschiges Objekt) und `1` (starke Reibung---ein raues Objekt). Es ist jedoch jeder positive Wert zulässig.
+
+  Die Stärke der Reibung ist proportional zur Normalkraft (dies wird als Coulomb-Reibung bezeichnet). Wenn die Reibungskraft zwischen zwei Formen (`A` und `B`) berechnet wird, werden die Reibungswerte beider Objekte über das geometrische Mittel kombiniert:
+
+```math
+F = sqrt( F_A * F_B )
+```
+
+  Wenn eines der Objekte keine Reibung hat, ist der Kontakt zwischen ihnen also ebenfalls reibungsfrei.
+
+Restitution
+: Der Rückprallkoeffizient legt fest, wie stark das Objekt abprallt. Der Wert liegt normalerweise zwischen 0 (unelastischer Stoß—das Objekt prallt überhaupt nicht ab) und 1 (vollkommen elastischer Stoß---die Geschwindigkeit des Objekts wird beim Abprallen exakt gespiegelt).
+
+  Die Rückprallkoeffizienten zweier Formen (`A` und `B`) werden mit folgender Formel kombiniert:
+
+```math
+R = max( R_A, R_B )
+```
+
+  Wenn eine Form mehrere Kontakte hat, wird der Rückprall nur näherungsweise simuliert, da Box2D einen iterativen Solver verwendet. Box2D verwendet bei geringer Kollisionsgeschwindigkeit außerdem unelastische Stöße, um Zittern durch wiederholtes Abprallen zu verhindern.
+
+Linear damping
+: Lineare Dämpfung verringert die lineare Geschwindigkeit des Körpers. Sie unterscheidet sich von Reibung, die nur bei Kontakt auftritt, und kann Objekten ein schwebendes Erscheinungsbild verleihen, als bewegten sie sich durch etwas Zähflüssigeres als Luft. Zulässige Werte liegen zwischen 0 und 1.
+
+  Box2D berechnet die Dämpfung aus Gründen der Stabilität und Leistung näherungsweise. Bei kleinen Werten ist die Dämpfungswirkung unabhängig vom Zeitschritt, während sie bei größeren Dämpfungswerten mit dem Zeitschritt variiert. Wenn dein Spiel mit einem festen Zeitschritt läuft, stellt dies kein Problem dar.
+
+Angular damping
+: Winkeldämpfung funktioniert wie lineare Dämpfung, verringert aber die Winkelgeschwindigkeit des Körpers. Zulässige Werte liegen zwischen 0 und 1.
+
+Locked rotation
+: Wenn du diese Eigenschaft aktivierst, wird die Drehung des Kollisionsobjekts vollständig unterbunden, unabhängig davon, welche Kräfte darauf wirken.
+
+Bullet
+: Wenn du diese Eigenschaft aktivierst, wird die kontinuierliche Kollisionserkennung (CCD) zwischen dem Kollisionsobjekt und anderen dynamischen Kollisionsobjekten eingeschaltet. Die Eigenschaft *Bullet* wird ignoriert, wenn *Type* nicht auf `Dynamic` gesetzt ist.
+
+Group
+: Der Name der Kollisionsgruppe, der das Objekt angehören soll. Du kannst 16 verschiedene Gruppen verwenden und sie so benennen, wie es für dein Spiel passt, zum Beispiel `players`, `bullets`, `enemies` und `world`. Wenn *Collision Shape* auf eine Kachelkarte gesetzt ist, wird dieses Feld nicht verwendet. Stattdessen werden die Gruppennamen aus der Kachelquelle übernommen. [Erfahre mehr über Kollisionsgruppen](/manuals/physics-groups).
+
+Mask
+: Die anderen _Gruppen_, mit denen dieses Objekt kollidieren soll. Du kannst eine Gruppe angeben oder mehrere Gruppen in einer durch Kommas getrennten Liste aufführen. Wenn du das Feld *Mask* leer lässt, kollidiert das Objekt mit nichts. [Erfahre mehr über Kollisionsgruppen](/manuals/physics-groups).
+
+Generate Collision Events
+: Wenn diese Eigenschaft aktiviert ist, kann das Objekt Kollisionsereignisse senden.
+
+Generate Contact Events
+: Wenn diese Eigenschaft aktiviert ist, kann das Objekt Kontaktereignisse senden.
+
+Generate Trigger Events
+: Wenn diese Eigenschaft aktiviert ist, kann das Objekt Trigger-Ereignisse senden.
+
+
+## Eigenschaften zur Laufzeit {#runtime-properties}
+
+Ein Physikobjekt hat verschiedene Eigenschaften, die mit `go.get()` und `go.set()` gelesen und geändert werden können:
+
+`angular_damping`
+: Der Wert der Winkeldämpfung der Kollisionsobjekt-Komponente (`number`). [API-Referenz](/ref/physics/#angular_damping).
+
+`angular_velocity`
+: Die aktuelle Winkelgeschwindigkeit der Kollisionsobjekt-Komponente (`vector3`). [API-Referenz](/ref/physics/#angular_velocity).
+
+`linear_damping`
+: Der Wert der linearen Dämpfung des Kollisionsobjekts (`number`). [API-Referenz](/ref/physics/#linear_damping).
+
+`linear_velocity`
+: Die aktuelle lineare Geschwindigkeit der Kollisionsobjekt-Komponente (`vector3`). [API-Referenz](/ref/physics/#linear_velocity).
+
+`mass`
+: Die festgelegte physikalische Masse der Kollisionsobjekt-Komponente. NUR LESBAR. (`number`). [API-Referenz](/ref/physics/#mass).

--- a/docs/de/manuals/physics-ray-casts.md
+++ b/docs/de/manuals/physics-ray-casts.md
@@ -1,0 +1,29 @@
+---
+title: Strahlabfragen in Defold
+brief: Strahlabfragen werden verwendet, um die Physikwelt entlang eines geraden Strahls auszulesen. Dieses Handbuch erklärt, wie das funktioniert.
+---
+
+## Strahlabfragen {#ray-casts}
+
+Mit Strahlabfragen (raycast) liest du die Physikwelt (physics world) entlang eines geraden Strahls aus. Um einen Strahl in die Physikwelt zu senden, gibst du eine Start- und eine Endposition sowie [eine Menge von Kollisionsgruppen (collision groups)](/manuals/physics-groups) an, gegen die geprüft werden soll.
+
+Trifft der Strahl ein Physikobjekt, erhältst du Informationen über das getroffene Objekt. Strahlen können dynamische, kinematische und statische Kollisionsobjekte (collision objects) schneiden. Sie interagieren nicht mit Triggern.
+
+```lua
+function update(self, dt)
+  -- request ray cast
+  local my_start = vmath.vector3(0, 0, 0)
+  local my_end = vmath.vector3(100, 1000, 1000)
+  local my_groups = { hash("my_group1"), hash("my_group2") }
+
+  local result = physics.raycast(my_start, my_end, my_groups)
+  if result then
+      -- act on the hit (see 'ray_cast_response' message for all values)
+      print(result.id)
+  end
+end
+```
+
+::: sidenote
+Strahlabfragen ignorieren Kollisionsobjekte, die den Startpunkt des Strahls enthalten. Dies ist eine Einschränkung von Box2D.
+:::

--- a/docs/de/manuals/physics-resolving-collisions.md
+++ b/docs/de/manuals/physics-resolving-collisions.md
@@ -1,0 +1,89 @@
+---
+title: Kinematische Kollisionen in Defold auflösen
+brief: Dieses Handbuch erklärt, wie du kinematische Kollisionen in der Physiksimulation auflöst.
+---
+
+# Kinematische Kollisionen auflösen {#resolving-kinematic-collisions}
+
+Wenn du kinematische Kollisionsobjekte (kinematic collision objects) verwendest, musst du Kollisionen selbst auflösen und die Objekte als Reaktion darauf bewegen. Eine naive Implementierung zum Trennen zweier kollidierender Objekte sieht so aus:
+
+```lua
+function on_message(self, message_id, message, sender)
+  -- Handle collision
+  if message_id == hash("contact_point_response") then
+    local newpos = go.get_position() + message.normal * message.distance
+    go.set_position(newpos)
+  end
+end
+```
+
+Dieser Code trennt dein kinematisches Kollisionsobjekt von anderen Physikobjekten, in die es eingedrungen ist. Die Verschiebung geht jedoch oft zu weit, sodass du in vielen Fällen ein Zittern siehst. Um das Problem besser zu verstehen, betrachte den folgenden Fall, in dem eine Spielfigur mit zwei Objekten, *A* und *B*, kollidiert ist:
+
+![Physikalische Kollision](images/physics/collision_multi.png)
+
+Die Physik-Engine sendet in dem Frame, in dem die Kollision auftritt, mehrere `"contact_point_response"`-Nachrichten: eine für Objekt *A* und eine für Objekt *B*. Wenn du die Figur als Reaktion auf jedes Eindringen bewegst, wie im naiven Code oben, ergibt sich folgende Trennung:
+
+- Bewege die Figur entsprechend ihrer Eindringtiefe aus Objekt *A* heraus (der schwarze Pfeil)
+- Bewege die Figur entsprechend ihrer Eindringtiefe aus Objekt *B* heraus (der schwarze Pfeil)
+
+Die Reihenfolge ist beliebig, aber das Ergebnis ist in beiden Fällen gleich: eine Gesamtverschiebung, die der *Summe der einzelnen Eindringvektoren* entspricht:
+
+![Naive Trennung bei einer Kollision](images/physics/separation_naive.png)
+
+Um die Figur korrekt von den Objekten *A* und *B* zu trennen, musst du die Eindringtiefe jedes Kontaktpunkts verarbeiten und prüfen, ob vorherige Verschiebungen die Trennung bereits vollständig oder teilweise bewirkt haben.
+
+Angenommen, die erste Kontaktpunktnachricht kommt von Objekt *A* und du bewegst die Figur um den Eindringvektor von *A* heraus:
+
+![Trennung bei einer Kollision, Schritt 1](images/physics/separation_step1.png)
+
+Dann ist die Figur bereits teilweise von *B* getrennt. Der schwarze Pfeil oben zeigt den noch nötigen Ausgleich für eine vollständige Trennung von Objekt *B*. Die Länge des Ausgleichsvektors lässt sich berechnen, indem du den Eindringvektor von *A* auf den Eindringvektor von *B* projizierst:
+
+![Projektion](images/physics/projection.png)
+
+```
+l = vmath.project(A, B) * vmath.length(B)
+```
+
+Den Ausgleichsvektor erhältst du, indem du die Länge von *B* um *l* verringerst. Um dies für eine beliebige Anzahl von Eindringungen zu berechnen, kannst du die nötige Korrektur in einem Vektor aufsummieren. Beginne mit einem Korrekturvektor der Länge null und führe für jeden Kontaktpunkt folgende Schritte aus:
+
+1. Projiziere die aktuelle Korrektur auf den Eindringvektor des Kontakts.
+2. Berechne, welcher Ausgleich des Eindringvektors noch nötig ist (gemäß der obigen Formel).
+3. Bewege das Objekt um den Ausgleichsvektor.
+4. Addiere den Ausgleich zur aufsummierten Korrektur.
+
+Eine vollständige Implementierung sieht so aus:
+
+```lua
+function init(self)
+  -- correction vector
+  self.correction = vmath.vector3()
+end
+
+function update(self, dt)
+  -- reset correction
+  self.correction = vmath.vector3()
+end
+
+function on_message(self, message_id, message, sender)
+  -- Handle collision
+  if message_id == hash("contact_point_response") then
+    -- Get the info needed to move out of collision. We might
+    -- get several contact points back and have to calculate
+    -- how to move out of all of them by accumulating a
+    -- correction vector for this frame:
+    if message.distance > 0 then
+      -- First, project the accumulated correction onto
+      -- the penetration vector
+      local proj = vmath.project(self.correction, message.normal * message.distance)
+      if proj < 1 then
+        -- Only care for projections that does not overshoot.
+        local comp = (message.distance - message.distance * proj) * message.normal
+        -- Apply compensation
+        go.set_position(go.get_position() + comp)
+        -- Accumulate correction done
+        self.correction = self.correction + comp
+      end
+    end
+  end
+end
+```

--- a/docs/de/manuals/physics-shapes.md
+++ b/docs/de/manuals/physics-shapes.md
@@ -1,0 +1,160 @@
+---
+title: Kollisionsformen
+brief: Kollisionsobjekte können primitive Formen, Hüllen oder Dreiecksmeshes enthalten oder Ressourcen für Kachelkarten und konvexe Formen verwenden.
+---
+
+# Kollisionsformen {#collision-shapes}
+
+Ein Kollisionsobjekt (collision object) kann mehrere eingebettete Kollisionsformen (collision shapes) enthalten. In der 3D-Physik können dazu auch Hüllen und Dreiecksmeshes aus glTF- oder GLB-Dateien gehören. Du kannst auch eine Kachelkarte (tile map) oder eine Ressource für eine konvexe Form über die Eigenschaft *Collision Shape* des Kollisionsobjekts verwenden.
+
+### Primitive Formen {#primitive-shapes}
+Die primitiven Formen sind *Quader*, *Kugel* und *Kapsel*. Du fügst eine primitive Form hinzu, indem du mit der <kbd>rechten Maustaste</kbd> auf das Kollisionsobjekt klickst und <kbd>Add Shape</kbd> auswählst:
+
+![Eine primitive Form hinzufügen](images/physics/add_shape.png)
+
+## Quaderform {#box-shape}
+Ein Quader hat eine Position, eine Drehung und Abmessungen (Breite, Höhe und Tiefe):
+
+![Quaderform](images/physics/box.png)
+
+## Kugelform {#sphere-shape}
+Eine Kugel hat eine Position, eine Drehung und einen Durchmesser:
+
+![Kugelform](images/physics/sphere.png)
+
+## Kapselform {#capsule-shape}
+Eine Kapsel hat eine Position, eine Drehung, einen Durchmesser und eine Höhe:
+
+![Kugelform](images/physics/capsule.png)
+
+::: important
+Kapselformen werden nur bei Verwendung der 3D-Physik unterstützt (konfiguriert im Bereich Physics der Datei *game.project*).
+:::
+
+### Komplexe Formen {#complex-shapes}
+Komplexe Formen können die Geometrie einer Kachelkarte oder Daten einer konvexen Hülle (convex hull) verwenden. Seit Defold 1.13.2 können 3D-Kollisionsobjekte auch Hüllen und Dreiecksmesh-Formen aus Meshes in glTF- oder GLB-Szenen erstellen.
+
+## Hüllen- und Mesh-Formen in 3D {#hull-and-mesh-shapes-in-3d}
+
+Verwende eine Form vom Typ *Hull* für eine konvexe Annäherung an ein Mesh oder eine Form vom Typ *Mesh*, wenn Kollisionen dessen Dreiecken folgen müssen, einschließlich konkaver Bereiche wie Öffnungen in der Levelgeometrie.
+
+1. Setze **Physics → Type** in *game.project* auf `3D`.
+2. Klicke in der Ansicht *Outline* mit der rechten Maustaste auf das Kollisionsobjekt und wähle <kbd>Add Shape ▸ Hull</kbd> oder <kbd>Add Shape ▸ Mesh</kbd>.
+3. Wähle die neue Form aus und setze ihre Eigenschaft *Scene* auf eine *.gltf*- oder *.glb*-Datei.
+4. Wähle im Feld *Mesh* ein benanntes Mesh aus. Falls es in der Liste fehlt, benenne das Mesh in deinem Modellierungswerkzeug und exportiere die Szene erneut.
+5. Positioniere und drehe die Form, um sie an der sichtbaren Geometrie des Spielobjekts (game object) auszurichten. Wiederhole diese Schritte bei Bedarf, um weitere Formen hinzuzufügen.
+
+Das ausgewählte Mesh liefert seine lokale Geometrie; Transformationen von glTF-Knoten werden nicht angewendet. Mesh-Kollisionsformen werden vom Bullet-3D-Backend unterstützt, auch für statische und nicht statische Kollisionsobjekte. Von den 2D-Physik-Backends werden sie nicht unterstützt.
+
+Auf die Geometrie eines Dreiecksmeshes kann über die Laufzeit-APIs für Formen nur lesend zugegriffen werden. Bearbeite das Quellmesh und erstelle einen neuen Build, um seine Dreiecke zu ändern. Informationen zur Skalierung des Spielobjekts findest du unter [Kollisionsformen skalieren](#scaling-collision-shapes).
+
+## Kollisionsform einer Kachelkarte {#tilemap-collision-shape}
+Defold enthält eine Funktion, mit der du ganz einfach Physikformen für die Kachelquelle (tile source) einer Kachelkarte erzeugen kannst. Das [Handbuch zu Kachelquellen](/manuals/tilesource/#tile-source-collision-shapes) erklärt, wie du einer Kachelquelle Kollisionsgruppen hinzufügst und Kacheln den Kollisionsgruppen zuweist ([Beispiel](/examples/tilemap/collisions/)).
+
+So fügst du einer Kachelkarte Kollisionen hinzu:
+
+1. Füge die Kachelkarte einem Spielobjekt hinzu, indem du mit der <kbd>rechten Maustaste</kbd> auf das Spielobjekt klickst und <kbd>Add Component File</kbd> auswählst. Wähle die Kachelkartendatei aus.
+2. Füge dem Spielobjekt eine Komponente (component) vom Typ Kollisionsobjekt hinzu, indem du mit der <kbd>rechten Maustaste</kbd> auf das Spielobjekt klickst und <kbd>Add Component ▸ Collision Object</kbd> auswählst.
+3. Statt der Komponente Formen hinzuzufügen, setze die Eigenschaft *Collision Shape* auf die *tilemap*-Datei.
+4. Richte die *Properties* der Kollisionsobjekt-Komponente wie gewohnt ein.
+
+![Kollision einer Kachelquelle](images/physics/collision_tilemap.png)
+
+::: important
+Beachte, dass die Eigenschaft *Group* hier **nicht** verwendet wird, da die Kollisionsgruppen in der Kachelquelle der Kachelkarte definiert sind.
+:::
+
+## Form einer konvexen Hülle {#convex-hull-shape}
+In der 3D-Physik kannst du eine Hülle direkt aus einem Mesh erstellen, indem du den [oben beschriebenen Arbeitsablauf im Editor](#hull-and-mesh-shapes-in-3d) verwendest. Die ältere Ressource `.convexshape` wird ebenfalls unterstützt und kann mit einem externen Editor aus Punkten erstellt werden:
+
+1. Erstelle mit einem externen Editor eine Datei für eine konvexe Hüllform (Dateierweiterung `.convexshape`).
+2. Bearbeite die Datei manuell mit einem Texteditor oder einem externen Werkzeug (siehe unten)
+3. Statt der Kollisionsobjekt-Komponente Formen hinzuzufügen, setze die Eigenschaft *Collision Shape* auf die Datei der *konvexen Form*.
+
+### Dateiformat {#file-format}
+Das Dateiformat für konvexe Hüllen verwendet dasselbe Datenformat wie alle anderen Defold-Dateien, nämlich das Protobuf-Textformat. Eine konvexe Hüllform definiert die Punkte der Hülle. In der 2D-Physik sollten die Punkte gegen den Uhrzeigersinn angegeben werden. Im 3D-Physikmodus wird eine abstrakte Punktwolke verwendet. 2D-Beispiel:
+
+```
+shape_type: TYPE_HULL
+data: 200.000
+data: 100.000
+data: 0.0
+data: 400.000
+data: 100.000
+data: 0.0
+data: 400.000
+data: 300.000
+data: 0.0
+data: 200.000
+data: 300.000
+data: 0.0
+```
+
+Das obige Beispiel definiert die vier Ecken eines Rechtecks:
+
+```
+ 200x300   400x300
+    4---------3
+    |         |
+    |         |
+    |         |
+    |         |
+    1---------2
+ 200x100   400x100
+```
+
+## Externe Werkzeuge {#external-tools}
+
+Es gibt verschiedene externe Werkzeuge, mit denen sich Kollisionsformen erstellen lassen:
+
+* Mit dem [Physics Editor](https://www.codeandweb.com/physicseditor/tutorials/how-to-create-physics-shapes-for-defold) von CodeAndWeb kannst du Spielobjekte mit Sprites und passenden Kollisionsformen erstellen.
+* Mit dem [Defold Polygon Editor](https://rossgrams.itch.io/defold-polygon-editor) kannst du konvexe Hüllformen erstellen.
+* Mit dem [Physics Body Editor](https://selimanac.github.io/physics-body-editor/) kannst du konvexe Hüllformen erstellen.
+
+
+# Kollisionsformen skalieren {#scaling-collision-shapes}
+Das Kollisionsobjekt und seine Formen erben die Skalierung des Spielobjekts. Um dieses Verhalten zu deaktivieren, entferne das Häkchen im Kontrollkästchen [Allow Dynamic Transforms](/manuals/project-settings/#allow-dynamic-transforms) im Bereich Physics von *game.project*. Beachte, dass nur eine gleichmäßige Skalierung unterstützt wird und der kleinste Skalierungswert verwendet wird, wenn die Skalierung nicht gleichmäßig ist.
+
+# Die Größe von Kollisionsformen ändern {#resizing-collision-shapes}
+Die Größe primitiver Formen kann zur Laufzeit mit `physics.set_shape()` geändert werden. Diese Funktion ersetzt weder die Vertices einer Hülle noch die Geometrie eines Dreiecksmeshes. Beispiel:
+
+```lua
+-- set capsule shape data
+local capsule_data = {
+  type = physics.SHAPE_TYPE_CAPSULE,
+  diameter = 10,
+  height = 20,
+}
+physics.set_shape("#collisionobject", "my_capsule_shape", capsule_data)
+
+-- set sphere shape data
+local sphere_data = {
+  type = physics.SHAPE_TYPE_SPHERE,
+  diameter = 10,
+}
+physics.set_shape("#collisionobject", "my_sphere_shape", sphere_data)
+
+-- set box shape data
+local box_data = {
+  type = physics.SHAPE_TYPE_BOX,
+  dimensions = vmath.vector3(10, 10, 5),
+}
+physics.set_shape("#collisionobject", "my_box_shape", box_data)
+```
+
+::: sidenote
+Auf dem Kollisionsobjekt muss bereits eine Form des richtigen Typs mit dem angegebenen Bezeichner vorhanden sein.
+:::
+
+# Kollisionsformen drehen {#rotating-collision-shapes}
+
+## Kollisionsformen in der 3D-Physik drehen {#rotating-collision-shapes-in-3d-physics}
+Kollisionsformen in der 3D-Physik können um alle Achsen gedreht werden.
+
+
+## Kollisionsformen in der 2D-Physik drehen {#rotating-collision-shapes-in-2d-physics}
+Kollisionsformen in der 2D-Physik können nur um die z-Achse gedreht werden. Eine Drehung um die x- oder y-Achse führt zu falschen Ergebnissen und sollte vermieden werden, auch wenn die Drehung um 180 Grad die Form im Wesentlichen entlang der x- oder y-Achse spiegelt. Um eine Physikform zu spiegeln, wird empfohlen, [`physics.set_hlip(url, flip)`](/ref/stable/physics/?#physics.set_hflip:url-flip) und [`physics.set_vlip(url, flip)`](/ref/stable/physics/?#physics.set_vflip:url-flip) zu verwenden.
+
+
+# Fehlersuche {#debugging}
+Du kannst das [Physik-Debugging aktivieren](/manuals/debugging-game-logic/#debugging-problems-with-physics), um die Kollisionsformen zur Laufzeit zu sehen.

--- a/docs/de/manuals/physics.md
+++ b/docs/de/manuals/physics.md
@@ -1,0 +1,42 @@
+---
+title: Physik in Defold
+brief: Defold enthält Physik-Engines für 2D und 3D. Damit kannst du Wechselwirkungen nach den Gesetzen der Newtonschen Physik zwischen verschiedenen Arten von Kollisionsobjekten simulieren.
+---
+
+# Physik {#physics}
+
+Defold enthält [Box2D](https://box2d.org/) für 2D-Physiksimulationen und Bullet für 3D-Physik. Über die [Einstellung Physics 2D im App Manifest](/manuals/app-manifest/#physics-2d) wählst du **Box2D Version 3**, **Box2D (Legacy Defold version)** oder **None** aus. Die bisherige Implementierung ist der Standard; Box2D 3 musst du ausdrücklich auswählen. Ein Wechsel der Implementierung kann die Simulationsergebnisse verändern und erfordern, dass du die versionsspezifischen [Box2D-Projekteinstellungen](/manuals/project-settings/#box2d) neu abstimmst.
+
+Der komponentenorientierte Arbeitsablauf mit Kollisionsobjekten (collision objects) und das Modul `physics`, die in diesen Handbüchern beschrieben werden, funktionieren mit beiden Box2D-Implementierungen; die Auswahl von **None** entfernt die 2D-Physik. Defold stellt außerdem die APIs [`b2d`](/ref/stable/b2d/), `b2d.body`, `b2d.fixture`, `b2d.shape`, `b2d.joint`, `b2d.chain` und `b2d.world` auf niedrigerer Ebene für den direkten Zugriff auf 2D-Körper, Formen, Gelenke, Ketten und Welten bereit. Nicht jede Funktion auf niedrigerer Ebene ist in beiden Box2D-Implementierungen verfügbar; prüfe in der generierten API-Dokumentation jeder Funktion, ob sie von der im App Manifest ausgewählten Implementierung unterstützt wird.
+
+Die wichtigsten Konzepte der in Defold verwendeten Physik-Engines sind:
+
+* **Kollisionsobjekte** - Ein Kollisionsobjekt ist eine Komponente (component), mit der du einem Spielobjekt (game object) physikalisches Verhalten gibst. Ein Kollisionsobjekt hat physikalische Eigenschaften wie Gewicht, Reibung und Form. [Erfahre, wie du ein Kollisionsobjekt erstellst](/manuals/physics-objects).
+* **Kollisionsformen** - Ein Kollisionsobjekt kann entweder mehrere Grundformen oder eine einzelne komplexe Form verwenden, um seine räumliche Ausdehnung zu definieren. [Erfahre, wie du einem Kollisionsobjekt Formen hinzufügst](/manuals/physics-shapes).
+* **Kollisionsgruppen** - Alle Kollisionsobjekte müssen einer vordefinierten Gruppe angehören, und jedes Kollisionsobjekt kann eine Liste anderer Gruppen angeben, mit denen es kollidieren kann. [Erfahre, wie du Kollisionsgruppen verwendest](/manuals/physics-groups).
+* **Kollisionsnachrichten** - Wenn zwei Kollisionsobjekte kollidieren, sendet die Physik-Engine Nachrichten an die Spielobjekte, zu denen die Komponenten gehören. [Erfahre mehr über Kollisionsnachrichten](/manuals/physics-messages)
+
+Zusätzlich zu den Kollisionsobjekten selbst kannst du auch **Zwangsbedingungen** für Kollisionsobjekte definieren, die meist als **Gelenke** bezeichnet werden. Damit verbindest du zwei Kollisionsobjekte und beschränkst ihre Bewegung oder übst auf andere Weise Kräfte aus, um ihr Verhalten in der Physiksimulation zu beeinflussen. [Erfahre mehr über Gelenke](/manuals/physics-joints).
+
+Du kannst die Physikwelt außerdem entlang eines geraden Strahls untersuchen und auslesen. Das wird als **Strahlabfrage (raycast)** bezeichnet. [Erfahre mehr über Strahlabfragen](/manuals/physics-ray-casts).
+
+
+## Einheiten der Physiksimulation {#units-used-by-the-physics-engine-simulation}
+
+Die Physik-Engine simuliert Newtonsche Physik und ist darauf ausgelegt, mit den Einheiten Meter, Kilogramm und Sekunde (MKS) gut zu funktionieren. Außerdem ist die Physik-Engine auf bewegliche Objekte mit einer Größe im Bereich von 0,1 bis 10 Metern abgestimmt (statische Objekte können größer sein), und standardmäßig behandelt die Engine 1 Einheit (Pixel) als 1 Meter. Diese Umrechnung zwischen Pixeln und Metern ist auf Simulationsebene praktisch, aus Sicht der Spieleentwicklung aber nicht sehr nützlich. Mit den Standardeinstellungen würde eine Kollisionsform mit einer Größe von 200 Pixeln als 200 Meter groß behandelt. Das liegt weit außerhalb des empfohlenen Bereichs, zumindest für ein bewegliches Objekt.
+
+Im Allgemeinen muss die Physiksimulation skaliert werden, damit sie mit der typischen Größe der Objekte in einem Spiel gut funktioniert. Der Skalierungsfaktor der Physiksimulation lässt sich in *game.project* über die [Einstellung für die Physikskalierung](/manuals/project-settings/#physics) ändern. Wenn du diesen Wert beispielsweise auf 0.02 setzt, werden 200 Pixel als 4 Meter behandelt. Beachte, dass die Schwerkraft (die ebenfalls in *game.project* geändert wird) erhöht werden muss, um die veränderte Skalierung auszugleichen.
+
+
+## Physikaktualisierungen {#physics-updates}
+
+Es wird empfohlen, die Physik-Engine in regelmäßigen Abständen zu aktualisieren, um eine stabile Simulation sicherzustellen (im Gegensatz zu Aktualisierungen in möglicherweise unregelmäßigen, von der Bildrate abhängigen Abständen). Du kannst die Physik mit einem festen Zeitschritt aktualisieren, indem du die [Einstellung Use Fixed Timestep](/manuals/project-settings/#physics) im Abschnitt Physics der Datei *game.project* aktivierst. Die Aktualisierungsfrequenz wird durch die [Einstellung Fixed Update Frequency](/manuals/project-settings/#engine) im Abschnitt Engine der Datei *game.project* gesteuert. Wenn du für die Physik einen festen Zeitschritt verwendest, wird außerdem empfohlen, über die Lebenszyklusfunktion `fixed_update(self, dt)` mit den Kollisionsobjekten deines Spiels zu interagieren, beispielsweise wenn du Kräfte auf sie ausübst.
+
+
+## Einschränkungen und häufige Probleme {#caveats-and-common-issues}
+
+Sammlungs-Proxys
+: Über Sammlungs-Proxys (collection proxies) kannst du mehr als eine Sammlung (collection) auf oberster Ebene, also eine *Spielwelt*, in die Engine laden. Dabei ist es wichtig zu wissen, dass jede Sammlung auf oberster Ebene eine eigene Physikwelt ist. Physikalische Wechselwirkungen ([Kollisionen, Trigger](/manuals/physics-messages) und [Strahlabfragen](/manuals/physics-ray-casts)) finden nur zwischen Objekten statt, die derselben Welt angehören. Selbst wenn die Kollisionsobjekte zweier Welten optisch genau übereinanderliegen, kann daher keine physikalische Wechselwirkung zwischen ihnen stattfinden.
+
+Kollisionen werden nicht erkannt
+: Wenn Kollisionen nicht korrekt behandelt oder erkannt werden, lies den Abschnitt zum [Debugging der Physik im Handbuch zur Fehlersuche](/manuals/debugging-game-logic/#debugging-problems-with-physics).

--- a/docs/de/manuals/porting-guidelines.md
+++ b/docs/de/manuals/porting-guidelines.md
@@ -1,0 +1,122 @@
+---
+title: Richtlinien für Portierung und Veröffentlichung
+brief: Dieses Handbuch beschreibt einige Aspekte, die du bei der Portierung eines Spiels auf eine neue Plattform oder bei der ersten Veröffentlichung deines Spiels berücksichtigen solltest.
+---
+
+# Richtlinien für Portierung und Veröffentlichung {#porting-and-release-guidelines}
+
+Diese Seite enthält einen hilfreichen Leitfaden und eine Checkliste mit Aspekten, die du bei der Veröffentlichung eines Spiels oder bei der Portierung auf eine neue Plattform berücksichtigen solltest.
+
+Ein Defold-Spiel auf eine neue Plattform zu portieren oder erstmals zu veröffentlichen, ist normalerweise ein unkomplizierter Vorgang. Theoretisch reicht es aus, die entsprechenden Abschnitte in der Datei *game.project* zu konfigurieren. Um jede Plattform bestmöglich zu nutzen, empfiehlt es sich jedoch, das Spiel an ihre jeweiligen Besonderheiten anzupassen.
+
+
+## Eingabe {#input}
+Passe das Spiel an die Eingabemethoden der Plattform an. Ziehe in Betracht, Unterstützung für [Gamepads](/manuals/input-gamepads) hinzuzufügen, sofern die Plattform sie unterstützt! Stelle außerdem sicher, dass das Spiel ein Pausenmenü bietet - wenn sich die Verbindung zu einem Controller plötzlich trennt, sollte das Spiel pausiert werden!
+
+## Lokalisierung {#localization}
+Übersetze sämtliche Texte im Spiel. Für eine Veröffentlichung in Europa sowie Nord- und Südamerika solltest du eine Übersetzung zumindest in die EFIGS-Sprachen (Englisch, Französisch, Italienisch, Deutsch und Spanisch) in Betracht ziehen. Stelle sicher, dass du im Spiel (über das Pausenmenü) leicht zwischen verschiedenen Sprachen wechseln kannst.
+
+::: important
+Nur iOS - Stelle sicher, dass du [Localizations](/manuals/project-settings/#localizations) in `game.project` angibst, da `sys.get_info()` niemals eine Sprache zurückgibt, die nicht in dieser Liste enthalten ist.
+:::
+
+Übersetze den Text auf der Store-Seite, denn das wirkt sich positiv auf die Verkaufszahlen aus! Einige Plattformen verlangen, dass der Text auf der Store-Seite in die Sprache jedes Landes übersetzt wird, in dem das Spiel verfügbar ist.
+
+## Materialien für den Store {#store-materials}
+
+### App-Symbol {#app-icon}
+Sorge dafür, dass sich dein Spiel von der Konkurrenz abhebt. Das Symbol ist oft dein erster Kontaktpunkt mit potenziellen Spielern. Es sollte auf einer Seite voller Spielsymbole leicht zu finden sein.
+
+### Banner und Bilder für den Store {#store-banners-and-images}
+Verwende eindrucksvolle und spannende Grafiken für dein Spiel. Es lohnt sich wahrscheinlich, etwas Geld in die Zusammenarbeit mit einem Grafiker zu investieren, um Grafiken zu erstellen, die Spieler ansprechen.
+
+
+## Spielstände {#save-games}
+
+### Spielstände auf Desktop- und Mobilgeräten sowie im Web {#save-games-on-desktop-mobile-and-web}
+Spielstände und andere gespeicherte Zustandsdaten können mit der Defold-API-Funktion `sys.save(filename, data)` gespeichert und mit `sys.load(filename)` geladen werden. Mit `sys.get_save_file(application_id, name)` kannst du einen Pfad zu einem betriebssystemspezifischen Speicherort für Dateien ermitteln, der sich üblicherweise im Benutzerordner des angemeldeten Benutzers befindet.
+
+### Spielstände auf Konsolen {#save-games-on-console}
+Die Verwendung von `sys.get_save_file()` und `sys.save()` funktioniert auf den meisten Plattformen gut, für Konsolen wird jedoch ein anderer Ansatz empfohlen. Konsolenplattformen ordnen üblicherweise jedem verbundenen Controller einen Benutzer zu. Entsprechend sollten Spielstände, Erfolge und andere Funktionen dem jeweiligen Benutzer zugeordnet werden.
+
+Die Gamepad-Eingabeereignisse enthalten eine Benutzer-ID, mit der die Aktionen eines Controllers einem Benutzer auf der Konsole zugeordnet werden können.
+
+Die Konsolenplattformen und ihre nativen Erweiterungen stellen plattformspezifische API-Funktionen bereit, um Daten für einen bestimmten Benutzer zu speichern und zu laden. Verwende diese APIs beim Speichern und Laden auf Konsolen.
+
+APIs von Konsolenplattformen für Dateivorgänge sind üblicherweise asynchron. Wenn du ein plattformübergreifendes Spiel entwickelst, das auch für Konsolen vorgesehen ist, empfiehlt es sich, das Spiel so zu gestalten, dass alle Dateivorgänge unabhängig von der Plattform asynchron sind. Beispiel:
+
+```lua
+local function save_game(data, user_id, cb)
+	if console then
+		local filename = "savegame"
+		consoleapi.save(user_id, filename, data, cb)
+	else
+		local filename = sys.get_save_file("mygame", "savegame" .. user_id)
+		local success = sys.save(filename, data)
+		cb(success)
+	end
+end
+```
+
+
+## Build-Artefakte {#build-artifacts}
+
+Stelle sicher, dass du für jede veröffentlichte Version [Debugsymbole erzeugst](/manuals/debugging-native-code/#symbolicate-a-callstack), damit du Abstürze debuggen kannst. Bewahre diese zusammen mit dem Anwendungs-Bundle auf.
+
+## Optimierung der Anwendung {#application-optimizations}
+
+Im [Handbuch zur Optimierung](/manuals/optimization) erfährst du, wie du deine Anwendung hinsichtlich Leistung, Größe, Speicherverbrauch und Akkuverbrauch optimieren kannst.
+
+
+
+## Leistung {#performance}
+Teste immer auf der Zielhardware! Prüfe die Leistung des Spiels und optimiere sie bei Bedarf. Verwende den [Profiler](/manuals/profiling), um Engpässe im Code zu finden.
+
+
+## Bildschirmauflösung und Bildwiederholfrequenz {#screen-resolution-and-refresh-rate}
+Für Plattformen mit fester Ausrichtung und Bildschirmauflösung: Prüfe, ob das Spiel mit der Bildschirmauflösung und dem Seitenverhältnis der Zielplattform funktioniert. Für Plattformen mit variabler Bildschirmauflösung und variablem Seitenverhältnis: Prüfe, ob das Spiel mit verschiedenen Bildschirmauflösungen und Seitenverhältnissen funktioniert. Berücksichtige dabei, welche Art von [Ansichtsprojektion](/manuals/render/#default-view-projection) im Render-Skript und in der Kamera verwendet wird.
+
+Lege für mobile Plattformen entweder die Bildschirmausrichtung in *game.project* fest oder stelle sicher, dass das Spiel sowohl im Quer- als auch im Hochformat funktioniert.
+
+* **Bildschirmgrößen** - Sieht alles auf einem Bildschirm gut aus, der größer oder kleiner ist als durch die Standardbreite und -höhe in *game.project* vorgegeben?
+  * Dabei spielen die im Render-Skript verwendete Projektion und die in der GUI verwendeten Layouts eine Rolle.
+* **Seitenverhältnisse** - Sieht alles auf einem Bildschirm gut aus, dessen Seitenverhältnis vom Standardseitenverhältnis abweicht, das sich aus der Breite und Höhe in *game.project* ergibt?
+  * Dabei spielen die im Render-Skript verwendete Projektion und die in der GUI verwendeten Layouts eine Rolle.
+* **Bildwiederholfrequenz** - Läuft das Spiel gut auf einem Bildschirm mit einer höheren Bildwiederholfrequenz als 60 Hz?
+  * Die Einstellungen vsync und swap interval im Abschnitt Display von *game.project* 
+
+
+## Mobiltelefone mit Notch oder Hole-Punch-Kamera {#mobile-phones-and-notch-and-hole-punch-cameras}
+Es ist immer üblicher geworden, eine kleine Aussparung im Bildschirm für die Frontkamera und Sensoren zu verwenden (auch als Notch oder Hole-Punch-Kamera bekannt). Achte bei der Portierung eines Spiels auf Mobilgeräte darauf, dass wichtige Informationen innerhalb des sicheren Bereichs (safe area) der Plattform bleiben.
+
+Defold unterstützt den sicheren Bereich auf Android und iOS von Haus aus. Lege `gui.safe_area_mode` in *game.project* fest, um zu steuern, welche gegenüberliegenden Randabstände des sicheren Bereichs die GUI-Anpassung beeinflussen. `none` ist der Standardwert und ignoriert die Randabstände; `long` wendet im Querformat die linken/rechten und im Hochformat die oberen/unteren Randabstände an; `short` wendet das jeweils andere Paar an; und `both` berücksichtigt alle vier Ränder. Ein GUI-Skript kann den projektweiten Modus für seine Szene mit [`gui.set_safe_area_mode()`](/ref/gui/#gui.set_safe_area_mode) überschreiben. Für eigene GUI- oder Rendering-Logik gibt [`window.get_safe_area()`](/ref/window/#window.get_safe_area) das sichere Rechteck und die einzelnen Randabstände zurück. Plattformen ohne integrierte Randabstände für den sicheren Bereich geben das gesamte Fenster und Randabstände von null zurück.
+
+Die [Safe Area-Erweiterung](/extension-safearea) bleibt eine Alternative für ältere Projekte oder Arbeitsabläufe, die ein Verhalten benötigen, das über die integrierten APIs hinausgeht; für die normale Behandlung des sicheren Bereichs auf Android und iOS ist sie nicht erforderlich.
+
+
+## Plattformspezifische Richtlinien {#platform-specific-guidelines}
+
+### Android
+Bewahre deinen [Schlüsselspeicher](/manuals/android/#creating-a-keystore) an einem sicheren Ort auf, damit du dein Spiel aktualisieren kannst.
+
+
+### Konsolen {#consoles}
+Bewahre das vollständige Bundle jeder Version auf. Du benötigst diese Dateien, wenn du einen Patch für das Spiel erstellen möchtest.
+
+
+### Nintendo Switch
+Integriere plattformspezifischen Code - Für Nintendo Switch gibt es eine separate Erweiterung mit einigen Hilfsfunktionen, beispielsweise für die Benutzerauswahl.
+
+Defold für Nintendo Switch verwendet Vulkan als Grafik-Backend - Teste das Spiel unbedingt mit dem [Vulkan-Grafik-Backend](https://github.com/defold/extension-vulkan).
+
+
+### PlayStation®4
+Integriere plattformspezifischen Code - Für PlayStation®4 gibt es eine separate Erweiterung mit einigen Hilfsfunktionen, beispielsweise für die Benutzerauswahl.
+
+
+### HTML5
+Webspiele auf Mobiltelefonen werden immer beliebter - Versuche, das Spiel auch in einem mobilen Browser gut zum Laufen zu bringen! Bedenke außerdem, dass von Webspielen schnelle Ladezeiten erwartet werden! - Optimiere daher unbedingt die Größe des Spiels. Berücksichtige auch das Ladeerlebnis insgesamt, um nicht unnötig Spieler zu verlieren.
+
+Im Jahr 2018 führten Browser eine Richtlinie für die automatische Tonwiedergabe ein, die Spiele und andere Webinhalte daran hindert, Töne abzuspielen, bevor eine Benutzerinteraktion (Berührung, Schaltfläche, Gamepad usw.) stattgefunden hat. Berücksichtige dies bei der Portierung auf HTML5 und starte die Wiedergabe von Tönen und Musik erst bei der ersten Benutzerinteraktion. Versuche, Töne vor einer Benutzerinteraktion abzuspielen, werden als Fehler in der Entwicklerkonsole des Browsers protokolliert, beeinträchtigen das Spiel jedoch nicht.
+
+Achte außerdem darauf, alle gerade abgespielten Töne zu pausieren, wenn das Spiel Werbung anzeigt.

--- a/docs/de/manuals/profiling.md
+++ b/docs/de/manuals/profiling.md
@@ -1,0 +1,166 @@
+---
+title: Profiling in Defold
+brief: Dieses Handbuch erklärt die in Defold verfügbaren Profiling-Funktionen.
+---
+
+# Profiling
+
+Defold enthält Profiling-Werkzeuge, die in die Engine und die Build-Pipeline integriert sind. Sie helfen dabei, Probleme mit der Leistung, dem Speicherverbrauch und der Ressourcennutzung zu finden. Profiling-Daten zur Laufzeit können von verschiedenen Werkzeugen ausgewertet werden:
+
+* Der grundlegende Profiler und der visuelle Profiler im Spiel sind auf allen Plattformen verfügbar.
+* Der [Remotery-Profiler](https://github.com/Celtoys/Remotery) und der interaktive Web-Frame-Profiler sind auf Desktop- und Mobilplattformen verfügbar.
+* HTML5-Builds können Defold-Messbereiche (Scopes) an die Web Performance API des Browsers übergeben.
+
+Die Einstellung **Profiler** im [Anwendungsmanifest](/manuals/app-manifest/#profiler) steuert, ob Profiler-Code in einen Build eingebunden wird. **Debug Only** ist die Standardeinstellung, **None** schließt ihn aus und **Always** bindet ihn sowohl in Debug- als auch in Release-Builds ein. Die Einstellungen unter `profiler` in *game.project* steuern das Verhalten zur Laufzeit, binden ausgeschlossenen Profiler-Code aber nicht wieder in einen Build ein. Insbesondere steuert **Track CPU** die stichprobenartige Erfassung der CPU-Auslastung; diese Einstellung ist von der Auswahl im Anwendungsmanifest unabhängig.
+
+## Der visuelle Profiler zur Laufzeit {#the-runtime-visual-profiler}
+
+Builds mit Profiler-Unterstützung enthalten einen visuellen Profiler für die Laufzeit, der aktuelle Informationen über der laufenden Anwendung einblendet:
+
+```lua
+function on_reload(self)
+    -- Toggle the visual profiler on hot reload.
+    profiler.enable_ui(true)
+end
+```
+
+![Visueller Profiler](images/profiling/visual_profiler.png)
+
+Der visuelle Profiler stellt verschiedene Funktionen bereit, mit denen du die Darstellung seiner Daten ändern kannst:
+
+```lua
+
+profiler.set_ui_mode()
+profiler.set_ui_view_mode()
+profiler.view_recorded_frame()
+```
+
+Weitere Informationen zu den Profiler-Funktionen findest du in der [API-Referenz für den Profiler](/ref/stable/profiler/).
+
+## Der Web-Profiler {#the-web-profiler}
+Während ein Desktop- oder Mobil-Build mit Profiler-Unterstützung läuft, kannst du über einen Browser auf interaktive Frame- und Ressourcen-Profiler zugreifen.
+
+### Remotery-Frame-Profiler
+Mit dem Frame-Profiler kannst du Messdaten deines Spiels während der Ausführung erfassen und einzelne Frames im Detail analysieren. So öffnest du den Profiler:
+
+1. Starte dein Spiel auf deinem Zielgerät.
+2. Wähle den Menüeintrag <kbd> Debug ▸ Open Web Profiler</kbd>.
+
+Der Frame-Profiler ist in mehrere Bereiche unterteilt, die jeweils unterschiedliche Ansichten des laufenden Spiels zeigen. Klicke oben rechts auf die Schaltfläche Pause, um die Aktualisierung der Ansichten durch den Profiler vorübergehend anzuhalten.
+
+![Web-Profiler](images/profiling/webprofiler_page.png)
+
+::: sidenote
+Wenn du mehrere Ziele gleichzeitig verwendest, kannst du manuell zwischen ihnen wechseln. Ändere dazu das Feld Connection Address oben auf der Seite so, dass es der URL des Remotery-Profilers entspricht, die beim Start des Ziels in der Konsole angezeigt wurde:
+
+```
+INFO:ENGINE: Defold Engine 1.3.4 (80b1b73)
+INFO:DLIB: Initialized Remotery (ws://127.0.0.1:17815/rmt)
+INFO:ENGINE: Loading data from: build/default
+```
+:::
+
+Sample Timeline
+: Sample Timeline zeigt die in der Engine erfassten Daten der Frames mit einer horizontalen Zeitleiste pro Thread. Main ist der Hauptthread, in dem die gesamte Spiellogik und der Großteil des Engine-Codes ausgeführt werden. Remotery steht für den Profiler selbst und Sound für den Thread zum Mischen und Wiedergeben von Audio. Du kannst mit dem Mausrad hinein- und herauszoomen und einzelne Frames auswählen, um ihre Details in der Ansicht Frame Data zu sehen.
+
+  ![Zeitleiste der Messdaten](images/profiling/webprofiler_sample_timeline.png)
+
+
+Frame Data
+: Die Ansicht Frame Data ist eine Tabelle, in der alle Daten des aktuell ausgewählten Frames im Detail aufgeschlüsselt sind. Du kannst sehen, wie viele Millisekunden in jedem Messbereich der Engine verbracht werden.
+
+  ![Frame-Daten](images/profiling/webprofiler_frame_data.png)
+
+
+Global Properties
+: Die Ansicht Global Properties zeigt eine Tabelle mit Zählern. Damit kannst du beispielsweise die Anzahl der Zeichenaufrufe (draw calls) oder die Anzahl der Komponenten (components) eines bestimmten Typs leicht verfolgen.
+
+  ![Globale Eigenschaften](images/profiling/webprofiler_global_properties.png)
+
+::: sidenote
+Der Wert LuaMem gibt den Speicherverbrauch der Lua-VM in Kilobytes an, wie ihn die automatische Speicherbereinigung von Lua meldet. Memory ist der Speicherverbrauch der Engine in Kilobytes.
+:::
+
+::: important
+Die [Einstellung Max Sample Count](/manuals/project-settings/#max-sample-count) begrenzt die Anzahl der Profiler-Messwerte, die pro Thread und pro Frame aufgezeichnet werden. Wenn der Profiler meldet, dass der Grenzwert überschritten wurde, prüfe zunächst den Profiling-Code nativer Erweiterungen auf ein unvollständiges Paar aus Beginn und Ende eines Messbereichs. Erhöhe die Obergrenze nur, wenn ein ordnungsgemäßer Frame mehr Messbereiche enthält, als der konfigurierte Grenzwert erlaubt.
+:::
+
+### Ressourcen-Profiler {#resource-profiler}
+Mit dem Ressourcen-Profiler kannst du dein Spiel während der Ausführung untersuchen und die Ressourcennutzung im Detail analysieren. So öffnest du den Profiler:
+
+1. Starte dein Spiel auf deinem Zielgerät.
+2. Öffne einen Browser und rufe http://localhost:8002 auf.
+
+Der Ressourcen-Profiler ist in 2 Bereiche unterteilt: Einer zeigt eine hierarchische Ansicht der Sammlungen (collections), Spielobjekte (game objects) und Komponenten, die aktuell in deinem Spiel instanziiert sind. Der andere zeigt alle aktuell geladenen Ressourcen.
+
+![Ressourcen-Profiler](images/profiling/webprofiler_resources_page.png)
+
+Sammlungsansicht
+: Die Sammlungsansicht zeigt eine hierarchische Liste aller Spielobjekte und Komponenten, die aktuell im Spiel instanziiert sind, sowie die Sammlung, aus der sie stammen. Dies ist ein sehr nützliches Werkzeug, um genauer zu untersuchen und zu verstehen, was du zu einem bestimmten Zeitpunkt in deinem Spiel instanziiert hast und woher die Objekte stammen.
+
+Ressourcenansicht
+: Die Ressourcenansicht zeigt alle aktuell in den Speicher geladenen Ressourcen, ihre Größe und die Anzahl der Referenzen auf jede Ressource. Das ist bei der Optimierung des Speicherverbrauchs deiner Anwendung nützlich, wenn du verstehen musst, was sich zu einem bestimmten Zeitpunkt im Speicher befindet.
+
+## Leistungszeitleiste im HTML5-Browser {#html5-browser-performance-timeline}
+
+HTML5 verwendet für seine Browserzeitleiste die Web Performance API anstelle von Remotery. So zeichnest du Defold-Messbereiche auf:
+
+1. Stelle sicher, dass der im Anwendungsmanifest ausgewählte Profiler-Modus Profiler-Unterstützung in der von dir ausgeführten Build-Variante einschließt.
+2. Aktiviere **Performance Timeline Enabled** (`profiler.performance_timeline_enabled`) in *game.project*.
+3. Starte den HTML5-Build und öffne die Entwicklerwerkzeuge des Browsers.
+4. Zeichne im Bereich **Performance** des Browsers eine Sitzung auf und untersuche die Defold-Messbereiche in der entstandenen Zeitleiste.
+
+Diese Browserzeitleiste ist sowohl vom visuellen Profiler im Spiel als auch vom interaktiven Remotery-Web-Profiler getrennt.
+
+
+## Build-Berichte {#build-reports}
+Wenn du ein Bundle deines Spiels erstellst, kannst du dabei einen Build-Bericht erzeugen. Damit erhältst du einen sehr nützlichen Überblick über die Größe aller Assets, die zu deinem Spiel-Bundle gehören. Aktiviere bei der Bundle-Erstellung einfach das Kontrollkästchen *Generate build report*.
+
+![Build-Bericht](images/profiling/build_report.png)
+
+Das Build-Werkzeug erzeugt neben dem Spiel-Bundle eine Datei namens `report.html`. Öffne die Datei in einem Webbrowser, um den Bericht zu untersuchen:
+
+![Build-Bericht](images/profiling/build_report_html.png)
+
+*Overview* bietet eine visuelle Gesamtübersicht der Projektgröße, aufgeschlüsselt nach Ressourcentyp.
+
+*Resources* zeigt eine detaillierte Liste der Ressourcen, die du nach Größe, Komprimierungsverhältnis, Verschlüsselung, Typ und Verzeichnisname sortieren kannst. Verwende das Feld „search“, um die angezeigten Ressourceneinträge zu filtern.
+
+Der Bereich *Structure* zeigt die Größen anhand der Anordnung der Ressourcen in der Dateistruktur des Projekts. Die Einträge sind entsprechend der relativen Größe der Datei- und Verzeichnisinhalte farblich von Grün (klein) bis Blau (groß) gekennzeichnet.
+
+
+## Externe Werkzeuge {#external-tools}
+Zusätzlich zu den integrierten Werkzeugen gibt es eine große Auswahl kostenloser, hochwertiger Werkzeuge für Tracing und Profiling. Hier eine Auswahl:
+
+ProFi (Lua)
+: Defold enthält keinen integrierten Lua-Profiler, aber es gibt externe Bibliotheken, die sich recht einfach verwenden lassen. Um herauszufinden, wo deine Skripte Zeit benötigen, kannst du entweder selbst Zeitmessungen in deinen Code einfügen oder eine Lua-Profiling-Bibliothek wie [ProFi](https://github.com/jgrahamc/ProFi) verwenden.
+
+  Beachte, dass reine Lua-Profiler mit jedem installierten Hook einen beträchtlichen zusätzlichen Aufwand verursachen. Daher solltest du die mit einem solchen Werkzeug ermittelten Zeitprofile mit etwas Vorsicht betrachten. Profile zur Zählung von Aufrufen sind allerdings ausreichend genau.
+
+Instruments (macOS und iOS)
+: Dieses Werkzeug zur Leistungsanalyse und -visualisierung ist Teil von Xcode. Damit kannst du das Verhalten einer oder mehrerer Anwendungen oder Prozesse aufzeichnen und untersuchen, gerätespezifische Funktionen wie WLAN und Bluetooth analysieren und vieles mehr.
+
+  ![Instruments](images/profiling/instruments.png)
+
+OpenGL-Profiler (macOS)
+: Teil des Pakets „Additional Tools for Xcode“, das du von Apple herunterladen kannst. Wähle dazu im Xcode-Menü <kbd>Xcode ▸ Open Developer Tool ▸ More Developer Tools...</kbd>.
+
+  Mit diesem Werkzeug kannst du eine laufende Defold-Anwendung untersuchen und sehen, wie sie OpenGL verwendet. Du kannst OpenGL-Funktionsaufrufe aufzeichnen, Haltepunkte für OpenGL-Funktionen setzen, Anwendungsressourcen wie Texturen, Programme und Shader untersuchen, Pufferinhalte ansehen und weitere Aspekte des OpenGL-Zustands prüfen.
+
+  ![OpenGL-Profiler](images/profiling/opengl.png)
+
+Android Profiler (Android)
+: https://developer.android.com/studio/profile/android-profiler.html
+
+  Eine Sammlung von Profiling-Werkzeugen, die Echtzeitdaten zur CPU-, Speicher- und Netzwerkaktivität deines Spiels erfasst. Du kannst den Methodenablauf bei der Codeausführung anhand von Stichproben aufzeichnen, Heap-Dumps erfassen, Speicherzuweisungen ansehen und Details zu über das Netzwerk übertragenen Dateien untersuchen. Um das Werkzeug zu verwenden, musst du `android:debuggable="true"` in `AndroidManifest.xml` setzen.
+
+  ![Android Profiler](images/profiling/android_profiler.png)
+
+  Hinweis: Seit Android Studio 4.1 kannst du die [Profiling-Werkzeuge auch ausführen, ohne Android Studio zu starten](https://developer.android.com/studio/profile/android-profiler.html#standalone-profilers).
+
+Graphics API Debugger (Android)
+: https://github.com/google/gapid
+
+  Dies ist eine Sammlung von Werkzeugen, mit denen du Aufrufe einer Anwendung an einen Grafiktreiber untersuchen, anpassen und erneut abspielen kannst. Um das Werkzeug zu verwenden, musst du `android:debuggable="true"` in `AndroidManifest.xml` setzen.
+
+  ![Graphics API Debugger](images/profiling/gapid.png)

--- a/docs/de/manuals/project-defignore.md
+++ b/docs/de/manuals/project-defignore.md
@@ -1,0 +1,32 @@
+---
+title: Ignorieren von Dateien in Defold-Projekten
+brief: Dieses Handbuch beschreibt, wie du Dateien und Ordner in Defold ignorierst.
+---
+
+# Dateien ignorieren {#ignoring-files}
+
+Du kannst den Defold-Editor und die Werkzeuge so konfigurieren, dass sie Dateien und Ordner in einem Projekt ignorieren. Das kann nützlich sein, wenn das Projekt Dateien enthält, deren Dateierweiterungen mit den von Defold verwendeten Dateierweiterungen in Konflikt stehen. Ein Beispiel dafür sind Dateien der Programmiersprache Go mit der Dateierweiterung `.go`, die der Editor auch für Dateien für Spielobjekte (game objects) verwendet.
+
+## Die Datei `.defignore` {#the-defignore-file}
+Die auszuschließenden Dateien und Ordner werden in einer Datei namens `.defignore` im Stammverzeichnis des Projekts festgelegt. Die Datei sollte die auszuschließenden Dateien und Ordner mit jeweils einem Eintrag pro Zeile auflisten. Beispiel:
+
+```
+/path/to/file.png
+/otherpath
+```
+
+Dadurch werden die Datei `/path/to/file.png` und alle Inhalte unter dem Pfad `/otherpath` ausgeschlossen.
+
+## Die Datei `.defunload` {#the-defunload-file}
+
+Bei bestimmten großen Projekten, die mehrere voneinander unabhängige Module enthalten, möchtest du möglicherweise Teile vom Laden ausschließen, um den Speicherverbrauch und die Ladezeiten im Editor zu verringern. Dazu kannst du die Pfade, die vom Laden ausgeschlossen werden sollen, in einer Datei namens `.defunload` unterhalb des Projektverzeichnisses auflisten.
+
+Einfach gesagt ermöglicht dir die Datei `.defunload`, Teile des Projekts im Editor auszublenden, ohne dass Referenzen auf die ausgeblendeten Ressourcen einen Build-Fehler verursachen.
+
+Für die Muster in `.defunload` gelten dieselben Regeln wie für die Datei `.defignore`. Entladene Sammlungen (collections) und Spielobjekte verhalten sich so, als wären sie leer, wenn geladene Ressourcen sie referenzieren. Andere Ressourcen, die den Mustern in `.defunload` entsprechen, befinden sich in einem entladenen Zustand und können im Editor nicht angezeigt werden. Wenn jedoch eine geladene Ressource von ihnen abhängt, werden die entladenen Ressourcen und ihre Abhängigkeiten automatisch geladen.
+
+Wenn beispielsweise ein Sprite von Bildern in einem Atlas abhängt, müssen wir den Atlas laden, sonst wird das fehlende Bild als Fehler gemeldet. In diesem Fall warnt dich eine Benachrichtigung vor dieser Situation und gibt an, welche entladene Ressource von welcher Stelle aus referenziert wurde.
+
+Der Editor verhindert, dass du von geladenen Ressourcen aus Referenzen auf `.defunloaded`-Ressourcen hinzufügst. Daher tritt diese Situation nur auf, wenn Ressourcen von der Festplatte gelesen werden.
+
+Im Gegensatz zur Datei `.defignore` musst du den Editor nach dem Bearbeiten der Datei `.defunload` neu starten, damit die Änderungen wirksam werden.

--- a/docs/de/manuals/project-settings.md
+++ b/docs/de/manuals/project-settings.md
@@ -1,0 +1,873 @@
+---
+title: Defold-Projekteinstellungen
+brief: Dieses Handbuch beschreibt, wie projektspezifische Einstellungen in Defold funktionieren.
+---
+
+# Projekteinstellungen {#project-settings}
+
+Die Datei *game.project* enthält alle projektweiten Einstellungen. Sie muss im Stammordner des Projekts bleiben und *game.project* heißen. Wenn die Engine startet und dein Spiel ausführt, sucht sie zuerst nach dieser Datei.
+
+Jede Einstellung in der Datei gehört zu einer Kategorie. Wenn du die Datei öffnest, zeigt Defold alle Einstellungen nach Kategorien gruppiert an.
+
+![Projekteinstellungen](images/project-settings/settings.jpg)
+
+
+## Dateiformat {#file-format}
+
+Die Einstellungen in *game.project* werden normalerweise in Defold geändert, die Datei lässt sich aber auch in jedem herkömmlichen Texteditor bearbeiten. Sie folgt dem INI-Dateiformat und sieht so aus:
+
+```ini
+[category1]
+setting1 = value
+setting2 = value
+[category2]
+...
+```
+
+Ein konkretes Beispiel ist:
+
+```ini
+[bootstrap]
+main_collection = /main/main.collectionc
+```
+
+Das bedeutet, dass die Einstellung *main_collection* zur Kategorie *bootstrap* gehört. Wenn du wie im obigen Beispiel eine Dateireferenz verwendest, muss an den Pfad das Zeichen 'c' angehängt werden. Damit verweist du auf die kompilierte Version der Datei. Beachte außerdem, dass der Ordner mit *game.project* das Stammverzeichnis des Projekts ist. Deshalb beginnt der Pfad der Einstellung mit '/'.
+
+
+## Zugriff zur Laufzeit {#runtime-access}
+
+Du kannst Werte aus *game.project* zur Laufzeit mit [`sys.get_config_string(key)`](/ref/sys/#sys.get_config_string), [`sys.get_config_number(key)`](/ref/sys/#sys.get_config_number), [`sys.get_config_int(key)`](/ref/sys/#sys.get_config_int) und [`sys.get_config_boolean(key)`](/ref/sys/#sys.get_config_boolean) lesen. Beispiele:
+
+```lua
+local title = sys.get_config_string("project.title")
+local gravity_y = sys.get_config_number("physics.gravity_y")
+local fullscreen = sys.get_config_boolean("display.fullscreen", false)
+```
+
+::: sidenote
+Der Schlüssel setzt sich aus Kategorie und Einstellungsname zusammen, getrennt durch einen Punkt. Er wird kleingeschrieben, und alle Leerzeichen werden durch Unterstriche ersetzt. Beispiele: Aus dem Feld „Title“ der Kategorie „Project“ wird `project.title`, und aus dem Feld „Gravity Y“ der Kategorie „Physics“ wird `physics.gravity_y`.
+:::
+
+
+## Abschnitte und Einstellungen {#sections-and-settings}
+
+Im Folgenden findest du alle verfügbaren Einstellungen, nach Kategorien geordnet.
+
+### Project
+
+#### Title
+Der Titel der Anwendung.
+
+#### Version
+Die Version der Anwendung.
+
+#### Publisher
+Name des Publishers.
+
+#### Developer
+Name des Entwicklers.
+
+#### Write Log File
+Steuert, wann die Engine eine Protokolldatei schreibt. Optionen:
+
+- "Never": Keine Protokolldatei schreiben.
+- "Debug": Eine Protokolldatei nur für Debug-Builds schreiben.
+- "Always": Eine Protokolldatei sowohl für Debug- als auch für Release-Builds schreiben.
+
+Wenn du mehr als eine Instanz aus dem Editor ausführst, heißt die Datei *instance_2_log.txt*, wobei `2` der Instanzindex ist. Wenn du eine einzelne Instanz oder ein Bundle ausführst, heißt die Datei *log.txt*. Die Protokolldatei wird unter einem der folgenden Pfade abgelegt, die der Reihe nach versucht werden:
+
+1. Der in *project.log_dir* angegebene Pfad (ausgeblendete Einstellung)
+2. Der Systempfad für Protokolle:
+  * macOS/iOS: `NSDocumentDirectory`
+  * Android: `Context.getExternalFilesDir()`
+  * Andere: Stammverzeichnis der Anwendung
+3. Der Pfad für Anwendungsunterstützungsdaten
+  * macOS/iOS: `NSApplicationSupportDirectory`
+  * Windows: `CSIDL_APPDATA` (z. B. `C:\Users\<username>\AppData\Roaming`)
+  * Android: `Context.getFilesDir()`
+  * Linux: Umgebungsvariable `HOME`
+
+#### Minimum Log Level
+Gib die Mindestprotokollstufe für das Protokollierungssystem an. Es werden nur Meldungen dieser oder einer höheren Stufe angezeigt.
+
+#### Compress Archive
+Aktiviert die Komprimierung von Archiven bei der Bundle-Erstellung. Beachte, dass dies derzeit für alle Plattformen außer Android gilt, da die APK dort bereits alle Daten komprimiert enthält.
+
+#### Dependencies
+Eine Liste der *Library URL*s des Projekts. Weitere Informationen findest du im [Handbuch zu Bibliotheken](/manuals/libraries/).
+
+#### Custom Resources
+`custom_resources`
+:[Custom Resources](../shared/custom-resources.md)
+
+Das Laden benutzerdefinierter Ressourcen wird im [Handbuch zum Dateizugriff](/manuals/file-access/#how-to-access-files-bundled-with-the-application) genauer beschrieben.
+
+Pfade, die Erweiterungen über `custom_resources.default` in `ext.properties` bereitstellen, werden mit dieser Einstellung kombiniert. Ein Beispiel findest du unter [benutzerdefinierte Ressourcen von Erweiterungen](/manuals/extensions/#custom-resources).
+
+#### Bundle Resources
+`bundle_resources`
+:[Bundle Resources](../shared/bundle-resources.md)
+
+Das Laden von Bundle-Ressourcen wird im [Handbuch zum Dateizugriff](/manuals/file-access/#how-to-access-files-bundled-with-the-application) genauer beschrieben.
+
+#### Bundle Exclude Resources
+`bundle_exclude_resources`
+Eine durch Kommas getrennte Liste von Ressourcen, die nicht im Bundle enthalten sein sollen. Sie werden also aus dem Ergebnis des Schritts entfernt, in dem die `bundle_resources` zusammengestellt werden.
+
+---
+
+### Bootstrap
+
+#### Main Collection
+Dateireferenz auf die Sammlung (collection), die zum Starten der Anwendung verwendet wird; standardmäßig `/logic/main.collection`.
+
+#### Render
+Die zu verwendende Render-Konfigurationsdatei, die die Rendering-Pipeline definiert; standardmäßig `/builtins/render/default.render`.
+
+---
+
+### Library
+
+#### Include Dirs
+Eine durch Leerzeichen getrennte Liste von Verzeichnissen, die aus deinem Projekt als Bibliothek freigegeben werden sollen. Weitere Informationen findest du im [Handbuch zu Bibliotheken](/manuals/libraries/).
+
+---
+
+### Script
+
+#### Shared State
+Aktiviere diese Option, um einen einzigen Lua-Zustand für alle Skripttypen gemeinsam zu verwenden.
+
+---
+
+### Engine
+
+#### Run While Iconified
+Erlaubt der Engine, weiterzulaufen, während das Anwendungsfenster minimiert ist (nur auf Desktop-Plattformen).
+
+#### Fixed Update Frequency
+Die Aktualisierungsfrequenz der Lebenszyklusfunktion `fixed_update(self, dt)` in Hertz.
+
+#### Max Time Step
+Wenn der Zeitschritt während eines einzelnen Frames zu groß wird, wird er auf diesen Höchstwert begrenzt. Angabe in Sekunden.
+
+---
+
+### Display
+
+#### Width
+Die Breite des Anwendungsfensters in Pixeln.
+
+#### Height
+Die Höhe des Anwendungsfensters in Pixeln.
+
+#### High Dpi
+Erstellt auf unterstützten Bildschirmen einen Backbuffer mit hoher Pixeldichte. Das Spiel wird normalerweise mit der doppelten Auflösung der Einstellungen *Width* und *Height* gerendert. Diese Einstellungen bestimmen weiterhin die logische Auflösung, die in Skripten und Eigenschaften verwendet wird.
+
+#### Samples
+Die Anzahl der Samples für die Kantenglättung durch Supersampling. Damit wird der Fensterhinweis `GLFW_FSAA_SAMPLES` gesetzt. Der Wert `0` bedeutet, dass die Kantenglättung ausgeschaltet ist.
+
+Diese Einstellung steuert das Fenster. Außerhalb des Bildschirms gerenderte [Renderziele mit Multisampling](/manuals/render/#multisampled-render-targets) haben eine eigene Sample-Anzahl.
+
+#### Fullscreen
+Aktiviere diese Option, wenn die Anwendung im Vollbildmodus starten soll. Ist sie deaktiviert, läuft die Anwendung im Fenstermodus.
+
+#### Update Frequency
+Die gewünschte Bildrate in Hertz. Setze den Wert für eine variable Bildrate auf 0. Ein Wert größer als 0 führt zu einer festen Bildrate, die zur Laufzeit auf die tatsächliche Bildrate begrenzt wird (du kannst die Spielschleife also nicht zweimal in einem Engine-Frame aktualisieren). Verwende [`sys.set_update_frequency(hz)`](https://defold.com/ref/stable/sys/?q=set_update_frequency#sys.set_update_frequency:frequency), um diesen Wert zur Laufzeit zu ändern. Diese Einstellung funktioniert auch in Builds ohne grafische Oberfläche (headless).
+
+#### Swap interval
+Dieser ganzzahlige Wert steuert, wie die Anwendung mit Vsync umgeht. 0 deaktiviert Vsync, und der Standardwert ist 1. Bei Verwendung eines OpenGL-Adapters legt dieser Wert die Anzahl der Frames fest, die das Fenster [zwischen Pufferwechseln aktualisieren](https://www.khronos.org/opengl/wiki/Swap_Interval) soll. Vulkan hat kein integriertes Konzept eines Wechselintervalls. Der Wert steuert dort stattdessen, ob Vsync aktiviert werden soll.
+
+#### Vsync
+Einstellung für die Abwärtskompatibilität. Diese Einstellung ist veraltet und zur Ablösung vorgesehen; verwende für neue Projekte **Swap Interval**. Wenn sie deaktiviert ist, erzwingt sie das tatsächlich verwendete Wechselintervall `0`. Wenn sie aktiviert ist, bestimmt **Swap Interval** den tatsächlichen Wert.
+
+#### Display Profiles
+Gibt die zu verwendende Datei mit Anzeigeprofilen an; standardmäßig `/builtins/render/default.display_profilesc`. Weitere Informationen findest du im [Handbuch zu GUI-Layouts](/manuals/gui-layouts/#creating-display-profiles).
+
+#### Dynamic Orientation
+Aktiviere diese Option, wenn die App beim Drehen des Geräts dynamisch zwischen Hoch- und Querformat wechseln soll. Beachte, dass die Entwicklungs-App diese Einstellung derzeit nicht berücksichtigt.
+
+#### Display Device Info
+Gibt beim Start GPU-Informationen in der Konsole aus.
+
+---
+
+### Render {#render-1}
+
+#### Clear Color Red
+Rotkanal der Löschfarbe, verwendet vom Render-Skript und beim Erstellen des Fensters.
+
+#### Clear Color Green
+Grünkanal der Löschfarbe, verwendet vom Render-Skript und beim Erstellen des Fensters.
+
+#### Clear Color Blue
+Blaukanal der Löschfarbe, verwendet vom Render-Skript und beim Erstellen des Fensters.
+
+#### Clear Color Alpha
+Alphakanal der Löschfarbe, verwendet vom Render-Skript und beim Erstellen des Fensters.
+
+---
+
+### Font
+
+#### Runtime Generation
+Verwendet die Schriftgenerierung zur Laufzeit.
+
+---
+
+### Physics
+
+#### Max Collision Object Count
+Maximale Anzahl der Kollisionsobjekte (collision objects).
+
+#### Type
+Die zu verwendende Art der Physik: `2D` oder `3D`.
+
+#### Gravity X
+Schwerkraft der Welt entlang der x-Achse. In Metern pro Sekunde.
+
+#### Gravity Y
+Schwerkraft der Welt entlang der y-Achse. In Metern pro Sekunde.
+
+#### Gravity Z
+Schwerkraft der Welt entlang der z-Achse. In Metern pro Sekunde.
+
+#### Debug
+Aktiviere diese Option, wenn die Physik zur Fehlersuche visualisiert werden soll.
+
+#### Debug Alpha
+Wert der Alphakomponente für die visualisierte Physik, `0`--`1`.
+
+#### World Count
+Maximale Anzahl gleichzeitig vorhandener Physikwelten; standardmäßig `4`. Wenn du über Sammlungs-Proxys (collection proxies) mehr als 4 Welten gleichzeitig lädst, musst du diesen Wert erhöhen. Beachte, dass jede Physikwelt eine beträchtliche Menge Speicher reserviert.
+
+#### Scale
+Teilt der Physik-Engine mit, wie sie die Physikwelten im Verhältnis zur Spielwelt skalieren soll, um numerische Genauigkeit zu erreichen: `0.01`--`1.0`. Wenn der Wert auf `0.02` gesetzt ist, behandelt die Physik-Engine 50 Einheiten als 1 Meter ($1 / 0.02$).
+
+#### Allow Dynamic Transforms
+Aktiviere diese Option, wenn die Physik-Engine die Transformation eines Spielobjekts (game object) auf alle daran angehängten Komponenten (components) vom Typ Kollisionsobjekt anwenden soll. Damit kannst du Kollisionsformen verschieben, skalieren und drehen, auch dynamische.
+
+#### Use Fixed Timestep
+Aktiviere diese Option, wenn die Physik-Engine Aktualisierungen mit festem Zeitschritt unabhängig von der Bildrate verwenden soll. Verwende diese Einstellung zusammen mit der Lebenszyklusfunktion `fixed_update(self, dt)` und der Projekteinstellung `engine.fixed_update_frequency`, um in regelmäßigen Abständen mit der Physik-Engine zu interagieren. Für neue Projekte wird die Einstellung `true` empfohlen.
+
+#### Debug Scale
+Die Größe, in der Einheitsobjekte der Physik wie Achsendreibeine und Normalen gezeichnet werden.
+
+#### Max Collisions
+Die Anzahl der Kollisionen, die an die Skripte gemeldet werden.
+
+#### Max Contacts
+Die Anzahl der Kontaktpunkte, die an die Skripte gemeldet werden.
+
+#### Contact Impulse Limit
+Ignoriert Kontaktimpulse, deren Werte unter dieser Einstellung liegen.
+
+#### Ray Cast Limit 2d
+Die maximale Anzahl von 2D-Strahlabfragen (raycasts) pro Frame.
+
+#### Ray Cast Limit 3d
+Die maximale Anzahl von 3D-Strahlabfragen pro Frame.
+
+#### Trigger Overlap Capacity
+Die maximale Anzahl überlappender Physik-Trigger.
+
+#### Velocity Threshold
+Mindestgeschwindigkeit, die zu elastischen Kollisionen führt.
+
+#### Max Fixed Timesteps
+Maximale Anzahl der Simulationsschritte bei Verwendung eines festen Zeitschritts (nur 3D).
+
+---
+
+### Graphics
+
+#### Default Texture Min Filter
+Gibt die Filterung an, die beim Verkleinern verwendet werden soll.
+
+#### Default Texture Mag Filter
+Gibt die Filterung an, die beim Vergrößern verwendet werden soll.
+
+#### Max Draw Calls
+Die maximale Anzahl der Renderaufrufe.
+
+#### Max Characters:
+Die Anzahl der Zeichen, für die im Text-Rendering-Puffer vorab Speicher reserviert wird, also die Anzahl der Zeichen, die pro Frame angezeigt werden können.
+
+#### Max Font Batches
+Die maximale Anzahl von Textgruppen für gebündeltes Rendern (Batching), die pro Frame angezeigt werden können.
+
+#### Max Debug Vertices
+Die maximale Anzahl der Debug-Vertices. Sie werden unter anderem zum Rendern von Physikformen verwendet.
+
+#### Texture Profiles
+Die für dieses Projekt zu verwendende Texturprofildatei; standardmäßig `/builtins/graphics/default.texture_profiles`.
+
+#### Verify Graphics Calls
+Prüft den Rückgabewert nach jedem Grafikaufruf und meldet Fehler im Protokoll.
+
+#### WebGL Version Hint
+`graphics.webgl_version_hint` wählt die Version des WebGL-Kontexts aus, die für HTML5 angefordert wird. Gültige Werte sind `1` (WebGL 1) und `2` (WebGL 2, der Standardwert). Setze den Wert auf `1`, um WebGL 1 auch in einem Browser als Ziel zu verwenden oder zu testen, der WebGL 2 unterstützt. Lasse [Exclude GLES 2.0](#exclude-gles-20) deaktiviert, wenn du WebGL 1 als Ziel verwendest, damit die erforderlichen Shader enthalten sind.
+
+#### OpenGL Version Hint
+Versionshinweis für den OpenGL-Kontext. Wenn eine bestimmte Version ausgewählt ist, wird sie als erforderliche Mindestversion verwendet (gilt nicht für OpenGL ES).
+
+#### OpenGL Core Profile Hint
+Setzt beim Erstellen des Kontexts den OpenGL-Profilhinweis 'core'. Das Core-Profil entfernt alle veralteten Funktionen aus OpenGL, etwa das Rendering im Immediate Mode. Gilt nicht für OpenGL ES.
+
+#### Vulkan Version Major
+`graphics.vulkan_version_major` ist der Hinweis für die Hauptversion des Vulkan-Kontexts bzw. der Vulkan-API. Dies gilt nur, wenn das Vulkan-Grafik-Backend ausgewählt ist. Der Standardwert ist `1`.
+
+#### Vulkan Version Minor
+`graphics.vulkan_version_minor` ist der Hinweis für die Nebenversion des Vulkan-Kontexts bzw. der Vulkan-API. Dies gilt nur, wenn das Vulkan-Grafik-Backend ausgewählt ist. Der Standardwert ist `0`.
+
+---
+
+### Shader
+
+#### Exclude GLES 2.0
+Kompiliert keine Shader für Geräte, auf denen OpenGLES 2.0 / WebGL 1.0 läuft.
+
+#### GLSL ES Default Precision Float
+`shader.glsl_es_default_precision_float` legt den standardmäßigen globalen Genauigkeitsqualifizierer für Gleitkommawerte in nach GLSL ES querkompilierten Shadern fest. Gültige Werte sind `mediump` und `highp`; der Standardwert ist `mediump`.
+
+#### GLSL ES Default Precision Int
+`shader.glsl_es_default_precision_int` legt den standardmäßigen globalen Genauigkeitsqualifizierer für Ganzzahlwerte in nach GLSL ES querkompilierten Shadern fest. Gültige Werte sind `mediump` und `highp`; der Standardwert ist `highp`.
+
+---
+
+### Input
+
+#### Repeat Delay
+Die Wartezeit in Sekunden, bevor eine gedrückt gehaltene Eingabe wiederholt wird.
+
+#### Repeat Interval
+Die Wartezeit in Sekunden zwischen den Wiederholungen einer gedrückt gehaltenen Eingabe.
+
+#### Gamepads
+Dateireferenz auf die Gamepad-Konfigurationsdatei, die Gamepad-Signale dem Betriebssystem zuordnet; standardmäßig `/builtins/input/default.gamepads`.
+
+#### Game Binding
+Dateireferenz auf die Eingabekonfigurationsdatei, die Hardwareeingaben Aktionen zuordnet; standardmäßig `/input/game.input_binding`.
+
+#### Use Accelerometer
+Aktiviere diese Option, damit die Engine in jedem Frame Eingabeereignisse des Beschleunigungssensors empfängt. Das Deaktivieren dieser Eingabe kann die Leistung etwas verbessern.
+
+---
+
+### Resource
+
+#### Http Cache
+Wenn diese Option aktiviert ist, wird ein HTTP-Cache verwendet, um Ressourcen über das Netzwerk schneller in die laufende Engine auf dem Gerät zu laden.
+
+#### Uri
+Der Speicherort der Build-Daten des Projekts im URI-Format.
+
+#### Max Resources
+Die maximale Anzahl der Ressourcen, die gleichzeitig geladen werden können.
+
+---
+
+### Network
+
+#### Http Timeout
+Das HTTP-Zeitlimit in Sekunden. Setze den Wert auf `0`, um das Zeitlimit zu deaktivieren.
+
+#### Http Thread Count
+Die Anzahl der Arbeitsthreads für den HTTP-Dienst.
+
+#### Http Cache Enabled
+Aktiviere diese Option, um den HTTP-Cache für Netzwerkanfragen mit `http.request()` zu verwenden. Der HTTP-Cache speichert die zu einer Anfrage gehörende Antwort und verwendet sie für nachfolgende Anfragen wieder. Er unterstützt die HTTP-Antwortheader `ETag` und `Cache-Control: max-age`.
+
+#### SSL Certificates
+Datei mit SSL-Stammzertifikaten, die beim Überprüfen der Zertifikatskette während SSL-Handshakes verwendet werden sollen.
+
+---
+
+### Collection
+
+#### Max Instances
+Maximale Anzahl der Spielobjektinstanzen in einer Sammlung; standardmäßig `1024`. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+#### Max Input Stack Entries
+Maximale Anzahl der Spielobjekte im Eingabestapel.
+
+---
+
+### Sound
+
+#### Gain
+Globaler Verstärkungsfaktor (Lautstärke), `0`--`1`.
+
+#### Use Linear Gain
+Wenn diese Option aktiviert ist, ist der Verstärkungsfaktor linear. Andernfalls wird eine Exponentialkurve verwendet.
+
+#### Max Sound Data
+Maximale Anzahl der Audioressourcen, also die Anzahl unterschiedlicher Audiodateien zur Laufzeit.
+
+#### Max Sound Buffers
+(Derzeit nicht verwendet) Maximale Anzahl gleichzeitig vorhandener Audiopuffer.
+
+#### Max Sound Sources
+(Derzeit nicht verwendet) Maximale Anzahl gleichzeitig wiedergegebener Klänge.
+
+#### Max Sound Instances
+Maximale Anzahl gleichzeitig vorhandener Audioinstanzen, also tatsächlich gleichzeitig wiedergegebener Klänge.
+
+#### Max Component Count
+Maximale Anzahl der Audiokomponenten pro Sammlung.
+
+#### Sample Frame Count
+Anzahl der Samples, die für jede Audioaktualisierung verwendet werden. 0 bedeutet automatisch (1024 für 48 kHz, 768 für 44,1 kHz).
+
+#### Use Thread
+Wenn diese Option aktiviert ist, verwendet das Audiosystem Threads für die Audiowiedergabe, um das Risiko von Aussetzern bei hoher Auslastung des Hauptthreads zu verringern.
+
+#### Stream Enabled
+Wenn diese Option aktiviert ist, verwendet das Audiosystem Streaming, um Quelldateien zu laden.
+
+#### Stream Cache Size
+Die maximale Größe des Audio-Chunk-Caches, der _alle_ Chunks enthält. Standardmäßig `2097152` Byte.
+Diese Zahl sollte größer sein als die Anzahl der geladenen Audiodateien multipliziert mit der Stream-Chunk-Größe.
+Andernfalls besteht das Risiko, dass neue Chunks in jedem Frame aus dem Cache verdrängt werden.
+
+#### Stream Chunk Size
+Die Größe jedes gestreamten Chunks in Byte.
+
+#### Stream Preload Size
+Bestimmt die Größe des ersten Chunks in Byte für Audiodateien, die aus dem Archiv gelesen werden.
+
+---
+
+### Sprite
+
+#### Max Count
+Maximale Anzahl der Sprites pro Sammlung. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+#### Subpixels
+Aktiviere diese Option, damit Sprites ohne Ausrichtung am Pixelraster erscheinen können.
+
+---
+
+### Tilemap
+
+#### Max Count {#max-count-1}
+Maximale Anzahl der Kachelkarten (tile maps) pro Sammlung. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+#### Max Tile Count
+Maximale Anzahl gleichzeitig sichtbarer Kacheln pro Sammlung.
+
+---
+
+### Spine
+
+#### Max Count {#max-count-2}
+Maximale Anzahl der Spine-Modellkomponenten. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+---
+
+### Mesh
+
+#### Max Count {#max-count-3}
+Maximale Anzahl der Mesh-Komponenten pro Sammlung. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+---
+
+### Model
+
+#### Max Count {#max-count-4}
+Maximale Anzahl der Modellkomponenten pro Sammlung. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+#### Split Meshes
+Teilt Meshes mit mehr als 65536 Vertices in neue Meshes auf.
+
+#### Max Bone Matrix Texture Width
+Maximale Breite der Knochenmatrixtextur. Es wird nur die für Animationen benötigte Größe verwendet, aufgerundet auf die nächste Zweierpotenz.
+
+#### Max Bone Matrix Texture Height
+Maximale Höhe der Knochenmatrixtextur. Es wird nur die für Animationen benötigte Größe verwendet, aufgerundet auf die nächste Zweierpotenz.
+
+---
+
+### GUI
+
+#### Max Count {#max-count-5}
+Maximale Anzahl der GUI-Komponenten. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+#### Max Particle Count
+Die maximale Anzahl gleichzeitig vorhandener Partikel in der GUI.
+
+#### Max Animation Count
+Die maximale Anzahl aktiver Animationen in der GUI.
+
+---
+
+### Label
+
+#### Max Count {#max-count-6}
+Maximale Anzahl der Beschriftungskomponenten (labels). [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+#### Subpixels {#subpixels-1}
+Aktiviere diese Option, damit Beschriftungen ohne Ausrichtung am Pixelraster erscheinen können.
+
+---
+
+### Particle FX
+
+#### Max Count {#max-count-7}
+Die maximale Anzahl gleichzeitig vorhandener Emitter. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+#### Max Particle Count {#max-particle-count-1}
+Die maximale Anzahl gleichzeitig vorhandener Partikel.
+
+---
+
+### Box2D
+
+#### Velocity Iterations
+Anzahl der Geschwindigkeitsiterationen für den Physik-Solver von Box2D 2.2.
+
+#### Position Iterations
+Anzahl der Positionsiterationen für den Physik-Solver von Box2D 2.2.
+
+#### Sub Step Count
+Anzahl der Teilschritte für den Physik-Solver von Box2D 3.x.
+
+---
+
+### Collection proxy
+
+#### Max Count {#max-count-8}
+Maximale Anzahl der Sammlungs-Proxys. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+---
+
+### Collection factory
+
+#### Max Count {#max-count-9}
+Maximale Anzahl der Sammlungsfabriken (collection factories). [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+---
+
+### Factory
+
+#### Max Count {#max-count-10}
+Maximale Anzahl der Fabriken (factories) für Spielobjekte. [(Siehe Informationen zur Optimierung der maximalen Komponentenanzahl)](#component-max-count-optimizations).
+
+---
+
+### iOS
+
+#### App Icon 57x57--180x180
+Bilddatei (.png), die als Anwendungssymbol mit den angegebenen Maßen für Breite und Höhe `W` &times; `H` verwendet werden soll.
+
+#### Launch Screen
+Storyboard-Datei (.storyboard). Wie du eine solche Datei erstellst, erfährst du im [iOS-Handbuch](/manuals/ios/#creating-a-storyboard).
+
+#### Icons Asset
+Die Symbol-Asset-Datei (.car), die die App-Symbole enthält.
+
+#### Prerendered Icons
+(iOS 6 und früher) Aktiviere diese Option, wenn deine Symbole vorgerendert sind. Ist sie deaktiviert, wird den Symbolen automatisch ein Glanzeffekt hinzugefügt.
+
+#### Bundle Identifier
+Anhand der Bundle-ID erkennt iOS Aktualisierungen deiner App. Deine Bundle-ID muss bei Apple registriert und für deine App eindeutig sein. Du kannst nicht dieselbe Kennung für iOS- und macOS-Apps verwenden. Sie muss aus zwei oder mehr durch einen Punkt getrennten Segmenten bestehen. Jedes Segment muss mit einem Buchstaben beginnen. Jedes Segment darf nur alphanumerische Zeichen, Unterstriche oder Bindestriche (-) enthalten (siehe [`CFBundleIdentifier`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430)).
+
+#### Bundle Name
+Der Kurzname des Bundles (15 Zeichen) (siehe [`CFBundleName`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430)).
+
+#### Bundle Version
+Die Version des Bundles, entweder eine Zahl oder x.y.z. (siehe [`CFBundleVersion`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430)).
+
+#### Info.plist
+Wenn angegeben, wird diese Datei *`Info.plist`* bei der Bundle-Erstellung für deine App anstelle des integrierten iOS-Basismanifests verwendet. Das integrierte Manifest enthält die Einträge für das lokale Netzwerk und Bonjour, die zur Zielerkennung des Editors in Builds erforderlich sind, die keine Release-Builds sind. Wenn du ein benutzerdefiniertes Manifest bereitstellst und auf einem Gerät Zielerkennung, Profiling, Hot Reload oder Protokollstreaming benötigst, behalte diese Einträge wie im [iOS-Handbuch](/manuals/ios/#creating-an-ios-application-bundle) beschrieben bei.
+
+#### Privacy Manifest
+Das Apple-Datenschutzmanifest für die Anwendung. Der Standardwert des Felds ist `/builtins/manifests/ios/PrivacyInfo.xcprivacy`.
+
+#### Custom Entitlements
+Wenn angegeben, werden die Berechtigungen im bereitgestellten Bereitstellungsprofil (`.entitlements`, `.xcent`, `.plist`) mit den Berechtigungen aus dem Bereitstellungsprofil zusammengeführt, das bei der Bundle-Erstellung für die Anwendung angegeben wird.
+
+#### Default Language
+Die Sprache, die verwendet wird, wenn die vom Benutzer bevorzugte Sprache nicht in der Liste `Localizations` der Anwendung enthalten ist (siehe [`CFBundleDevelopmentRegion`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430)). Verwende den zweibuchstabigen Standard ISO 639-1, wenn die bevorzugte Sprache darin verfügbar ist, andernfalls den dreibuchstabigen Standard ISO 639-2.
+
+#### Localizations
+Dieses Feld enthält durch Kommas getrennte Zeichenfolgen, die den Sprachnamen oder das ISO-Sprachkürzel der unterstützten Lokalisierungen angeben (siehe [`CFBundleLocalizations`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-109552)).
+
+---
+
+### Android
+
+#### App Icon 36x36--192x192
+Bilddatei (.png), die als Anwendungssymbol mit den angegebenen Maßen für Breite und Höhe `W` &times; `H` verwendet werden soll.
+
+#### Push Icon Small--LargeXxxhdpi
+Bilddateien (.png), die als benutzerdefinierte Symbole für Push-Benachrichtigungen unter Android verwendet werden sollen. Die Symbole werden automatisch sowohl für lokale als auch für entfernte Push-Benachrichtigungen verwendet. Wenn keine angegeben sind, wird standardmäßig das Anwendungssymbol verwendet.
+
+#### Push Field Title
+Gibt an, welches JSON-Feld der Nutzdaten als Titel der Benachrichtigung verwendet werden soll. Wenn du diese Einstellung leer lässt, wird standardmäßig der Anwendungsname als Titel der Push-Benachrichtigungen verwendet.
+
+#### Push Field Text
+Gibt an, welches JSON-Feld der Nutzdaten als Benachrichtigungstext verwendet werden soll. Wenn du die Einstellung leer lässt, wird wie unter iOS der Text aus dem Feld `alert` verwendet.
+
+#### Version Code
+Ein ganzzahliger Wert, der die Version der App angibt. Erhöhe diesen Wert bei jeder weiteren Aktualisierung.
+
+#### Minimum SDK Version
+Das niedrigste API-Level, das zum Ausführen der Anwendung erforderlich ist (`android:minSdkVersion`).
+
+#### Target SDK Version
+Das API-Level, auf das die Anwendung ausgerichtet ist (`android:targetSdkVersion`).
+
+#### Package
+Paketkennung. Sie muss aus zwei oder mehr durch einen Punkt getrennten Segmenten bestehen. Jedes Segment muss mit einem Buchstaben beginnen. Jedes Segment darf nur alphanumerische Zeichen oder Unterstriche enthalten.
+
+#### GCM Sender Id
+Die Sender-ID für Google Cloud Messaging. Setze diesen Wert auf die von Google zugewiesene Zeichenfolge, um Push-Benachrichtigungen zu aktivieren.
+
+#### FCM Application Id
+Die Anwendungs-ID für Firebase Cloud Messaging.
+
+#### Manifest
+Wenn gesetzt, wird bei der Bundle-Erstellung die angegebene XML-Datei als Android-Manifest verwendet. Ein benutzerdefiniertes Manifest ersetzt das integrierte Basismanifest von Defold. Manifestfragmente nativer Erweiterungen werden weiterhin damit zusammengeführt, spätere Änderungen am integrierten Basismanifest werden jedoch nicht automatisch übernommen. Vergleiche benutzerdefinierte Manifeste deshalb bei einem Upgrade mit dem aktuellen integrierten Manifest. Setze bei Spielen `android:appCategory="game"` am Element `<application>`. Setze `android:appCategory` bei Anwendungen, die keine Spiele sind, nur dann, wenn eine der von Android definierten [Anwendungskategorien](https://developer.android.com/guide/topics/manifest/application-element#appCategory) die App zutreffend beschreibt.
+
+#### Iap Provider
+Gibt den zu verwendenden Store an. Gültige Optionen sind `Amazon` und `GooglePlay`. Weitere Informationen findest du unter [extension-iap](/extension-iap/).
+
+#### Input Method
+Gibt die Methode an, mit der Tastatureingaben auf Android-Geräten erfasst werden. Gültige Optionen sind `KeyEvent` (alte Methode) und `HiddenInputField` (neue Methode).
+
+#### Immersive Mode
+Wenn gesetzt, werden die Navigations- und Statusleisten ausgeblendet, und deine App kann alle Berührungsereignisse auf dem Bildschirm erfassen.
+
+#### Display Cutout
+Erweitert die Darstellung bis in den Bereich der Bildschirmaussparung.
+
+#### Debuggable
+Gibt an, ob sich die Anwendung mit Werkzeugen wie [GAPID](https://github.com/google/gapid) oder [Android Studio](https://developer.android.com/studio/profile/android-profiler) debuggen lässt. Dies setzt das Flag `android:debuggable` im Android-Manifest ([offizielle Dokumentation](https://developer.android.com/guide/topics/manifest/application-element#debug)).
+
+#### R8 Keep Rules
+`android.r8_keep_rules` wählt eine `.keep`-Datei aus, um die Verkleinerung, Optimierung und Verschleierung von Java-Code mit R8 in Android-Builds zu aktivieren. Lasse die Einstellung leer, um D8 ohne Verkleinerung zu verwenden.
+
+Wähle `/builtins/manifests/android/dmengine.keep`, um die Standardregeln von Defold direkt zu verwenden. Erweiterungen liefern eigene [Regeln zum Beibehalten von Code](/manuals/extensions/#r8-keep-rules-for-android), die mit dieser Datei kombiniert werden.
+
+Kopiere die integrierte Datei nur dann in dein Projekt, wenn du projektspezifische Regeln hinzufügen musst. Behalte die integrierten Regeln in der Kopie bei: Die Auswahl einer benutzerdefinierten Datei ersetzt den gesamten Regelsatz des Projekts.
+
+Im [Android-Handbuch](/manuals/android/#shrinking-java-code-with-r8) erfährst du, wie du R8 aktivierst und seine Zuordnung der verschleierten Namen zusammen mit einem Release-Bundle aufbewahrst.
+
+#### Extract Native Libraries
+Gibt an, ob das Paketinstallationsprogramm native Bibliotheken aus der APK in das Dateisystem extrahiert. Wenn der Wert auf `false` gesetzt ist, werden deine nativen Bibliotheken unkomprimiert in der APK gespeichert. Obwohl deine APK dadurch größer sein kann, lädt deine Anwendung schneller, weil die Bibliotheken zur Laufzeit direkt aus der APK geladen werden. Dies setzt das Flag `android:extractNativeLibs` im Android-Manifest ([offizielle Dokumentation](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs)).
+
+---
+
+### macOS
+
+#### App Icon
+Bundle-Symboldatei (.icns), die unter macOS als Anwendungssymbol verwendet werden soll.
+
+#### Info.plist {#infoplist-1}
+Wenn gesetzt, wird bei der Bundle-Erstellung die angegebene Datei info.plist verwendet.
+
+#### Privacy Manifest {#privacy-manifest-1}
+Das Apple-Datenschutzmanifest für die Anwendung. Der Standardwert des Felds ist `/builtins/manifests/osx/PrivacyInfo.xcprivacy`.
+
+#### Bundle Identifier {#bundle-identifier-1}
+Anhand der Bundle-ID erkennt macOS Aktualisierungen deiner App. Deine Bundle-ID muss bei Apple registriert und für deine App eindeutig sein. Du kannst nicht dieselbe Kennung für iOS- und macOS-Apps verwenden. Sie muss aus zwei oder mehr durch einen Punkt getrennten Segmenten bestehen. Jedes Segment muss mit einem Buchstaben beginnen. Jedes Segment darf nur alphanumerische Zeichen, Unterstriche oder Bindestriche (-) enthalten.
+
+#### Default Language {#default-language-1}
+Die Sprache, die verwendet wird, wenn die vom Benutzer bevorzugte Sprache nicht in der Liste `Localizations` der Anwendung enthalten ist (siehe [`CFBundleDevelopmentRegion`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430)). Verwende den zweibuchstabigen Standard ISO 639-1, wenn die bevorzugte Sprache darin verfügbar ist, andernfalls den dreibuchstabigen Standard ISO 639-2.
+
+#### Localizations {#localizations-1}
+Dieses Feld enthält durch Kommas getrennte Zeichenfolgen, die den Sprachnamen oder das ISO-Sprachkürzel der unterstützten Lokalisierungen angeben (siehe [`CFBundleLocalizations`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-109552)).
+
+---
+
+### Windows
+
+#### App Icon {#app-icon-1}
+Bilddatei (.ico), die unter Windows als Anwendungssymbol verwendet werden soll. Wie du eine .ico-Datei erstellst, erfährst du im [Windows-Handbuch](/manuals/windows).
+
+---
+
+### HTML5
+
+Weitere Informationen zu vielen dieser Optionen findest du im [Handbuch zur HTML5-Plattform](/manuals/html5/).
+
+#### Heap Size
+Die Heap-Größe in Megabyte, die Emscripten verwenden soll.
+
+#### .html Shell
+Verwendet bei der Bundle-Erstellung die angegebene HTML-Vorlagendatei. Standardmäßig `/builtins/manifests/web/engine_template.html`.
+
+#### Custom .css
+Verwendet bei der Bundle-Erstellung die angegebene CSS-Datei für das Design. Standardmäßig `/builtins/manifests/web/light_theme.css`.
+
+#### Splash Image
+Wenn gesetzt, wird bei der Bundle-Erstellung das angegebene Startbild für die Anzeige beim Start anstelle des Defold-Logos verwendet.
+
+#### Archive Location Prefix
+Bei der Bundle-Erstellung für HTML5 werden die Spieldaten in eine oder mehrere Archivdatendateien aufgeteilt. Wenn die Engine das Spiel startet, werden diese Archivdateien in den Speicher eingelesen. Verwende diese Einstellung, um den Speicherort der Daten anzugeben.
+
+#### Archive Location Suffix
+Suffix, das an die Archivdateien angehängt wird. Dies ist beispielsweise nützlich, um Inhalte von einem CDN zu erzwingen, die nicht aus dem Cache stammen (zum Beispiel mit `?version2`).
+
+#### Engine Arguments
+Liste der Argumente, die an die Engine übergeben werden.
+
+#### Wasm Streaming
+Aktiviert das Streaming der wasm-Datei (schneller und mit geringerem Speicherverbrauch, erfordert jedoch den MIME-Typ `application/wasm`).
+
+#### Show Fullscreen Button
+Aktiviert die Schaltfläche Fullscreen in der Datei `index.html`.
+
+#### Show Made With Defold
+Aktiviert den Link Made With Defold in der Datei `index.html`.
+
+#### Show Console Banner
+Wenn diese Option aktiviert ist, werden beim Start der Engine Informationen über die Engine und ihre Version in der Browserkonsole ausgegeben (mit `console.log()`).
+
+#### Scale Mode
+Gibt die Methode an, mit der die Zeichenfläche des Spiels skaliert werden soll.
+
+#### Retry Count
+Die Anzahl der Wiederholungsversuche nach einem fehlgeschlagenen Download beim Start, einschließlich Netzwerkfehlern, HTTP-Fehlerstatus und Größenabweichungen bei der JavaScript- oder WebAssembly-Datei der Engine. Die erste Anfrage zählt separat. Für die Überprüfung der Archivdateien gilt eine eigene Höchstzahl an Wiederholungsversuchen; siehe [Download-Überprüfung](/manuals/html5/#download-verification) und `Retry Time`.
+
+#### Retry Time
+Die Wartezeit in Sekunden zwischen Versuchen, eine Datei herunterzuladen, wenn der Download fehlgeschlagen ist (siehe `Retry Count`).
+
+#### Verify Downloaded File Size
+`html5.verify_downloaded_file_size` prüft heruntergeladene Engine- und Archivdateien auf ihre erwarteten Größen. Standardmäßig aktiviert (`true`). Setze den Wert nur dann auf `false`, wenn ein Server, Proxy oder CDN Dateien absichtlich umschreibt und ihre Größen ändert. Eine fehlgeschlagene Überprüfung führt zu erneuten Download-Versuchen, bevor der Start fehlschlägt. Für Engine-Downloads und die Überprüfung von Archivdateien gelten unterschiedliche Höchstzahlen an Wiederholungsversuchen; siehe [Download-Überprüfung](/manuals/html5/#download-verification).
+
+#### Transparent Graphics Context
+Aktiviere diese Option, wenn der Grafikkontext einen transparenten Hintergrund haben soll.
+
+---
+
+### IAP
+
+#### Auto Finish Transactions
+Aktiviere diese Option, um IAP-Transaktionen automatisch abzuschließen. Ist sie deaktiviert, musst du nach einer erfolgreichen Transaktion ausdrücklich `iap.finish()` aufrufen.
+
+---
+
+### Live update
+
+#### Settings
+Die Ressourcendatei mit Live-Update-Einstellungen, die bei der Bundle-Erstellung verwendet werden soll.
+
+---
+
+### Native extension
+
+#### _App Manifest_
+Wenn gesetzt, wird das Anwendungsmanifest verwendet, um den Engine-Build anzupassen. Damit kannst du ungenutzte Teile aus der Engine entfernen, um die Größe der fertigen Binärdatei zu verringern. Wie du ungenutzte Funktionen ausschließt, erfährst du [im Handbuch zum Anwendungsmanifest](/manuals/app-manifest).
+
+---
+
+### Profiler
+
+Die Einstellung **Profiler** im Anwendungsmanifest steuert, ob Profiler-Code in Debug- und Release-Builds gelinkt wird. Die folgenden Einstellungen steuern das Laufzeitverhalten des Profiler-Codes, der im ausgewählten Build enthalten ist. Einzelheiten findest du im [Handbuch zum Profiling](/manuals/profiling/).
+
+#### Enabled
+Aktiviert den Profiler im Spiel.
+
+#### Track Cpu
+Das Sampling der CPU-Auslastung ist in Debug-Builds standardmäßig aktiviert. Aktiviere diese Einstellung, wenn CPU-Sampling auch in einem Release-Build benötigt wird, der über das Anwendungsmanifest Profiler-Unterstützung enthält.
+
+#### Sleep Between Server Updates
+Die Wartezeit in Millisekunden zwischen Serveraktualisierungen.
+
+#### Performance Timeline Enabled
+Aktiviert die Leistungszeitleiste im Browser (nur HTML5).
+
+#### Max Sample Count
+`profiler.max_sample_count` ist die maximale Anzahl der Profiler-Samples, die pro Thread und Frame aufgezeichnet werden. Der Standardwert ist `4096` und der Mindestwert `128`. Erhöhe diesen Wert nur, wenn ein gültiges Profil das Limit überschreitet. Prüfe zuvor den Profiling-Code nativer Erweiterungen auf nicht zusammenpassende Aufrufe zum Beginn und Ende von Messbereichen.
+
+---
+
+## Konfigurationswerte beim Start der Engine setzen {#setting-config-values-on-engine-startup}
+
+Beim Start der Engine kannst du über die Befehlszeile Konfigurationswerte angeben, die die Einstellungen aus *game.project* überschreiben:
+
+```bash
+# Specify a bootstrap collection
+$ dmengine --config=bootstrap.main_collection=/my.collectionc
+
+# Set two custom config values
+$ dmengine --config=test.my_value=4711 --config=test2.my_value2=foobar
+```
+
+Benutzerdefinierte Werte kannst du wie jeden anderen Konfigurationswert mit der passenden Funktion lesen, die unter [Zugriff zur Laufzeit](#runtime-access) beschrieben ist:
+
+```lua
+local my_value = sys.get_config_number("test.my_value")
+local my_value2 = sys.get_config_string("test.my_value2")
+local my_flag = sys.get_config_boolean("test.my_flag", false)
+```
+
+
+:[Component max count optimizations](../shared/component-max-count-optimizations.md)
+
+
+## Benutzerdefinierte Projekteinstellungen {#custom-project-settings}
+
+Du kannst benutzerdefinierte Einstellungen für das Hauptprojekt oder für eine [native Erweiterung](/manuals/extensions/) definieren. Benutzerdefinierte Einstellungen für das Hauptprojekt müssen in einer Datei `game.properties` im Stammverzeichnis des Projekts definiert werden. Dateien namens `ext.properties` werden überall im Projekt und in abgerufenen Bibliotheksabhängigkeiten erkannt; sie benötigen keine benachbarte Datei `ext.manifest`. Alle gefundenen Erweiterungsmetadaten werden zusammengeführt. Anschließend wird die Datei `game.properties` aus dem Stammverzeichnis angewendet und kann diese Metadaten überschreiben.
+
+Die Einstellungsdatei verwendet dasselbe INI-Format wie *game.project*, und Eigenschaftsattribute werden mit einer Punktnotation und einem Suffix definiert:
+
+```
+[my_category]
+my_property.private = 1
+...
+```
+
+Die Standardmetadatei, die immer angewendet wird, ist [hier](https://github.com/defold/defold/blob/dev/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties) verfügbar.
+
+Die folgenden Attribute sind derzeit verfügbar:
+
+```
+[my_extension]
+// `type` - used for the value string parsing
+my_property.type = string // one of the following values: bool, string, number, integer, string_array, resource
+
+// `help` - displayed as a help tooltip in the editor
+my_property.help = string
+
+// `default` - value used as default if user didn't set value manually
+my_property.default = string
+
+// `private` - private value used during the bundle process but will be removed from the bundle itself
+my_property.private = 1 // boolean value 1 or 0
+
+// `label` - editor input label
+my_property.label = My Awesome Property
+
+// `minimum` and/or `maximum` - valid range for numeric properties, validated in the editor UI
+my_property.minimum = 0
+my_property.maximum = 255
+
+// `options` - drop-down choices for the editor UI, comma-separated value[:label] pairs
+my_property.options = android: Android, ios: iOS
+
+// `resource` type only:
+my_property.filter = jpg,png // allowed file extensions for resource selector dialog
+my_property.preserve-extension = 1 // use original resource extension instead of a built one
+
+// deprecation
+my_property.deprecated = 1 // mark property as deprecated
+my_property.severity-default = warning // if deprecated property is specified, but set to a default value
+my_property.severity-override = error  // if deprecated property is specified and set to a non-default value
+
+```
+Zusätzlich kannst du die folgenden Attribute für eine Einstellungskategorie setzen:
+```
+[my_extension]
+// `group` - game.project category group, e.g. Main, Platforms, Components, Runtime, Distribution
+group = Runtime
+// `title` - displayed category title
+title = My Awesome Extension
+// `help` - displayed category help
+help = Settings for My Awesome Extension
+```
+
+
+Sowohl Bob als auch der Editor lesen diese Metadatendateien ein. Der Editor verwendet sie, um die entsprechenden Felder, Auswahlmöglichkeiten, Validierungen und Hilfe-Tooltips in der Ansicht für *game.project* zu erstellen.

--- a/docs/de/manuals/project-setup.md
+++ b/docs/de/manuals/project-setup.md
@@ -1,0 +1,42 @@
+---
+title: Projekteinrichtung
+brief: Dieses Handbuch beschreibt, wie du in Defold ein Projekt erstellst oder öffnest.
+---
+
+# Projekteinrichtung {#project-setup}
+
+Du kannst direkt im Defold-Editor ganz einfach ein neues Projekt erstellen. Du kannst auch ein vorhandenes Projekt öffnen, das sich bereits auf deinem Computer befindet.
+
+## Ein neues lokales Projekt erstellen {#creating-a-new-project}
+
+Klicke auf die Option <kbd>New Project</kbd> und wähle aus, welche Art von Projekt du erstellen möchtest. Gib einen Speicherort auf deiner Festplatte an, an dem die Projektdateien gespeichert werden sollen. Klicke auf <kbd>Create New Project</kbd>, um das Projekt am ausgewählten Speicherort zu erstellen. Du kannst ein neues Projekt aus einer Vorlage erstellen:
+
+![Projekt öffnen](images/workflow/open_project.png)
+
+Oder aus einem Tutorial mit einer Schritt-für-Schritt-Anleitung:
+
+![Projekt aus einem Tutorial erstellen](images/workflow/create_from_tutorial.png)
+
+Oder aus einem fertigen Beispielspiel:
+
+![Projekt aus einem Beispiel erstellen](images/workflow/create_from_sample.png)
+
+### Das Projekt zu GitHub hinzufügen {#adding-the-project-to-github}
+
+Ein lokales Projekt ist in kein Versionsverwaltungssystem eingebunden. Das bedeutet, dass die Dateien nur auf deiner Festplatte liegen und es keinen Verlauf gibt, mit dem du Änderungen rückgängig machen kannst. Dateien, die du über den Bereich *Assets* des Editors löschst, werden in den Papierkorb des Systems verschoben, sofern dies unterstützt wird. Sie können jedoch endgültig gelöscht werden, wenn dieser Vorgang nicht verfügbar ist oder fehlschlägt. Der Papierkorb schützt nicht vor beliebigen Bearbeitungen und bietet keinen Versionsverlauf. Daher wird empfohlen, ein Versionsverwaltungssystem wie Git zu verwenden, um Änderungen an deinen Dateien nachzuverfolgen. Das macht es auch sehr einfach, mit anderen Personen an einem Projekt zusammenzuarbeiten. Du kannst ein lokales Projekt in wenigen Schritten auf GitHub hochladen:
+
+1. Erstelle ein Konto auf [GitHub](https://github.com/) oder melde dich bei einem bestehenden Konto an
+2. Erstelle mit der Option [New Repository](https://help.github.com/en/articles/creating-a-new-repository) ein Repository
+3. Lade alle Projektdateien über die Option [Upload Files](https://help.github.com/en/articles/adding-a-file-to-a-repository) hoch
+
+Das Projekt steht nun unter Versionsverwaltung. Du solltest [das Projekt klonen](https://help.github.com/en/articles/cloning-a-repository), um es auf deiner lokalen Festplatte zu speichern, und anschließend von diesem neuen Speicherort aus arbeiten.
+
+## Ein vorhandenes Projekt öffnen {#open-an-existing-project}
+
+Klicke auf die Option <kbd>Open From Disk</kbd>, um ein Projekt zu öffnen, das sich bereits auf deinem Computer befindet.
+
+![Projekt importieren](images/workflow/open_from_disk.png)
+
+## Ein zuletzt verwendetes Projekt öffnen {#open-a-recent-project}
+
+Sobald du ein Projekt einmal geöffnet hast, erscheint es in der Liste der zuletzt verwendeten Projekte. Die Liste zeigt die Projekte an, an denen du zuletzt gearbeitet hast. Du kannst jedes dieser Projekte schnell öffnen, indem du es in der Liste doppelt anklickst.

--- a/docs/de/manuals/properties.md
+++ b/docs/de/manuals/properties.md
@@ -1,0 +1,166 @@
+---
+title: Eigenschaften in Defold
+brief: Dieses Handbuch erklärt, welche Arten von Eigenschaften es in Defold gibt und wie sie verwendet und animiert werden.
+---
+
+# Eigenschaften {#properties}
+
+Defold stellt Eigenschaften (properties) für Spielobjekte (game objects), Komponenten (components) und GUI-Knoten (GUI nodes) bereit, die gelesen, gesetzt und animiert werden können. Es gibt die folgenden Arten von Eigenschaften:
+
+* Systemdefinierte Transformationen von Spielobjekten (Position, Drehung und Skalierung) und komponentenspezifische Eigenschaften (zum Beispiel die Größe eines Sprites in Pixeln oder die Masse eines Kollisionsobjekts (collision object))
+* Benutzerdefinierte Eigenschaften von Skriptkomponenten, die in Lua-Skripten definiert werden (Einzelheiten findest du in der [Dokumentation zu Skripteigenschaften](/manuals/script-properties))
+* Eigenschaften von GUI-Knoten
+* Shader-Konstanten, die in Shadern und Materialdateien definiert werden (Einzelheiten findest du in der [Dokumentation zu Materialien](/manuals/material))
+
+Numerische Eigenschaften zeigen einen Ziehgriff an, wenn du den Mauszeiger über ihr Eingabefeld bewegst. Du kannst ihren Wert erhöhen oder verringern, indem du den Griff nach rechts oder links beziehungsweise nach oben oder unten ziehst.
+
+Je nachdem, wo eine Eigenschaft vorkommt, greifst du über eine allgemeine Funktion oder eine eigenschaftsspezifische Funktion auf sie zu. Viele Eigenschaften können automatisch animiert werden. Es wird dringend empfohlen, Eigenschaften über das integrierte System zu animieren, statt sie selbst (innerhalb einer `update()`-Funktion) zu verändern. Das ist sowohl aus Leistungsgründen als auch wegen der bequemeren Handhabung sinnvoll.
+
+Zusammengesetzte Eigenschaften vom Typ `vector3`, `vector4` oder `quaternion` stellen auch ihre Teilkomponenten (`x`, `y`, `z` und `w`) bereit. Du kannst die Teilkomponenten einzeln ansprechen, indem du an den Namen einen Punkt (`.`) und den Namen der Teilkomponente anhängst. So setzt du zum Beispiel die x-Komponente der Position eines Spielobjekts:
+
+```lua
+-- Set the x position of "game_object" to 10.
+go.set("game_object", "position.x", 10)
+```
+
+Die Funktionen `go.get()`, `go.set()` und `go.animate()` nehmen als ersten Parameter eine Referenz und als zweiten einen Eigenschaftsbezeichner entgegen. Die Referenz bezeichnet das Spielobjekt oder die Komponente und kann eine Zeichenfolge, ein Hashwert oder eine URL sein. URLs werden im [Handbuch zur Adressierung](/manuals/addressing) ausführlich erklärt. Der Eigenschaftsbezeichner ist eine Zeichenfolge oder ein Hashwert, der die Eigenschaft benennt:
+
+```lua
+-- Set the x-scale of the sprite component
+local url = msg.url("#sprite")
+local prop = hash("scale.x")
+go.set(url, prop, 2.0)
+```
+
+Bei GUI-Knoten wird der Knoten als erster Parameter an eine eigenschaftsspezifische Funktion oder an die allgemeinen Funktionen `gui.get()` und `gui.set()` übergeben:
+
+```lua
+-- Get the color of the button
+local node = gui.get_node("button")
+local color = gui.get_color(node)
+local same_color = gui.get(node, "color")
+gui.set(node, "color.x", 1)
+```
+
+## Eigenschaften von Spielobjekten und Komponenten {#game-object-and-component-properties}
+
+Alle Spielobjekte und einige Komponententypen haben Eigenschaften, die zur Laufzeit gelesen und verändert werden können. Lies diese Werte mit [`go.get()`](/ref/go#go.get) und schreibe sie mit [`go.set()`](/ref/go#go.set). Je nach Datentyp des Eigenschaftswerts kannst du die Werte mit [`go.animate()`](/ref/go#go.animate) animieren. Ein kleiner Teil der Eigenschaften kann nur gelesen werden.
+
+`get`{.mark}
+: Kann mit [`go.get()`](/ref/go#go.get) gelesen werden.
+
+`get+set`{.mark}
+: Kann mit [`go.get()`](/ref/go#go.get) gelesen und mit [`go.set()`](/ref/go#go.set) geschrieben werden. Numerische Werte können mit [`go.animate()`](/ref/go#go.animate) animiert werden.
+
+*Eigenschaften von Spielobjekten*
+
+| Eigenschaft   | Beschreibung                            | Typ            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *position* | Die lokale Position des Spielobjekts. | `vector3`      | `get+set`{.mark} |
+| *rotation* | Die lokale Drehung des Spielobjekts, ausgedrückt als `quaternion`.  | `quaternion` | `get+set`{.mark} |
+| *euler*    | Die lokale Drehung des Spielobjekts als Euler-Winkel. | `vector3` | `get+set`{.mark} |
+| *scale*    | Die lokale nicht gleichmäßige Skalierung des Spielobjekts, ausgedrückt als Vektor, dessen Komponenten jeweils einen Multiplikator entlang einer Achse enthalten. Um die Größe in X und Y zu verdoppeln, ohne Z zu verändern, verwende `vmath.vector3(2.0, 2.0, 1.0)`. | `vector3` | `get+set`{.mark} |
+| *scale.xy*    | Die lokale nicht gleichmäßige Skalierung des Spielobjekts entlang der X- und Y-Achse. Verwende diese Eigenschaft oder `go.set_scale_xy()`, wenn keine Skalierung in Z beabsichtigt ist. | `vector3` | `get+set`{.mark} |
+
+::: sidenote
+Es gibt auch spezifische Funktionen für die Transformation des Spielobjekts: `go.get_position()`, `go.set_position()`, `go.get_rotation()`, `go.set_rotation()`,  `go.get_scale()`, `go.set_scale()` und `go.set_scale_xy()`.
+:::
+
+*Eigenschaften von Sprite-Komponenten*
+
+| Eigenschaft   | Beschreibung                            | Typ            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *size*     | Die unskalierte Größe des Sprites---seine Größe aus dem Quellatlas. | `vector3` | `get`{.mark} |
+| *image* | Der Hashwert des Texturpfads des Sprites. | `hash` | `get`{.mark}|
+| *scale* | Die nicht gleichmäßige Skalierung des Sprites. | `vector3` | `get+set`{.mark}|
+| *scale.xy* | Die nicht gleichmäßige Skalierung des Sprites entlang der X- und Y-Achse. | `vector3` | `get+set`{.mark}|
+| *material* | Das vom Sprite verwendete Material. | `hash` | `get+set`{.mark}|
+| *cursor* | Die Position (im Bereich 0--1) des Wiedergabezeigers. | `number` | `get+set`{.mark}|
+| *playback_rate* | Die Bildrate (Bilder pro Sekunde, FPS) der Flipbook-Animation. | `number` | `get+set`{.mark}|
+
+*Eigenschaften von Kollisionsobjekt-Komponenten*
+
+| Eigenschaft   | Beschreibung                            | Typ            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *mass*     | Die Masse des Kollisionsobjekts. | `number` | `get`{.mark} |
+| *linear_velocity* | Die aktuelle lineare Geschwindigkeit des Kollisionsobjekts. | `vector3` | `get`{.mark} |
+| *angular_velocity* | Die aktuelle Winkelgeschwindigkeit des Kollisionsobjekts. | `vector3` | `get`{.mark} |
+| *linear_damping* | Die lineare Dämpfung des Kollisionsobjekts. | `vector3` | `get+set`{.mark} |
+| *angular_damping* | Die Winkeldämpfung des Kollisionsobjekts. | `vector3` | `get+set`{.mark} |
+
+*Eigenschaften von Modellkomponenten (3D)*
+
+| Eigenschaft   | Beschreibung                            | Typ            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *animation* | Die aktuelle Animation.                | `hash`          | `get`{.mark}     |
+| *texture0*--*texture15* | Die Hashwerte der Texturpfade des Modells. | `hash` | `get+set`{.mark}|
+| *cursor*  | Die Position (im Bereich 0--1) des Wiedergabezeigers. | `number`   | `get+set`{.mark} |
+| *playback_rate* | Die Wiedergabegeschwindigkeit der Animation. Ein Multiplikator für die Wiedergabegeschwindigkeit der Animation. | `number` | `get+set`{.mark} |
+| *material* | Das vom Modell verwendete Material. | `hash` | `get+set`{.mark}|
+
+*Eigenschaften von Beschriftungskomponenten*
+
+| Eigenschaft   | Beschreibung                            | Typ            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *text* | Der Textinhalt der Beschriftung (label). Verfügbar seit Defold 1.13.2. | `string` | `get+set`{.mark} |
+| *scale* | Die Skalierung der Beschriftung. | `vector3` | `get+set`{.mark} |
+| *scale.xy* | Die Skalierung der Beschriftung entlang der X- und Y-Achse. | `vector3` | `get+set`{.mark}|
+| *color*     | Die Farbe der Beschriftung. | `vector4` | `get+set`{.mark} |
+| *outline* | Die Konturfarbe der Beschriftung. | `vector4` | `get+set`{.mark} |
+| *shadow* | Die Schattenfarbe der Beschriftung. | `vector4` | `get+set`{.mark} |
+| *size* | Die Größe der Beschriftung. Die Größe begrenzt den Text, wenn der Zeilenumbruch aktiviert ist. | `vector3` | `get+set`{.mark} |
+| *material* | Das von der Beschriftung verwendete Material. | `hash` | `get+set`{.mark}|
+| *font* | Die von der Beschriftung verwendete Schriftart. | `hash` | `get+set`{.mark}|
+
+
+## Eigenschaften von GUI-Knoten {#gui-node-properties}
+
+GUI-Knoten haben eigenschaftsspezifische Getter- und Setter-Funktionen wie `gui.get_position()` und `gui.set_position()`. Die unten aufgeführten integrierten Eigenschaften können alternativ mit `gui.get(node, property)` und `gui.set(node, property, value)` gelesen und geschrieben werden. Andere Knotenwerte benötigen möglicherweise weiterhin ihre eigenen Funktionen. Materialkonstanten von GUI-Knoten verwenden ebenfalls die allgemeinen Funktionen. Um eine Komponente einer Vektoreigenschaft anzusprechen, hänge ihren Namen an, zum Beispiel `gui.set(node, "color.x", 1)`.
+
+Die allgemeinen und die eigenschaftsspezifischen Funktionen verwenden nicht immer dieselben Datentypen. `gui.get()` gibt einen `vector4` für die vollständigen Eigenschaften `position`, `scale`, `size` und `euler` zurück, während die entsprechenden eigenschaftsspezifischen Funktionen einen `vector3` zurückgeben. `gui.set()` akzeptiert für diese Eigenschaften sowohl einen `vector3` als auch einen `vector4`. Die allgemeine Eigenschaft `rotation` verwendet ein Quaternion; verwende `euler`, wenn du die Drehung in Grad setzt.
+
+* `position` (oder `gui.PROP_POSITION`)
+* `rotation` (oder `gui.PROP_ROTATION`)
+* `euler` (oder `gui.PROP_EULER`)
+* `scale` (oder `gui.PROP_SCALE`)
+* `color` (oder `gui.PROP_COLOR`)
+* `outline` (oder `gui.PROP_OUTLINE`)
+* `shadow` (oder `gui.PROP_SHADOW`)
+* `size` (oder `gui.PROP_SIZE`)
+* `fill_angle` (oder `gui.PROP_FILL_ANGLE`)
+* `inner_radius` (oder `gui.PROP_INNER_RADIUS`)
+* `leading` (oder `gui.PROP_LEADING`)
+* `tracking` (oder `gui.PROP_TRACKING`)
+* `slice9` (oder `gui.PROP_SLICE9`)
+
+Beachte, dass alle Farbwerte in einem `vector4` kodiert sind, dessen Komponenten den RGBA-Werten entsprechen:
+
+`x`
+: Der rote Farbanteil
+
+`y`
+: Der grüne Farbanteil
+
+`z`
+: Der blaue Farbanteil
+
+`w`
+: Der Alpha-Anteil
+
+*Eigenschaften von GUI-Knoten*
+
+| Eigenschaft   | Beschreibung                            | Typ            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *color*   | Die Flächenfarbe des Knotens.            | `vector4`      | `gui.get_color()` `gui.set_color()` |
+| *outline* | Die Konturfarbe des Knotens.         | `vector4`       | `gui.get_outline()` `gui.set_outline()` |
+| *position* | Die Position des Knotens. | `vector3` | `gui.get_position()` `gui.set_position()` |
+| *rotation* | Die Drehung des Knotens. Der Getter gibt ein Quaternion zurück; der Setter akzeptiert ein Quaternion oder Euler-Winkel als Vektor. | `quaternion`, `vector3` oder `vector4` | `gui.get_rotation()` `gui.set_rotation()` |
+| *euler* | Die Drehung des Knotens, ausgedrückt als Euler-Winkel in Grad. | `vector3` | `gui.get_euler()` `gui.set_euler()` |
+| *scale* | Die Skalierung des Knotens, ausgedrückt als Multiplikator entlang jeder Achse. | `vector3` |`gui.get_scale()` `gui.set_scale()` |
+| *shadow* | Die Schattenfarbe des Knotens. | `vector4` | `gui.get_shadow()` `gui.set_shadow()` |
+| *size* | Die unskalierte Größe des Knotens. | `vector3` | `gui.get_size()` `gui.set_size()` |
+| *fill_angle* | Der Füllwinkel eines Kreissektor-Knotens (pie node), ausgedrückt in Grad gegen den Uhrzeigersinn. | `number` | `gui.get_fill_angle()` `gui.set_fill_angle()` |
+| *inner_radius* | Der innere Radius eines Kreissektor-Knotens. | `number` | `gui.get_inner_radius()` `gui.set_inner_radius()` |
+| *leading* | Der Skalierungsfaktor für den Zeilenabstand eines Textknotens. | `number` | `gui.get_leading()` `gui.set_leading()` |
+| *tracking* | Der Skalierungsfaktor für den Zeichenabstand eines Textknotens. | `number` | `gui.get_tracking()` `gui.set_tracking()` |
+| *slice9* | Die Randabstände eines Knotens mit Neun-Segment-Skalierung (9-slice). | `vector4` | `gui.get_slice9()` `gui.set_slice9()` |

--- a/docs/de/manuals/property-animation.md
+++ b/docs/de/manuals/property-animation.md
@@ -1,0 +1,180 @@
+---
+title: Handbuch zu Eigenschaftsanimationen in Defold
+brief: Dieses Handbuch beschreibt, wie du Eigenschaftsanimationen in Defold verwendest.
+---
+
+# Eigenschaftsanimation {#property-animation}
+
+Alle numerischen Eigenschaften (`numbers`, `vector3`, `vector4` und Quaternionen) sowie Shader-Konstanten können mit dem integrierten Animationssystem über die Funktion `go.animate()` animiert werden. Die Engine interpoliert die Eigenschaften automatisch für dich entsprechend den angegebenen Wiedergabemodi und Easing-Funktionen. Du kannst auch eigene Easing-Funktionen angeben.
+
+  ![Eigenschaftsanimation](images/animation/property_animation.png)
+  ![Wiederholte Sprungbewegung](images/animation/bounce.gif)
+
+## Eigenschaftsanimation {#property-animation-1}
+
+Um eine Eigenschaft eines Spielobjekts (game object) oder einer Komponente (component) zu animieren, verwende die Funktion `go.animate()`. Für Eigenschaften von GUI-Knoten (GUI nodes) lautet die entsprechende Funktion `gui.animate()`.
+
+```lua
+-- Set the position property y component to 200
+go.set(".", "position.y", 200)
+-- Then animate it
+go.animate(".", "position.y", go.PLAYBACK_LOOP_PINGPONG, 100, go.EASING_OUTBOUNCE, 2)
+```
+
+Um alle Animationen einer bestimmten Eigenschaft anzuhalten, rufe `go.cancel_animations()` oder bei GUI-Knoten `gui.cancel_animations()` auf:
+
+```lua
+-- Stop euler z rotation animation on the current game object
+go.cancel_animations(".", "euler.z")
+```
+
+Wenn du die Animation einer zusammengesetzten Eigenschaft wie `position` abbrichst, werden auch alle Animationen ihrer einzelnen Komponenten (`position.x`, `position.y` und `position.z`) abgebrochen.
+
+Das [Handbuch zu Eigenschaften](/manuals/properties) enthält alle verfügbaren Eigenschaften von Spielobjekten, Komponenten und GUI-Knoten.
+
+## Eigenschaftsanimation bei GUI-Knoten {#gui-node-property-animation}
+
+Fast alle Eigenschaften von GUI-Knoten lassen sich animieren. Du kannst zum Beispiel einen Knoten unsichtbar machen, indem du seine Eigenschaft `color` auf vollständige Transparenz setzt, und ihn anschließend einblenden, indem du die Farbe zu Weiß animierst (also ohne Einfärbung).
+
+```lua
+local node = gui.get_node("button")
+local color = gui.get_color(node)
+-- Animate the color to white
+gui.animate(node, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_INOUTQUAD, 0.5)
+-- Animate the outline red color component
+gui.animate(node, "outline.x", 1, gui.EASING_INOUTQUAD, 0.5)
+-- And move to x position 100
+gui.animate(node, hash("position.x"), 100, gui.EASING_INOUTQUAD, 0.5)
+```
+
+## Callbacks bei Abschluss {#completion-callbacks}
+
+Die Funktionen zur Eigenschaftsanimation `go.animate()` und `gui.animate()` unterstützen als letztes Argument eine optionale Lua-Callback-Funktion. Diese Funktion wird aufgerufen, wenn die Animation bis zum Ende abgespielt wurde. Bei wiederholten Animationen wird die Funktion nie aufgerufen, ebenso wenig, wenn eine Animation manuell über `go.cancel_animations()` oder `gui.cancel_animations()` abgebrochen wird. Mit dem Callback kannst du beim Abschluss einer Animation Ereignisse auslösen oder mehrere Animationen miteinander verketten.
+
+## Easing
+
+Easing legt fest, wie sich der animierte Wert mit der Zeit ändert. Die folgenden Bilder zeigen die Funktionen, die über die Zeit angewendet werden, um das Easing zu erzeugen.
+
+Die folgenden Easing-Werte sind für `go.animate()` gültig:
+
+|---|---|
+| `go.EASING_LINEAR` | |
+| `go.EASING_INBACK` | `go.EASING_OUTBACK` |
+| `go.EASING_INOUTBACK` | `go.EASING_OUTINBACK` |
+| `go.EASING_INBOUNCE` | `go.EASING_OUTBOUNCE` |
+| `go.EASING_INOUTBOUNCE` | `go.EASING_OUTINBOUNCE` |
+| `go.EASING_INELASTIC` | `go.EASING_OUTELASTIC` |
+| `go.EASING_INOUTELASTIC` | `go.EASING_OUTINELASTIC` |
+| `go.EASING_INSINE` | `go.EASING_OUTSINE` |
+| `go.EASING_INOUTSINE` | `go.EASING_OUTINSINE` |
+| `go.EASING_INEXPO` | `go.EASING_OUTEXPO` |
+| `go.EASING_INOUTEXPO` | `go.EASING_OUTINEXPO` |
+| `go.EASING_INCIRC` | `go.EASING_OUTCIRC` |
+| `go.EASING_INOUTCIRC` | `go.EASING_OUTINCIRC` |
+| `go.EASING_INQUAD` | `go.EASING_OUTQUAD` |
+| `go.EASING_INOUTQUAD` | `go.EASING_OUTINQUAD` |
+| `go.EASING_INCUBIC` | `go.EASING_OUTCUBIC` |
+| `go.EASING_INOUTCUBIC` | `go.EASING_OUTINCUBIC` |
+| `go.EASING_INQUART` | `go.EASING_OUTQUART` |
+| `go.EASING_INOUTQUART` | `go.EASING_OUTINQUART` |
+| `go.EASING_INQUINT` | `go.EASING_OUTQUINT` |
+| `go.EASING_INOUTQUINT` | `go.EASING_OUTINQUINT` |
+
+Die folgenden Easing-Werte sind für `gui.animate()` gültig:
+
+|---|---|
+| `gui.EASING_LINEAR` | |
+| `gui.EASING_INBACK` | `gui.EASING_OUTBACK` |
+| `gui.EASING_INOUTBACK` | `gui.EASING_OUTINBACK` |
+| `gui.EASING_INBOUNCE` | `gui.EASING_OUTBOUNCE` |
+| `gui.EASING_INOUTBOUNCE` | `gui.EASING_OUTINBOUNCE` |
+| `gui.EASING_INELASTIC` | `gui.EASING_OUTELASTIC` |
+| `gui.EASING_INOUTELASTIC` | `gui.EASING_OUTINELASTIC` |
+| `gui.EASING_INSINE` | `gui.EASING_OUTSINE` |
+| `gui.EASING_INOUTSINE` | `gui.EASING_OUTINSINE` |
+| `gui.EASING_INEXPO` | `gui.EASING_OUTEXPO` |
+| `gui.EASING_INOUTEXPO` | `gui.EASING_OUTINEXPO` |
+| `gui.EASING_INCIRC` | `gui.EASING_OUTCIRC` |
+| `gui.EASING_INOUTCIRC` | `gui.EASING_OUTINCIRC` |
+| `gui.EASING_INQUAD` | `gui.EASING_OUTQUAD` |
+| `gui.EASING_INOUTQUAD` | `gui.EASING_OUTINQUAD` |
+| `gui.EASING_INCUBIC` | `gui.EASING_OUTCUBIC` |
+| `gui.EASING_INOUTCUBIC` | `gui.EASING_OUTINCUBIC` |
+| `gui.EASING_INQUART` | `gui.EASING_OUTQUART` |
+| `gui.EASING_INOUTQUART` | `gui.EASING_OUTINQUART` |
+| `gui.EASING_INQUINT` | `gui.EASING_OUTQUINT` |
+| `gui.EASING_INOUTQUINT` | `gui.EASING_OUTINQUINT` |
+
+![Lineare Interpolation](images/properties/easing_linear.png)
+![Back-Kurve (In)](images/properties/easing_inback.png)
+![Back-Kurve (Out)](images/properties/easing_outback.png)
+![Back-Kurve (In-out)](images/properties/easing_inoutback.png)
+![Back-Kurve (Out-in)](images/properties/easing_outinback.png)
+![Bounce-Kurve (In)](images/properties/easing_inbounce.png)
+![Bounce-Kurve (Out)](images/properties/easing_outbounce.png)
+![Bounce-Kurve (In-out)](images/properties/easing_inoutbounce.png)
+![Bounce-Kurve (Out-in)](images/properties/easing_outinbounce.png)
+![Elastische Kurve (In)](images/properties/easing_inelastic.png)
+![Elastische Kurve (Out)](images/properties/easing_outelastic.png)
+![Elastische Kurve (In-out)](images/properties/easing_inoutelastic.png)
+![Elastische Kurve (Out-in)](images/properties/easing_outinelastic.png)
+![Sinuskurve (In)](images/properties/easing_insine.png)
+![Sinuskurve (Out)](images/properties/easing_outsine.png)
+![Sinuskurve (In-out)](images/properties/easing_inoutsine.png)
+![Sinuskurve (Out-in)](images/properties/easing_outinsine.png)
+![Exponentialkurve (In)](images/properties/easing_inexpo.png)
+![Exponentialkurve (Out)](images/properties/easing_outexpo.png)
+![Exponentialkurve (In-out)](images/properties/easing_inoutexpo.png)
+![Exponentialkurve (Out-in)](images/properties/easing_outinexpo.png)
+![Kreiskurve (In)](images/properties/easing_incirc.png)
+![Kreiskurve (Out)](images/properties/easing_outcirc.png)
+![Kreiskurve (In-out)](images/properties/easing_inoutcirc.png)
+![Kreiskurve (Out-in)](images/properties/easing_outincirc.png)
+![Quadratische Kurve (In)](images/properties/easing_inquad.png)
+![Quadratische Kurve (Out)](images/properties/easing_outquad.png)
+![Quadratische Kurve (In-out)](images/properties/easing_inoutquad.png)
+![Quadratische Kurve (Out-in)](images/properties/easing_outinquad.png)
+![Kubische Kurve (In)](images/properties/easing_incubic.png)
+![Kubische Kurve (Out)](images/properties/easing_outcubic.png)
+![Kubische Kurve (In-out)](images/properties/easing_inoutcubic.png)
+![Kubische Kurve (Out-in)](images/properties/easing_outincubic.png)
+![Quartische Kurve (In)](images/properties/easing_inquart.png)
+![Quartische Kurve (Out)](images/properties/easing_outquart.png)
+![Quartische Kurve (In-out)](images/properties/easing_inoutquart.png)
+![Quartische Kurve (In-out)](images/properties/easing_outinquart.png)
+![Quintische Kurve (In)](images/properties/easing_inquint.png)
+![Quintische Kurve (Out)](images/properties/easing_outquint.png)
+![Quintische Kurve (In-out)](images/properties/easing_inoutquint.png)
+![Quintische Kurve (Out-in)](images/properties/easing_outinquint.png)
+
+## Eigenes Easing {#custom-easing}
+
+Du kannst eigene Easing-Kurven erstellen, indem du einen `vector` mit einer Reihe von Werten definierst und diesen Vektor anstelle einer der oben aufgeführten vordefinierten Easing-Konstanten übergibst. Die Vektorwerte beschreiben eine Kurve vom Startwert (`0`) zum Zielwert (`1`). Die Laufzeitumgebung liest Werte aus dem Vektor aus und interpoliert linear, um Werte zwischen den im Vektor angegebenen Punkten zu berechnen.
+
+Der folgende Vektor zum Beispiel:
+
+```lua
+local values = { 0, 0.4, 0.2, 0.2, 0.5, 1 }
+local my_easing = vmath.vector(values)
+```
+
+ergibt diese Kurve:
+
+![Eigene Kurve](images/animation/custom_curve.png)
+
+Das folgende Beispiel lässt die y-Position eines Spielobjekts entsprechend einer Rechteckkurve zwischen der aktuellen Position und 200 springen:
+
+```lua
+local values = { 0, 0, 0, 0, 0, 0, 0, 0,
+                 1, 1, 1, 1, 1, 1, 1, 1,
+                 0, 0, 0, 0, 0, 0, 0, 0,
+                 1, 1, 1, 1, 1, 1, 1, 1,
+                 0, 0, 0, 0, 0, 0, 0, 0,
+                 1, 1, 1, 1, 1, 1, 1, 1,
+                 0, 0, 0, 0, 0, 0, 0, 0,
+                 1, 1, 1, 1, 1, 1, 1, 1 }
+local square_easing = vmath.vector(values)
+go.animate("go", "position.y", go.PLAYBACK_LOOP_PINGPONG, 200, square_easing, 2.0)
+```
+
+![Rechteckkurve](images/animation/square_curve.png)

--- a/docs/de/manuals/push.md
+++ b/docs/de/manuals/push.md
@@ -1,0 +1,6 @@
+---
+title: Push-Benachrichtigungen für iOS und Android in Defold
+brief: Dieses Dokument beschreibt, wie du entfernte und lokale Push-Benachrichtigungen für iOS und Android in deinem Spiel oder deiner Anwendung einrichtest und implementierst.
+---
+
+[Dieses Handbuch wurde verschoben](/extension-push)

--- a/docs/de/manuals/refactoring.md
+++ b/docs/de/manuals/refactoring.md
@@ -1,0 +1,20 @@
+---
+title: Refactoring
+brief: Dieses Handbuch erklärt, wie du die Struktur deines Projekts mithilfe der leistungsfähigen Refactoring-Funktionen leicht ändern kannst.
+---
+
+# Refactoring
+
+Refactoring bezeichnet die Umstrukturierung von vorhandenem Code und Assets. Während der Entwicklung eines Projekts ergibt sich häufig die Notwendigkeit, Dinge zu ändern oder zu verschieben: Namen müssen geändert werden, um Namenskonventionen einzuhalten oder die Verständlichkeit zu verbessern, und Code- oder Asset-Dateien müssen an eine sinnvollere Stelle in der Projekthierarchie verschoben werden.
+
+Defold unterstützt dich beim effizienten Refactoring, indem es nachverfolgt, wie Assets verwendet werden. Referenzen auf Assets, die umbenannt und/oder verschoben werden, aktualisiert Defold automatisch. Bei deiner Entwicklungsarbeit solltest du frei entscheiden können. Dein Projekt hat eine flexible Struktur, die du nach Belieben ändern kannst, ohne befürchten zu müssen, dass alles nicht mehr funktioniert und auseinanderfällt.
+
+::: important
+Automatisches Refactoring funktioniert nur, wenn du Änderungen innerhalb des Editors vornimmst. Wenn du eine Datei außerhalb des Editors umbenennst oder verschiebst, werden Referenzen auf diese Datei nicht automatisch geändert.
+:::
+
+Wenn du allerdings eine Referenz ungültig machst, indem du beispielsweise ein Asset löschst, kann der Editor das Problem nicht beheben. Er gibt dir aber hilfreiche Hinweise auf Fehler. Wenn du zum Beispiel eine Animation aus einem Atlas löschst und diese Animation irgendwo verwendet wird, meldet Defold einen Fehler, sobald du versuchst, das Spiel zu starten. Der Editor markiert außerdem die Stellen, an denen Fehler auftreten, damit du das Problem schnell finden kannst:
+
+![Refactoring-Fehler](images/workflow/delete_error.png)
+
+Build-Fehler werden im Bereich *Build Errors* am unteren Rand des Editors angezeigt. Ein <kbd>Doppelklick</kbd> auf einen Fehler führt dich zur Stelle, an der das Problem auftritt.

--- a/docs/de/manuals/render.md
+++ b/docs/de/manuals/render.md
@@ -1,0 +1,538 @@
+---
+title: Die Rendering-Pipeline in Defold
+brief: Dieses Handbuch erklärt, wie Defolds Rendering-Pipeline funktioniert und wie du sie programmieren kannst.
+---
+
+# Rendering {#render}
+
+Jedes Objekt, das die Engine auf dem Bildschirm anzeigt – Sprites, Modelle, Kacheln, Partikel oder GUI-Knoten (GUI nodes) –, wird von einem Renderer gezeichnet. Das Herzstück des Renderers ist ein Render-Skript (render script), das die Rendering-Pipeline steuert. Standardmäßig wird jedes 2D-Objekt mit der richtigen Bitmap, der angegebenen Farbmischung und in der richtigen Z-Tiefe gezeichnet---du musst dich also möglicherweise über die Reihenfolge und einfache Farbmischung hinaus nie mit dem Rendering befassen. Für die meisten 2D-Spiele funktioniert die Standard-Pipeline gut, aber dein Spiel kann besondere Anforderungen haben. In diesem Fall kannst du mit Defold eine maßgeschneiderte Rendering-Pipeline schreiben.
+
+### Rendering-Pipeline - Was, wann und wo? {#render-pipeline-what-when-and-where}
+
+Die Rendering-Pipeline steuert, was gerendert wird, wann es gerendert wird und auch wo es gerendert wird. Was gerendert wird, bestimmen [Render-Prädikate](#render-predicates) (render predicates). Wann ein Prädikat gerendert wird, wird im [Render-Skript](#the-render-script) festgelegt, und wo ein Prädikat gerendert wird, bestimmen [Ansicht und Projektion](#default-view-projection). Die Rendering-Pipeline kann außerdem Grafik, die von einem Render-Prädikat gezeichnet wird und außerhalb eines festgelegten Begrenzungsquaders oder Sichtvolumens liegt, aussondern. Dieser Vorgang heißt Aussondern von Geometrie außerhalb des Sichtvolumens (Frustum Culling).
+
+
+## Das Standard-Rendering {#the-default-render}
+
+Die Renderdatei enthält eine Referenz auf das aktuelle Render-Skript sowie benutzerdefinierte Materialien, die im Render-Skript verfügbar sein sollen (zur Verwendung mit [`render.enable_material()`](/ref/render/#render.enable_material))
+
+Das Herzstück der Rendering-Pipeline ist das _Render-Skript_. Es ist ein Lua-Skript mit den Funktionen `init()`, `update()` und `on_message()` und dient hauptsächlich dazu, mit der zugrunde liegenden Grafik-API zu interagieren. Das Render-Skript nimmt im Lebenszyklus deines Spiels einen besonderen Platz ein. Einzelheiten findest du in der [Dokumentation zum Anwendungslebenszyklus](/manuals/application-lifecycle).
+
+Im Ordner „Builtins“ deiner Projekte findest du die standardmäßige Render-Ressource ("default.render") und das standardmäßige Render-Skript ("default.render_script").
+
+![Integriertes Rendering](images/render/builtin.png)
+
+So richtest du einen benutzerdefinierten Renderer ein:
+
+1. Kopiere die Dateien "default.render" und "default.render_script" an eine Stelle in deiner Projekthierarchie. Du kannst natürlich ein Render-Skript von Grund auf neu erstellen. Es empfiehlt sich aber, mit einer Kopie des Standardskripts zu beginnen, besonders wenn du mit Defold und/oder Grafikprogrammierung noch nicht vertraut bist.
+
+2. Bearbeite deine Kopie der Datei "default.render" und ändere die Eigenschaft *Script* so, dass sie auf deine Kopie des Render-Skripts verweist.
+
+3. Ändere die Eigenschaft *Render* (unter *bootstrap*) in der Einstellungsdatei *game.project* so, dass sie auf deine Kopie der Datei "default.render" verweist.
+
+
+## Render-Prädikate {#render-predicates}
+
+Um die Zeichenreihenfolge von Objekten steuern zu können, erstellst du Render-_Prädikate_. Ein Prädikat legt anhand einer Auswahl von Material-_Tags_ fest, was gezeichnet werden soll.
+
+Jedem Objekt, das auf den Bildschirm gezeichnet wird, ist ein Material zugewiesen. Es steuert, wie das Objekt auf den Bildschirm gezeichnet werden soll. Im Material gibst du ein oder mehrere _Tags_ an, die mit dem Material verknüpft werden sollen.
+
+In deinem Render-Skript kannst du dann ein *Render-Prädikat* erstellen und angeben, welche Tags zu diesem Prädikat gehören sollen. Wenn du die Engine anweist, das Prädikat zu zeichnen, wird jedes Objekt gezeichnet, dessen Material alle für das Prädikat angegebenen Tags enthält.
+
+```
+Sprite 1        Sprite 2        Sprite 3        Sprite 4
+Material A      Material A      Material B      Material C
+  outlined        outlined        greyscale       outlined
+  tree            tree            tree            house
+```
+
+```lua
+-- a predicate matching all sprites with tag "tree"
+local trees = render.predicate({"tree"})
+-- will draw Sprite 1, 2 and 3
+render.draw(trees)
+
+-- a predicate matching all sprites with tag "outlined"
+local outlined = render.predicate({"outlined"})
+-- will draw Sprite 1, 2 and 4
+render.draw(outlined)
+
+-- a predicate matching all sprites with tags "outlined" AND "tree"
+local outlined_trees = render.predicate({"outlined", "tree"})
+-- will draw Sprite 1 and 2
+render.draw(outlined_trees)
+```
+
+
+Eine ausführliche Beschreibung der Funktionsweise von Materialien findest du in der [Materialdokumentation](/manuals/material).
+
+
+## Standardansicht und -projektion {#default-view-projection}
+
+Das standardmäßige Render-Skript ist so konfiguriert, dass es eine für 2D-Spiele geeignete orthografische Projektion verwendet. Es bietet drei verschiedene orthografische Projektionen: `Stretch` (Standard), `Fixed Fit` und `Fixed`. Als Alternative zu den orthografischen Projektionen im standardmäßigen Render-Skript kannst du auch die Projektionsmatrix verwenden, die eine Kamerakomponente (camera component) bereitstellt.
+
+### Gestreckte Projektion {#stretch-projection}
+
+Die gestreckte Projektion zeichnet immer einen Bereich deines Spiels, der den in *game.project* festgelegten Abmessungen entspricht, auch wenn die Fenstergröße geändert wird. Ändert sich das Seitenverhältnis, werden die Spielinhalte entweder vertikal oder horizontal gestreckt:
+
+![Gestreckte Projektion](images/render/stretch_projection.png)
+
+*Gestreckte Projektion mit ursprünglicher Fenstergröße*
+
+![Gestreckte Projektion nach Größenänderung](images/render/stretch_projection_resized.png)
+
+*Gestreckte Projektion mit horizontal gestrecktem Fenster*
+
+Die gestreckte Projektion ist die Standardprojektion. Wenn du zu einer anderen Projektion gewechselt hast und wieder zurückwechseln möchtest, sendest du dazu eine Nachricht an das Render-Skript:
+
+```lua
+msg.post("@render:", "use_stretch_projection", { near = -1, far = 1 })
+```
+
+### Fest eingepasste Projektion {#fixed-fit-projection}
+
+Wie die gestreckte Projektion zeigt die fest eingepasste Projektion immer einen Spielbereich, der den in *game.project* festgelegten Abmessungen entspricht. Wenn jedoch die Fenstergröße und damit das Seitenverhältnis geändert werden, behalten die Spielinhalte ihr ursprüngliches Seitenverhältnis bei, und vertikal oder horizontal werden zusätzliche Spielinhalte angezeigt:
+
+![Fest eingepasste Projektion](images/render/fixed_fit_projection.png)
+
+*Fest eingepasste Projektion mit ursprünglicher Fenstergröße*
+
+![Fest eingepasste Projektion nach Größenänderung](images/render/fixed_fit_projection_resized.png)
+
+*Fest eingepasste Projektion mit horizontal gestrecktem Fenster*
+
+![Fest eingepasste Projektion bei kleinerem Fenster](images/render/fixed_fit_projection_resized_smaller.png)
+
+*Fest eingepasste Projektion mit einem auf 50 % der ursprünglichen Größe verkleinerten Fenster*
+
+Du aktivierst die fest eingepasste Projektion, indem du eine Nachricht an das Render-Skript sendest:
+
+```lua
+msg.post("@render:", "use_fixed_fit_projection", { near = -1, far = 1 })
+```
+
+### Feste Projektion {#fixed-projection}
+
+Die feste Projektion behält das ursprüngliche Seitenverhältnis bei und rendert deine Spielinhalte mit einer festen Zoomstufe. Wenn die Zoomstufe auf einen anderen Wert als 100 % eingestellt ist, zeigt sie also mehr oder weniger als den Spielbereich, der durch die Abmessungen in *game.project* definiert ist:
+
+![Feste Projektion](images/render/fixed_projection_zoom_2_0.png)
+
+*Feste Projektion mit Zoomstufe 2*
+
+![Feste Projektion](images/render/fixed_projection_zoom_0_5.png)
+
+*Feste Projektion mit Zoomstufe 0,5*
+
+![Feste Projektion](images/render/fixed_projection_zoom_2_0_resized.png)
+
+*Feste Projektion mit Zoomstufe 2 und einem auf 50 % der ursprünglichen Größe verkleinerten Fenster*
+
+Du aktivierst die feste Projektion, indem du eine Nachricht an das Render-Skript sendest:
+
+```lua
+msg.post("@render:", "use_fixed_projection", { near = -1, far = 1, zoom = 2 })
+```
+
+### Kameraprojektion {#camera-projection}
+
+Wenn du das standardmäßige Render-Skript verwendest und im Projekt aktivierte [Kamerakomponenten](/manuals/camera) vorhanden sind, haben diese Vorrang vor allen anderen im Render-Skript eingestellten Ansichten und Projektionen. Mehr zur Arbeit mit Kamerakomponenten in Render-Skripten findest du in der [Kameradokumentation](/manuals/camera).
+
+Orthografische Kameras unterstützen einen `Orthographic Mode`, der steuert, wie sich die Kamera an das Fenster anpasst:
+- `Fixed` verwendet den Wert `Orthographic Zoom` der Kamera.
+- `Auto Fit` (einpassen) hält den gesamten Entwurfsbereich sichtbar.
+- `Auto Cover` (ausfüllen) füllt das Fenster aus und kann Inhalte beschneiden.
+
+Du kannst die Modi im Editor oder zur Laufzeit über die Kamera-API wechseln:
+
+```lua
+-- Use auto-fit behavior with an orthographic camera
+camera.set_orthographic_mode("main:/go#camera", camera.ORTHO_MODE_AUTO_FIT)
+-- Query current mode
+local mode = camera.get_orthographic_mode("main:/go#camera")
+```
+
+## Geometrie außerhalb des Sichtvolumens aussondern {#frustum-culling}
+
+Mit der Render-API in Defold kannst du Geometrie außerhalb des Sichtvolumens aussondern. Wenn dieses Aussondern aktiviert ist, wird jede Grafik ignoriert, die außerhalb eines festgelegten Begrenzungsquaders oder Sichtvolumens liegt. In einer großen Spielwelt, von der jeweils nur ein Teil sichtbar ist, kann das Aussondern von Geometrie außerhalb des Sichtvolumens die Datenmenge, die zum Rendern an die GPU gesendet werden muss, erheblich verringern. Dadurch steigt die Leistung und auf Mobilgeräten wird der Akku geschont. Üblicherweise werden die Ansicht und die Projektion der Kamera verwendet, um den Begrenzungsquader zu erstellen. Das standardmäßige Render-Skript verwendet die Ansicht und die Projektion (von der Kamera), um ein Sichtvolumen zu berechnen.
+
+Aktiviere das Aussondern von Geometrie außerhalb des Sichtvolumens für einen Zeichenaufruf (draw call), indem du eine kombinierte Ansichts- und Projektionsmatrix in der Option `frustum` an `render.draw()` übergibst:
+
+```lua
+local frustum = self.proj * self.view
+render.draw(predicates.particle, { frustum = frustum })
+```
+
+Beim Rendern mit einer Kamerakomponente kann `render.set_camera()` die kombinierte Ansichts- und Projektionsmatrix der Kamera automatisch für nachfolgende Zeichenaufrufe verwenden:
+
+```lua
+render.set_camera("main:/go#camera", { use_frustum = true })
+render.draw(predicates.particle)
+render.set_camera()
+```
+
+Bei beiden Methoden werden Partikeleffekt-Emitter anhand ihrer Begrenzungen ausgesondert.
+
+Das Aussondern von Geometrie außerhalb des Sichtvolumens ist in der Engine für jeden Komponententyp einzeln implementiert. Aktueller Stand:
+
+| Komponente  | Unterstützt |
+|-------------|-----------|
+| Sprite      | JA        |
+| Modell      | JA        |
+| Mesh        | JA (1)    |
+| Beschriftung | JA       |
+| Spine       | JA        |
+| Partikeleffekt | JA     |
+| Kachelkarte (tile map) | JA |
+| Rive        | NEIN      |
+
+1 = Der Begrenzungsquader des Meshes muss von dir festgelegt werden. [Mehr erfahren](/manuals/mesh/#frustum-culling).
+
+
+::: sidenote
+Ab Defold 1.13.0 verwenden die Primitive von Komponenten (components) eine Vertex-Reihenfolge gegen den Uhrzeigersinn, wobei die Normale des Primitivs zur Kamera zeigt. Sprites, GUI-Knoten, Kachelkarten (Kachelraster) und Partikeleffekte verwenden dieselbe Reihenfolge wie andere Komponententypen. Deshalb können für alle Komponenten dieselben Einstellungen zum Aussondern von Flächen verwendet werden.
+
+Dies kann Projekte betreffen, die das Aussondern von Flächen für andere Komponenten als Modelle einstellen. Wenn eine Komponente unerwartet ausgesondert wird, stelle sicher, dass mit `render.set_cull_face(graphics.FACE_TYPE_BACK)` die Rückseiten ausgewählt sind, oder entferne den Aufruf von `render.set_cull_face()`, um den Standardmodus `graphics.FACE_TYPE_BACK` zu verwenden.
+:::
+
+## Koordinatensysteme {#coordinate-systems}
+
+Beim Rendern von Komponenten ist üblicherweise auch davon die Rede, in welchem Koordinatensystem sie gerendert werden. In den meisten Spielen werden einige Komponenten im Weltkoordinatensystem und andere im Bildschirmkoordinatensystem gezeichnet.
+
+GUI-Komponenten und ihre Knoten werden normalerweise im Bildschirmkoordinatensystem gezeichnet. Die untere linke Ecke des Bildschirms hat dabei die Koordinate (0,0), die obere rechte Ecke die Koordinate (Bildschirmbreite, Bildschirmhöhe). Das Bildschirmkoordinatensystem wird niemals durch eine Kamera versetzt oder auf andere Weise verschoben. Dadurch werden die GUI-Knoten unabhängig davon, wie die Welt gerendert wird, immer auf dem Bildschirm gezeichnet.
+
+Sprites, Kachelkarten und andere Komponenten von Spielobjekten (game objects) in deiner Spielwelt werden normalerweise im Weltkoordinatensystem gezeichnet. Wenn du dein Render-Skript nicht änderst und keine Kamerakomponente verwendest, um die Ansicht und Projektion zu ändern, entspricht dieses Koordinatensystem dem Bildschirmkoordinatensystem. Sobald du jedoch eine Kamera hinzufügst und sie bewegst oder die Ansicht und Projektion änderst, weichen die beiden Koordinatensysteme voneinander ab. Wenn sich die Kamera bewegt, wird die untere linke Ecke des Bildschirms gegenüber (0, 0) versetzt, sodass andere Teile der Welt gerendert werden. Wenn sich die Projektion ändert, werden die Koordinaten sowohl verschoben (also gegenüber 0, 0 versetzt) als auch durch einen Skalierungsfaktor verändert.
+
+
+## Das Render-Skript {#the-render-script}
+
+Im Folgenden siehst du den Code für ein benutzerdefiniertes Render-Skript, das eine leicht abgewandelte Version des integrierten Skripts ist.
+
+init()
+: Die Funktion `init()` richtet die Prädikate, die Ansicht und die Löschfarbe ein. Diese Variablen werden beim eigentlichen Rendern verwendet.
+
+```lua
+function init(self)
+    -- Define the render predicates. Each predicate is drawn by itself and
+    -- that allows us to change the state of OpenGL between the draws.
+    self.predicates = create_predicates("tile", "gui", "text", "particle", "model")
+
+    -- Create and fill data tables will be used in update()
+    local state = create_state()
+    self.state = state
+    local camera_world = create_camera(state, "camera_world", true)
+    init_camera(camera_world, get_stretch_projection)
+    local camera_gui = create_camera(state, "camera_gui")
+    init_camera(camera_gui, get_gui_projection)
+    update_state(state)
+end
+```
+
+update()
+: Die Funktion `update()` wird einmal pro Frame aufgerufen. Ihre Aufgabe ist es, das eigentliche Zeichnen durch Aufrufe der zugrunde liegenden OpenGL-ES-APIs (OpenGL Embedded Systems API) auszuführen. Um genau zu verstehen, was in der Funktion `update()` passiert, musst du die Funktionsweise von OpenGL verstehen. Es gibt viele hilfreiche Informationsquellen zu OpenGL ES. Die offizielle Website ist ein guter Ausgangspunkt. Du findest sie unter https://www.khronos.org/opengles/
+
+  Dieses Beispiel enthält die zum Zeichnen von 3D-Modellen notwendige Einrichtung. Die Funktion `init()` hat ein Prädikat `self.predicates.model` definiert. An anderer Stelle wurde ein Material mit dem Tag "model" erstellt. Außerdem gibt es einige Modellkomponenten, die dieses Material verwenden:
+
+```lua
+function update(self)
+    local state = self.state
+     if not state.valid then
+        if not update_state(state) then
+            return
+        end
+    end
+
+    local predicates = self.predicates
+    -- clear screen buffers
+    --
+    render.set_depth_mask(true)
+    render.set_stencil_mask(0xff)
+    render.clear(state.clear_buffers)
+
+    local camera_world = state.cameras.camera_world
+    render.set_viewport(0, 0, state.window_width, state.window_height)
+    render.set_view(camera_world.view)
+    render.set_projection(camera_world.proj)
+
+
+    -- render models
+    --
+    render.set_blend_func(graphics.BLEND_FACTOR_SRC_ALPHA, graphics.BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
+    render.enable_state(graphics.STATE_CULL_FACE)
+    render.enable_state(graphics.STATE_DEPTH_TEST)
+    render.set_depth_mask(true)
+    render.draw(predicates.model_pred)
+    render.set_depth_mask(false)
+    render.disable_state(graphics.STATE_DEPTH_TEST)
+    render.disable_state(graphics.STATE_CULL_FACE)
+
+     -- render world (sprites, tilemaps, particles etc)
+     --
+    render.set_blend_func(graphics.BLEND_FACTOR_SRC_ALPHA, graphics.BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
+    render.enable_state(graphics.STATE_DEPTH_TEST)
+    render.enable_state(graphics.STATE_STENCIL_TEST)
+    render.enable_state(graphics.STATE_BLEND)
+    render.draw(predicates.tile)
+    render.draw(predicates.particle)
+    render.disable_state(graphics.STATE_STENCIL_TEST)
+    render.disable_state(graphics.STATE_DEPTH_TEST)
+
+    -- debug
+    render.draw_debug3d()
+
+    -- render GUI
+    --
+    local camera_gui = state.cameras.camera_gui
+    render.set_view(camera_gui.view)
+    render.set_projection(camera_gui.proj)
+    render.enable_state(graphics.STATE_STENCIL_TEST)
+    render.draw(predicates.gui, camera_gui.frustum)
+    render.draw(predicates.text, camera_gui.frustum)
+    render.disable_state(graphics.STATE_STENCIL_TEST)
+end
+```
+
+Bisher ist dies ein einfaches und geradliniges Render-Skript. Es zeichnet in jedem Frame auf dieselbe Weise. Manchmal ist es jedoch wünschenswert, einen Zustand im Render-Skript zu speichern und abhängig davon unterschiedliche Operationen auszuführen. Es kann auch wünschenswert sein, aus anderen Teilen des Spielcodes mit dem Render-Skript zu kommunizieren.
+
+on_message()
+: Ein Render-Skript kann eine Funktion `on_message()` definieren und Nachrichten aus anderen Teilen deines Spiels oder deiner Anwendung empfangen. Ein häufiger Fall, in dem eine externe Komponente Informationen an das Render-Skript sendet, ist die _Kamera_. Eine Kamerakomponente, die den Kamerafokus erhalten hat, sendet in jedem Frame automatisch ihre Ansicht und Projektion an das Render-Skript. Diese Nachricht heißt `"set_view_projection"`:
+
+```lua
+local MSG_CLEAR_COLOR =         hash("clear_color")
+local MSG_WINDOW_RESIZED =      hash("window_resized")
+local MSG_SET_VIEW_PROJ =       hash("set_view_projection")
+
+function on_message(self, message_id, message)
+    if message_id == MSG_CLEAR_COLOR then
+        -- Someone sent us a new clear color to be used.
+        update_clear_color(state, message.color)
+    elseif message_id == MSG_SET_VIEW_PROJ then
+        -- The camera component that has camera focus will sent set_view_projection
+        -- messages to the @render socket. We can use the camera information to
+        -- set view (and possibly projection) of the rendering.
+        camera.view = message.view
+        self.camera_projection = message.projection or vmath.matrix4()
+        update_camera(camera, state)
+    end
+end
+```
+
+Jedes Skript oder GUI-Skript kann jedoch über den speziellen Socket `@render` Nachrichten an das Render-Skript senden:
+
+```lua
+-- Change the clear color.
+msg.post("@render:", "clear_color", { color = vmath.vector4(0.3, 0.4, 0.5, 0) })
+```
+
+## Render-Ressourcen {#render-resources}
+Um bestimmte Engine-Ressourcen an das Render-Skript zu übergeben, kannst du sie der Tabelle `Render Resources` in der dem Projekt zugewiesenen `.render`-Datei hinzufügen:
+
+![Render-Ressourcen](images/render/render_resources.png)
+
+So verwendest du diese Ressourcen in einem Render-Skript:
+
+```lua
+-- "my_material" will now be used for all draw calls associated with the predicate
+render.enable_material("my_material")
+-- anything drawn by the predicate will end up in "my_render_target"
+render.set_render_target("my_render_target")
+render.draw(self.my_full_screen_predicate)
+render.set_render_target(render.RENDER_TARGET_DEFAULT)
+render.disable_material()
+
+-- bind the render target result texture to whatever is getting rendered via the predicate
+render.enable_texture(0, "my_render_target", graphics.BUFFER_TYPE_COLOR0_BIT)
+render.draw(self.my_tile_predicate)
+```
+
+::: sidenote
+Defold unterstützt derzeit nur `Materials` und `Render Targets` als referenzierte Render-Ressourcen. Im Laufe der Zeit wird dieses System jedoch weitere Ressourcentypen unterstützen.
+:::
+
+### Renderziele mit Multisampling {#multisampled-render-targets}
+
+Renderziele (render targets) unterstützen Multisample-Kantenglättung (MSAA). Sie glättet Geometriekanten in einem Renderdurchlauf außerhalb der Bildschirmausgabe. Die Anzahl der Samples des Renderziels ist unabhängig von [Display ▸ Samples](/manuals/project-settings/#samples), das die Kantenglättung für das Fenster steuert.
+
+Stelle für eine `.render_target`-Ressource im Editor **Sample Count** auf `1`, `2`, `4`, `8` oder `16` ein. Ein Wert von `1` deaktiviert Multisampling. Füge die Ressource in deiner `.render`-Datei zur Tabelle **Render Resources** hinzu und verwende ihren zugewiesenen Namen mit `render.set_render_target()`, wie im obigen Beispiel.
+
+Alternativ kannst du in der Funktion `init()` deines Render-Skripts ein Renderziel erstellen. Füge `sample_count` neben den angehängten Puffern in die äußere Parametertabelle ein:
+
+```lua
+self.offscreen = render.render_target({
+    sample_count = 4,
+    [graphics.BUFFER_TYPE_COLOR0_BIT] = {
+        format = graphics.TEXTURE_FORMAT_RGBA,
+        width = 1024,
+        height = 1024,
+        min_filter = graphics.TEXTURE_FILTER_LINEAR,
+        mag_filter = graphics.TEXTURE_FILTER_LINEAR,
+        u_wrap = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE,
+        v_wrap = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE,
+    },
+})
+self.scene_predicate = render.predicate({"scene"})
+self.present_predicate = render.predicate({"present"})
+```
+
+Dieses Beispiel verwendet ein Renderziel, das nur Farbpuffer enthält. Alle angehängten Farb-, Tiefen- und Stencil-Puffer eines Renderziels teilen sich dessen Sample-Anzahl. Füge einen Tiefenpuffer hinzu und aktiviere den üblichen Tiefentest-Zustand, wenn der Durchlauf einen Tiefentest erfordert.
+
+Gib für den folgenden Ausschnitt aus `update()` den Materialien der Szene das Tag `scene` und dem Material eines bildschirmfüllenden Vierecks das Tag `present`. Das Material des Vierecks muss Textureinheit `0` abtasten. Lege für jeden Durchlauf die passende Ansicht und Projektion fest:
+
+```lua
+render.set_render_target(self.offscreen)
+render.set_viewport(0, 0, 1024, 1024)
+render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = vmath.vector4(0, 0, 0, 1)})
+-- Set the scene view and projection here.
+render.draw(self.scene_predicate)
+
+render.set_render_target(render.RENDER_TARGET_DEFAULT)
+render.set_viewport(0, 0, render.get_window_width(), render.get_window_height())
+-- Set the full-screen quad view and projection here.
+render.enable_texture(0, self.offscreen, graphics.BUFFER_TYPE_COLOR0_BIT)
+render.draw(self.present_predicate)
+render.disable_texture(0)
+```
+
+Der Wechsel zu einem anderen Renderziel beendet den Durchlauf und führt die Multisamples seiner angehängten Farbpuffer automatisch zusammen. `render.enable_texture()` bindet die daraus entstandene Farbtextur, sodass das Viereck einen gewöhnlichen Textur-Sampler verwendet. Ein separater Befehl zum Zusammenführen ist nicht erforderlich.
+
+Die angeforderte Sample-Anzahl ist standardmäßig `1` und muss eine positive ganze Zahl sein. Grafik-Backends reduzieren nicht unterstützte Anforderungen auf eine unterstützte Anzahl, die eine Zweierpotenz ist. Falls nötig, fallen sie auf `1` zurück und protokollieren eine Warnung, wenn sich die Anzahl ändert. Höhere Sample-Anzahlen erhöhen den Speicherbedarf der angehängten Puffer.
+
+Wenn du eine Renderziel-Ressource verwendest, prüfe ihre tatsächliche Sample-Anzahl aus einem Spielobjekt-Skript `.script` mit `resource.get_render_target_info()`. Zum Beispiel, nachdem du `/render/offscreen.render_target` zu **Render Resources** hinzugefügt hast:
+
+```lua
+function init(self)
+    local info = resource.get_render_target_info("/render/offscreen.render_targetc")
+    print("Render target sample count:", info.sample_count)
+end
+```
+
+Verwende diese tatsächliche Anzahl, wenn du die Unterstützung auf einem Gerät prüfst, anstatt anzunehmen, dass die angeforderte Anzahl verfügbar war. Die vollständigen Parameter- und Ergebnistabellen findest du unter [`render.render_target()`](/ref/beta/render/#render.render_target:parameters) und [`resource.get_render_target_info()`](/ref/beta/resource/#resource.get_render_target_info:path).
+
+## Textur-Handles {#texture-handles}
+
+Texturen werden in Defold intern durch ein Handle dargestellt. Dies entspricht im Wesentlichen einer Zahl, die ein Texturobjekt überall in der Engine eindeutig identifizieren soll. Du kannst also die Spielobjektwelt mit der Rendering-Welt verbinden, indem du diese Handles zwischen dem Render-System und einem Spielobjekt-Skript übergibst. Beispielsweise kann ein Skript, das einem Spielobjekt zugewiesen ist, eine dynamische Textur erstellen und sie an den Renderer senden, damit sie als globale Textur in einem Zeichenbefehl verwendet wird.
+
+In einer `.script`-Datei:
+
+```lua
+local my_texture_resource = resource.create_texture("/my_texture.texture", tparams)
+-- note: my_texture_resource is a hash to the resource path, which can't be used as a handle!
+local my_texture_handle = resource.get_texture_info(my_texture_resource)
+-- my_texture_handle contains information about the texture, such as width, height and so on
+-- it does also contain the handle, which is what we are after
+msg.post("@render:", "set_texture", { handle = my_texture_handle.handle })
+```
+
+In einer `.render_script`-Datei:
+
+```lua
+function on_message(self, message_id, message)
+    if message_id == hash("set_texture") then
+        self.my_texture = message.handle
+    end
+end
+
+function update(self)
+    -- bind the custom texture to the draw state
+    render.enable_texture(0, self.my_texture)
+    -- do drawing..
+end
+```
+
+::: sidenote
+Derzeit lässt sich nicht ändern, auf welche Textur eine Ressource verweist. Solche direkten Handles kannst du nur im Render-Skript verwenden.
+:::
+
+## Unterstützte Grafik-APIs {#supported-graphics-apis}
+Die Render-Skript-API von Defold übersetzt Renderoperationen in die folgenden Grafik-APIs:
+
+:[Graphics API](../shared/graphics-api.md)
+
+
+## Systemnachrichten {#system-messages}
+
+`"set_view_projection"`
+: Diese Nachricht wird von Kamerakomponenten gesendet, die den Kamerafokus erhalten haben.
+
+`"window_resized"`
+: Die Engine sendet diese Nachricht, wenn sich die Fenstergröße ändert. Du kannst auf diese Nachricht reagieren, um das Rendering bei einer Änderung der Größe des Zielfensters anzupassen. Auf Desktopgeräten bedeutet dies, dass die Größe des eigentlichen Spielfensters geändert wurde. Auf Mobilgeräten wird diese Nachricht bei jeder Änderung der Ausrichtung gesendet.
+
+```lua
+local MSG_WINDOW_RESIZED =      hash("window_resized")
+
+function on_message(self, message_id, message)
+  if message_id == MSG_WINDOW_RESIZED then
+    -- The window was resized. message.width and message.height contain the new dimensions.
+    ...
+  end
+end
+```
+
+`"draw_line"`
+: Zeichnet eine Debug-Linie. Verwende diese Nachricht, um `ray_casts`, Vektoren und mehr zu visualisieren. Die Linien werden mit dem Aufruf `render.draw_debug3d()` gezeichnet.
+
+```lua
+-- draw a white line
+local p1 = vmath.vector3(0, 0, 0)
+local p2 = vmath.vector3(1000, 1000, 0)
+local col = vmath.vector4(1, 1, 1, 1)
+msg.post("@render:", "draw_line", { start_point = p1, end_point = p2, color = col } )  
+```
+
+`"draw_text"`
+: Zeichnet Debug-Text. Verwende diese Nachricht, um Debug-Informationen auszugeben. Der Text wird mit der integrierten Schriftart `always_on_top.font` gezeichnet. Die Systemschrift hat ein Material mit dem Tag `debug_text` und wird im standardmäßigen Render-Skript zusammen mit anderem Text gerendert.
+
+```lua
+-- draw a text message
+local pos = vmath.vector3(500, 500, 0)
+msg.post("@render:", "draw_text", { text = "Hello world!", position = pos })  
+```
+
+Der visuelle Profiler, den du über die Nachricht `"toggle_profile"` an den Socket `@system` aufrufen kannst, ist nicht Teil des per Skript steuerbaren Renderers. Er wird getrennt von deinem Render-Skript gezeichnet.
+
+
+## Zeichenaufrufe und Bündelung von Zeichenoperationen {#draw-calls-and-batching}
+
+Ein Zeichenaufruf bezeichnet den Vorgang, die GPU so einzurichten, dass sie ein Objekt mit einer Textur und einem Material sowie optionalen zusätzlichen Einstellungen auf den Bildschirm zeichnet. Dieser Vorgang ist normalerweise ressourcenintensiv, daher wird empfohlen, die Anzahl der Zeichenaufrufe möglichst gering zu halten. Mit dem [integrierten Profiler](/manuals/profiling/) kannst du die Anzahl der Zeichenaufrufe und die zum Rendern benötigte Zeit messen.
+
+Defold versucht, Renderoperationen nach den unten beschriebenen Regeln zu bündeln (Batching), um die Anzahl der Zeichenaufrufe zu verringern. Die Regeln unterscheiden sich zwischen GUI-Komponenten und allen anderen Komponententypen.
+
+
+### Bündelungsregeln für Komponenten außerhalb der GUI {#batch-rules-for-non-gui-components}
+
+Jeder Aufruf von `render.draw()` steuert, wie passende Einträge mit Sortierung im Weltkoordinatensystem geordnet werden. Der Standard ist `render.SORT_BACK_TO_FRONT`; verwende `render.SORT_FRONT_TO_BACK` zum Rendern von nah nach fern oder `render.SORT_NONE`, um die Einfügereihenfolge beizubehalten:
+
+```lua
+render.draw(self.opaque_predicate, {
+    sort_order = render.SORT_FRONT_TO_BACK
+})
+render.draw(self.transparent_predicate, {
+    sort_order = render.SORT_BACK_TO_FRONT
+})
+```
+
+Die gewählte Reihenfolge bestimmt, welche Einträge nebeneinander liegen, und kann dadurch die Bündelung beeinflussen. In dieser sortierten Liste wird jedes Objekt mit dem vorherigen Objekt zu demselben Zeichenaufruf zusammengefasst, wenn die folgenden Bedingungen erfüllt sind:
+
+* Es gehört zum selben Sammlungs-Proxy (collection proxy)
+* Es hat denselben Komponententyp (Sprite, Partikeleffekt, Kachelkarte usw.)
+* Es verwendet dieselbe Textur (Atlas oder Kachelquelle)
+* Es hat dasselbe Material
+* Es hat dieselben Shader-Konstanten (wie die Einfärbung)
+
+Wenn also zwei Sprite-Komponenten im selben Sammlungs-Proxy nach der gewählten Sortierung nebeneinander liegen und dieselbe Textur, dasselbe Material und dieselben Konstanten verwenden, werden sie zu demselben Zeichenaufruf zusammengefasst.
+
+
+### Bündelungsregeln für GUI-Komponenten {#batch-rules-for-gui-components}
+
+Die Knoten einer GUI-Komponente werden in der Knotenliste von oben nach unten gerendert. Jeder Knoten in der Liste wird mit dem vorherigen Knoten zu demselben Zeichenaufruf zusammengefasst, wenn die folgenden Bedingungen erfüllt sind:
+
+* Er hat denselben Typ (Box, Text, Kreissektor usw.)
+* Er verwendet dieselbe Textur (Atlas oder Kachelquelle)
+* Er hat denselben Mischmodus.
+* Er hat dieselbe Schriftart (nur bei Textknoten)
+* Er hat dieselben Stencil-Einstellungen
+
+::: sidenote
+Knoten werden pro Komponente gerendert. Das bedeutet, dass Knoten aus verschiedenen GUI-Komponenten nicht gebündelt werden.
+:::
+
+Die Möglichkeit, Knoten in Hierarchien anzuordnen, erleichtert es, sie zu überschaubaren Einheiten zusammenzufassen. Hierarchien können jedoch das gebündelte Rendern unterbrechen, wenn du unterschiedliche Knotentypen mischst. Mit GUI-Ebenen kannst du GUI-Knoten wirkungsvoller bündeln und dabei die Knotenhierarchien beibehalten. Mehr über GUI-Ebenen und ihren Einfluss auf Zeichenaufrufe erfährst du im [GUI-Handbuch](/manuals/gui#layers-and-draw-calls).

--- a/docs/de/manuals/resource.md
+++ b/docs/de/manuals/resource.md
@@ -1,0 +1,67 @@
+---
+title: Ressourcenverwaltung in Defold
+brief: Dieses Handbuch erklärt, wie Defold Ressourcen automatisch verwaltet und wie du das Laden von Ressourcen manuell steuern kannst, um Vorgaben für Speicherbedarf und Bundle-Größe einzuhalten.
+---
+
+# Ressourcenverwaltung {#resource-management}
+
+Wenn du ein sehr kleines Spiel entwickelst, bereiten dir die Grenzen der Zielplattform (Speicherbedarf, Bundle-Größe, Rechenleistung und Akkuverbrauch) möglicherweise nie Probleme. Bei größeren Spielen und insbesondere auf tragbaren Geräten gehört der Speicherverbrauch jedoch wahrscheinlich zu den größten Einschränkungen. Ein erfahrenes Team plant die Ressourcenbudgets sorgfältig anhand der Grenzen der Plattform. Defold bietet eine Reihe von Funktionen, mit denen du den Speicherverbrauch und die Bundle-Größe verwalten kannst. Dieses Handbuch gibt einen Überblick über diese Funktionen.
+
+## Der statische Ressourcenbaum {#the-static-resource-tree}
+
+Wenn du einen Build für ein Spiel in Defold erstellst, legst du den Ressourcenbaum statisch fest. Jeder einzelne Teil des Spiels ist mit dem Baum verknüpft, ausgehend von der Startsammlung (bootstrap collection), die üblicherweise "main.collection" heißt. Der Ressourcenbaum folgt jeder Referenz und umfasst alle Ressourcen, die mit diesen Referenzen verbunden sind:
+
+- Daten von Spielobjekten (game objects) und Komponenten (components), etwa Atlanten, Töne usw.
+- Prototypen von Fabrikkomponenten (factory components): Spielobjekte und Sammlungen (collections).
+- Referenzen von Sammlungs-Proxy-Komponenten (collection proxy components): Sammlungen.
+- [Benutzerdefinierte Ressourcen](/manuals/project-settings/#custom-resources), die in *game.project* deklariert sind.
+
+![Ressourcenbaum](images/resource/resource_tree.png)
+
+::: sidenote
+Defold kennt außerdem [Bundle-Ressourcen](/manuals/project-settings/#bundle-resources). Bundle-Ressourcen sind im Anwendungs-Bundle enthalten, gehören aber nicht zum Ressourcenbaum. Dabei kann es sich um beliebige Dateien handeln, von plattformspezifischen Hilfsdateien bis hin zu externen Dateien, die [aus dem Dateisystem geladen](/manuals/file-access/#how-to-access-files-bundled-with-the-application) und von deinem Spiel verwendet werden (zum Beispiel FMOD-Soundbanken).
+:::
+
+Wenn du ein *Bundle erstellst*, wird nur aufgenommen, was sich im Ressourcenbaum befindet. Alles, auf das im Baum keine Referenz verweist, bleibt außen vor. Du musst nicht manuell auswählen, was in das Bundle aufgenommen oder davon ausgeschlossen werden soll.
+
+Wenn das Spiel *ausgeführt wird*, beginnt die Engine an der Wurzel des Baums, der Startsammlung, und lädt Ressourcen in den Speicher:
+
+- Jede referenzierte Sammlung und ihren Inhalt.
+- Spielobjekte und Komponentendaten.
+- Prototypen von Fabrikkomponenten (Spielobjekte und Sammlungen).
+
+Die Engine lädt die folgenden Arten referenzierter Ressourcen jedoch nicht automatisch zur Laufzeit:
+
+- Spielweltsammlungen, auf die Sammlungs-Proxys verweisen. Spielwelten sind relativ groß, deshalb musst du ihr Laden und Entladen manuell im Code auslösen. Einzelheiten findest du im [Handbuch zu Sammlungs-Proxys](/manuals/collection-proxy).
+- Dateien, die über die Einstellung *Custom Resources* in *game.project* hinzugefügt wurden. Diese Dateien werden manuell mit der Funktion [`sys.load_resource()`](/ref/sys/#sys.load_resource) geladen.
+
+Du kannst das Standardverhalten von Defold beim Erstellen von Bundles und Laden von Ressourcen ändern, um genau zu steuern, wie und wann Ressourcen in den Speicher geladen werden.
+
+![Laden von Ressourcen](images/resource/loading.png)
+
+## Fabrikressourcen dynamisch laden {#dynamically-loading-factory-resources}
+
+Ressourcen, auf die Fabrikkomponenten verweisen, werden normalerweise in den Speicher geladen, wenn die Komponente geladen wird. Die Ressourcen stehen dann zum dynamischen Erzeugen von Objekten im Spiel bereit, sobald die Fabrik (factory) in der Laufzeitumgebung existiert. Um das Standardverhalten zu ändern und das Laden der Fabrikressourcen aufzuschieben, kannst du einfach das Kontrollkästchen *Load Dynamically* der Fabrik aktivieren.
+
+![Dynamisch laden](images/resource/load_dynamically.png)
+
+Wenn dieses Kästchen aktiviert ist, nimmt die Engine die referenzierten Ressourcen weiterhin in das Spiel-Bundle auf, lädt die Fabrikressourcen jedoch nicht automatisch. Stattdessen hast du zwei Möglichkeiten:
+
+1. Rufe [`factory.create()`](/ref/factory/#factory.create) oder [`collectionfactory.create()`](/ref/collectionfactory/#collectionfactory.create) auf, wenn du Objekte dynamisch erzeugen möchtest. Dadurch werden die Ressourcen synchron geladen und anschließend neue Instanzen erzeugt.
+2. Rufe [`factory.load()`](/ref/factory/#factory.load) oder [`collectionfactory.load()`](/ref/collectionfactory/#collectionfactory.load) auf, um die Ressourcen asynchron zu laden. Sobald die Ressourcen zum dynamischen Erzeugen von Objekten bereitstehen, wird ein Callback aufgerufen.
+
+Lies das [Handbuch zu Fabriken](/manuals/factory) und das [Handbuch zu Sammlungsfabriken (collection factories)](/manuals/collection-factory), um Einzelheiten zur Funktionsweise zu erfahren.
+
+## Dynamisch geladene Ressourcen entladen {#unloading-dynamically-loaded-resources}
+
+Defold führt Referenzzähler für alle Ressourcen. Wenn der Zähler einer Ressource null erreicht, bedeutet das, dass nichts mehr auf sie verweist. Die Ressource wird dann automatisch aus dem Speicher entladen. Wenn du beispielsweise alle von einer Fabrik erzeugten Objekte und auch das Objekt löschst, das die Fabrikkomponente enthält, werden die Ressourcen aus dem Speicher entladen, auf die die Fabrik zuvor verwiesen hat.
+
+Für Fabriken, bei denen *Load Dynamically* aktiviert ist, kannst du die Funktion [`factory.unload()`](/ref/factory/#factory.unload) oder [`collectionfactory.unload()`](/ref/collectionfactory/#collectionfactory.unload) aufrufen. Dieser Aufruf entfernt die Referenz der Fabrikkomponente auf die Ressource. Wenn nichts anderes auf die Ressource verweist (zum Beispiel, weil alle erzeugten Objekte gelöscht wurden), wird sie aus dem Speicher entladen.
+
+## Ressourcen vom Bundle ausschließen {#excluding-resources-from-bundle}
+
+Mit Sammlungs-Proxys ist es möglich, alle Ressourcen, auf die die Komponente verweist, von der Bundle-Erstellung auszuschließen. Das ist nützlich, wenn du die Bundle-Größe möglichst gering halten musst. Wenn du zum Beispiel Spiele als HTML5 im Web ausführst, lädt der Browser das gesamte Bundle herunter, bevor er das Spiel ausführt.
+
+![Ausschließen](images/resource/exclude.png)
+
+Wenn du bei einem Sammlungs-Proxy *Exclude* aktivierst, wird die referenzierte Ressource nicht in das Spiel-Bundle aufgenommen. Stattdessen kannst du ausgeschlossene Sammlungen in einem ausgewählten Cloud-Speicher ablegen. Das [Handbuch zu Live Update](/manuals/live-update/) erklärt, wie diese Funktion funktioniert.

--- a/docs/de/manuals/scene-editing.md
+++ b/docs/de/manuals/scene-editing.md
@@ -1,0 +1,244 @@
+---
+title: Der Szeneneditor von Defold
+brief: Im Szeneneditor bearbeitest du Sammlungen, Spielobjekte, GUIs, Partikeleffekte und andere visuelle Assets. Dieses Handbuch erklärt die Auswahl, die Werkzeuge und die Navigation in der Szenenansicht in 2D und 3D – einschließlich des freien Kameramodus und der Kameraeinstellungen.
+---
+
+# Der Szeneneditor von Defold {#the-defold-scene-editor}
+
+Der **Szeneneditor** (Scene Editor) ist der visuelle Editor zum Erstellen und Bearbeiten von Szenen wie Sammlungen (collection), Spielobjekten (game object) und anderen visuellen Assets.
+
+Die anfängliche Kameraansicht hängt von der Ressource ab. 3D-Ressourcen wie Modelle und glTF-Szenen verwenden standardmäßig eine **perspektivische** Ansicht, während 2D-Ressourcen wie Sprites, Kachelkarten (tile map) und GUI-Szenen standardmäßig eine **orthografische** Ansicht verwenden. Du kannst die Kameraausrichtung, die Projektion und das Raster über die Werkzeugleiste der Szene ändern.
+
+## Den Szeneneditor öffnen {#opening-the-scene-editor}
+
+Öffne den Szeneneditor durch einen Doppelklick auf eine visuelle Ressource im Bereich *Assets*, zum Beispiel:
+
+- **Szenenstruktur** — Sammlungen (`.collection`), Spielobjekte (`.go`)
+- **2D-Assets** — Atlas (`.atlas`), Kachelkarten (`.tilemap`), Sprites (`.sprite`), Kachelquellen (`.tilesource`)
+- **3D-Assets** — Modelle (`.model`, `.glb`, `.gltf`)
+- **UI** — GUI-Szenen (`.gui`)
+- **Effekte** — Partikeleffekte (`.particlefx`)
+- Und weitere
+
+## Gespeicherte Szenenansichten {#remembered-scene-views}
+
+Der Editor speichert den Kamerazustand für jede Szenenressource, wenn deren Registerkarte geschlossen oder der Editor beendet wird. Beim erneuten Öffnen derselben Ressource wird ihre Ansicht wiederhergestellt. So können verschiedene Sammlungen oder Modelle unterschiedliche Kamerapositionen, Ausrichtungen und Projektionen beibehalten.
+
+Sichtbarkeitsfilter werden ebenfalls für jede Szene gespeichert. Wenn du Modelle oder Hilfslinien für Komponenten (component) in einer Szene ausblendest, musst du in einer anderen Szene nicht dieselben Filter verwenden. Dies sind Ansichtseinstellungen des Editors; sie ändern weder die Kamera des Spiels noch die Sichtbarkeit zur Laufzeit.
+
+Bei Ressourcen ohne gespeicherten Kamerazustand starten Modell-, Mesh- und glTF-Ressourcen mit einer perspektivischen Ansicht. Die Ansicht von Kollisionsobjekten richtet sich nach der Einstellung für 2D-/3D-Physik des Projekts; Sammlungen und Spielobjekte wählen ihre anfängliche Ansicht anhand ihrer Szenengeometrie.
+
+## Navigation in der Szenenansicht (Kamerasteuerung) {#scene-view-navigation-camera-controls}
+
+Die Kamera des Szeneneditors lässt sich mit Maus und Tastatur steuern. Die verfügbaren Steuerelemente hängen davon ab, ob du die normale Kameranavigation oder den **freien Kameramodus** (Free Camera Mode) verwendest.
+
+### Normale Navigation (alle visuellen Editoren) {#standard-navigation-all-visual-editors}
+
+Diese Steuerelemente stehen in visuellen Editoren zur Verfügung:
+
+- **Verschieben**
+  - <kbd>Alt</kbd>/<kbd>⌥ Option</kbd> + <kbd>Left Mouse Button</kbd>
+- **Vergrößern und verkleinern**
+  - <kbd>Mouse Wheel</kbd> oder
+  - <kbd>Ctrl</kbd>/<kbd>^ Control</kbd> + <kbd>Alt</kbd>/<kbd>⌥ Option</kbd> + <kbd>Left Mouse Button</kbd>
+- **Um die Auswahl drehen/kreisen (3D)**
+  - <kbd>Ctrl</kbd>/<kbd>^ Control</kbd> + <kbd>Left Mouse Button</kbd>
+
+Du kannst auch **Frame Selection** (<kbd>F</kbd>) verwenden, um die Kamera auf die aktuelle Auswahl auszurichten.
+
+## Szenenausrichtung in 2D und 3D {#2d-and-3d-scene-orientation}
+
+Du kannst die Szenenansicht sowohl für die Arbeit in 2D als auch in 3D verwenden:
+
+- In **2D** arbeitest du normalerweise in einer orthografischen Ansicht mit einem für 2D ausgerichteten Raster.
+- In **3D** gehst du normalerweise so vor:
+  - Du richtest die Ansicht für 3D neu aus,
+  - verwendest eine **perspektivische** Kamera,
+  - wählst eine geeignete Rasterebene (häufig **Y** für den „Boden“).
+
+Diese Funktionen erreichst du über die Werkzeugleiste und das Menü **View**.
+
+![Szeneneditor in 3D](images/editor/3d_scene.png)
+
+## Übersicht der Werkzeugleiste {#toolbar-overview}
+
+Oben rechts in der Szenenansicht befindet sich eine Werkzeugleiste mit häufig verwendeten Werkzeugen und Ansichtsoptionen (von links nach rechts):
+
+- **Move tool** (<kbd>W</kbd>)
+- **Rotate tool** (<kbd>E</kbd>)
+- **Scale tool** (<kbd>R</kbd>)
+- **Grid Settings** (`▦`)
+- **Align/Realign Camera 2D/3D** (`2D`) — wechselt zwischen der Ausrichtung in 2D und 3D (Tastenkürzel <kbd>.</kbd>)
+- **Camera Perspective/Orthographic**
+- **Visibility Filters** (`👁`)
+
+![Werkzeugleiste](images/editor/toolbar.png)
+
+## Objekte auswählen und verändern {#manipulating-objects}
+
+### Objekte auswählen {#selecting-objects}
+
+Wähle Objekte im Hauptfenster mit einem <kbd>Linksklick</kbd> aus. Das Rechteck (oder der Quader), das das Objekt in der Editoransicht umgibt, wird cyanfarben hervorgehoben, um das ausgewählte Element zu kennzeichnen. Das ausgewählte Objekt wird auch in der Ansicht `Outline` hervorgehoben, wie im Bild oben zu sehen.
+
+  Du kannst Objekte auch folgendermaßen auswählen:
+
+- Wähle mit <kbd>Linksklick</kbd> und <kbd>Ziehen</kbd> alle Objekte innerhalb des Auswahlbereichs aus.
+- Wähle Objekte in `Outline` mit einem <kbd>Linksklick</kbd> aus. Wenn du dabei <kbd>⇧ Shift</kbd> gedrückt hältst, kannst du die Auswahl erweitern. Wenn du <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> gedrückt hältst, kannst du angeklickte Objekte auswählen oder ihre Auswahl aufheben.
+
+#### Verschiebewerkzeug {#move-tool}
+
+![Verschiebewerkzeug](images/editor/icon_move.png){.left}
+
+Verwende das *Move Tool*, um Objekte zu verschieben. Du findest es in der Werkzeugleiste oben rechts im Szeneneditor oder aktivierst es durch Drücken der Taste <kbd>W</kbd>.
+
+![Objekt verschieben](images/editor/move.png){.inline}![Objekt in 3D verschieben](images/editor/move_3d.png){.inline}
+
+Das Gizmo verändert sich und zeigt mehrere Manipulatoren – Quadrate und Pfeile (der ausgewählte Manipulator wird orange), an denen du <kbd>ziehen</kbd> kannst, um Objekte zu verschieben:
+
+- einen cyanfarbenen quadratischen Griff in der Mitte, mit dem du das Objekt nur im Bildschirmkoordinatensystem verschiebst,
+- 3 rote, grüne und blaue Pfeile entlang der einzelnen Achsen, mit denen du das Objekt nur entlang der jeweiligen X-, Y- oder Z-Achse verschiebst.
+- 3 rote, grüne und blaue quadratische Griffe (umrandet und mit transparenter Füllung), mit denen du das Objekt nur auf der jeweiligen Ebene verschiebst, z. B. auf der X-Y-Ebene (blau) und auf den Ebenen X-Z (grün) und Y-Z (rot), die sichtbar werden, wenn du die Kamera in 3D drehst.
+
+#### Drehwerkzeug {#rotate-tool}
+
+![Drehwerkzeug](images/editor/icon_rotate.png){.left}
+
+Verwende das *Rotate Tool*, um Objekte zu drehen. Wähle es in der Werkzeugleiste aus oder drücke die Taste <kbd>E</kbd>.
+
+![Objekt drehen](images/editor/rotate.png){.inline}![Objekt in 3D drehen](images/editor/rotate_3d.png){.inline}
+
+Dieses Werkzeug besteht aus vier kreisförmigen Manipulatoren (der ausgewählte Manipulator wird orange), an denen du <kbd>ziehen</kbd> kannst, um Objekte zu drehen:
+
+- ein cyanfarbener Manipulator (der äußere, größte Kreis), der das Objekt im Bildschirmkoordinatensystem dreht
+- 3 kleinere rote, grüne und blaue kreisförmige Manipulatoren, mit denen du das Objekt einzeln um die X-, Y- und Z-Achse drehst. In der orthografischen 2D-Ansicht stehen zwei davon senkrecht zur X- und Y-Achse, sodass diese Kreise nur als zwei Linien erscheinen, die das Objekt kreuzen.
+
+#### Skalierungswerkzeug {#scale-tool}
+
+![Skalierungswerkzeug](images/editor/icon_scale.png){.left}
+
+Verwende das *Scale Tool*, um Objekte zu skalieren. Wähle es in der Werkzeugleiste aus oder drücke die Taste <kbd>R</kbd>.
+
+![Objekt skalieren](images/editor/scale.png){.inline}![Objekt in 3D skalieren](images/editor/scale_3d.png){.inline}
+
+Dieses Werkzeug besteht aus mehreren quadratischen/würfelförmigen Manipulatoren (der ausgewählte Manipulator wird orange), an denen du <kbd>ziehen</kbd> kannst, um Objekte zu skalieren:
+
+- ein cyanfarbener Würfel in der Mitte skaliert das Objekt gleichmäßig entlang aller Achsen (einschließlich Z).
+- 3 rote, blaue und grüne würfelförmige Manipulatoren skalieren das Objekt einzeln entlang der X-, Y- und Z-Achse.
+- 3 rote, grüne und blaue quadratische Manipulatoren (umrandet und mit transparenter Füllung) skalieren das Objekt einzeln auf der X-Y-, X-Z- oder Y-Z-Ebene.
+
+### Sichtbarkeitsfilter {#visibility-filters}
+
+Klicke auf das **Augensymbol für die Sichtbarkeit** (`👁`) in der Werkzeugleiste, um verschiedene Komponententypen sowie Begrenzungsrechtecke bzw. Begrenzungsquader und Hilfslinien ein- oder auszublenden (`Component Guides` oder Tastenkombination <kbd>Ctrl</kbd> + <kbd>H</kbd> (Win/Linux) oder <kbd>^ Ctrl</kbd> + <kbd>⌘ Cmd</kbd> + <kbd>H</kbd>(Mac)).
+
+![Sichtbarkeitsfilter](images/editor/visibilityfilters.png)
+
+## Rastereinstellungen {#grid-settings}
+
+Du kannst das Raster an deine Arbeitsweise anpassen (besonders nützlich in 3D). Klicke auf die Schaltfläche **Grid Settings** (`▦`), um das Popup mit den Rastereinstellungen zu öffnen.
+
+Der Editor speichert separate Rastereinstellungen für 2D- und 3D-Ansichten. Stelle Größe, Ebene und Darstellung ein, während der gewünschte Modus aktiv ist. Beim Wechsel des Modus werden dessen Rastereinstellungen wiederhergestellt. **Reset to Defaults** setzt die Einstellungen des aktiven Modus zurück.
+
+![Rastereinstellungen](images/editor/grid_popup.png)
+
+Die Einstellungen umfassen:
+
+- **Grid size (X/Y/Z)**
+  Legt den Abstand zwischen den Rasterlinien entlang jeder Achse fest. Verwende kleinere Werte, um kleine Objekte präzise zu platzieren, oder größere Werte für einen umfassenderen Überblick.
+- **Active plane (X/Y/Z)**
+  Wählt die Ebene aus, auf der das Raster gezeichnet wird. Bei der Arbeit in 2D ist dies normalerweise **Z** (die standardmäßige X-Y-Ebene). In 3D ist **Y** üblich, um eine Bodenebene darzustellen.
+- **Grid color**
+  Legt die Farbe der Rasterlinien fest. Dies ist nützlich, um einen Kontrast zu verschiedenen Szenenhintergründen zu schaffen.
+- **Grid opacity**
+  Steuert, wie transparent die Rasterlinien sind. Bei niedrigeren Werten ist das Raster weniger aufdringlich und bietet weiterhin eine Orientierungshilfe.
+- Eine Schaltfläche **Reset to Defaults**
+  Stellt die ursprünglichen Werte aller Rastereinstellungen wieder her.
+
+## Kameratyp: perspektivisch und orthografisch {#camera-type-perspective-vs-orthographic}
+
+Der Szeneneditor unterstützt beide Typen:
+
+- **Orthografische** Kamera (üblich bei der Arbeit in 2D)
+- **Perspektivische** Kamera (üblich bei der Arbeit in 3D)
+
+Verwende den Kameraumschalter in der Werkzeugleiste, um zwischen ihnen zu wechseln. In 3D-Szenen fühlt sich die perspektivische Navigation meist natürlicher an.
+
+## Freier Kameramodus {#free-camera-mode}
+
+Für die schnelle Navigation in 3D bietet der Szeneneditor den **freien Kameramodus**, eine Kamera aus der Ichperspektive im Stil eines „Ego-Shooters“.
+
+### Den freien Kameramodus aktivieren {#activating-free-camera-mode}
+
+- Halte <kbd>Right Mouse Button</kbd> gedrückt — der freie Kameramodus ist aktiv, solange du die Taste gedrückt hältst
+- <kbd>Shift</kbd> + <kbd>`</kbd> (Backtick) — schaltet den freien Kameramodus ein; er bleibt nach dem Loslassen aktiv
+
+::: sidenote
+Bei einigen Tastaturbelegungen (z. B. der schwedischen) ist die Backtick-Taste eine Tottaste und löst die Tastenkombination möglicherweise nicht wie erwartet aus. Du
+kannst diese Tastenkombination unter `File ▸ Preferences ▸ Keys` neu zuweisen und eine Tastenkombination für `Scene -> Free Camera -> Activate` eingeben.
+:::
+
+Wenn der freie Kameramodus aktiv ist, wird die Szenenansicht durch eine Linie entlang ihrer Ränder hervorgehoben.
+
+### Den freien Kameramodus beenden {#exiting-free-camera-mode}
+
+- Lasse <kbd>Right Mouse Button</kbd> los (wenn er durch Gedrückthalten aktiviert wurde), oder
+- drücke <kbd>Left Mouse Button</kbd> oder <kbd>Right Mouse Button</kbd> und lasse die Taste wieder los, oder drücke <kbd>Esc</kbd>, wenn der freie Kameramodus per Umschaltung aktiviert wurde.
+
+### Umschauen (Blicksteuerung mit der Maus) {#looking-around-mouse-look}
+
+Während der freie Kameramodus aktiv ist, steuern diese Tasten die Kamerabewegung (anstelle der Editorwerkzeuge):
+
+- Bewege die Maus, um die **Gierung** (links/rechts) und die **Neigung** (oben/unten) zu steuern
+- Die Neigung ist begrenzt, um ein Überschlagen der Kamera zu vermeiden
+
+Du kannst die Y-Achse bei Bedarf auch umkehren (siehe **Einstellungen der freien Kamera** weiter unten).
+
+### Bewegen {#moving}
+
+Während der freie Kameramodus aktiv ist:
+
+- <kbd>W</kbd> — vorwärts
+- <kbd>S</kbd> — rückwärts
+- <kbd>A</kbd> — links
+- <kbd>D</kbd> — rechts
+- <kbd>E</kbd> — nach oben
+- <kbd>Q</kbd> — nach unten
+
+::: sidenote
+Du kannst alle Bewegungstasten unter `File ▸ Preferences ▸ Keys` neu zuweisen. Suche dort nach `Scene -> Free Camera`.
+:::
+
+Tasten zur Änderung der Geschwindigkeit:
+
+- Halte <kbd>Shift</kbd> gedrückt — schneller bewegen
+- Halte <kbd>Alt</kbd>/<kbd>⌥ Option</kbd> gedrückt — langsamer/präziser bewegen
+
+### Gehmodus (optional) {#walking-mode-optional}
+
+Der freie Kameramodus unterstützt den **Gehmodus** (Walking Mode).
+
+Wenn er aktiviert ist:
+- Die Aufwärts-/Abwärtsbewegung wird so eingeschränkt, dass sie eher dem Gehen auf einer Bodenebene aus der Ichperspektive entspricht.
+- Dies ist nützlich, wenn du ein Level erkundest und eine gleichbleibende Bewegung „am Boden“ möchtest.
+
+## Popup mit Kameraeinstellungen {#camera-settings-popup}
+
+Die Schaltfläche für die perspektivische Kamera in der Werkzeugleiste bietet ein Popup mit Einstellungen für die Kamera.
+
+![Einstellungen der perspektivischen Kamera](images/editor/camera_popup.png)
+
+Das Popup enthält:
+
+- **Move Speed**
+  Passt die Bewegungsgeschwindigkeit der freien Kamera an.
+
+- **Look Sensitivity**
+  Passt an, wie schnell sich die Kamera als Reaktion auf Mausbewegungen dreht.
+
+- **Invert Y**
+  Kehrt die vertikale Blicksteuerung mit der Maus um.
+
+- **Walking Mode**
+  Schränkt die Bewegung für eine bodennahe Navigation ein.
+
+- **Reset to Defaults**
+  Stellt die Standardeinstellungen der Kamera wieder her.

--- a/docs/de/manuals/script-properties.md
+++ b/docs/de/manuals/script-properties.md
@@ -1,0 +1,175 @@
+---
+title: Eigenschaften von Skriptkomponenten
+brief: Dieses Handbuch erklärt, wie du Skriptkomponenten benutzerdefinierte Eigenschaften hinzufügst und im Editor sowie aus Skripten zur Laufzeit darauf zugreifst.
+---
+
+# Skripteigenschaften {#script-properties}
+
+Skripteigenschaften (script properties) bieten eine einfache und leistungsfähige Möglichkeit, benutzerdefinierte Eigenschaften für eine bestimmte Instanz eines Spielobjekts (game object) zu definieren und zugänglich zu machen. Skripteigenschaften bestimmter Instanzen lassen sich direkt im Editor bearbeiten. Ihre Einstellungen können im Code verwendet werden, um das Verhalten eines Spielobjekts zu ändern. Skripteigenschaften sind in vielen Fällen sehr nützlich:
+
+* Wenn du Werte für bestimmte Instanzen im Editor überschreiben und dadurch Skripte besser wiederverwenden möchtest.
+* Wenn du ein Spielobjekt mit Anfangswerten dynamisch erzeugen möchtest.
+* Wenn du die Werte einer Eigenschaft animieren möchtest.
+* Wenn du von einem Skript aus auf Zustandsdaten in einem anderen zugreifen möchtest. (Beachte, dass es bei häufigen Zugriffen auf Eigenschaften zwischen Objekten besser sein kann, die Daten in einen gemeinsamen Speicher zu verschieben.)
+
+Typische Anwendungsfälle sind das Festlegen der Lebenspunkte oder Geschwindigkeit einer bestimmten Gegner-KI, der Einfärbung eines einsammelbaren Objekts, des Atlas eines Sprites oder der Nachricht, die ein Schaltflächenobjekt beim Drücken senden soll---und/oder ihres Empfängers.
+
+## Eine Skripteigenschaft definieren {#defining-a-script-property}
+
+Skripteigenschaften werden einer Skriptkomponente (script component) hinzugefügt, indem du sie mit der speziellen Funktion `go.property()` definierst. Die Funktion muss auf der obersten Ebene verwendet werden---außerhalb von Lebenszyklusfunktionen wie `init()` und `update()`. Der für die Eigenschaft angegebene Standardwert bestimmt ihren Typ: `number`, `boolean`, `string`, `hash`, `msg.url`, `vmath.vector3`, `vmath.vector4`, `vmath.quaternion` und `resource` (siehe unten).
+
+::: important
+Beachte, dass sich der ursprüngliche Zeichenfolgenwert eines Hash-Werts nur im Debug-Build ermitteln lässt, um die Fehlersuche zu erleichtern. Im Release-Build ist dieser Zeichenfolgenwert nicht vorhanden. Daher ist es dort nicht sinnvoll, mit `tostring()` die Zeichenfolge aus einem `hash`-Wert auszulesen.
+:::
+
+
+```lua
+-- can.script
+-- Define script properties for health and an attack target
+go.property("health", 100)
+go.property("target", msg.url())
+
+function init(self)
+  -- store initial position of target.
+  -- self.target is a url referencing another object.
+  self.target_pos = go.get_position(self.target)
+  ...
+end
+
+function on_message(self, message_id, message, sender)
+  if message_id == hash("take_damage") then
+    -- decrease the health property
+    self.health = self.health - message.damage
+    if self.health <= 0 then
+      go.delete()
+    end
+  end
+end
+```
+
+Für jede aus diesem Skript erstellte Skriptkomponenteninstanz lassen sich dann die Eigenschaftswerte festlegen.
+
+![Komponente mit Eigenschaften](images/script-properties/component.png)
+
+ Wähle die Skriptkomponente in der Ansicht *Outline* im Editor aus. Die Eigenschaften erscheinen in der Ansicht *Properties*, wo du sie bearbeiten kannst:
+
+![Properties](images/script-properties/properties.png)
+
+Jede Eigenschaft, die mit einem neuen, für die Instanz spezifischen Wert überschrieben wird, ist blau markiert. Klicke auf die Schaltfläche zum Zurücksetzen neben dem Eigenschaftsnamen, um den Wert auf den im Skript festgelegten Standardwert zurückzusetzen.
+
+
+::: important
+Skripteigenschaften werden beim Erstellen des Projekts geparst. Wertausdrücke werden nicht ausgewertet. Das bedeutet, dass beispielsweise `go.property("hp", 3+6)` nicht funktioniert, `go.property("hp", 9)` dagegen schon.
+:::
+
+### Texteigenschaften {#text-properties}
+
+Seit Defold 1.13.2 definiert eine Zeichenfolge als Standardwert eine Texteigenschaft. Texteigenschaften unterstützen UTF-8 und Zeilenumbruchzeichen und werden im Editor in einem mehrzeiligen Feld bearbeitet:
+
+```lua
+go.property("greeting", "Hello!\nWelcome, José!")
+
+function init(self)
+    go.set("#label", "text", self.greeting)
+end
+```
+
+Wähle eine Skriptkomponente in einem Spielobjekt oder einer Sammlung (collection) aus, um ihre Texteigenschaften wie andere Skripteigenschaften zu überschreiben. Eingebettete NUL-Zeichen sind weder in Standardwerten noch in überschreibenden Werten erlaubt.
+
+Andere Skripte können eine Texteigenschaft über die URL der Skriptkomponente lesen und schreiben. Füge beispielsweise das obige Skript und eine Beschriftungskomponente zu einem Spielobjekt namens `speaker` in der Sammlung hinzu und gib den Komponenten die Bezeichner `script` und `label`. Aktualisiere sie aus der Funktion `init()` eines anderen Skripts:
+
+```lua
+function init(self)
+    local greeting = go.get("/speaker#script", "greeting")
+    go.set("/speaker#script", "greeting", greeting .. "\nEnjoy the game!")
+    go.set("/speaker#label", "text", go.get("/speaker#script", "greeting"))
+end
+```
+
+Das Ändern der Skripteigenschaft aktualisiert die Beschriftung nicht automatisch; die letzte Zeile kopiert den neuen Wert ausdrücklich in die Eigenschaft `text` der Beschriftung.
+
+## Auf Skripteigenschaften zugreifen {#accessing-script-properties}
+
+Jede definierte Skripteigenschaft ist als gespeichertes Feld in `self`, der Referenz auf die Skriptinstanz, verfügbar:
+
+```lua
+-- my_script.script
+go.property("my_property", 1)
+
+function update(self, dt)
+  -- Read and write the property
+  if self.my_property == 1 then
+      self.my_property = 3
+  end
+end
+```
+
+Benutzerdefinierte Skripteigenschaften lassen sich auch mit `go.get()` lesen und mit `go.set()` schreiben. Numerische Eigenschaften, einschließlich Vektoren und Quaternionen, können mit `go.animate()` animiert werden. Texteigenschaften lassen sich lesen und schreiben, können aber nicht animiert werden:
+
+```lua
+-- another.script
+
+-- increase "my_property" in "myobject#script" by 1
+local val = go.get("myobject#my_script", "my_property")
+go.set("myobject#my_script", "my_property", val + 1)
+
+-- animate "my_property" in "myobject#my_script"
+go.animate("myobject#my_script", "my_property", go.PLAYBACK_LOOP_PINGPONG, 100, go.EASING_LINEAR, 2.0)
+```
+
+## Mit einer Fabrik erstellte Objekte {#factory-created-objects}
+
+Wenn du das Spielobjekt mit einer Fabrik (factory) erstellst, kannst du die Skripteigenschaften zum Zeitpunkt der Erstellung festlegen:
+
+```lua
+local props = { health = 50, target = msg.url("player") }
+local id = factory.create("#can_factory", nil, nil, props)
+
+-- Accessing factory-created script properties
+local url = msg.url(nil, id, "can")
+local can_health = go.get(url, "health")
+```
+
+Wenn du über `collectionfactory.create()` eine Hierarchie von Spielobjekten dynamisch erzeugst, musst du den Objektbezeichnern Eigenschaftstabellen zuordnen. Diese Zuordnungen werden in einer Tabelle zusammengefasst und an die Funktion `create()` übergeben:
+
+```lua
+local props = {}
+props[hash("/can1")] = { health = 150 }
+props[hash("/can2")] = { health = 250, target = msg.url("player") }
+props[hash("/can3")] = { health = 200 }
+
+local ids = collectionfactory.create("#cangang_factory", nil, nil, props)
+```
+
+Die über `factory.create()` und `collectionfactory.create()` angegebenen Eigenschaftswerte überschreiben sowohl die Werte in der Prototypdatei als auch die Standardwerte im Skript.
+
+Wenn mehrere Skriptkomponenten eines Spielobjekts dieselbe Eigenschaft definieren, wird jede Komponente mit dem an `factory.create()` oder `collectionfactory.create()` übergebenen Wert initialisiert.
+
+
+## Ressourceneigenschaften {#resource-properties}
+
+Ressourceneigenschaften (resource properties) werden genauso definiert wie Skripteigenschaften für die grundlegenden Datentypen:
+
+```lua
+go.property("my_atlas", resource.atlas("/atlas.atlas"))
+go.property("my_font", resource.font("/font.font"))
+go.property("my_material", resource.material("/material.material"))
+go.property("my_texture", resource.texture("/texture.png"))
+go.property("my_tile_source", resource.tile_source("/tilesource.tilesource"))
+```
+
+Eine definierte Ressourceneigenschaft erscheint wie jede andere Skripteigenschaft in der Ansicht *Properties*, jedoch als Feld zur Auswahl einer Datei oder Ressource:
+
+![Ressourceneigenschaften](images/script-properties/resource-properties.png)
+
+Du greifst mit `go.get()` oder über die Skriptinstanzreferenz `self` auf Ressourceneigenschaften zu und verwendest sie mit `go.set()`:
+
+```lua
+function init(self)
+  go.set("#sprite", "image", self.my_atlas)
+  go.set("#label", "font", self.my_font)
+  go.set("#sprite", "material", self.my_material)
+  go.set("#model", "texture0", self.my_texture)
+  go.set("#tilemap", "tile_source", self.my_tile_source)
+end
+```

--- a/docs/de/manuals/script.md
+++ b/docs/de/manuals/script.md
@@ -1,0 +1,204 @@
+---
+title: Spiellogik in Skripten schreiben
+brief: Dieses Handbuch beschreibt, wie du mit Skriptkomponenten Spiellogik hinzufügst.
+---
+
+# Skripte {#scripts}
+
+Mit Skriptkomponenten (script components) kannst du Spiellogik in der [Programmiersprache Lua](/manuals/lua) erstellen.
+
+
+## Skripttypen {#script-types}
+
+In Defold gibt es drei Arten von Lua-Skripten, denen jeweils unterschiedliche Defold-Bibliotheken zur Verfügung stehen.
+
+Spielobjekt-Skripte
+: Dateierweiterung _.script_. Diese Skripte werden Spielobjekten (game objects) genau wie jede andere [Komponente (component)](/manuals/components) hinzugefügt. Defold führt den Lua-Code als Teil der Lebenszyklusfunktionen der Engine aus. Spielobjekt-Skripte werden üblicherweise verwendet, um Spielobjekte und die übergreifende Spiellogik zu steuern, etwa das Laden von Levels, Spielregeln und Ähnliches. Spielobjekt-Skripte haben Zugriff auf die [GO](/ref/go)-Funktionen und alle Defold-Bibliotheksfunktionen mit Ausnahme der [GUI](/ref/gui)- und [Render](/ref/render)-Funktionen.
+
+
+GUI-Skripte
+: Dateierweiterung _.gui_script_. Sie werden von GUI-Komponenten ausgeführt und enthalten üblicherweise die Logik, die zur Anzeige von GUI-Elementen wie Statusanzeigen, Menüs usw. erforderlich ist. Defold führt den Lua-Code als Teil der Lebenszyklusfunktionen der Engine aus. GUI-Skripte haben Zugriff auf die [GUI](/ref/gui)-Funktionen und alle Defold-Bibliotheksfunktionen mit Ausnahme der [GO](/ref/go)- und [Render](/ref/render)-Funktionen.
+
+
+Render-Skripte
+: Dateierweiterung _.render_script_. Sie werden von der Rendering-Pipeline ausgeführt und enthalten die Logik, die zum Rendern der gesamten Grafik einer Anwendung oder eines Spiels in jedem Frame erforderlich ist. Das Render-Skript nimmt im Lebenszyklus deines Spiels eine besondere Rolle ein. Einzelheiten findest du in der [Dokumentation zum Anwendungslebenszyklus](/manuals/application-lifecycle). Render-Skripte haben Zugriff auf die [Render](/ref/render)-Funktionen und alle Defold-Bibliotheksfunktionen mit Ausnahme der [GO](/ref/go)- und [GUI](/ref/gui)-Funktionen.
+
+
+## Skriptausführung, Callbacks und self {#script-execution-callbacks-and-self}
+
+Defold führt Lua-Skripte als Teil des Lebenszyklus der Engine aus und macht diesen Lebenszyklus über eine Reihe vordefinierter Callback-Funktionen zugänglich. Wenn du einem Spielobjekt eine Skriptkomponente hinzufügst, wird das Skript Teil des Lebenszyklus des Spielobjekts und seiner Komponente(n). Beim Laden wird das Skript im Lua-Kontext ausgewertet. Anschließend führt die Engine die folgenden Funktionen aus und übergibt als Parameter eine Referenz auf die aktuelle Instanz der Skriptkomponente. Du kannst diese `self`-Referenz verwenden, um den Zustand in der Komponenteninstanz zu speichern.
+
+::: important
+`self` ist ein `userdata`-Objekt, das sich wie eine Lua-Tabelle verhält. Du kannst es jedoch nicht mit `pairs()` oder `ipairs()` durchlaufen und auch nicht mit `pprint()` ausgeben.
+:::
+
+#### `init(self)`
+Wird aufgerufen, wenn die Komponente initialisiert wird.
+
+```lua
+function init(self)
+  -- These variables are available through the lifetime of the component instance
+  self.my_var = "something"
+  self.age = 0
+end
+```
+
+#### `final(self)`
+Wird aufgerufen, wenn die Komponente gelöscht wird. Das ist zum Aufräumen nützlich, beispielsweise wenn du Spielobjekte dynamisch erzeugt hast, die zusammen mit der Komponente gelöscht werden sollen.
+
+```lua
+function final(self)
+  if self.my_var == "something" then
+      -- do some cleanup
+  end
+end
+```
+
+#### `fixed_update(self, dt)`
+Aktualisierung unabhängig von der Bildrate. Der Parameter `dt` enthält die Zeitdifferenz seit der letzten Aktualisierung. Diese Funktion wird abhängig vom zeitlichen Ablauf eines Frames und der Frequenz der Aktualisierungen mit festem Zeitschritt `0-N` Mal aufgerufen. Sie wird nur aufgerufen, wenn `Physics`-->`Use Fixed Timestep` aktiviert ist und `Engine`-->`Fixed Update Frequency` in *game.project* größer als 0 ist. Das ist nützlich, wenn du Physikobjekte in regelmäßigen Abständen verändern möchtest, um eine stabile Physiksimulation zu erreichen.
+
+```lua
+function fixed_update(self, dt)
+  msg.post("#co", "apply_force", {force = vmath.vector3(1, 0, 0), position = go.get_world_position()})
+end
+```
+
+#### `update(self, dt)`
+Wird einmal pro Frame nach dem `fixed_update`-Callback aller Skripte aufgerufen (wenn Fixed Timestep aktiviert ist). Der Parameter `dt` enthält die Zeitdifferenz seit dem letzten Frame.
+
+```lua
+function update(self, dt)
+  self.age = self.age + dt -- increase age with the timestep
+end
+```
+
+#### `late_update(self, dt)`
+Wird einmal pro Frame nach dem `update`-Callback aller Skripte, aber unmittelbar vor dem Rendern aufgerufen. Der Parameter `dt` enthält die Zeitdifferenz seit dem letzten Frame.
+
+```lua
+function late_update(self, dt)
+  go.set_position("/camera", self.final_camera_position)
+end
+```
+
+#### on_message(self, message_id, message, sender)
+Wenn Nachrichten über [`msg.post()`](/ref/msg#msg.post) an die Skriptkomponente gesendet werden, ruft die Engine diese Funktion der Empfängerkomponente auf. Erfahre [mehr über die Nachrichtenübermittlung](/manuals/message-passing).
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("increase_score") then
+        self.total_score = self.total_score + message.score
+    end
+end
+```
+
+#### `on_input(self, action_id, action)`
+Wenn diese Komponente den Eingabefokus erhalten hat (siehe [`acquire_input_focus`](/ref/go/#acquire_input_focus)), ruft die Engine diese Funktion auf, sobald eine Eingabe registriert wird. Erfahre [mehr über die Eingabeverarbeitung](/manuals/input).
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        print("Touch", action.x, action.y)
+    end
+end
+```
+
+#### `on_reload(self)`
+Diese Funktion wird aufgerufen, wenn das Skript über die Editorfunktion Hot Reload (<kbd>Edit ▸ Reload Resource</kbd>) neu geladen wird. Sie ist sehr nützlich für die Fehlersuche, zum Testen und für Feinabstimmungen. Erfahre [mehr über Hot Reload](/manuals/hot-reload).
+
+```lua
+function on_reload(self)
+  print(self.age) -- print the age of this game object
+end
+```
+
+
+## Reaktive Logik {#reactive-logic}
+
+Ein Spielobjekt mit einer Skriptkomponente implementiert eine bestimmte Logik. Oft hängt diese Logik von einem äußeren Faktor ab. Die künstliche Intelligenz (KI) eines Gegners könnte darauf reagieren, dass sich der Spieler in einem bestimmten Umkreis um den Gegner befindet; eine Tür könnte durch eine Interaktion des Spielers entriegelt und geöffnet werden usw.
+
+Mit der Funktion `update()` kannst du komplexes Verhalten als Zustandsautomaten implementieren, der in jedem Frame ausgeführt wird---manchmal ist das der passende Ansatz. Jeder Aufruf von `update()` verursacht jedoch einen Aufwand. Wenn du die Funktion nicht wirklich benötigst, solltest du sie löschen und stattdessen versuchen, deine Logik _reaktiv_ aufzubauen. Es ist weniger aufwendig, passiv auf eine Nachricht zu warten, die eine Reaktion auslöst, als die Spielwelt aktiv nach Daten abzusuchen, auf die reagiert werden soll. Außerdem führt eine reaktive Lösung eines Entwurfsproblems oft auch zu klareren und stabileren Entwürfen und Implementierungen.
+
+Sehen wir uns ein konkretes Beispiel an. Angenommen, du möchtest, dass eine Skriptkomponente 2 Sekunden nach ihrer Initialisierung eine Nachricht sendet. Sie soll dann auf eine bestimmte Antwortnachricht warten und 5 Sekunden nach Erhalt der Antwort eine weitere Nachricht senden. Der nicht reaktive Code dafür würde etwa so aussehen:
+
+```lua
+function init(self)
+    -- Counter to keep track of time.
+    self.counter = 0
+    -- We need this to keep track of our state.
+    self.state = "first"
+end
+
+function update(self, dt)
+    self.counter = self.counter + dt
+    if self.counter >= 2.0 and self.state == "first" then
+        -- send message after 2 seconds
+        msg.post("some_object", "some_message")
+        self.state = "waiting"
+    end
+    if self.counter >= 5.0 and self.state == "second" then
+        -- send message 5 seconds after we received "response"
+        msg.post("another_object", "another_message")
+        -- Nil the state so we don’t reach this state block again.
+        self.state = nil
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("response") then
+        -- “first” state done. enter next
+        self.state = "second"
+        -- zero the counter
+        self.counter = 0
+    end
+end
+```
+
+Selbst in diesem recht einfachen Fall erhalten wir eine ziemlich verworrene Logik. Mit Koroutinen in einem Modul (siehe unten) ließe sie sich übersichtlicher gestalten. Versuchen wir stattdessen jedoch, sie reaktiv umzusetzen und einen integrierten Zeitsteuerungsmechanismus zu verwenden.
+
+```lua
+local function send_first()
+	msg.post("some_object", "some_message")
+end
+
+function init(self)
+	-- Wait 2s then call send_first()
+	timer.delay(2, false, send_first)
+end
+
+local function send_second()
+	msg.post("another_object", "another_message")
+end
+
+function on_message(self, message_id, message, sender)
+	if message_id == hash("response") then
+		-- Wait 5s then call send_second()
+		timer.delay(5, false, send_second)
+	end
+end
+```
+
+Das ist übersichtlicher und leichter nachzuvollziehen. Wir beseitigen interne Zustandsvariablen, deren Verlauf in der Logik oft schwer nachzuvollziehen ist---und die zu schwer erkennbaren Fehlern führen können. Außerdem entfernen wir die Funktion `update()` vollständig. Dadurch muss die Engine unser Skript nicht mehr 60 Mal pro Sekunde aufrufen, selbst wenn es gerade nichts zu tun hat.
+
+
+## Vorverarbeitung {#preprocessing}
+
+Mit einem Lua-Präprozessor und speziellen Auszeichnungen kannst du Code abhängig von der Build-Variante bedingt einbinden. Beispiel:
+
+```lua
+-- Use one of the following keywords: RELEASE, DEBUG or HEADLESS
+--#IF DEBUG
+local lives_num = 999
+--#ELSE 
+local lives_num = 3
+--#ENDIF
+```
+
+Der Präprozessor ist als Build-Erweiterung verfügbar. Auf der [Seite der Erweiterung auf GitHub](https://github.com/defold/extension-lua-preprocessor) erfährst du mehr darüber, wie du ihn installierst und verwendest.
+
+
+## Unterstützung durch den Editor {#editor-support}
+
+Der Defold-Editor unterstützt das Bearbeiten von Lua-Skripten mit Syntaxhervorhebung und automatischer Vervollständigung. Um Defold-Funktionsnamen zu vervollständigen, drücke *Ctrl+Space*. Damit öffnest du eine Liste der Funktionen, die zu deiner bisherigen Eingabe passen.
+
+![Automatische Vervollständigung](images/script/completion.png)

--- a/docs/de/manuals/shader.md
+++ b/docs/de/manuals/shader.md
@@ -1,0 +1,459 @@
+---
+title: Shader-Programme in Defold
+brief: Dieses Handbuch beschreibt Vertex- und Fragment-Shader im Detail und erklärt, wie du sie in Defold verwendest.
+---
+
+# Shader {#shaders}
+
+Shader-Programme bilden den Kern des Grafik-Renderings. Es sind Programme in einer C-ähnlichen Sprache namens GLSL (GL Shading Language), die von der Grafikhardware ausgeführt werden, um Operationen entweder auf den zugrunde liegenden 3D-Daten (den Vertices) oder auf den Pixeln durchzuführen, die schließlich auf dem Bildschirm erscheinen (den „Fragmenten“). Shader werden zum Zeichnen von Sprites, zum Beleuchten von 3D-Modellen, zum Erstellen bildschirmfüllender Nachbearbeitungseffekte und für vieles mehr verwendet.
+
+Dieses Handbuch beschreibt, wie Defolds Rendering-Pipeline mit GPU-Shadern zusammenarbeitet. Um Shader für deine Inhalte zu erstellen, musst du auch das Konzept der Materialien und die Funktionsweise der Rendering-Pipeline verstehen.
+
+* Einzelheiten zur Rendering-Pipeline findest du im [Rendering-Handbuch](/manuals/render).
+* Einzelheiten zu Materialien findest du im [Materialhandbuch](/manuals/material).
+* Einzelheiten zu Compute-Programmen findest du im [Compute-Handbuch](/manuals/compute).
+
+Die Spezifikationen von OpenGL ES 2.0 (OpenGL for Embedded Systems) und OpenGL ES Shading Language findest du im [Khronos OpenGL Registry](https://www.khronos.org/registry/gles/).
+
+Beachte, dass du auf Desktop-Computern Shader schreiben kannst, die Funktionen verwenden, die in OpenGL ES 2.0 nicht verfügbar sind. Dein Grafikkartentreiber kompiliert und führt möglicherweise problemlos Shader-Code aus, der auf Mobilgeräten nicht funktioniert.
+
+
+## Konzepte {#concepts}
+
+Vertex-Shader
+: Ein Vertex-Shader kann keine Vertices erstellen oder löschen, sondern nur die Position eines Vertex ändern. Vertex-Shader werden häufig verwendet, um die Positionen von Vertices aus dem 3D-Weltkoordinatensystem in das 2D-Bildschirmkoordinatensystem zu transformieren.
+
+  Die Eingabe eines Vertex-Shaders besteht aus Vertex-Daten (in Form von `attributes`) und Konstanten (`uniforms`). Häufig verwendete Konstanten sind die Matrizen, die benötigt werden, um die Position eines Vertex in das Bildschirmkoordinatensystem zu transformieren und zu projizieren.
+
+  Die Ausgabe des Vertex-Shaders ist die berechnete Bildschirmposition des Vertex (`gl_Position`). Außerdem können Daten über `varying`-Variablen vom Vertex-Shader an den Fragment-Shader übergeben werden.
+
+Fragment-Shader
+: Nachdem der Vertex-Shader fertig ist, bestimmt der Fragment-Shader die Farbe jedes Fragments (oder Pixels) der resultierenden Primitive.
+
+  Die Eingabe eines Fragment-Shaders besteht aus Konstanten (`uniforms`) sowie allen `varying`-Variablen, die vom Vertex-Shader gesetzt wurden.
+
+  Die Ausgabe des Fragment-Shaders ist der Farbwert für das jeweilige Fragment (`gl_FragColor`).
+
+Compute-Shader
+: Ein Compute-Shader ist ein universell einsetzbarer Shader, mit dem beliebige Aufgaben auf einer GPU ausgeführt werden können. Er ist überhaupt kein Teil der Grafik-Pipeline. Compute-Shader laufen in einem separaten Ausführungskontext und sind nicht von der Eingabe anderer Shader abhängig.
+
+  Die Eingabe eines Compute-Shaders besteht aus Konstantenpuffern (`uniforms`), Texturbildern (`image2D`), Samplern (`sampler2D`) und Speicherpuffern (`buffer`).
+
+  Die Ausgabe des Compute-Shaders ist nicht ausdrücklich festgelegt. Anders als bei Vertex- und Fragment-Shadern gibt es keine bestimmte Ausgabe, die erzeugt werden muss. Da Compute-Shader universell einsetzbar sind, legt die programmierende Person fest, welche Art von Ergebnis der Compute-Shader erzeugen soll.
+
+Weltmatrix
+: Die Vertex-Positionen der Form eines Modells werden relativ zum Ursprung des Modells gespeichert. Das wird als „Modellkoordinatensystem“ (model space) bezeichnet. Die Spielwelt hingegen ist ein „Weltkoordinatensystem“ (world space), in dem Position, Ausrichtung und Skalierung jedes Vertex relativ zum Weltursprung angegeben werden. Durch diese Trennung kann die Game-Engine jedes Modell verschieben, drehen und skalieren, ohne die ursprünglichen Vertex-Werte zu zerstören, die in der Modellkomponente (model component) gespeichert sind.
+
+  Wenn ein Modell in der Spielwelt platziert wird, müssen die lokalen Vertex-Koordinaten des Modells in Weltkoordinaten umgerechnet werden. Diese Umrechnung erfolgt durch eine *Welttransformationsmatrix*, die angibt, welche Verschiebung (Bewegung), Drehung und Skalierung auf die Vertices eines Modells angewendet werden sollen, damit sie korrekt im Koordinatensystem der Spielwelt platziert werden.
+
+  ![Welttransformation](images/shader/world_transform.png)
+
+Ansichts- und Projektionsmatrix
+: Damit die Vertices der Spielwelt auf dem Bildschirm erscheinen, werden die 3D-Koordinaten jeder Matrix zunächst in Koordinaten relativ zur Kamera umgerechnet. Dies erfolgt mit einer _Ansichtsmatrix_. Anschließend werden die Vertices mit einer _Projektionsmatrix_ in das 2D-Bildschirmkoordinatensystem projiziert:
+
+  ![Projektion](images/shader/projection.png)
+
+Attribute
+: Ein Wert, der einem einzelnen Vertex zugeordnet ist. Attribute werden von der Engine an den Shader übergeben. Wenn du auf ein Attribut zugreifen möchtest, deklarierst du es einfach in deinem Shader-Programm. Verschiedene Komponententypen (component types) haben unterschiedliche Sätze von Attributen:
+  - Ein Sprite besitzt `position` und `texcoord0`.
+  - Ein Kachelraster (Tilegrid) besitzt `position` und `texcoord0`.
+  - Ein GUI-Knoten (GUI node) besitzt `position`, `textcoord0` und `color`.
+  - Ein Partikeleffekt (ParticleFX) besitzt `position`, `texcoord0` und `color`.
+  - Ein Modell besitzt `position`, `texcoord0` und `normal`.
+  - Eine Schriftressource besitzt `position`, `texcoord0`, `face_color`, `outline_color` und `shadow_color`.
+
+Konstanten
+: Shader-Konstanten bleiben für die Dauer des Zeichenaufrufs (draw call) unverändert. Konstanten werden den Abschnitten *Constants* der Materialdatei hinzugefügt und anschließend im Shader-Programm als `uniform` deklariert. Sampler-Uniforms werden dem Abschnitt *Samplers* des Materials hinzugefügt und anschließend im Shader-Programm als `uniform` deklariert. Die Matrizen, die für Vertex-Transformationen in einem Vertex-Shader benötigt werden, sind als Konstanten verfügbar:
+
+  - `CONSTANT_TYPE_WORLD` ist die *Weltmatrix*, die vom lokalen Koordinatensystem eines Objekts in das Weltkoordinatensystem abbildet.
+  - `CONSTANT_TYPE_VIEW` ist die *Ansichtsmatrix*, die vom Weltkoordinatensystem in das Kamerakoordinatensystem abbildet.
+  - `CONSTANT_TYPE_PROJECTION` ist die *Projektionsmatrix*, die vom Kamerakoordinatensystem in das Bildschirmkoordinatensystem abbildet.
+  - `CONSTANT_TYPE_WORLDVIEW`, `CONSTANT_TYPE_VIEWPROJ` und `CONSTANT_TYPE_WORLDVIEWPROJ` stellen die entsprechenden kombinierten Matrizen bereit.
+  - `CONSTANT_TYPE_WORLD_INVERSE`, `CONSTANT_TYPE_VIEW_INVERSE`, `CONSTANT_TYPE_PROJECTION_INVERSE`, `CONSTANT_TYPE_VIEWPROJ_INVERSE`, `CONSTANT_TYPE_WORLDVIEW_INVERSE` und `CONSTANT_TYPE_WORLDVIEWPROJ_INVERSE` stellen inverse Matrizen bereit, ohne dass der Shader sie berechnen muss.
+  - `CONSTANT_TYPE_TIME` ist ein von der Engine bereitgestellter `vec4`: die seit dem Engine-Start vergangene Zeit in `.x`, die Frame-Deltazeit in `.y` und null in `.z` und `.w`.
+  - `CONSTANT_TYPE_USER` ist eine Konstante vom Typ `vec4`, die du nach Belieben verwenden kannst.
+
+  Das [Materialhandbuch](/manuals/material) erklärt, wie du Konstanten festlegst.
+
+Sampler
+: Shader können Uniform-Variablen vom Typ *sampler* deklarieren. Sampler werden verwendet, um Werte aus einer Bildquelle zu lesen:
+
+  - `sampler2D` tastet eine 2D-Bildtextur ab.
+  - `sampler2DArray` tastet eine Array-Textur aus 2D-Bildern ab. Dies wird hauptsächlich für mehrseitige Atlanten verwendet.
+  - `samplerCube` tastet eine Cubemap-Textur aus 6 Bildern ab.
+  - `image2D` lädt (und speichert gegebenenfalls) Texturdaten in ein Bildobjekt. Dies wird hauptsächlich zur Speicherung in Compute-Shadern verwendet.
+
+  Du kannst einen Sampler nur in den Texturabfragefunktionen der GLSL-Standardbibliothek verwenden. Das [Materialhandbuch](/manuals/material) erklärt, wie du Sampler-Einstellungen festlegst.
+
+UV-Koordinaten
+: Einem Vertex ist eine 2D-Koordinate zugeordnet, die auf einen Punkt auf einer 2D-Textur abbildet. Ein Teil oder die gesamte Textur kann deshalb auf die Form aufgetragen werden, die durch einen Satz von Vertices beschrieben wird.
+
+  ![UV-Koordinaten](images/shader/uv_map.png)
+
+  Eine UV-Abbildung wird üblicherweise im 3D-Modellierungsprogramm erzeugt und im Mesh gespeichert. Die Texturkoordinaten für jeden Vertex werden dem Vertex-Shader als Attribut bereitgestellt. Anschließend wird eine `varying`-Variable verwendet, um die UV-Koordinate für jedes Fragment durch Interpolation der Vertex-Werte zu ermitteln.
+
+Varying-Variablen
+: Variablen vom Typ `Varying` werden verwendet, um Informationen zwischen der Vertex-Stufe und der Fragment-Stufe zu übergeben.
+
+  1. Eine Varying-Variable wird im Vertex-Shader für jeden Vertex gesetzt.
+  2. Während der Rasterisierung wird dieser Wert für jedes Fragment des gerenderten Primitivs interpoliert. Der Abstand des Fragments zu den Vertices der Form bestimmt den interpolierten Wert.
+  3. Die Variable wird für jeden Aufruf des Fragment-Shaders gesetzt und kann für Fragmentberechnungen verwendet werden.
+
+  ![Varying-Interpolation](images/shader/varying_vertex.png)
+
+  Wenn du beispielsweise an jeder Ecke eines Dreiecks ein `varying` auf einen RGB-Farbwert vom Typ `vec3` setzt, werden die Farben über die gesamte Form interpoliert. Ebenso ermöglicht das Setzen von Texturabfragekoordinaten (oder *UV-Koordinaten*) an jedem Vertex eines Rechtecks dem Fragment-Shader, Texturfarbwerte für die gesamte Fläche der Form abzufragen.
+
+  ![Varying-Interpolation](images/shader/varying.png)
+
+## Moderne GLSL-Shader schreiben {#writing-modern-glsl-shaders}
+
+Da die Defold-Engine mehrere Plattformen und Grafik-APIs unterstützt, muss es für Entwickler einfach sein, Shader zu schreiben, die überall funktionieren. Die Asset-Pipeline erreicht dies hauptsächlich auf zwei Wegen (im Folgenden als `Shader-Pipelines` bezeichnet):
+
+1. Die alte Pipeline, in der Shader in ES2-kompatiblem GLSL-Code geschrieben werden.
+2. Die moderne Pipeline, in der Shader in SPIR-v-kompatiblem GLSL-Code geschrieben werden.
+
+Seit Defold 1.9.2 wird empfohlen, Shader zu schreiben, die die neue Pipeline verwenden. Dafür müssen die meisten Shader so umgestellt werden, dass sie mindestens Version 140 (OpenGL 3.1) verwenden. Stelle beim Umstellen eines Shaders sicher, dass diese Anforderungen erfüllt sind:
+
+### Versionsdeklaration {#version-declaration}
+Setze mindestens #version 140 an den Anfang des Shaders:
+
+```glsl
+#version 140
+```
+
+Auf diese Weise wird die Shader-Pipeline im Build-Vorgang ausgewählt, weshalb du die alten Shader weiterhin verwenden kannst. Wird keine Präprozessordirektive für die Version gefunden, greift Defold auf die alte Pipeline zurück.
+
+### Attribute {#attributes}
+Ersetze in Vertex-Shadern das Schlüsselwort `attribute` durch `in`:
+
+```glsl
+// instead of:
+// attribute vec4 position;
+// do:
+in vec4 position;
+```
+
+Hinweis: Fragment-Shader (und Compute-Shader) erhalten keine Vertex-Eingaben.
+
+### Varyings
+In Vertex-Shadern sollte Varyings ein `out` vorangestellt werden. In Fragment-Shadern werden Varyings zu `in`:
+
+```glsl
+// In a vertex shader, instead of:
+// varying vec4 var_color;
+// do:
+out vec4 var_color;
+
+// In a fragment shader, instead of:
+// varying vec4 var_color;
+// do:
+in vec4 var_color;
+```
+
+### Uniforms (in Defold Konstanten genannt) {#uniforms-called-constants-in-defold}
+
+Opake Uniform-Typen (Sampler, Images, Atomics, SSBOs) müssen nicht umgestellt werden. Du kannst sie wie bisher verwenden:
+
+```glsl
+uniform sampler2D my_texture;
+uniform image2D my_image;
+```
+
+Nicht opake Uniform-Typen musst du in einem `uniform block` unterbringen. Ein Uniform-Block ist einfach eine Gruppe von Uniform-Variablen und wird mit dem Schlüsselwort `uniform` deklariert:
+
+```glsl
+uniform vertex_inputs
+{
+    mat4 mtx_world;
+    mat4 mtx_proj;
+    mat4 mtx_view;
+    mat4 mtx_normal;
+    ...
+};
+
+void main()
+{
+    // Individual members of the uniform block can be used as-is
+    gl_Position = mtx_proj * mtx_view * mtx_world * vec4(position, 1.0);
+}
+```
+
+Alle Elemente des Uniform-Blocks werden Materialien und Komponenten als einzelne Konstanten bereitgestellt. Für die Verwendung von Render-Konstantenpuffern oder `go.set` und `go.get` ist keine Umstellung erforderlich.
+
+### Integrierte Variablen {#built-in-variables}
+
+In Fragment-Shadern ist `gl_FragColor` ab Version 140 veraltet und zur Ablösung vorgesehen. Verwende stattdessen `out`:
+
+```glsl
+// instead of:
+// gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+// do:
+out vec4 color_out;
+
+void main()
+{
+    color_out = vec4(1.0, 0.0, 0.0, 1.0);
+}
+```
+
+### Texturfunktionen {#texture-functions}
+
+Spezifische Funktionen zur Texturabtastung wie `texture2D` und `texture2DArray` gibt es nicht mehr. Verwende stattdessen einfach die Funktion `texture`:
+
+```glsl
+uniform sampler2D my_texture;
+uniform sampler2DArray my_texture_array;
+
+// instead of:
+// vec4 sampler_2d = texture2D(my_texture, uv);
+// vec4 sampler_2d_array = texture2DArray(my_texture_array, vec3(uv, slice));
+// do:
+vec4 sampler_2d = texture(my_texture, uv);
+vec4 sampler_2d_array = texture(my_texture_array, vec3(uv, slice));
+```
+
+### Genauigkeit {#precision}
+
+Defold erzeugt beim Cross-Kompilieren von Shadern für GLSL ES globale Standardqualifizierer für die Genauigkeit. Die Standardwerte sind `mediump` für Gleitkommawerte und `highp` für Ganzzahlen. Sie können mit **GLSL ES Default Precision Float** (`shader.glsl_es_default_precision_float`) und **GLSL ES Default Precision Int** (`shader.glsl_es_default_precision_int`) in den [Projekteinstellungen](/manuals/project-settings/#shader) geändert werden; beide akzeptieren `mediump` oder `highp`.
+
+Ein expliziter Qualifizierer an einer Variablen, Eingabe oder Ausgabe hat Vorrang vor dem erzeugten globalen Standardwert. Bei Fragment-Shadern für OpenGL ES 2.0 und WebGL 1.0 wird `highp` nicht von jedem Gerät unterstützt. Wenn `highp` als globaler Standardwert ausgewählt ist, sichert Defold ihn mit `GL_FRAGMENT_PRECISION_HIGH` ab und greift auf Geräten, die ihn nicht unterstützen, auf `mediump` zurück.
+
+### Alles zusammenführen {#putting-it-together}
+
+Als abschließendes Beispiel, in dem all diese Regeln angewendet werden, folgen hier die integrierten Sprite-Shader, die in das neue Format umgewandelt wurden:
+
+```glsl
+#version 140
+
+uniform vx_uniforms
+{
+    mat4 view_proj;
+};
+
+// positions are in world space
+in vec4 position;
+in vec2 texcoord0;
+
+out vec2 var_texcoord0;
+
+void main()
+{
+    gl_Position = view_proj * vec4(position.xyz, 1.0);
+    var_texcoord0 = texcoord0;
+}
+```
+
+```glsl
+#version 140
+
+in vec2 var_texcoord0;
+
+out vec4 color_out;
+
+uniform sampler2D texture_sampler;
+
+uniform fs_uniforms
+{
+    vec4 tint;
+};
+
+void main()
+{
+    // Premultiply alpha since all runtime textures already are
+    vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
+    color_out = texture(texture_sampler, var_texcoord0.xy) * tint_pm;
+}
+
+```
+
+## Codeausschnitte in Shader einbinden {#including-snippets-into-shaders}
+
+Shader in Defold unterstützen das Einbinden von Quellcode aus Dateien innerhalb des Projekts, die die Erweiterung `.glsl` haben. Um eine GLSL-Datei aus einem Shader einzubinden, verwende das Pragma `#include` mit doppelten Anführungszeichen oder spitzen Klammern. Includes müssen entweder Pfade relativ zum Projekt oder einen Pfad relativ zu der Datei verwenden, die sie einbindet:
+
+```glsl
+// In file /main/my-shader.fp
+
+// Absolute path
+#include "/main/my-snippet.glsl"
+// The file is in the same folder
+#include "my-snippet.glsl"
+// The file is in a sub-folder on the same level as 'my-shader'
+#include "sub-folder/my-snippet.glsl"
+// The file is in a sub-folder on the parent directory, i.e /some-other-folder/my-snippet.glsl
+#include "../some-other-folder/my-snippet.glsl"
+// The file is on the parent directory, i.e /root-level-snippet.glsl
+#include "../root-level-snippet.glsl"
+```
+
+Bei der Verarbeitung von Includes gibt es einige Besonderheiten:
+
+  - Dateien müssen relativ zum Projekt angegeben werden, das heißt, du kannst nur Dateien einbinden, die sich innerhalb des Projekts befinden. Jeder absolute Pfad muss mit einem führenden `/` angegeben werden
+  - Du kannst Code überall in der Datei einbinden, aber keine Datei innerhalb einer Anweisung. Beispielsweise funktioniert `const float #include "my-float-name.glsl" = 1.0` nicht
+
+### Include-Schutz {#header-guards}
+
+Codeausschnitte können selbst weitere `.glsl`-Dateien einbinden. Dadurch kann der endgültig erzeugte Shader denselben Code mehrfach enthalten. Je nach Inhalt der Dateien können Kompilierungsprobleme entstehen, weil dieselben Symbole mehr als einmal deklariert werden. Um dies zu vermeiden, kannst du einen *Include-Schutz (header guards)* verwenden, ein in mehreren Programmiersprachen verbreitetes Konzept. Beispiel:
+
+```glsl
+// In my-shader.vs
+#include "math-functions.glsl"
+#include "pi.glsl"
+
+// In math-functions.glsl
+#include "pi.glsl"
+
+// In pi.glsl
+const float PI = 3.14159265359;
+```
+
+In diesem Beispiel wird die Konstante `PI` zweimal definiert, was beim Ausführen des Projekts zu Compilerfehlern führt. Du solltest die Inhalte stattdessen mit einem Include-Schutz versehen:
+
+```glsl
+// In pi.glsl
+#ifndef PI_GLSL_H
+#define PI_GLSL_H
+
+const float PI = 3.14159265359;
+
+#endif // PI_GLSL_H
+```
+
+Der Code aus `pi.glsl` wird zweimal in `my-shader.vs` eingefügt. Da du ihn jedoch mit einem Include-Schutz umschlossen hast, wird das Symbol PI nur einmal definiert und der Shader erfolgreich kompiliert.
+
+Je nach Anwendungsfall ist dies jedoch nicht immer zwingend erforderlich. Wenn du Code stattdessen lokal in einer Funktion oder an anderer Stelle wiederverwenden möchtest, an der die Werte nicht global im Shader-Code verfügbar sein müssen, solltest du wahrscheinlich keinen Include-Schutz verwenden. Beispiel:
+
+```glsl
+// In red-color.glsl
+vec3 my_red_color = vec3(1.0, 0.0, 0.0);
+
+// In my-shader.fp
+vec3 get_red_color()
+{
+  #include "red-color.glsl"
+  return my_red_color;
+}
+
+vec3 get_red_color_inverted()
+{
+  #include "red-color.glsl"
+  return 1.0 - my_red_color;
+}
+```
+
+## Editorspezifischer Shader-Code {#editor-specific-shader-code}
+
+Wenn Shader im Ansichtsbereich (viewport) des Defold-Editors gerendert werden, steht die Präprozessordefinition `EDITOR` zur Verfügung. Dadurch kannst du Shader-Code schreiben, der sich bei der Ausführung im Editor anders verhält als bei der Ausführung in der eigentlichen Game-Engine.
+
+Dies ist besonders nützlich für:
+  - Das Hinzufügen von Debug-Visualisierungen, die nur im Editor erscheinen sollen.
+  - Die Implementierung editorspezifischer Funktionen wie Drahtgittermodi oder Materialvorschauen.
+  - Das Bereitstellen einer alternativen Rendering-Darstellung für Materialien, die im Ansichtsbereich des Editors möglicherweise nicht richtig funktionieren.
+
+Verwende die Präprozessordirektive `#ifdef EDITOR`, um Code bedingt zu kompilieren, der nur im Editor ausgeführt werden soll:
+
+```glsl
+#ifdef EDITOR
+    // This code will only execute when the shader is rendered in the Defold Editor
+    color_out = vec4(1.0, 0.0, 1.0, 1.0); // Magenta color for editor preview
+#else
+    // This code will execute when running in the game
+    color_out = texture(texture_sampler, var_texcoord0) * tint_pm;
+#endif
+```
+
+## Der Rendering-Vorgang {#the-rendering-process}
+
+Bevor die Daten, die du für dein Spiel erstellst, auf dem Bildschirm erscheinen, durchlaufen sie eine Reihe von Schritten:
+
+![Rendering-Pipeline](images/shader/pipeline.png)
+
+Alle visuellen Komponenten (Sprites, GUI-Knoten, Partikeleffekte oder Modelle) bestehen aus Vertices, Punkten in der 3D-Welt, die die Form der Komponente beschreiben. Der Vorteil dabei ist, dass die Form aus jedem Winkel und aus jeder Entfernung betrachtet werden kann. Die Aufgabe des Vertex-Shader-Programms besteht darin, einen einzelnen Vertex in eine Position im Ansichtsbereich umzurechnen, damit die Form auf dem Bildschirm erscheinen kann. Bei einer Form mit 4 Vertices wird das Vertex-Shader-Programm 4 Mal ausgeführt, jeweils parallel.
+
+![Vertex-Shader](images/shader/vertex_shader.png)
+
+Die Eingabe des Programms ist die Vertex-Position (und weitere Attributdaten, die dem Vertex zugeordnet sind). Die Ausgabe ist eine neue Vertex-Position (`gl_Position`) sowie alle `varying`-Variablen, die für jedes Fragment interpoliert werden sollen.
+
+Das einfachste Vertex-Shader-Programm setzt die Ausgabeposition lediglich auf einen Vertex am Nullpunkt (was nicht besonders nützlich ist):
+
+```glsl
+void main()
+{
+    gl_Position = vec4(0.0,0.0,0.0,1.0);
+}
+```
+
+Ein vollständigeres Beispiel ist der integrierte Sprite-Vertex-Shader:
+
+```glsl
+-- sprite.vp
+uniform mediump mat4 view_proj;             // [1]
+
+attribute mediump vec4 position;            // [2]
+attribute mediump vec2 texcoord0;
+
+varying mediump vec2 var_texcoord0;         // [3]
+
+void main()
+{
+  gl_Position = view_proj * vec4(position.xyz, 1.0);    // [4]
+  var_texcoord0 = texcoord0;                            // [5]
+}
+```
+1. Ein Uniform (eine Konstante), das das Produkt aus Ansichts- und Projektionsmatrix enthält.
+2. Attribute für den Sprite-Vertex. `position` wurde bereits in das Weltkoordinatensystem transformiert. `texcoord0` enthält die UV-Koordinate für den Vertex.
+3. Deklariere eine Varying-Ausgabevariable. Diese Variable wird für jedes Fragment zwischen den für jeden Vertex gesetzten Werten interpoliert und an den Fragment-Shader gesendet.
+4. `gl_Position` wird auf die Ausgabeposition des aktuellen Vertex im Projektionskoordinatensystem gesetzt. Dieser Wert hat 4 Komponenten: `x`, `y`, `z` und `w`. Die Komponente `w` wird verwendet, um eine perspektivisch korrekte Interpolation zu berechnen. Dieser Wert ist normalerweise 1,0 für jeden Vertex, bevor eine Transformationsmatrix angewendet wird.
+5. Setze die Varying-UV-Koordinate für diese Vertex-Position. Nach der Rasterisierung wird sie für jedes Fragment interpoliert und an den Fragment-Shader gesendet.
+
+
+
+
+Nach dem Vertex-Shading steht die Form der Komponente auf dem Bildschirm fest: Primitive Formen werden erzeugt und gerastert. Das bedeutet, dass die Grafikhardware jede Form in *Fragmente* oder Pixel aufteilt. Anschließend führt sie das Fragment-Shader-Programm einmal für jedes Fragment aus. Bei einem Bild auf dem Bildschirm mit einer Größe von 16 × 24 Pixeln wird das Programm 384 Mal ausgeführt, jeweils parallel.
+
+![Fragment-Shader](images/shader/fragment_shader.png)
+
+Die Eingabe des Programms ist alles, was die Rendering-Pipeline und der Vertex-Shader senden, üblicherweise die *UV-Koordinaten* des Fragments, Einfärbungsfarben usw. Die Ausgabe ist die endgültige Farbe des Pixels (`gl_FragColor`).
+
+Das einfachste Fragment-Shader-Programm setzt die Farbe jedes Pixels lediglich auf Schwarz (auch dies ist kein besonders nützliches Programm):
+
+```glsl
+void main()
+{
+    gl_FragColor = vec4(0.0,0.0,0.0,1.0);
+}
+```
+
+Auch hier ist der integrierte Sprite-Fragment-Shader ein vollständigeres Beispiel:
+
+```glsl
+// sprite.fp
+varying mediump vec2 var_texcoord0;             // [1]
+
+uniform lowp sampler2D DIFFUSE_TEXTURE;         // [2]
+uniform lowp vec4 tint;                         // [3]
+
+void main()
+{
+  lowp vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);          // [4]
+  lowp vec4 diff = texture2D(DIFFUSE_TEXTURE, var_texcoord0.xy);// [5]
+  gl_FragColor = diff * tint_pm;                                // [6]
+}
+```
+1. Die Varying-Variable für die Texturkoordinate wird deklariert. Der Wert dieser Variablen wird für jedes Fragment zwischen den Werten interpoliert, die für jeden Vertex der Form gesetzt wurden.
+2. Eine Uniform-Variable vom Typ `sampler2D` wird deklariert. Der Sampler wird zusammen mit den interpolierten Texturkoordinaten verwendet, um die Textur abzufragen, damit das Sprite korrekt texturiert werden kann. Da es sich um ein Sprite handelt, ordnet die Engine diesem Sampler das Bild zu, das in der Eigenschaft *Image* des Sprites festgelegt ist.
+3. Eine Konstante vom Typ `CONSTANT_TYPE_USER` wird im Material definiert und als `uniform` deklariert. Ihr Wert ermöglicht die Einfärbung des Sprites. Der Standardwert ist reines Weiß.
+4. Der Farbwert der Einfärbung wird mit seinem Alphawert vormultipliziert, da alle Texturen zur Laufzeit bereits vormultipliziertes Alpha enthalten.
+5. Taste die Textur an der interpolierten Koordinate ab und gib den abgetasteten Wert zurück.
+6. `gl_FragColor` wird auf die Ausgabefarbe für das Fragment gesetzt: die diffuse Farbe aus der Textur, multipliziert mit dem Einfärbungswert.
+
+Der resultierende Fragmentwert durchläuft anschließend Tests. Ein häufiger Test ist der *Tiefentest*, bei dem der Tiefenwert des Fragments mit dem Wert im Tiefenpuffer für das getestete Pixel verglichen wird. Je nach Test kann das Fragment verworfen oder ein neuer Wert in den Tiefenpuffer geschrieben werden. Eine häufige Anwendung dieses Tests besteht darin, näher an der Kamera liegende Grafik weiter hinten liegende Grafik verdecken zu lassen.
+
+Wenn der Test ergibt, dass das Fragment in den Framebuffer geschrieben werden soll, wird es mit den bereits im Puffer vorhandenen Pixeldaten *gemischt*. Mischparameter, die im Render-Skript festgelegt werden, ermöglichen es, die Quellfarbe (den vom Fragment-Shader geschriebenen Wert) und die Zielfarbe (die Farbe aus dem Bild im Framebuffer) auf verschiedene Weise zu kombinieren. Eine häufige Anwendung des Mischens besteht darin, transparente Objekte rendern zu können.
+
+## Weiterführende Informationen {#further-study}
+
+- [Shadertoy](https://www.shadertoy.com) enthält eine riesige Anzahl von Shadern, die von Nutzern beigetragen wurden. Die Website ist eine großartige Inspirationsquelle, auf der du verschiedene Shading-Techniken kennenlernen kannst. Viele der dort vorgestellten Shader lassen sich mit sehr wenig Aufwand nach Defold portieren. Das [Shadertoy-Tutorial](https://www.defold.com/tutorials/shadertoy/) erklärt die einzelnen Schritte, um einen vorhandenen Shader für Defold umzuwandeln.
+
+- Das [Tutorial zur Farbkorrektur](https://www.defold.com/tutorials/grading/) zeigt, wie du einen bildschirmfüllenden Farbkorrektureffekt mithilfe von Texturen mit Farbnachschlagetabellen erstellst.
+
+- [The Book of Shaders](https://thebookofshaders.com/00/) zeigt dir, wie du Shader in deinen Projekten verwendest und integrierst und dadurch deren Leistung und Grafikqualität verbesserst.

--- a/docs/de/manuals/socket-connections.md
+++ b/docs/de/manuals/socket-connections.md
@@ -1,0 +1,22 @@
+---
+title: Socket-Verbindungen
+brief: Dieses Handbuch erklärt, wie du Socket-Verbindungen herstellst.
+---
+
+## Socket-Verbindungen {#socket-connections}
+
+Defold enthält die [LuaSocket-Bibliothek](https://lunarmodules.github.io/luasocket/) zum Herstellen von TCP- und UDP-Socket-Verbindungen. Das folgende Beispiel zeigt, wie du eine Socket-Verbindung herstellst, Daten sendest und eine Antwort liest:
+
+```Lua
+local client = socket.tcp()
+client:connect("127.0.0.1", 8123)
+client:settimeout(0)
+client:send("foobar")
+local response = client:receive("*l")
+```
+
+Dadurch wird ein TCP-Socket erstellt und mit der IP-Adresse 127.0.0.1 (localhost) und Port 8123 verbunden. Der Wert für die Zeitüberschreitung wird auf 0 gesetzt, damit der Socket nicht blockiert, und die Zeichenfolge "foobar" wird über den Socket gesendet. Außerdem wird eine Datenzeile (Bytes, die mit einem Zeilenumbruchzeichen enden) aus dem Socket gelesen. Beachte, dass das obige Beispiel keinerlei Fehlerbehandlung enthält.
+
+### API-Referenz und Beispiele {#api-reference-and-examples}
+
+In der [API-Referenz](/ref/socket/) erfährst du mehr über die Funktionen, die LuaSocket bereitstellt. Die [offizielle LuaSocket-Dokumentation](https://lunarmodules.github.io/luasocket/) enthält außerdem viele Beispiele für die Arbeit mit der Bibliothek. Weitere Beispiele und Hilfsmodule findest du in der [DefNet-Bibliothek](https://github.com/britzl/defnet/).

--- a/docs/de/manuals/sony-playstation.md
+++ b/docs/de/manuals/sony-playstation.md
@@ -1,0 +1,23 @@
+---
+title: Entwicklung mit Defold für PlayStation®4 und PlayStation®5
+brief: Dieses Handbuch beschreibt, wie du Zugang zur Unterstützung für PlayStation®4 und PlayStation®5 erhältst
+---
+
+# Spieleentwicklung für PlayStation®4- und PlayStation®5-Konsolen  {#game-development-for-playstation4-and-playstation5-consoles}
+Aufgrund von Lizenzbeschränkungen ist der Zugang zu Defold-Versionen mit Unterstützung für die Entwicklung auf PS4 und PS5 nicht in der Standardversion von Defold enthalten. Um Zugang zu Defold-Versionen mit Unterstützung für die Spieleentwicklung auf PS4 und PS5 zu erhalten, musst du jeweils als lizenzierter Spieleentwickler für PS4 beziehungsweise PS5 registriert sein.
+
+## Registrierung als Entwickler für die Spieleentwicklung auf PS4 und PS5 {#registering-as-developer-for-ps4-and-ps5-game-development}
+Du kannst dich auf der [Seite von PlayStation™ Partners](https://register.playstation.net/partnership) als Spieleentwickler für die Spieleentwicklung auf PS4™ und PS5™ registrieren
+
+Sobald Sony dich zugelassen hat, erhältst du Zugang zum Playstation 5 DevNet und/oder zum Playstation 4 DevNet. Navigiere zu Development > Tools & Middleware > Tools & Middleware directory > Defold. Klicke auf die Schaltfläche „Confirm Status“.
+
+## Zugang zur Unterstützung für PS4™ und PS5™ in Defold  {#ps4tm-and-ps5tm-access-in-defold}
+Sobald das Defold-Team eine Bestätigung deines Status als lizenzierter Entwickler für PS4™ und PS5™ erhalten hat, gewährt es dir Zugang zu Folgendem:
+
+* Zugriff auf den Quellcode der Erweiterung für PS4™ und PS5™ mit konsolenspezifischen API-Integrationen.
+* Zugriff auf den Quellcode der Version der Game-Engine von Defold mit Unterstützung für PS4™ und PS5™ wird nur lizenzierten Spieleentwicklern für PS5™ gewährt. Beachte, dass der Zugriff auf den Quellcode nicht erforderlich ist, um Builds von Spielen zu erstellen. Das Defold-Team gewährt diesen Zugriff jedoch, falls du Quellcodebeiträge zum Engine-Kern leisten möchtest.
+* [Kommandozeilenwerkzeug](/manuals/bob) mit Unterstützung für die Erstellung von Bundles für die Plattformen PS4™ und PS5™. Die Erstellung von Bundles im Defold-Editor wird nicht unterstützt.
+* Forum, in dem du spezifische Unterstützung für PS4™ und PS5™ erhalten kannst.
+
+## Häufig gestellte Fragen (FAQ) {#faq}
+:[Consoles FAQ](../shared/consoles-faq.md)

--- a/docs/de/manuals/sound-streaming.md
+++ b/docs/de/manuals/sound-streaming.md
@@ -1,0 +1,137 @@
+---
+title: Audiostreaming in Defold
+brief: Dieses Handbuch erklärt, wie du Audiodaten in die Defold-Game-Engine streamst.
+---
+
+# Audiostreaming {#sound-streaming}
+
+Standardmäßig werden Audiodaten vollständig geladen. Es kann jedoch sinnvoll sein, die Daten blockweise zu laden, bevor sie verwendet werden. Dies wird häufig als „Streaming“ bezeichnet.
+
+Ein Vorteil des Audiostreamings ist der geringere Speicherbedarf zur Laufzeit. Wenn du Inhalte beispielsweise von einer HTTP-URL streamst, kannst du sie außerdem jederzeit aktualisieren und den anfänglichen Download vermeiden.
+
+### Beispiel {#example}
+
+Ein Beispielprojekt zeigt diese Einrichtung: [https://github.com/defold/example-sound-streaming](https://github.com/defold/example-sound-streaming)
+
+## Audiostreaming aktivieren {#how-to-enable-streaming-sounds}
+
+### Einfacher Weg {#easy-way}
+
+Am einfachsten verwendest du Audiostreaming, indem du die [Einstellung `sound.stream_enabled`](https://defold.com/manuals/project-settings/#stream-enabled) in *game.project* aktivierst. Wenn diese Option aktiviert ist, beginnt die Engine mit dem Streaming der Audiodaten.
+
+Hinweis: Wenn viele Audiodateien gleichzeitig geladen sind, musst du möglicherweise den Wert von `sound.stream_cache_size` erhöhen (siehe unten).
+
+### Ressourcen zur Laufzeit {#runtime-resources}
+
+Du kannst auch eine neue Audiodatenressource (sound data resource) erstellen und sie einer Audiokomponente (sound component) zuweisen.
+
+Gehe dazu so vor:
+* Lade den ersten Teil der Audiodateidaten.
+    * Hinweis: Gemeint ist die unverarbeitete Audiodatei einschließlich des ogg/wav-Headers.
+* Erstelle eine neue Audiodatenressource, indem du [`resource.create_sound_data()`](/ref/resource/#resource.create_sound_data) aufrufst.
+* Weise die neue Audiodatenressource mit [`go.set()`](/ref/go#go.set) der Audiokomponente zu.
+
+Hier siehst du einen Auszug aus dem Beispielprojekt, der mit `http.request()` die anfänglichen Daten der Audiodatei abruft.
+
+::: sidenote
+Tatsächliches Streaming setzt voraus, dass der Webserver [HTTP-Bereichsanfragen](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests) berücksichtigt und den Status `206` zurückgibt. Wenn der Server den Header `Range` ignoriert und den Status `200` zurückgibt, erstellt das folgende Beispiel stattdessen eine normale Ressource ohne Streaming aus der vollständigen Antwort.
+:::
+
+```lua
+local function play_sound(self, hash)
+    go.set(self.component, "sound", hash) -- override the resource data on the component
+    sound.play(self.component)            -- start playing the sound
+end
+
+local function parse_content_range(value)
+    if not value then
+        return nil
+    end
+    local rstart, rend, filesize = value:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
+    return tonumber(rstart), tonumber(rend), tonumber(filesize)
+end
+
+-- Callback for the http response.
+local function http_result(self, _id, response)
+    if response.status ~= 200 and response.status ~= 206 then
+        return
+    end
+
+    local options = {
+        data = response.response,
+    }
+
+    if response.status == 206 then
+        local rstart, _, filesize = parse_content_range(response.headers["content-range"])
+        if rstart ~= 0 or not filesize then
+            print("Invalid Content-Range response")
+            return
+        end
+
+        -- A partial resource enables streaming. filesize is the size of the
+        -- complete file, not only the returned range.
+        if #response.response < filesize then
+            options.filesize = filesize
+            options.partial = true
+        end
+    end
+
+    local relative_path = self.filename
+    print("Creating resource", relative_path)
+    local resource_hash = resource.create_sound_data(relative_path, options)
+    play_sound(self, resource_hash)
+end
+
+local function load_web_sound(base_url, relative_path)
+    local url = base_url .. "/" .. relative_path
+    local headers = {}
+    headers['Range'] = string.format("bytes=%d-%d", 0, 16384-1)
+
+    http.request(url, "GET", http_result, headers, nil, { ignore_cache = true })
+end
+```
+
+## Ressourcenanbieter {#resource-providers}
+
+Du kannst den ersten Block der Audiodatei auch auf andere Weise laden. Beachte dabei, dass die restlichen Blöcke über das Ressourcensystem und seine Ressourcenanbieter (resource providers) geladen werden. In diesem Beispiel fügen wir einen neuen (HTTP-)Dateianbieter hinzu, indem wir mit [liveupdate.add_mount()](/ref/liveupdate/#liveupdate.add_mount) einen Live-Update-Mount hinzufügen.
+
+Ein funktionsfähiges Beispiel findest du unter [https://github.com/defold/example-sound-streaming](https://github.com/defold/example-sound-streaming).
+
+```lua
+-- See http_result() from above example
+
+local function load_web_sound(base_url, relative_path)
+    local url = base_url .. "/" .. relative_path
+    local headers = {}
+    -- Request the initial part of the file
+    headers['Range'] = string.format("bytes=%d-%d", 0, 16384-1)
+
+    http.request(url, "GET", http_result, headers, nil, { ignore_cache = true })
+end
+
+function init(self)
+    self.base_url = "http://my.server.com"
+    self.filename = "/path/to/sound.ogg"
+
+    liveupdate.add_mount("webmount", self.base_url, 100, function (_self, _name, _uri, _result)
+                    -- once the mount is ready, we can start our request for downloading the first chunk
+                    load_web_sound(self.base_url, self.filename)
+                end)
+end
+
+function final(self)
+    liveupdate.remove_mount("webmount")
+end
+```
+
+## Cache für Audiodatenblöcke {#sound-chunk-cache}
+
+Die [Einstellung `sound.stream_cache_size`](https://defold.com/manuals/project-settings/#stream-cache-size) in *game.project* steuert den Speicherverbrauch der Audiodaten zur Laufzeit. Die geladenen Audiodaten überschreiten diese Grenze daher niemals.
+
+Der erste Block jeder Audiodatei kann nicht aus dem Cache verdrängt werden und belegt dort Speicher, solange die Ressourcen geladen sind. Die Größe des ersten Blocks wird durch die [Einstellung `sound.stream_preload_size`](https://defold.com/manuals/project-settings/#stream-preload-size) in *game.project* gesteuert.
+
+Du kannst außerdem die Größe jedes Audiodatenblocks steuern, indem du die [Einstellung `sound.stream_chunk_size`](https://defold.com/manuals/project-settings/#stream-chunk-size) in *game.project* änderst. Dadurch kannst du die Größe des Audio-Caches möglicherweise noch weiter verringern, wenn viele Audiodateien gleichzeitig geladen sind. Audiodateien, die kleiner als die Größe eines Audiodatenblocks sind, werden nicht gestreamt. Wenn ein neuer Block nicht in den Cache passt, wird der älteste Block verdrängt.
+
+::: important
+Die Gesamtgröße des Caches für Audiodatenblöcke sollte größer sein als die Anzahl der geladenen Audiodateien multipliziert mit der Größe eines Streaming-Blocks. Andernfalls besteht die Gefahr, dass in jedem Frame neue Blöcke verdrängt werden und die Audiodaten nicht korrekt wiedergegeben werden.
+:::

--- a/docs/de/manuals/sound.md
+++ b/docs/de/manuals/sound.md
@@ -1,0 +1,220 @@
+---
+title: Audio in Defold
+brief: Dieses Handbuch erklärt, wie du Töne in dein Defold-Projekt einbindest, wiedergibst und steuerst.
+---
+
+# Audio {#sound}
+
+Defolds Audioimplementierung ist einfach, aber leistungsfähig. Du musst nur zwei Konzepte kennen:
+
+Audiokomponenten (sound components)
+: Diese Komponenten enthalten einen konkreten Ton, der abgespielt werden soll, und können ihn wiedergeben.
+
+Audiogruppen (sound groups)
+: Jede Audiokomponente kann einer _Gruppe_ zugeordnet werden. Gruppen bieten eine einfache und intuitive Möglichkeit, zusammengehörende Töne zu verwalten. Du kannst beispielsweise eine Gruppe `sound_fx` einrichten und jeden Ton, der zu dieser Gruppe gehört, mit einem einfachen Funktionsaufruf in der Lautstärke absenken.
+
+## Eine Audiokomponente erstellen {#creating-a-sound-component}
+
+Audiokomponenten können nur direkt in einem Spielobjekt (game object) instanziiert werden. Erstelle ein neues Spielobjekt, klicke mit der rechten Maustaste darauf, wähle <kbd>Add Component ▸ Sound</kbd> und drücke *OK*.
+
+![Komponente auswählen](images/sound/sound_add_component.jpg)
+
+Die erstellte Komponente hat einige Eigenschaften, die du festlegen solltest:
+
+![Komponente auswählen](images/sound/sound_properties.png)
+
+*Sound*
+: Sollte auf eine Audiodatei in deinem Projekt gesetzt werden. Die Datei sollte im Format _Wave_, _Ogg Vorbis_ oder _Ogg Opus_ vorliegen. Defold unterstützt Wave-Dateien mit 8-Bit- und 16-Bit-PCM. Die Wiedergabe von Ogg Opus ist optional und erfordert **Include Sound Decoder: Opus** im [App-Manifest](/manuals/app-manifest/#sound); der Opus-Decoder ist standardmäßig nicht enthalten.
+
+*Looping*
+: Wenn diese Option aktiviert ist, wird der Ton so oft wiedergegeben, wie in _Loopcount_ angegeben, oder bis er ausdrücklich gestoppt wird.
+
+*Loopcount*
+: Die Anzahl der Wiedergaben eines wiederholt abgespielten Tons, bevor er stoppt (0 bedeutet, dass der Ton wiederholt werden soll, bis er ausdrücklich gestoppt wird).
+
+*Group*
+: Der Name der Audiogruppe, zu der der Ton gehören soll. Wenn diese Eigenschaft leer bleibt, wird der Ton der integrierten Gruppe `master` zugewiesen.
+
+*Gain*
+: Du kannst den Verstärkungsfaktor (gain) für den Ton direkt an der Komponente festlegen. So kannst du den Verstärkungsfaktor eines Tons einfach anpassen, ohne zu deinem Audioprogramm zurückzukehren und die Datei erneut zu exportieren. Weiter unten findest du Einzelheiten zur Berechnung des Verstärkungsfaktors.
+
+*Pan*
+: Du kannst das Stereopanorama (pan) für den Ton direkt an der Komponente festlegen. Der Wert muss zwischen -1 (-45 Grad links) und 1 (45 Grad rechts) liegen.
+
+*Speed*
+: Du kannst die Wiedergabegeschwindigkeit für den Ton direkt an der Komponente festlegen. Ein Wert von 1.0 entspricht der normalen Geschwindigkeit, 0.5 der halben und 2.0 der doppelten Geschwindigkeit.
+
+
+## Den Ton wiedergeben {#playing-the-sound}
+
+Wenn du eine Audiokomponente richtig eingerichtet hast, kannst du ihren Ton durch einen Aufruf von [`sound.play()`](/ref/sound/#sound.play:url-[play_properties]-[complete_function]) wiedergeben:
+
+```lua
+sound.play("go#sound", {delay = 1, gain = 0.5, pan = -1.0, speed = 1.25})
+```
+
+::: sidenote
+Ein Ton wird auch dann weiter abgespielt, wenn das Spielobjekt, zu dem die Audiokomponente gehörte, gelöscht wird. Du kannst [`sound.stop()`](/ref/sound/#sound.stop:url) aufrufen, um den Ton zu stoppen (siehe unten).
+:::
+Jede an eine Komponente gesendete Nachricht bewirkt, dass sie eine weitere Instanz des Tons wiedergibt, bis der verfügbare Audiopuffer voll ist und die Engine Fehler in der Konsole ausgibt. Es empfiehlt sich, einen Mechanismus zur Begrenzung der Wiedergabe und zur Gruppierung von Tönen zu implementieren.
+
+## Den Ton stoppen {#stopping-the-sound}
+
+Wenn du die Wiedergabe eines Tons stoppen möchtest, kannst du [`sound.stop()`](/ref/sound/#sound.stop:url) aufrufen:
+
+```lua
+sound.stop("go#sound")
+```
+
+## Verstärkungsfaktor {#gain}
+
+![Verstärkungsfaktor](images/sound/sound_gain.png)
+
+Das Audiosystem hat 4 Ebenen für Verstärkungsfaktoren:
+
+- Den an der Audiokomponente festgelegten Verstärkungsfaktor.
+- Den Verstärkungsfaktor, der beim Starten des Tons durch einen Aufruf von `sound.play()` oder beim Ändern des Verstärkungsfaktors der Wiedergabeinstanz durch einen Aufruf von `sound.set_gain()` festgelegt wird.
+- Den Verstärkungsfaktor, der durch einen Aufruf der Funktion [`sound.set_group_gain()`](/ref/sound#sound.set_group_gain) für die Gruppe festgelegt wird.
+- Den für die Gruppe `master` festgelegten Verstärkungsfaktor. Du kannst ihn mit `sound.set_group_gain(hash("master"), gain)` ändern.
+
+Wenn **Use Linear Gain** in den [Audio-Projekteinstellungen](/manuals/project-settings/#sound) aktiviert ist (die Standardeinstellung), ergibt sich der Verstärkungsfaktor der Ausgabe aus der Multiplikation dieser vier Verstärkungsfaktoren. Ein Verstärkungsfaktor von `1.0` bedeutet eine unveränderte Verstärkung (0 dB). Wenn die lineare Verstärkung deaktiviert ist, wendet Defold beim Mischen eine nichtlineare Kurve an. Daher beschreiben die direkte Multiplikation der vier Faktoren und die unten gezeigte Umrechnung in Dezibel den resultierenden Ausgangspegel nicht.
+
+## Audiogruppen {#sound-groups}
+
+Jede Audiokomponente, für die der Name einer Audiogruppe angegeben ist, wird einer Audiogruppe mit diesem Namen zugeordnet. Wenn du keine Gruppe angibst, wird der Ton der Gruppe `master` zugewiesen. Du kannst die Gruppe einer Audiokomponente auch ausdrücklich auf `master` setzen, was dieselbe Wirkung hat.
+
+Es stehen einige Funktionen zur Verfügung, um alle verfügbaren Gruppen und ihre Namen als Zeichenfolge abzurufen sowie Verstärkungsfaktoren abzurufen und festzulegen. Außerdem kannst du den Effektivwert (RMS, siehe http://en.wikipedia.org/wiki/Root_mean_square) und den Spitzenwert des Verstärkungsfaktors abrufen. Es gibt auch eine Funktion, mit der du prüfen kannst, ob der Musikplayer des Zielgeräts läuft:
+
+```lua
+-- If sound playing on this iPhone/Android device, silence everything
+if sound.is_music_playing() then
+    for i, group_hash in ipairs(sound.get_groups()) do
+        sound.set_group_gain(group_hash, 0)
+    end
+end
+```
+
+Die Gruppen werden durch einen Hashwert identifiziert. Den Namen als Zeichenfolge kannst du mit [`sound.get_group_name()`](/ref/sound#sound.get_group_name) abrufen. Damit kannst du Gruppennamen in Entwicklungswerkzeugen anzeigen, zum Beispiel in einem Mischpult zum Testen der Gruppenpegel.
+
+![Mischpult für Audiogruppen](images/sound/sound_mixer.png)
+
+::: important
+Du solltest keinen Code schreiben, der sich auf den Namen einer Audiogruppe als Zeichenfolge verlässt, da diese Zeichenfolgen in Release-Builds nicht verfügbar sind.
+:::
+
+Wenn **Use Linear Gain** aktiviert ist, kannst du einen positiven Verstärkungsfaktor mit der Standardformel in Dezibel umrechnen:
+
+```math
+db = 20 \times \log \left( gain \right)
+```
+
+```lua
+for i, group_hash in ipairs(sound.get_groups()) do
+    -- The name string is only available in debug. Returns "unknown_*" in release.
+    local name = sound.get_group_name(group_hash)
+    local gain = sound.get_group_gain(group_hash)
+
+    -- Convert to decibel.
+    local db = 20 * math.log10(gain)
+
+    -- Get RMS (gain Root Mean Square). Left and right channel separately.
+    local left_rms, right_rms = sound.get_rms(group_hash, 2048 / 65536.0)
+    left_rmsdb = 20 * math.log10(left_rms)
+    right_rmsdb = 20 * math.log10(right_rms)
+
+    -- Get gain peak. Left and right separately.
+    left_peak, right_peak = sound.get_peak(group_hash, 2048 * 10 / 65536.0)
+    left_peakdb = 20 * math.log10(left_peak)
+    right_peakdb = 20 * math.log10(right_peak)
+end
+
+-- Set the master gain to +6 dB (math.pow(10, 6/20)).
+sound.set_group_gain("master", 1.995)
+```
+
+Defold 1.10.2 hat eine seit Langem bestehende Dämpfung von ungefähr 3 dB im Audiomischer korrigiert. Wenn die Abmischung eines älteren Projekts diese Dämpfung ausgeglichen hat und nach dem Upgrade lauter klingt, passe die globale Einstellung **Sound ▸ Gain** oder die Verstärkungsfaktoren der betroffenen Gruppen erneut an.
+
+## Die Wiedergabe von Tönen begrenzen {#gating-sounds}
+
+Wenn dein Spiel bei einem Ereignis denselben Ton abspielt und dieses Ereignis häufig ausgelöst wird, besteht die Gefahr, dass derselbe Ton zwei- oder mehrmals fast gleichzeitig wiedergegeben wird. In diesem Fall sind die Töne _phasenverschoben_, was zu sehr auffälligen Artefakten führen kann.
+
+![Phasenverschiebung](images/sound/sound_phase_shift.png)
+
+Am einfachsten lässt sich dieses Problem mit einem Sperrmechanismus (Gate) lösen, der Audionachrichten filtert und verhindert, dass derselbe Ton innerhalb eines festgelegten Zeitintervalls mehr als einmal wiedergegeben wird:
+
+```lua
+-- Don't allow the same sound to be played within "gate_time" interval.
+local gate_time = 0.3
+
+function init(self)
+    -- Store played sound timers in a table and count down each frame until they have been
+    -- in the table for "gate_time" seconds. Then remove them.
+    self.sounds = {}
+end
+
+function update(self, dt)
+    -- Count down the stored timers
+    for k,_ in pairs(self.sounds) do
+        self.sounds[k] = self.sounds[k] - dt
+        if self.sounds[k] < 0 then
+            self.sounds[k] = nil
+        end
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("play_gated_sound") then
+        -- Only play sounds that are not currently in the gating table.
+        if self.sounds[message.soundcomponent] == nil then
+            -- Store sound timer in table
+            self.sounds[message.soundcomponent] = gate_time
+            -- Play the sound
+            sound.play(message.soundcomponent, { gain = message.gain })
+        else
+            -- An attempt to play a sound was gated
+            print("gated " .. message.soundcomponent)
+        end
+    end
+end
+```
+
+Um den Sperrmechanismus zu verwenden, sende ihm einfach eine Nachricht `play_gated_sound` und gib die Ziel-Audiokomponente und den Verstärkungsfaktor des Tons an. Wenn die Sperre offen ist, ruft der Sperrmechanismus `sound.play()` mit der Ziel-Audiokomponente auf:
+
+```lua
+msg.post("/sound_gate#script", "play_gated_sound", { soundcomponent = "/sounds#explosion1", gain = 1.0 })
+```
+
+::: important
+Es funktioniert nicht, den Sperrmechanismus auf Nachrichten `play_sound` reagieren zu lassen, da dieser Name von der Defold-Engine reserviert ist. Wenn du reservierte Nachrichtennamen verwendest, tritt unerwartetes Verhalten auf.
+:::
+
+
+## Änderungen zur Laufzeit {#runtime-manipulation}
+Du kannst Töne zur Laufzeit über verschiedene Eigenschaften verändern (Informationen zur Verwendung findest du in der [API-Dokumentation](/ref/sound/)). Die folgenden Eigenschaften lassen sich mit `go.get()` und `go.set()` verändern:
+
+`gain`
+: Der Verstärkungsfaktor der Audiokomponente (`number`).
+
+`pan`
+: Das Stereopanorama der Audiokomponente (`number`). Der Wert muss zwischen -1 (-45 Grad links) und 1 (45 Grad rechts) liegen.
+
+`speed`
+: Die Wiedergabegeschwindigkeit der Audiokomponente (`number`). Ein Wert von 1.0 entspricht der normalen Geschwindigkeit, 0.5 der halben und 2.0 der doppelten Geschwindigkeit.
+
+`sound`
+: Der Ressourcenpfad zum Ton (`hash`). Du kannst den Ressourcenpfad verwenden, um den Ton mit `resource.set_sound(path, buffer)` zu ändern. Beispiel:
+
+```lua
+local boom = sys.load_resource("/sounds/boom.wav")
+local path = go.get("#sound", "sound")
+resource.set_sound(path, boom)
+```
+
+
+## Projektkonfiguration {#project-configuration}
+
+Die Datei *game.project* enthält einige [Projekteinstellungen](/manuals/project-settings#sound) für Audiokomponenten.
+
+## Audiostreaming {#sound-streaming}
+
+Du kannst auch [Töne streamen](/manuals/sound-streaming)

--- a/docs/de/manuals/spine.md
+++ b/docs/de/manuals/spine.md
@@ -1,0 +1,6 @@
+---
+title: Skelettanimation mit Spine in Defold
+brief: Dieses Handbuch erklärt, wie du Spine-Animationen aus _Spine_ in Defold importierst.
+---
+
+[Dieses Handbuch ist umgezogen](/extension-spine)

--- a/docs/de/manuals/spinemodel.md
+++ b/docs/de/manuals/spinemodel.md
@@ -1,0 +1,6 @@
+---
+title: Spine-Modellkomponenten in Defold
+brief: Dieses Handbuch erklärt, wie du Spine-Modellkomponenten in Defold erstellst.
+---
+
+[Dieses Handbuch wurde verschoben](/extension-spine)

--- a/docs/de/manuals/sprite.md
+++ b/docs/de/manuals/sprite.md
@@ -1,0 +1,133 @@
+---
+title: 2D-Bilder anzeigen
+brief: Dieses Handbuch beschreibt, wie du mit der Sprite-Komponente 2D-Bilder und Animationen anzeigst.
+---
+
+# Sprites
+
+Eine Sprite-Komponente (sprite component) zeigt ein einfaches Bild oder eine Flipbook-Animation auf dem Bildschirm an.
+
+![Sprite](images/graphics/sprite.png)
+
+Die Sprite-Komponente kann für ihre Grafik entweder einen [Atlas](/manuals/atlas) oder eine [Kachelquelle (tile source)](/manuals/tilesource) verwenden.
+
+## Sprite-Eigenschaften {#sprite-properties}
+
+Neben den Eigenschaften *Id*, *Position* und *Rotation* gibt es die folgenden komponentenspezifischen Eigenschaften:
+
+*Image*
+: Wenn der Shader nur einen Sampler hat, heißt dieses Feld `Image`. Andernfalls ist jeder Platz nach dem Textur-Sampler im Material benannt.
+Jeder Platz legt die Atlas- oder Kachelquellenressource fest, die das Sprite für diesen Textur-Sampler verwendet.
+
+*Default Animation*
+: Die Animation, die für das Sprite verwendet werden soll. Die Animationsinformationen werden aus dem ersten Atlas oder der ersten Kachelquelle übernommen.
+
+*Material*
+: Das Material, das zum Rendern des Sprites verwendet werden soll.
+
+*Blend Mode*
+: Der Mischmodus, der beim Rendern des Sprites verwendet werden soll.
+
+*Size Mode*
+: Bei `Automatic` legt der Editor die Größe des Sprites fest. Bei `Manual` kannst du die Größe selbst festlegen.
+
+*Slice 9*
+: Lege hier fest, dass die Pixelgröße der Sprite-Textur an den Rändern erhalten bleibt, wenn du die Größe des Sprites änderst.
+
+:[Slice-9](../shared/slice-9-texturing.md)
+
+### Mischmodi {#blend-modes}
+:[blend-modes](../shared/blend-modes.md)
+
+## Änderungen zur Laufzeit {#runtime-manipulation}
+
+Du kannst Sprites zur Laufzeit mit verschiedenen Funktionen und Eigenschaften ändern (Hinweise zur Verwendung findest du in der [API-Dokumentation](/ref/sprite/)). Funktionen:
+
+* `sprite.play_flipbook()` - Spielt eine Animation auf einer Sprite-Komponente ab.
+* `sprite.set_hflip()` und `sprite.set_vflip()` - Legen die horizontale und vertikale Spiegelung der Animation eines Sprites fest.
+
+Ein Sprite hat außerdem verschiedene Eigenschaften, die du mit `go.get()` und `go.set()` ändern kannst:
+
+`cursor`
+: Die normalisierte Wiedergabeposition der Animation (`number`).
+
+`image`
+: Das Bild des Sprites (`hash`). Du kannst es mit einer Ressourceneigenschaft für einen Atlas oder eine Kachelquelle und `go.set()` ändern. Ein Beispiel findest du in der [API-Referenz](/ref/sprite/#image).
+
+`material`
+: Das Material des Sprites (`hash`). Du kannst es mit einer Ressourceneigenschaft für ein Material und `go.set()` ändern. Ein Beispiel findest du in der [API-Referenz](/ref/sprite/#material).
+
+`playback_rate`
+: Die Wiedergabegeschwindigkeit der Animation (`number`).
+
+`scale`
+: Die ungleichmäßige Skalierung des Sprites (`vector3`).
+
+`size`
+: Die Größe des Sprites (`vector3`). Sie kann nur geändert werden, wenn `Size Mode` des Sprites auf `Manual` gesetzt ist.
+
+## Materialkonstanten {#material-constants}
+
+{% include shared/material-constants.md component='sprite' variable='tint' %}
+
+`tint`
+: Die Einfärbung des Sprites (`vector4`). Der `vector4` stellt die Einfärbung dar, wobei `x`, `y`, `z` und `w` dem Rot-, Grün-, Blau- und Alphaanteil entsprechen.
+
+## Materialattribute {#material-attributes}
+
+Ein Sprite kann Vertex-Attribute des aktuell zugewiesenen Materials überschreiben. Die Komponente übergibt diese Attribute an den Vertex-Shader (weitere Informationen findest du im [Handbuch zu Materialien](/manuals/material/#attributes)).
+
+Die im Material angegebenen Attribute erscheinen als reguläre Eigenschaften im Inspektor und können für einzelne Sprite-Komponenten festgelegt werden. Wenn eines der Attribute überschrieben wird, erscheint es als überschriebene Eigenschaft und wird in der Sprite-Datei auf dem Datenträger gespeichert:
+
+![Sprite-Attribute](../images/graphics/sprite-attributes.png)
+
+## Projektkonfiguration {#project-configuration}
+
+Die Datei *game.project* enthält einige [Projekteinstellungen](/manuals/project-settings#sprite) für Sprites.
+
+## Sprites mit mehreren Texturen {#multi-textured-sprites}
+
+Wenn ein Sprite mehrere Texturen verwendet, gibt es einige Dinge zu beachten.
+
+### Animationen {#animations}
+
+Die Animationsdaten (Bildrate, Einzelbildnamen) werden derzeit aus der ersten Textur übernommen. Wir nennen diese die „steuernde Animation“.
+
+Die Bild-IDs der steuernden Animation werden verwendet, um die Bilder in einer anderen Textur zu finden.
+Daher musst du sicherstellen, dass die Einzelbild-IDs zwischen den Texturen übereinstimmen.
+
+Wenn dein `diffuse.atlas` beispielsweise eine Animation `run` wie diese enthält:
+
+```
+run:
+    /main/images/hero_run_color_1.png
+    /main/images/hero_run_color_2.png
+    ...
+```
+
+Dann lauten die Einzelbild-IDs etwa `run/hero_run_color_1`, was beispielsweise in einem `normal.atlas` wahrscheinlich nicht zu finden ist:
+
+```
+run:
+    /main/images/hero_run_normal_1.png
+    /main/images/hero_run_normal_2.png
+    ...
+```
+
+Deshalb verwenden wir `Rename patterns` im [Atlas](/manuals/material/), um sie umzubenennen.
+Trage in den jeweiligen Atlanten `_color=` und `_normal=` ein, und du erhältst in beiden Atlanten Einzelbildnamen wie diese:
+
+```
+run/hero_run_1
+run/hero_run_2
+...
+```
+
+### UV-Koordinaten {#uvs}
+
+Die UV-Koordinaten werden aus der ersten Textur übernommen. Da es nur einen Satz von Vertices gibt, können wir ohnehin keine gute Übereinstimmung garantieren,
+wenn die weiteren Texturen mehr UV-Koordinaten oder eine andere Form haben.
+
+Das musst du beachten: Stelle sicher, dass die Bilder hinreichend ähnliche Formen haben, da es sonst zum Übergreifen benachbarter Texturpixel (texture bleeding) kommen kann.
+
+Die Abmessungen der Bilder in den einzelnen Texturen können unterschiedlich sein.

--- a/docs/de/manuals/texture-filtering.md
+++ b/docs/de/manuals/texture-filtering.md
@@ -1,0 +1,34 @@
+---
+title: Texturfilterung
+brief: Dieses Handbuch beschreibt die verfügbaren Optionen für die Texturfilterung beim Rendern von Grafiken.
+---
+
+# Texturfilterung und Abtastung {#texture-filtering-and-sampling}
+
+Die Texturfilterung (texture filtering) bestimmt das sichtbare Ergebnis, wenn ein _Texel_ (ein Pixel in einer Textur) nicht genau mit einem Bildschirmpixel übereinstimmt. Das passiert, wenn du ein Grafikelement, das die Textur enthält, um weniger als ein Pixel bewegst. Die folgenden Filtermethoden sind verfügbar:
+
+Nächster Nachbar (Nearest)
+: Das nächstgelegene Texel wird ausgewählt, um das Bildschirmpixel einzufärben. Du solltest diese Abtastmethode wählen, wenn du eine exakte Eins-zu-eins-Zuordnung zwischen den Pixeln deiner Texturen und den Pixeln auf dem Bildschirm möchtest. Bei der Nächster-Nachbar-Filterung springt bei Bewegungen alles von Pixel zu Pixel. Das kann ruckelig aussehen, wenn sich das Sprite langsam bewegt.
+
+Linear
+: Der Farbwert des Texels wird mit den Farbwerten seiner Nachbarn gemittelt, bevor das Bildschirmpixel eingefärbt wird. Dadurch wirken langsame, kontinuierliche Bewegungen flüssig, da die Farbe eines Sprites allmählich in die Pixel einfließt, bevor sie diese vollständig einfärbt--so lässt sich ein Sprite um weniger als ein ganzes Pixel bewegen.
+
+Die Einstellung für die verwendete Filterung wird in der Datei mit den [Projekteinstellungen](/manuals/project-settings/#graphics) gespeichert. Es gibt zwei Einstellungen:
+
+default_texture_min_filter
+: Die Filterung bei Verkleinerung wird angewendet, wenn das Texel kleiner als das Bildschirmpixel ist.
+
+default_texture_mag_filter
+: Die Filterung bei Vergrößerung wird angewendet, wenn das Texel größer als das Bildschirmpixel ist.
+
+Beide Einstellungen akzeptieren die Werte `linear`, `nearest`, `nearest_mipmap_nearest`, `nearest_mipmap_linear`, `linear_mipmap_nearest` oder `linear_mipmap_linear`. Zum Beispiel:
+
+```ini
+[graphics]
+default_texture_min_filter = nearest
+default_texture_mag_filter = nearest
+```
+
+Wenn du nichts angibst, sind beide standardmäßig auf `linear` gesetzt.
+
+Beachte, dass die Einstellung in *game.project* von den Standard-Samplern verwendet wird. Wenn du Sampler in einem benutzerdefinierten Material angibst, kannst du die Filtermethode für jeden Sampler gesondert festlegen. Einzelheiten findest du im [Handbuch zu Materialien](/manuals/material/).

--- a/docs/de/manuals/texture-profiles.md
+++ b/docs/de/manuals/texture-profiles.md
@@ -1,0 +1,268 @@
+---
+title: Texturprofile in Defold
+brief:  Defold unterstützt die automatische Verarbeitung von Texturen und die Komprimierung von Bilddaten. Dieses Handbuch beschreibt die verfügbaren Funktionen.
+---
+
+# Texturprofile {#texture-profiles}
+
+Defold unterstützt die automatische Verarbeitung von Texturen und die Komprimierung von Bilddaten (in *Atlanten (Atlas)*, *Kachelquellen (tile sources)*, *Cubemaps* und eigenständigen Texturen für Modelle, GUI usw.).
+
+Es gibt zwei Arten der Komprimierung: Software-Bildkomprimierung und Hardware-Texturkomprimierung.
+
+1. Software-Komprimierung (wie PNG und JPEG) verringert den Speicherplatzbedarf von Bildressourcen. Dadurch wird das fertige Bundle kleiner. Die Bilddateien müssen jedoch beim Einlesen in den Arbeitsspeicher dekomprimiert werden. Auch wenn ein Bild auf dem Datenträger klein ist, kann es daher viel Arbeitsspeicher belegen.
+
+2. Hardware-Texturkomprimierung verringert ebenfalls den Speicherplatzbedarf von Bildressourcen. Anders als Software-Komprimierung verringert sie jedoch auch den Arbeitsspeicherbedarf von Texturen. Das liegt daran, dass die Grafikhardware komprimierte Texturen direkt verarbeiten kann, ohne sie zuvor dekomprimieren zu müssen.
+
+Die Verarbeitung von Texturen wird über ein bestimmtes Texturprofil (texture profile) konfiguriert. In dieser Datei erstellst du _Profile_, die festlegen, welche Komprimierungsformate und welche Komprimierungsart beim Erstellen von Bundles für eine bestimmte Plattform verwendet werden sollen. _Profile_ werden anschließend mit passenden _Dateipfadmustern_ verknüpft. So kannst du genau steuern, welche Dateien in deinem Projekt komprimiert werden und wie dies geschieht.
+
+Da alle verfügbaren Verfahren zur Hardware-Texturkomprimierung verlustbehaftet sind, entstehen Artefakte in deinen Texturdaten. Diese Artefakte hängen stark davon ab, wie dein Ausgangsmaterial aussieht und welche Komprimierungsmethode verwendet wird. Du solltest dein Ausgangsmaterial testen und experimentieren, um die besten Ergebnisse zu erzielen. Google kann dir dabei helfen.
+
+Du kannst auswählen, welche Software-Bildkomprimierung auf die endgültigen Texturdaten (komprimiert oder unkomprimiert) in den Bundle-Archiven angewendet wird. Defold unterstützt die Komprimierungsformate [Basis Universal](https://github.com/BinomialLLC/basis_universal) und [ASTC](https://www.khronos.org/opengl/wiki/ASTC_Texture_Compression).
+
+::: sidenote
+Komprimierung ist ein ressourcenintensiver und zeitaufwendiger Vorgang, der zu _sehr_ langen Build-Zeiten führen kann. Diese hängen von der Anzahl der zu komprimierenden Texturbilder sowie von den gewählten Texturformaten und der Art der Software-Komprimierung ab.
+:::
+
+### Basis Universal
+
+Basis Universal (kurz BasisU) komprimiert das Bild in ein Zwischenformat, das zur Laufzeit in ein Hardwareformat transkodiert wird, das für die GPU des aktuellen Geräts geeignet ist. Das Basis-Universal-Format bietet eine hohe Qualität, ist aber verlustbehaftet.
+Alle Bilder werden außerdem mit LZ4 komprimiert, um die Dateigröße beim Speichern im Spielarchiv weiter zu verringern.
+
+### ASTC
+
+ASTC ist ein flexibles und effizientes Format zur Texturkomprimierung, das von ARM entwickelt und von der Khronos Group standardisiert wurde. Es bietet eine große Auswahl an Blockgrößen und Bitraten, mit denen du Bildqualität und Speicherbedarf wirksam aufeinander abstimmen kannst. ASTC unterstützt verschiedene Blockgrößen von 4×4 bis 12×12 Texeln. Diese entsprechen Bitraten von 8 Bit pro Texel bis hinunter zu 0,89 Bit pro Texel. Diese Flexibilität ermöglicht eine feine Abstimmung zwischen Texturqualität und Speicherplatzbedarf.
+
+ASTC unterstützt verschiedene Blockgrößen von 4×4 bis 12×12 Texeln. Diese entsprechen Bitraten von 8 Bit pro Texel bis hinunter zu 0,89 Bit pro Texel. Diese Flexibilität ermöglicht eine feine Abstimmung zwischen Texturqualität und Speicherplatzbedarf. Die folgende Tabelle zeigt die unterstützten Blockgrößen und ihre jeweiligen Bitraten:
+
+| Blockgröße (Breite x Höhe) | Bit pro Pixel |
+| --------------------------- | -------------- |
+| 4x4                         | 8.00           |
+| 5x4                         | 6.40           |
+| 5x5                         | 5.12           |
+| 6x5                         | 4.27           |
+| 6x6                         | 3.56           |
+| 8x5                         | 3.20           |
+| 8x6                         | 2.67           |
+| 10x5                        | 2.56           |
+| 10x6                        | 2.13           |
+| 8x8                         | 2.00           |
+| 10x8                        | 1.60           |
+| 10x10                       | 1.28           |
+| 12x10                       | 1.07           |
+| 12x12                       | 0.89           |
+
+
+#### Unterstützte Geräte {#supported-devices}
+
+ASTC liefert zwar sehr gute Ergebnisse, wird aber nicht von allen Grafikkarten unterstützt. Hier findest du eine kurze Liste unterstützter Geräte nach Hersteller:
+
+| GPU-Hersteller     | Unterstützung                                                          |
+| ------------------ | --------------------------------------------------------------------- |
+| ARM (Mali)         | Alle ARM-Mali-GPUs, die OpenGL ES 3.2 oder Vulkan unterstützen, unterstützen ASTC. |
+| Qualcomm (Adreno)  | Adreno-GPUs, die OpenGL ES 3.2 oder Vulkan unterstützen, unterstützen ASTC. |
+| Apple              | Apple-GPUs unterstützen ASTC seit dem A8-Chip.                          |
+| NVIDIA             | ASTC wird hauptsächlich von mobilen GPUs unterstützt (z. B. Tegra-basierten Chips). |
+| AMD (Radeon)       | AMD-GPUs, die Vulkan unterstützen, unterstützen ASTC in der Regel über Software. |
+| Intel (integriert) | Moderne Intel-GPUs unterstützen ASTC über Software.                    |
+
+## Texturprofile {#texture-profiles-1}
+
+Jedes Projekt enthält eine bestimmte Datei mit der Endung *.texture_profiles*, die die Konfiguration für die Texturkomprimierung enthält. Standardmäßig ist dies die Datei *builtins/graphics/default.texture_profiles*. Ihre Konfiguration ordnet jede Texturressource einem Profil zu, das RGBA ohne Hardware-Texturkomprimierung und die standardmäßige ZLib-Dateikomprimierung verwendet.
+
+So fügst du Texturkomprimierung hinzu:
+
+- Wähle <kbd>File ▸ New...</kbd> und anschließend *Texture Profiles*, um eine neue Texturprofildatei zu erstellen. (Alternativ kannst du *default.texture_profiles* an einen Speicherort außerhalb von *builtins* kopieren.)
+- Wähle einen Namen und einen Speicherort für die neue Datei.
+- Ändere den Eintrag *texture_profiles* in *game.project* so, dass er auf die neue Datei verweist.
+- Öffne die Datei mit der Endung *.texture_profiles* und konfiguriere sie nach deinen Anforderungen.
+
+![Neue Profildatei](images/texture_profiles/texture_profiles_new_file.png)
+
+![Texturprofil festlegen](images/texture_profiles/texture_profiles_game_project.png)
+
+Du kannst die Verwendung von Texturprofilen in den Editoreinstellungen ein- und ausschalten. Wähle <kbd>File ▸ Preferences...</kbd>. Die Registerkarte *General* enthält das Kontrollkästchen *Enable texture profiles*.
+
+![Einstellungen für Texturprofile](images/texture_profiles/texture_profiles_preferences.png)
+
+## Pfadeinstellungen {#path-settings}
+
+Der Abschnitt *Path Settings* der Texturprofildatei enthält eine Liste von Pfadmustern und legt fest, welches *Profil* bei der Verarbeitung von Ressourcen verwendet werden soll, die zum Pfad passen. Die Pfade werden als „Ant Glob“-Muster angegeben (Einzelheiten findest du in der [Dokumentation](http://ant.apache.org/manual/dirtasks.html#patterns)). Muster können mit den folgenden Platzhaltern angegeben werden:
+
+`*`
+: Entspricht null oder mehr Zeichen. Beispielsweise passt `sprite*.png` auf die Dateien *`sprite.png`*, *`sprite1.png`* und *`sprite_with_a_long_name.png`*.
+
+`?`
+: Entspricht genau einem Zeichen. Beispielsweise passt `sprite?.png` auf die Dateien *sprite1.png*, *`spriteA.png`*, aber nicht auf *`sprite.png`* oder *`sprite_with_a_long_name.png`*.
+
+`**`
+: Entspricht einem vollständigen Verzeichnisbaum oder---wenn als Name eines Verzeichnisses verwendet---null oder mehr Verzeichnissen. Beispielsweise passt `/gui/**` auf alle Dateien im Verzeichnis */gui* und in allen seinen Unterverzeichnissen.
+
+![Pfade](images/texture_profiles/texture_profiles_paths.png)
+
+Dieses Beispiel enthält zwei Pfadmuster und die zugehörigen Profile.
+
+`/gui/**/*.atlas`
+: Alle Dateien mit der Endung *.atlas* im Verzeichnis *`/gui`* oder in einem seiner Unterverzeichnisse werden gemäß dem Profil „gui_atlas“ verarbeitet.
+
+`/**/*.atlas`
+: Alle Dateien mit der Endung *.atlas* an beliebiger Stelle im Projekt werden gemäß dem Profil „atlas“ verarbeitet.
+
+Beachte, dass der allgemeinere Pfad am Ende steht. Der Abgleichalgorithmus arbeitet von oben nach unten. Der erste Eintrag, der zum Ressourcenpfad passt, wird verwendet. Ein passender Pfadausdruck weiter unten in der Liste überschreibt niemals den ersten Treffer. Wären die Pfade in umgekehrter Reihenfolge angegeben, würde jeder Atlas mit dem Profil „atlas“ verarbeitet, auch die Atlanten im Verzeichnis *`/gui`*.
+
+Texturressourcen, die auf _keinen_ Pfad in der Profildatei passen, werden kompiliert und auf die nächstgelegene Zweierpotenz skaliert, bleiben ansonsten aber unverändert.
+
+## Profile {#profiles}
+
+Der Abschnitt *profiles* der Texturprofildatei enthält eine Liste benannter Profile. Jedes Profil enthält eine oder mehrere *platforms*, wobei jede Plattform durch eine Liste von Eigenschaften beschrieben wird.
+
+![Profile](images/texture_profiles/texture_profiles_profiles.png)
+
+*Platforms*
+: Gibt eine passende Plattform an. `OS_ID_GENERIC` passt auf alle Plattformen, `OS_ID_WINDOWS` auf Bundles für Windows, `OS_ID_IOS` auf iOS-Bundles und so weiter. Beachte, dass `OS_ID_GENERIC`, wenn es angegeben ist, für alle Plattformen einbezogen wird.
+
+::: important
+Wenn zwei [Pfadeinstellungen](#path-settings) auf dieselbe Datei passen und die Pfade unterschiedliche Profile mit unterschiedlichen Plattformen verwenden, werden **beide** Profile verwendet und **zwei** Texturen erzeugt.
+:::
+
+*Formats*
+: Ein oder mehrere zu erzeugende Texturformate. Wenn mehrere Formate angegeben sind, werden für jedes Format Texturen erzeugt und in das Bundle aufgenommen. Die Engine wählt Texturen in einem Format aus, das von der Plattform unterstützt wird, auf der sie ausgeführt wird.
+
+*Mipmaps*
+: Wenn aktiviert, werden Mipmaps für die Plattform erzeugt. Standardmäßig deaktiviert.
+
+*Premultiply alpha*
+: Wenn aktiviert, wird Alpha in die Texturdaten vormultipliziert. Standardmäßig aktiviert.
+
+*Max Texture Size*
+: Wenn ein Wert ungleich null angegeben ist, werden die Pixelabmessungen der Texturen auf die angegebene Zahl begrenzt. Jede Textur, deren Breite oder Höhe den angegebenen Wert überschreitet, wird herunterskaliert.
+
+Jeder einem Profil hinzugefügte Eintrag unter *Formats* hat die folgenden Eigenschaften:
+
+*Format*
+: Das Format, das beim Kodieren der Textur verwendet wird. Alle verfügbaren Texturformate findest du weiter unten.
+
+*Compressor*
+: Der Kompressor, der beim Kodieren der Textur verwendet wird.
+
+*Compressor Preset*
+: Wählt eine Komprimierungsvoreinstellung aus, die beim Kodieren des resultierenden komprimierten Bildes verwendet wird. Jede Komprimierungsvoreinstellung gehört zu einem bestimmten Kompressor, und ihre Einstellungen hängen vom Kompressor selbst ab. Um diese Einstellungen zu vereinfachen, gibt es die aktuellen Komprimierungsvoreinstellungen in vier Stufen:
+
+| Voreinstellung | Hinweis                                      |
+| --------- | --------------------------------------------- |
+| `LOW`     | Schnellste Komprimierung. Niedrige Bildqualität |
+| `MEDIUM`  | Standardkomprimierung. Beste Bildqualität      |
+| `HIGH`    | Langsamste Komprimierung. Kleinere Dateigröße   |
+| `HIGHEST` | Langsame Komprimierung. Kleinste Dateigröße     |
+
+Beachte, dass der Kompressor `uncompressed` nur eine Voreinstellung namens `uncompressed` hat. Sie bedeutet, dass keine Komprimierung auf die Texturen angewendet wird.
+Eine Liste der verfügbaren Kompressoren findest du unter [Kompressoren](#compressors).
+
+## Texturformate {#texture-formats}
+
+Texturen für die Grafikhardware können in unkomprimierte oder *verlustbehaftet* komprimierte Daten mit unterschiedlicher Kanalanzahl und Bittiefe umgewandelt werden. Bei einer festen Hardware-Komprimierung hat das resultierende Bild unabhängig vom Bildinhalt eine feste Größe. Das bedeutet, dass der Qualitätsverlust bei der Komprimierung vom Inhalt der ursprünglichen Textur abhängt.
+
+Da die Transkodierung bei der Basis-Universal-Komprimierung von den Fähigkeiten der GPU des Geräts abhängt, werden für die Verwendung mit Basis Universal generische Formate empfohlen, etwa:
+`TEXTURE_FORMAT_RGB`, `TEXTURE_FORMAT_RGBA`, `TEXTURE_FORMAT_RGB_16BPP`, `TEXTURE_FORMAT_RGBA_16BPP`, `TEXTURE_FORMAT_LUMINANCE` und `TEXTURE_FORMAT_LUMINANCE_ALPHA`.
+
+Der Basis-Universal-Transkoder unterstützt viele Ausgabeformate, etwa `ASTC4x4`, `BCx`, `ETC2`, `ETC1` und `PVRTC1`.
+
+Die folgenden verlustbehafteten Komprimierungsformate werden derzeit unterstützt:
+
+| Format                            | Komprimierung | Einzelheiten |
+| --------------------------------- | ----------- | -------------------------------- |
+| `TEXTURE_FORMAT_RGB`              | keine       | 3 Farbkanäle. Alpha wird verworfen. |
+| `TEXTURE_FORMAT_RGBA`             | keine       | 3 Farbkanäle und vollständiger Alphakanal. |
+| `TEXTURE_FORMAT_RGB_16BPP`        | keine       | 3 Farbkanäle. 5+6+5 Bit. |
+| `TEXTURE_FORMAT_RGBA_16BPP`       | keine       | 3 Farbkanäle und vollständiger Alphakanal. 4+4+4+4 Bit. |
+| `TEXTURE_FORMAT_LUMINANCE`        | keine       | 1 Graustufenkanal, kein Alpha. RGB-Kanäle werden zu einem Kanal multipliziert. Alpha wird verworfen. |
+| `TEXTURE_FORMAT_LUMINANCE_ALPHA`  | keine       | 1 Graustufenkanal und vollständiger Alphakanal. RGB-Kanäle werden zu einem Kanal multipliziert. |
+
+Bei ASTC beträgt die Anzahl der Kanäle immer 4 (RGB + Alpha), und das Format selbst legt die Blockgröße der Komprimierung fest.
+Beachte, dass diese Formate nur mit einem ASTC-Kompressor kompatibel sind - jede andere Kombination führt zu einem Build-Fehler.
+
+`TEXTURE_FORMAT_RGBA_ASTC_4X4`
+`TEXTURE_FORMAT_RGBA_ASTC_5X4`
+`TEXTURE_FORMAT_RGBA_ASTC_5X5`
+`TEXTURE_FORMAT_RGBA_ASTC_6X5`
+`TEXTURE_FORMAT_RGBA_ASTC_6X6`
+`TEXTURE_FORMAT_RGBA_ASTC_8X5`
+`TEXTURE_FORMAT_RGBA_ASTC_8X6`
+`TEXTURE_FORMAT_RGBA_ASTC_8X8`
+`TEXTURE_FORMAT_RGBA_ASTC_10X5`
+`TEXTURE_FORMAT_RGBA_ASTC_10X6`
+`TEXTURE_FORMAT_RGBA_ASTC_10X8`
+`TEXTURE_FORMAT_RGBA_ASTC_10X10`
+`TEXTURE_FORMAT_RGBA_ASTC_12X10`
+`TEXTURE_FORMAT_RGBA_ASTC_12X12`
+
+
+## Kompressoren {#compressors}
+
+Die folgenden Texturkompressoren werden standardmäßig unterstützt. Die Daten werden dekomprimiert, wenn die Texturdatei in den Arbeitsspeicher geladen wird.
+
+| Name                              | Formate                   | Hinweis                                                                                       |
+| --------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------- |
+| `Uncompressed`                    | Alle Formate              | Es wird keine Komprimierung angewendet. Standard.                                              |
+| `BasisU`                          | Alle RGB/RGBA-Formate      | Hochwertige, verlustbehaftete Komprimierung mit Basis Universal. Eine niedrigere Qualitätsstufe ergibt eine geringere Größe. |
+| `ASTC`                            | Alle ASTC-Formate          | Verlustbehaftete ASTC-Komprimierung. Eine niedrigere Qualitätsstufe ergibt eine geringere Größe. |
+
+::: sidenote
+Defold unterstützt installierbare Kompressoren in der Pipeline zur Texturkomprimierung. Dadurch kannst du einen Algorithmus zur Texturkomprimierung in einer Erweiterung implementieren, etwa WEBP oder einen vollständig eigenen Algorithmus.
+:::
+
+## Beispielbild {#example-image}
+
+Das folgende Beispiel soll das Ergebnis veranschaulichen.
+Beachte, dass Bildqualität, Komprimierungsdauer und komprimierte Größe immer vom Eingabebild abhängen und variieren können.
+
+Ausgangsbild (1024x512):
+![Neue Profildatei](images/texture_profiles/kodim03_pow2.png)
+
+### Komprimierungsdauer {#compression-times}
+
+| Voreinstellung | Komprimierungsdauer | Relative Dauer |
+| --------- | ---------------- | ------------- |
+| `LOW`     | 0m0.143s         | 0.5x            |
+| `MEDIUM`  | 0m0.294s         | 1.0x            |
+| `HIGH`    | 0m1.764s         | 6.0x            |
+| `HIGHEST` | 0m1.109s         | 3.8x            |
+
+### Signalverlust {#signal-loss}
+
+Der Vergleich wird mit dem Werkzeug `basisu` durchgeführt (Messung des PSNR).
+100 dB bedeutet keinen Signalverlust (d. h., das Bild ist mit dem Originalbild identisch).
+
+| Voreinstellung | Signal                                           |
+| --------- | ------------------------------------------------ |
+| `LOW`     | Max:  34 Mean: 0.470 RMS: 1.088 PSNR: 47.399 dB |
+| `MEDIUM`  | Max:  35 Mean: 0.439 RMS: 1.061 PSNR: 47.620 dB |
+| `HIGH`    | Max:  37 Mean: 0.898 RMS: 1.606 PSNR: 44.018 dB |
+| `HIGHEST` | Max:  51 Mean: 1.298 RMS: 2.478 PSNR: 40.249 dB |
+
+### Dateigrößen nach der Komprimierung {#compression-file-sizes}
+
+Die ursprüngliche Dateigröße beträgt 1572882 Byte.
+
+| Voreinstellung | Dateigrößen | Verhältnis |
+| --------- | ---------- | ------- |
+| `LOW`     | 357225     | 22.71 %  |
+| `MEDIUM`  | 365548     | 23.24 %  |
+| `HIGH`    | 277186     | 17.62 %  |
+| `HIGHEST` | 254380     | 16.17 %  |
+
+
+### Bildqualität {#image-quality}
+
+Hier siehst du die resultierenden Bilder (mit dem Werkzeug `basisu` aus der ASTC-Kodierung gewonnen).
+
+`LOW`
+![Komprimierungsvoreinstellung LOW](images/texture_profiles/kodim03_pow2.fast.png)
+
+`MEDIUM`
+![Komprimierungsvoreinstellung MEDIUM](images/texture_profiles/kodim03_pow2.normal.png)
+
+`HIGH`
+![Komprimierungsvoreinstellung HIGH](images/texture_profiles/kodim03_pow2.high.png)
+
+`HIGHEST`
+![Beste Komprimierungsvoreinstellung](images/texture_profiles/kodim03_pow2.best.png)

--- a/docs/de/manuals/tilemap.md
+++ b/docs/de/manuals/tilemap.md
@@ -1,0 +1,118 @@
+---
+title: Defold-Handbuch zu Kachelkarten
+brief: Dieses Handbuch beschreibt Defolds Unterstützung für Kachelkarten im Detail.
+---
+
+# Kachelkarte {#tile-map}
+
+Eine *Kachelkarte* (tile map) ist eine Komponente (component), mit der du Kacheln aus einer *Kachelquelle* (tile source) auf einer großen Rasterfläche anordnen oder aufmalen kannst. Kachelkarten werden häufig verwendet, um die Umgebung von Spielleveln zu gestalten. Du kannst auch die *Kollisionsformen* (collision shapes) aus der Kachelquelle in deinen Karten für die Kollisionserkennung und Physiksimulation verwenden ([Beispiel](/examples/tilemap/collisions/)).
+
+Bevor du eine Kachelkarte erstellen kannst, musst du eine Kachelquelle erstellen. Im [Handbuch zu Kachelquellen](/manuals/tilesource) erfährst du, wie du eine Kachelquelle erstellst.
+
+## Eine Kachelkarte erstellen {#creating-a-tile-map}
+
+So erstellst du eine neue Kachelkarte:
+
+- <kbd>Klicke mit der rechten Maustaste</kbd> auf eine Stelle im *Assets*-Browser und wähle dann <kbd>New... ▸ Tile Map</kbd>.
+- Gib der Datei einen Namen.
+- Die neue Kachelkarte wird automatisch im Kachelkarteneditor geöffnet.
+
+  ![Neue Kachelkarte](images/tilemap/tilemap.png)
+
+- Setze die Eigenschaft *Tile Source* auf eine Kachelquellendatei, die du vorbereitet hast.
+
+So malst du Kacheln auf deine Kachelkarte:
+
+1. Wähle eine Ebene (*Layer*) zum Bemalen in der Ansicht *Outline* aus oder erstelle eine.
+2. Wähle eine Kachel als Pinsel aus (drücke <kbd>Space</kbd>, um die Kachelpalette anzuzeigen), oder wähle durch Klicken und Ziehen in der Palette mehrere Kacheln aus, um einen rechteckigen Pinsel aus mehreren Kacheln zu erstellen.
+
+   ![Palette](images/tilemap/palette.png)
+
+3. Male mit dem ausgewählten Pinsel. Um eine Kachel zu löschen, wähle entweder eine leere Kachel aus und verwende sie als Pinsel oder wähle den Radierer aus (<kbd>Edit ▸ Select Eraser</kbd>).
+
+   ![Kacheln malen](images/tilemap/paint_tiles.png)
+
+Du kannst Kacheln direkt aus einer Ebene aufnehmen und die Auswahl als Pinsel verwenden. Halte <kbd>Shift</kbd> gedrückt und klicke auf eine Kachel, um sie als aktuellen Pinsel aufzunehmen. Während du <kbd>Shift</kbd> gedrückt hältst, kannst du auch durch Klicken und Ziehen einen Block aus Kacheln auswählen, den du als größeren Pinsel verwendest. Auf ähnliche Weise kannst du Kacheln ausschneiden, indem du <kbd>Shift+Ctrl</kbd> gedrückt hältst, oder sie löschen, indem du <kbd>Shift+Alt</kbd> gedrückt hältst.
+
+Verwende <kbd>Z</kbd>, um den Pinsel im Uhrzeigersinn zu drehen. Verwende <kbd>X</kbd>, um den Pinsel horizontal zu spiegeln, und <kbd>Y</kbd>, um ihn vertikal zu spiegeln.
+
+![Kacheln aufnehmen](images/tilemap/pick_tiles.png)
+
+## Deinem Spiel eine Kachelkarte hinzufügen {#adding-a-tile-map-to-your-game}
+
+So fügst du deinem Spiel eine Kachelkarte hinzu:
+
+1. Erstelle ein Spielobjekt (game object), das die Kachelkartenkomponente aufnehmen soll. Das Spielobjekt kann sich in einer Datei befinden oder direkt in einer Sammlung (collection) erstellt werden.
+2. Klicke mit der rechten Maustaste auf den Wurzeleintrag des Spielobjekts und wähle <kbd>Add Component File</kbd>.
+3. Wähle die Kachelkartendatei aus.
+
+![Kachelkarte verwenden](images/tilemap/use_tilemap.png)
+
+## Änderungen zur Laufzeit {#runtime-manipulation}
+
+Du kannst Kachelkarten zur Laufzeit über verschiedene Funktionen und Eigenschaften verändern (Informationen zur Verwendung findest du in der [API-Dokumentation](/ref/tilemap/)).
+
+### Kacheln aus einem Skript ändern {#changing-tiles-from-script}
+
+Du kannst den Inhalt einer Kachelkarte dynamisch lesen und schreiben, während dein Spiel läuft. Verwende dazu die Funktionen [`tilemap.get_tile()`](/ref/tilemap/#tilemap.get_tile) und [`tilemap.set_tile()`](/ref/tilemap/#tilemap.set_tile):
+
+```lua
+local tile = tilemap.get_tile("/level#map", "ground", x, y)
+
+if tile == 2 then
+    -- Replace grass-tile (2) with dangerous hole tile (number 4).
+    tilemap.set_tile("/level#map", "ground", x, y, 4)
+end
+```
+
+## Eigenschaften von Kachelkarten {#tilemap-properties}
+
+Neben den Eigenschaften *Id*, *Position*, *Rotation* und *Scale* gibt es die folgenden komponentenspezifischen Eigenschaften:
+
+*Tile Source*
+: Die Kachelquellenressource, die für die Kachelkarte verwendet werden soll.
+
+*Material*
+: Das Material, das zum Rendern der Kachelkarte verwendet werden soll.
+
+*Blend Mode*
+: Der Mischmodus, der beim Rendern der Kachelkarte verwendet werden soll.
+
+### Mischmodi {#blend-modes}
+:[blend-modes](../shared/blend-modes.md)
+
+### Eigenschaften ändern {#changing-properties}
+
+Eine Kachelkarte verfügt über verschiedene Eigenschaften, die mit `go.get()` und `go.set()` verändert werden können:
+
+`tile_source`
+: Die Kachelquelle der Kachelkarte (`hash`). Du kannst sie mit einer Ressourceneigenschaft für Kachelquellen und `go.set()` ändern. Ein Beispiel findest du in der [API-Referenz](/ref/tilemap/#tile_source).
+
+`material`
+: Das Material der Kachelkarte (`hash`). Du kannst es mit einer Ressourceneigenschaft für Materialien und `go.set()` ändern. Ein Beispiel findest du in der [API-Referenz](/ref/tilemap/#material).
+
+### Materialkonstanten {#material-constants}
+
+{% include shared/material-constants.md component='tilemap' variable='tint' %}
+
+`tint`
+: Die Einfärbung der Kachelkarte (`vector4`). Der `vector4` stellt die Einfärbung dar, wobei x, y, z und w den Anteilen für Rot, Grün, Blau und Alpha entsprechen.
+
+## Projektkonfiguration {#project-configuration}
+
+Die Datei *game.project* enthält einige [Projekteinstellungen](/manuals/project-settings#tilemap) für Kachelkarten.
+
+## Externe Werkzeuge {#external-tools}
+
+Es gibt externe Karten- und Leveleditoren, die direkt in Defold-Kachelkarten exportieren können:
+
+### Tiled
+
+[Tiled](https://www.mapeditor.org/) ist ein bekannter und weitverbreiteter Karteneditor für orthogonale, isometrische und hexagonale Karten. Tiled unterstützt eine breite Palette an Funktionen und kann [direkt nach Defold exportieren](https://doc.mapeditor.org/en/stable/manual/export-defold/). Mehr über den Export von Kachelkartendaten und zusätzlichen Metadaten erfährst du in [diesem Blogbeitrag des Defold-Nutzers „goeshard“](https://goeshard.org/2025/01/01/using-tiled-object-layers-with-defold-tilemaps/)
+
+
+### Tilesetter
+
+Mit [Tilesetter](https://www.tilesetter.org/docs/exporting#defold) kannst du automatisch vollständige Kachelsätze aus einfachen Basiskacheln erstellen. Außerdem enthält es einen Karteneditor, der direkt nach Defold exportieren kann.
+
+

--- a/docs/de/manuals/tilesource.md
+++ b/docs/de/manuals/tilesource.md
@@ -1,0 +1,100 @@
+---
+title: Handbuch zu Kachelquellen in Defold
+brief: Hier erfährst du, wie du eine Kachelquelle verwendest und erstellst.
+---
+
+# Kachelquelle {#tile-source}
+
+Eine *Kachelquelle* (tile source) kann von einer [Kachelkartenkomponente (tile map component)](/manuals/tilemap) verwendet werden, um Kacheln auf eine Rasterfläche zu zeichnen, oder als Grafikquelle für ein [Sprite](/manuals/sprite) oder eine [Partikeleffektkomponente (particle effect component)](/manuals/particlefx) dienen. Du kannst auch die *Kollisionsformen* (collision shapes) der Kachelquelle in einer Kachelkarte für die [Kollisionserkennung und Physiksimulation](/manuals/physics) verwenden ([Beispiel](/examples/tilemap/collisions/)).
+
+## Eine Kachelquelle erstellen {#creating-a-tile-source}
+
+Du benötigst ein Bild, das alle Kacheln enthält. Jede Kachel muss genau dieselben Abmessungen haben und in einem Raster angeordnet sein. Defold unterstützt _Abstände_ zwischen den Kacheln und einen _Rand_ um jede Kachel.
+
+![Kachelbild](images/tilemap/small_map.png)
+
+Sobald du das Quellbild erstellt hast, kannst du eine Kachelquelle erstellen:
+
+- Importiere das Bild in dein Projekt, indem du es an einen Speicherort im Projekt im Browser *Assets* ziehst.
+- Erstelle eine neue Kachelquelldatei (<kbd>Rechtsklick</kbd> auf einen Speicherort im Browser *Assets*, dann <kbd>New... ▸ Tile Source</kbd> auswählen).
+- Gib der neuen Datei einen Namen.
+- Die Datei wird nun im Kachelquelleneditor geöffnet.
+- Klicke auf die Schaltfläche zum Durchsuchen neben der Eigenschaft *Image* und wähle dein Bild aus. Jetzt solltest du das Bild im Editor sehen.
+- Passe die *Properties* an das Quellbild an. Wenn alles richtig eingestellt ist, sind die Kacheln genau ausgerichtet.
+
+![Eine Kachelquelle erstellen](images/tilemap/tilesource.png)
+
+Size
+: Die Größe des Quellbilds.
+
+Tile Width
+: Die Breite jeder Kachel.
+
+Tile Height
+: Die Höhe jeder Kachel.
+
+Tile Margin
+: Die Anzahl der Pixel, die jede Kachel umgeben (im Bild oben orange).
+
+Tile Spacing
+: Die Anzahl der Pixel zwischen den Kacheln (im Bild oben blau).
+
+Inner Padding
+: Legt fest, wie viele leere Pixel automatisch um die Kachel herum in der resultierenden Textur hinzugefügt werden sollen, die beim Ausführen des Spiels verwendet wird.
+
+Extrude Border
+: Legt fest, wie oft die Randpixel automatisch um die Kachel herum in der resultierenden Textur wiederholt werden sollen, die beim Ausführen des Spiels verwendet wird.
+
+Collision
+: Legt das Bild fest, mit dem automatisch Kollisionsformen für Kacheln erzeugt werden.
+
+## Flipbook-Animationen einer Kachelquelle {#tile-source-flip-book-animations}
+
+Um eine Animation in einer Kachelquelle zu definieren, müssen die Kacheln der Einzelbilder in einer Folge von links nach rechts nebeneinanderliegen. Die Folge kann von einer Zeile in die nächste übergehen. Alle neu erstellten Kachelquellen haben eine Standardanimation namens „`anim`“. Du kannst neue Animationen hinzufügen, indem du einen <kbd>Rechtsklick</kbd> auf den obersten Eintrag der Kachelquelle in der Ansicht *Outline* ausführst und <kbd>Add ▸ Animation</kbd> auswählst.
+
+Wenn du eine Animation auswählst, werden ihre *Properties* angezeigt.
+
+![Animation einer Kachelquelle](images/tilemap/animation.png)
+
+Id
+: Die Kennung der Animation. Sie muss innerhalb der Kachelquelle eindeutig sein.
+
+Start Tile
+: Die erste Kachel der Animation. Die Nummerierung beginnt bei 1 in der oberen linken Ecke und verläuft nach rechts, Zeile für Zeile bis zur unteren rechten Ecke.
+
+End Tile
+: Die letzte Kachel der Animation.
+
+Playback
+: Legt fest, wie die Animation abgespielt werden soll:
+
+  - `None` spielt die Animation nicht ab; das erste Bild wird angezeigt.
+  - `Once Forward` spielt die Animation einmal vom ersten bis zum letzten Bild ab.
+  - `Once Backward` spielt die Animation einmal vom letzten bis zum ersten Bild ab.
+  - `Once Ping Pong` spielt die Animation einmal vom ersten bis zum letzten Bild und dann zurück zum ersten Bild ab.
+  - `Loop Forward` spielt die Animation wiederholt vom ersten bis zum letzten Bild ab.
+  - `Loop Backward` spielt die Animation wiederholt vom letzten bis zum ersten Bild ab.
+  - `Loop Ping Pong` spielt die Animation wiederholt vom ersten bis zum letzten Bild und dann zurück zum ersten Bild ab.
+
+Fps
+: Die Wiedergabegeschwindigkeit der Animation, angegeben in Bildern pro Sekunde (FPS).
+
+Flip horizontal
+: Spiegelt die Animation horizontal.
+
+Flip vertical
+: Spiegelt die Animation vertikal.
+
+## Kollisionsformen einer Kachelquelle {#tile-source-collision-shapes}
+
+Defold verwendet ein Bild, das in der Eigenschaft *Collision* angegeben ist, um eine _konvexe_ Form für jede Kachel zu erzeugen. Die Form umschließt den Teil der Kachel, der Farbinformationen enthält, also nicht zu 100 % transparent ist.
+
+Oft ist es sinnvoll, für die Kollision dasselbe Bild zu verwenden, das auch die eigentliche Grafik enthält. Du kannst jedoch ein separates Bild angeben, wenn du Kollisionsformen möchtest, die von der Darstellung abweichen. Wenn du ein Kollisionsbild angibst, wird die Vorschau aktualisiert und zeigt auf jeder Kachel einen Umriss der erzeugten Kollisionsform.
+
+Die Ansicht *Outline* der Kachelquelle listet die Kollisionsgruppen (collision groups) auf, die du der Kachelquelle hinzugefügt hast. Neue Kachelquelldateien erhalten eine Kollisionsgruppe namens "default". Du kannst neue Gruppen hinzufügen, indem du einen <kbd>Rechtsklick</kbd> auf den obersten Eintrag der Kachelquelle in der Ansicht *Outline* ausführst und <kbd>Add ▸ Collision Group</kbd> auswählst.
+
+Um die Kachelformen auszuwählen, die zu einer bestimmten Gruppe gehören sollen, wähle die Gruppe in der Ansicht *Outline* aus und klicke dann auf jede Kachel, die du der Gruppe zuordnen möchtest. Der Umriss der Kachel und der Form wird in der Farbe der Gruppe dargestellt. Die Farbe wird der Gruppe im Editor automatisch zugewiesen.
+
+![Kollisionsformen](images/tilemap/collision.png)
+
+Um eine Kachel aus ihrer Kollisionsgruppe zu entfernen, wähle den obersten Eintrag der Kachelquelle in der Ansicht *Outline* aus und klicke dann auf die Kachel.

--- a/docs/de/manuals/unity.md
+++ b/docs/de/manuals/unity.md
@@ -1,0 +1,680 @@
+---
+title: Defold für Unity-Nutzer
+brief: Dieser Leitfaden hilft dir beim schnellen Umstieg auf Defold, wenn du bereits Erfahrung mit Unity hast. Er behandelt einige der wichtigsten Konzepte aus Unity und erläutert die entsprechenden Werkzeuge und Methoden in Defold.
+---
+
+# Defold für Unity-Nutzer {#defold-for-unity-users}
+
+Wenn du bereits Erfahrung mit Unity hast, hilft dir dieser Leitfaden dabei, schnell produktiv mit Defold zu arbeiten. Er konzentriert sich auf das Wesentliche und verweist auf die offiziellen Defold-Handbücher, wenn du ausführlichere Informationen benötigst.
+
+## Einführung {#introduction}
+
+Defold ist eine vollständig kostenlose, durchgehend plattformübergreifende 3D-Game-Engine mit einem Editor für Windows, Linux und macOS. Der vollständige Quellcode ist auf [GitHub](https://github.com/defold/defold/) verfügbar.
+
+Defold ist auf Leistung ausgelegt, auch auf leistungsschwachen Geräten. Es verwendet ein kleines Komponentenmodell, in dem viele Gameplay-Interaktionen durch Code und Nachrichtenübermittlung verarbeitet werden.
+
+Defold ist viel kleiner als Unity. Die Größe der Engine mit einem leeren Projekt liegt auf allen Plattformen zwischen 1 und 3 MB. Du kannst weitere Teile der Engine entfernen und einige Spielinhalte in [Live Update](/manuals/live-update) auslagern, um sie später separat herunterzuladen. Einen Größenvergleich und weitere Gründe für Defold findest du auf der [Webseite „Warum Defold?“](https://defold.com/why/).
+
+Um Defold an deine Anforderungen anzupassen, kannst du Folgendes selbst schreiben oder vorhandene Lösungen verwenden:
+
+1. Eine vollständig skriptgesteuerte Rendering-Pipeline (Render-Skript + Materialien/Shader) mit einigen Backends zur Auswahl (OpenGL, Vulkan usw.).
+2. Code und Komponenten (components) als native Erweiterungen (C++/C#).
+3. Editor-Skripte und UI-Widgets zum Anpassen des Editors.
+3. Einen veränderten Build der Engine und des Editors, da der vollständige Quellcode und eine Build-Pipeline verfügbar sind.
+
+Wir empfehlen außerdem ein Video von Game From Scratch über [Defold für Unity-Entwickler](https://www.youtube.com/watch?v=-3CzCbd4QZ0).
+
+---
+
+## Installation
+
+1. Lade Defold für dein Betriebssystem herunter.
+2. Entpacke es und starte es.
+
+Das war's. Kein Hub, keine Installation zusätzlicher SDKs, Toolchains oder Plattform-Bundles. Deshalb sagen wir, dass Defold keine Einrichtung benötigt.
+
+Weitere Informationen findest du in diesem kurzen [Installationshandbuch](/manuals/install/).
+
+### Versionen {#versions}
+
+Defold wird häufig aktualisiert und hat keinen „LTS“-Versionszweig. Wir empfehlen, immer die neueste Version zu verwenden. Neue Versionen erscheinen regelmäßig, normalerweise monatlich, mit einer öffentlichen Betaphase von etwa zwei Wochen. Du kannst Defold direkt im Editor aktualisieren.
+
+---
+
+## Willkommensbildschirm {#welcome-screen}
+
+Defold begrüßt dich mit einem Willkommensbildschirm ähnlich dem Unity Hub, auf dem du zuletzt verwendete Projekte öffnen kannst:
+
+![Vergleich der Willkommensbildschirme](images/unity/unity_defold_start.png)
+
+Oder du beginnst ein neues Projekt mit:
+- `Templates` - grundlegenden leeren Projekten für einen schnelleren Einstieg auf einer bestimmten Plattform oder in einem bestimmten Genre,
+- `Tutorials` - geführten Lerneinheiten, die dir bei deinen ersten Schritten helfen,
+- `Samples` - offiziellen oder von der Community beigetragenen Anwendungsfällen und Beispielen,
+
+![Vergleich der Vorlagen auf dem Willkommensbildschirm](images/unity/unity_defold_templates.png)
+
+Wenn du dein erstes Projekt erstellst und/oder öffnest, wird es im Defold-Editor geöffnet.
+
+## Hallo Welt {#hello-world}
+
+So kannst du schnell etwas in Defold umsetzen: Befolge die Schritte und kehre anschließend zurück, um den Rest des Handbuchs zu lesen.
+
+1. Wähle unter `Templates` ein leeres Projekt aus, gib ihm unter `Title` einen Namen, wähle einen Speicherort und erstelle es mit einem Klick auf `Create New Project`. Es wird im Defold-Editor geöffnet.
+![Hallo Welt, Schritt 1](images/unity/helloworld_1.png)
+2. Öffne links im Bereich `Assets` den Ordner `main` und doppelklicke auf `main.collection`, um die Datei zu öffnen.
+3. Klicke rechts im Bereich `Outline` mit der rechten Maustaste auf `Collection` und wähle `Add Game Object`.
+![Hallo Welt, Schritt 2](images/unity/helloworld_2.png)
+4. Klicke mit der rechten Maustaste auf das erstellte Spielobjekt (game object) `go` und wähle `Add Component` und dann `Label`.
+![Hallo Welt, Schritt 3](images/unity/helloworld_3.png)
+5. Gib darunter auf der linken Seite im Bereich `Properties` etwas in die Eigenschaft `Text` ein.
+6. Ziehe die Beschriftung in der zentralen Szenenansicht ungefähr an die Position `(480,320,0)` und lege sie dort ab, oder ändere ihre Position unter `Properties`: `Position`.
+![Hallo Welt, Schritt 4](images/unity/helloworld_4.png)
+7. Nachdem du die Position der Beschriftung geändert hast, speichere das Projekt über `File` -> `Save All` oder mit der Tastenkombination <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>Cmd</kbd>+<kbd>S</kbd> auf dem Mac).
+8. Erstelle einen Build deines Projekts über `Project` -> `Build` oder mit der Tastenkombination <kbd>Ctrl</kbd>+<kbd>B</kbd> (<kbd>Cmd</kbd>+<kbd>B</kbd> auf dem Mac).
+![Hallo Welt, Schritt 5](images/unity/helloworld_5.png)
+
+Du hast gerade deinen ersten Projekt-Build in Defold erstellt und solltest deinen Text im Fenster sehen. Die Konzepte Spielobjekt und Komponente sollten dir vertraut sein. Sammlungen (collections), Outline, Eigenschaften und der Grund, warum wir die Beschriftung ein Stück nach rechts oben verschieben mussten, werden im Folgenden erklärt.
+
+---
+
+## Überblick über den Defold-Editor {#defold-editor-overview}
+
+Wir stellen den Defold-Editor hier aus der Perspektive dessen vor, was Unity-Nutzer anfangs wissen möchten. Wir empfehlen dir aber, anschließend das vollständige [Handbuch zum Editor](/manuals/editor) zu lesen.
+
+### Vergleich der Editoren {#editors-comparison}
+
+Der erste Unterschied zwischen Unity und Defold, der dir auffallen wird, ist das Standardlayout des Editors. Wir zeigen einen Unity-Editor mit einem leicht angepassten Layout, das dem Standardlayout von Defold entspricht. Die Editoren stehen nebeneinander, damit sich die Hauptbereiche leichter visuell vergleichen lassen und du die Unity-Registerkarten leichter wiedererkennst.
+
+![Vergleich der Editoren](images/unity/defold_unity_editor.png)
+
+Standardmäßig öffnet sich der Defold-Editor mit einer orthografischen 2D-Vorschau. Wenn du an einem 3D-Projekt arbeitest oder eine Ansicht möchtest, die Unity stärker ähnelt, empfehlen wir, von 2D zu 3D zu wechseln, indem du in der Werkzeugleiste den Schalter `2D` deaktivierst und die Kameraprojektion auf perspektivisch umstellst, indem du den Schalter `Perspective` aktivierst:
+
+![Defold-Werkzeugleiste](images/unity/defold_2d.png)
+
+Du kannst auch die `Grid Settings` in der Werkzeugleiste anpassen, um wie in Unity die `Y`-Ebene zu verwenden:
+
+![Defold-3D-Einstellungen](images/unity/defold_3d.png)
+
+### Überblick über die Bereiche in Defold {#defold-panes-overview}
+
+Der Defold-Editor ist in 6 Hauptbereiche unterteilt.
+
+![Editor 2](images/editor/editor_overview.png)
+
+Im Folgenden werden die Bezeichnungen und funktionalen Unterschiede von Defold verglichen:
+
+| Defold | Unity | Unterschiede |
+|---|---|---|
+| 1. Assets | Project (Assets Browser) | In Defold ist der Bereich Assets links angedockt. Defold erstellt keine `meta`-Dateien. |
+| 2. Main Editor | Scene View | Der Defold-Editor ist kontextabhängig (unterschiedliche Editoren für unterschiedliche Dateitypen), während Unity separate spezialisierte Fenster verwendet (z. B. Animator, Shader Graph). Defold hat außerdem einen integrierten Code-Editor. |
+| 3. Outline | Hierarchy | Defold zeigt nur die aktuell geöffnete Datei oder das ausgewählte Element (Spielobjekt oder Komponente), keine globale Hierarchie. |
+| 4. Properties | Inspector | Defold zeigt nur die Eigenschaften der **aktuellen Auswahl** in Outline an, nicht die aller Komponenten im Spielobjekt. |
+| 5. Tools | Console | Defold stellt Werkzeuge in Registerkarten wie Console, Curve Editor, Build Errors, Search Results, Breakpoints und Debugger bereit. |
+| 6. Changed Files | Unity Version Control (Plastic) | Sobald Git in dein Defold-Projekt integriert ist, werden hier geänderte Dateien angezeigt. Du kannst Git weiterhin extern verwenden. |
+
+Weitere nützliche Bezeichnungen rund um den Editor:
+
+| Defold | Unity | Unterschiede |
+|---|---|---|
+| Game Build | Game Preview | Zeigt das laufende Spiel, dessen Build mit der Engine erstellt wurde. Defold kann mehrere Instanzen des Spiels aus dem Editor starten, ähnlich dem Multiplayer Play Mode von Unity 6+. In Defold läuft das Spiel immer in einem separaten Fenster und ist nicht angedockt. Defold kann das Spiel auch auf einem externen Gerät ausführen (z. B. einem Mobiltelefon), ähnlich wie Unity Remote. |
+| Tabs | Tabs | Defold ermöglicht die Bearbeitung nebeneinander in zwei Bereichen innerhalb der Ansicht Main Editor. Registerkarten und Bereiche sind in einem einzigen Editorfenster angedockt; die Sichtbarkeit der Bereiche lässt sich umschalten (<kbd>F6</kbd>, <kbd>F7</kbd>, <kbd>F8</kbd>), und ihre Größe lässt sich anpassen. |
+| Toolbar | Toolbar / Scene View Options | Erst in neueren Unity-Versionen wurden die Transformationswerkzeuge ähnlich wie in Defold in die Szenenansicht verschoben. |
+| Console | Console | Die Defold-Konsole lässt sich nicht abkoppeln. Build-Fehler werden in Defold in einer separaten Registerkarte `Build Errors` angezeigt. |
+| Build Errors | Kompilierungsfehler in Console | Lua-Skripte werden interpretiert, daher gibt es keine Kompilierungsfehler. Für dein Projekt wird jedoch ein Build erstellt, bei dem einige Fehler auftreten können. Defold verwendet außerdem einen Lua Language Server zur statischen Analyse von Skripten. |
+| Search Results | Search / Project Search | Defold bietet keine Filterung nach Typen und Labels. |
+| Curve Editor | Unity Curve Editor | Der Curve Editor von Defold ermöglicht nur das Bearbeiten von Kurven für Partikeleffekt-Eigenschaften. |
+| [Debugger](/manuals/debugging/) | Visual Studio Debugger | Der Debugger ist ohne weitere Einrichtung vollständig in Defold integriert. Es gibt eine zusätzliche Registerkarte, um Haltepunkte zu verfolgen, zu aktivieren und zu deaktivieren. |
+
+---
+
+## Grundlegende Konzepte {#key-concepts}
+
+Wenn man sie ausreichend verallgemeinert, sind die grundlegenden Konzepte der meisten Game-Engines sehr ähnlich. Sie sollen Entwicklern das Erstellen von Spielen erleichtern, ähnlich dem Zusammensetzen von Bausteinen, während sie komplexe und plattformbezogene Aufgaben selbst übernehmen.
+
+### Bausteine {#building-blocks}
+
+Defold arbeitet mit nur wenigen grundlegenden Bausteinen:
+
+![Bausteine](images/unity/blocks.png)
+
+Weitere Informationen findest du im vollständigen Handbuch zu den [Defold-Bausteinen](/manuals/building-blocks/).
+
+### Spielobjekte  {#game-objects}
+Defold verwendet ähnlich wie Unity **„Spielobjekte“**. In beiden Engines sind Spielobjekte Datencontainer mit einem Bezeichner (ID), und alle haben Transformationen: Position, Drehung und Skalierung. In Defold ist die Transformation jedoch integriert und keine separate Komponente.
+
+Du kannst Eltern-Kind-Beziehungen zwischen Spielobjekten erstellen. In Defold ist dies nur im Editor innerhalb einer „Sammlung“ (unten erläutert) oder dynamisch in einem Skript möglich. Spielobjekte können andere Spielobjekte nicht wie in Unity als verschachtelte Objekte enthalten.
+
+### Komponenten {#components}
+In beiden Engines lassen sich Spielobjekte mit **„Komponenten“** erweitern. Defold stellt einen minimalen Satz wesentlicher Komponenten bereit. Es wird weniger zwischen 2D und 3D unterschieden als in Unity (z. B. bei Kollidern), daher gibt es insgesamt weniger Komponenten, und einige aus Unity könnten dir fehlen.
+
+#### Komponenten für Verhalten {#behaviour-components}
+
+In Unity bezeichnet „Komponente“ normalerweise ein `MonoBehaviour`, das an ein `GameObject` angehängt ist. Du kannst eigene Komponenten erstellen, indem du von `MonoBehaviour` erbst, oder integrierte Komponenten wie Light, einige Physikfunktionen und sonstige Dinge verwenden, und so weiter und so fort.
+
+In Defold bezieht sich Komponente ausschließlich auf das, was den integrierten Komponenten in Unity oder Ähnlichem entspricht. Defold behandelt ein Skript jedoch nicht als MonoBehaviour und verlangt außer dem Erstellen von Listener-Ereignissen/Callbacks keine ausdrückliche „Kennzeichnung“, um es an ein Spielobjekt anzuhängen.
+
+Benutzerdefiniertes Gameplay-Verhalten wird normalerweise nicht in Form vieler separater Skriptkomponenten zu demselben Spielobjekt hinzugefügt. Stattdessen wird es üblicherweise in Lua-Modulen implementiert und von einem zentralen `.script` verwendet oder von einem übergeordneten Systemskript verarbeitet, das viele Objekte steuert. Der Abschnitt zum Schreiben von Code weiter unten erläutert dies ausführlicher.
+
+Lies [hier mehr über Defold-Komponenten](/manuals/components/).
+
+Die folgende Tabelle zeigt ähnliche Unity-Komponenten zum schnellen Nachschlagen, mit Links zum jeweiligen Handbuch der Defold-Komponente:
+
+| Defold | Unity | Unterschiede |
+|---|---|---|
+| [Sprite](/manuals/sprite/) | Sprite Renderer | In Defold kannst du die Einfärbung (Farbeigenschaft) nur über Code ändern. |
+| [Kachelkarte (tile map)](/manuals/tilemap/) | Tilemap / Grid | Defold hat einen integrierten Kachelkarten-Editor, der quadratische Raster unterstützt (es gibt aber eine Erweiterung z. B. für [Hexagon](https://github.com/selimanac/defold-hexagon/)) und keine integrierten Regeln zum automatischen Anordnen von Kacheln bietet. Werkzeuge wie [Tiled](https://defold.com/assets/tiled/), [TileSetter](https://defold.com/assets/tilesetter/) oder [Sprite Fusion](https://defold.com/assets/spritefusion/) bieten Exportmöglichkeiten für Defold. |
+| [Beschriftung](/manuals/label/) | Text / TextMeshPro | Seit Defold 1.13.2 unterstützen Beschriftungskomponenten und GUI-Textknoten integriertes [Rich-Text-Markup](/manuals/font-richtext/) für Farben, Farbverläufe, Konturen und animierte Effekte. Eine separate [RichText-Erweiterung](https://defold.com/assets/richtext/) ist ebenfalls verfügbar. |
+| [Audio](/manuals/sound/) | AudioSource | Defold hat nur eine globale Audioquelle (keine räumliche). Es gibt eine offizielle [FMOD-Erweiterung](https://github.com/defold/extension-fmod) für Defold. |
+| [Fabrik](/manuals/factory/) | Prefab Instantiate() | In Defold ist eine Fabrik (factory) eine Komponente mit einem bestimmten Prototyp (Prefab). |
+| [Sammlungsfabrik](/manuals/collection-factory/) | - (Keine direkt entsprechende Komponente) | Eine Sammlungsfabrik (collection factory) in Defold kann mehrere Spielobjekte mit Eltern-Kind-Beziehungen gleichzeitig erzeugen. |
+| [Kollisionsobjekt](/manuals/physics-objects) | Rigidbody + Collider | In Defold sind Physikobjekte und Kollisionsformen in einer einzigen Komponente zusammengefasst. |
+| [Kollisionsformen](/manuals/physics-shapes/)  | BoxCollider / SphereCollider / CapsuleCollider | In Defold werden Formen (Quader, Kugel, Kapsel) innerhalb der Kollisionsobjekt-Komponente konfiguriert. Beide unterstützen Kollisionsformen aus Kachelkarten und Daten für konvexe Hüllen. |
+| [Kamera](/manuals/camera/) | Camera | In Unity hat die Kamera einige zusätzliche integrierte Einstellungen für Rendering und Nachbearbeitung, während Defold die benutzerdefinierte Steuerung über das Render-Skript dem Nutzer überlässt. |
+| [GUI](/manuals/gui/) | UI Toolkit / Unity UI / uGUI Canvas | Defolds GUI ist eine leistungsfähige Komponente zum Erstellen vollständiger Benutzeroberflächen und Vorlagen. Unity hat keine entsprechende einzelne UI-Komponente, sondern mehrere UI-Frameworks. Defold hat auch eine Erweiterung für [Erweiterung](https://github.com/britzl/extension-imgui). |
+| [GUI-Skript](/manuals/gui-script/) | Unity UI / uGUI-Skripte | Defolds GUI lässt sich über GUI-Skripte mit der dafür vorgesehenen `gui`-API steuern. |
+| [Modell](/manuals/model/) | MeshRenderer + Material | In Defold bündelt eine Modellkomponente eine 3D-Modelldatei, Texturen und ein Material mit Shadern. |
+| [Mesh](/manuals/mesh/) | MeshRenderer / MeshFilter / Procedural Mesh | In Defold ist Mesh eine Komponente zur Verwaltung einer Menge von Vertices über Code. Sie ähnelt einem Defold-Modell, arbeitet aber auf einer noch niedrigeren Ebene. |
+| [ParticleFX](/manuals/particlefx/) | Particle System | Defolds Partikeleditor unterstützt 2D-/3D-Partikeleffekte mit vielen Eigenschaften und ermöglicht es dir, sie mit Kurven im Curve Editor über die Zeit zu animieren. Er bietet weder Spuren noch Kollisionen. |
+| [Skript](/manuals/script/) | Script | Weitere Informationen zu Unterschieden bei der Programmierung findest du unten. |
+
+#### Erweiterungen und benutzerdefinierte Komponenten {#extensions-and-custom-components}
+
+Defold bietet außerdem offizielle [Spine](/extension-spine/)- und [Rive](/extension-rive/)-Komponenten über Erweiterungen an.
+
+Du kannst mit nativen Erweiterungen auch eigene [benutzerdefinierte Komponenten](https://github.com/defold/extension-simpledata) erstellen, wie beispielsweise diese von der Community entwickelte [Komponente zur Objektinterpolation](https://github.com/indiesoftby/defold-object-interpolation).
+
+Einige Unity-Komponenten haben in Defold keine direkt verfügbare Entsprechung, zum Beispiel Audio Listener, Light, Terrain, LineRenderer, TrailRenderer, Cloth oder Animator. Diese gesamte Funktionalität lässt sich jedoch in Skripten implementieren, und es sind bereits Lösungen verfügbar: beispielsweise verschiedene Beleuchtungs-Pipelines, die Mesh-Komponente zum Erzeugen beliebiger Meshes (einschließlich Gelände) oder [Hyper Trails](https://defold.com/assets/hypertrails/) für anpassbare Spureneffekte. Defold könnte in Zukunft auch neue integrierte Komponenten hinzufügen, etwa Lichtquellen.
+
+### Ressourcen {#resources}
+
+Einige Komponenten benötigen ähnlich wie in Unity **„Ressourcen“ (resources)**, zum Beispiel benötigen Sprites und Modelle Texturen. Einige davon werden in der folgenden Tabelle verglichen:
+
+| Defold | Unity | Unterschiede |
+|---|---|---|
+| [Atlas](/manuals/atlas/) | Sprite Atlas / Texture2D | Defold hat auch eine [Erweiterung für Texture Packer](https://defold.com/extension-texturepacker/). |
+| [Kachelquelle](/manuals/tilesource/) | Tile Palette + Asset | In Defold lässt sich eine Kachelquelle als Textur für Kachelkarten, aber auch für Sprites oder Partikel verwenden. |
+| [Schriftart](/manuals/font/) | Font | Wird von der Beschriftungskomponente oder von Textknoten in Defolds GUI verwendet, ähnlich wie Text/TextMeshPro in Unity. |
+| [Material](/manuals/material/) | Material | In Defold heißen Shader Vertex-Programm und Fragment-Programm. |
+
+### Sammlung im Vergleich zur Szene {#collection-vs-scene}
+
+In Defold können Spielobjekte und Komponenten ähnlich wie Unity-Prefabs in separaten Dateien liegen oder in einer zusammenführenden **„Sammlungsdatei“** definiert sein.
+
+Eine Sammlung in Defold ist im Wesentlichen eine Textdatei mit einer statischen Szenenbeschreibung. Sie ist **kein** Laufzeitobjekt. Sie definiert lediglich, welche Spielobjekte im Spiel instanziiert werden sollen und wie Eltern-Kind-Beziehungen zwischen diesen Objekten hergestellt werden sollen.
+
+#### Spielwelten {#game-worlds}
+
+Unity-Szenen teilen standardmäßig denselben globalen Spielzustand und dieselbe Physiksimulation, also effektiv dieselbe *Welt* (*Spielwelt*). In Defold hast du zwei Möglichkeiten:
+1. Instanziiere Spielobjekte aus einer einzelnen Spielobjektdatei über eine `Factory` oder aus einer Sammlungsdatei über eine `Collection Factory` in einer bestimmten, bereits instanziierten *Welt*, ähnlich wie Prefabs.
+2. Erstelle zur Laufzeit eine separate *Spielwelt* mit eigenen Spielobjekten, einer eigenen Physikwelt, eigenen Engine-Vorgängen und einem eigenen Namensraum für Adressen über eine beim Start geladene Sammlung oder über eine Komponente vom Typ `Collection Proxy`, einen Sammlungs-Proxy (collection proxy).
+
+Fabriken und Proxy-Komponenten werden ebenfalls weiter unten erläutert.
+Lies mehr über Sammlungen im [Handbuch zu den Bausteinen](/manuals/building-blocks/#collections).
+
+---
+
+## Projektressourcen und Assets {#project-resources-and-assets}
+
+Unity und Defold speichern Spielinhalte beide im Projektverzeichnis, unterscheiden sich aber darin, wie Assets erfasst und vorbereitet werden.
+
+### Assets
+
+Unity legt Assets unter `Assets/` ab und erzeugt `.meta`-Dateien. Defold hat keine Metadateien. Das Projekt in Defold entspricht einfach deiner Ordnerstruktur, genau wie auf dem Datenträger, und der Bereich `Assets` bildet sie immer ab.
+
+### Ressourcenformate {#resource-formats}
+
+Unity importiert Assets und konvertiert sie im Hintergrund in andere Formate. In Defold arbeitest du direkt mit Quellressourcen (`.png`, `.gltf`, `.wav`, `.ogg` usw.) und weist sie `Components` zu.
+
+Unity kann ein einzelnes Bild als Sprite verwenden. In Defold lassen sich Bilder direkt für Modelle/Meshes verwenden, aber Sprites/GUI/Kachelkarten/Partikel benötigen einen Atlas (gepackte Texturen) oder eine Kachelquelle (Kacheln auf einem Raster).
+
+Die meisten Defold-Ressourcen werden als Text gespeichert, was sich gut für die Versionsverwaltung eignet.
+
+### Bibliotheks-Cache {#library-cache}
+
+Unity erzeugt einen Ordner `Library/` für importierte Assets. Defold hat kein solches Verzeichnis; Assets werden beim Erstellen von Builds verarbeitet, und die Ergebnisse werden im Build-Ordner zwischengespeichert (sowie optional in lokalen/entfernten Build-Caches).
+
+---
+
+## Code schreiben {#code-writing}
+
+Die Defold-Entsprechung zu `MonoBehaviour`-Skripten ist eine Skriptkomponente, allerdings gibt es einige wissenswerte Unterschiede.
+
+### Lua
+
+Defold-Skripte werden in der dynamisch typisierten Multiparadigmensprache [Lua](https://www.lua.org/) geschrieben.
+
+Es gibt mehrere Arten von Lua-Skripten: `*.script`, `*.gui_script`, `*.render_script`, `*.editor_script` und `*.lua`-Module.
+
+### Teal
+
+Defold unterstützt Transpiler, die Lua-Code erzeugen, zum Beispiel [Teal](https://teal-language.org/), einen statisch typisierten Lua-Dialekt. Diese Funktionalität ist allerdings stärker eingeschränkt und erfordert zusätzliche Einrichtung. Weitere Informationen findest du im [Repository der Teal-Erweiterung](https://github.com/defold/extension-teal).
+
+### Native Erweiterungen in C++/C# {#cc-native-extensions}
+
+In Defold lassen sich native Erweiterungen in mehreren anderen Sprachen schreiben: je nach Zielplattform in C, C++, C#, Objective-C, Java oder JS. Wenn du dich mit C# sehr gut auskennst, ist es technisch möglich, den Großteil deiner Spiellogik in einer C#-Erweiterung zu strukturieren und lediglich aus einem kleinen Lua-Startskript aufzurufen. Dies erfordert jedoch fortgeschrittene API-Kenntnisse und wird Anfängern nicht empfohlen.
+
+Lies mehr über Erweiterungen im [Defold-Handbuch zu nativen Erweiterungen](/manuals/extensions/).
+
+
+### Von MonoBehaviours zu Lua-Modulen {#from-monobehaviours-to-lua-modules}
+
+Unity hat ein offenes Skriptmodell. Da `MonoBehaviour` der wichtigste Weg ist, Verhalten im Editor hinzuzufügen, beginnen viele Unity-Projekte mit einem Steuerungsskript pro wichtigem GameObject: `PlayerController`, `EnemyController`, `BulletController`, `GameManager`, `EnemyManager` und so weiter.
+
+Defold gibt seine Standardarchitektur konkreter vor. Ein Spielobjekt kann ein `.script` haben, aber du musst nur selten für jedes Spielobjekt ein Skript erstellen. Dank Defolds leistungsfähiger Adressierung und Nachrichtenübermittlung kann ein einzelnes Skript Hunderte oder Tausende anderer Objekte und ihre Komponenten steuern, ohne dass diese eigene Skripte haben. Passend zu jedem Spielobjekt ein Skript zu erstellen, ist selten erforderlich und kann zu kontraproduktiver Komplexität führen.
+
+Für wiederverwendbares Gameplay-Verhalten gehen Unity-Entwickler oft zur Komposition über: kleinere `MonoBehaviour`-Skripte wie `Health.cs`, `Attack.cs` oder `EnemyFinder.cs`, die an dasselbe GameObject angehängt werden. In Defold behältst du normalerweise ein angehängtes `.script` als zentralen Koordinator bei und legst wiederverwendbare Logik in gewöhnlichen Lua-Modulen ab.
+
+In Unity könnte diese Komposition so aussehen:
+
+```text
+Player
+├── PlayerMovement.cs
+├── PlayerAttack.cs
+├── EnemyFinder.cs
+└── Health.cs
+```
+
+In Defold werden dieselben Zuständigkeiten oft zwischen einem angehängten Skript und wiederverwendbaren Modulen aufgeteilt:
+
+```text
+player.go
+├── sprite
+├── collisionobject
+└── player.script
+
+modules/
+├── player_movement.lua
+├── player_attack.lua
+├── enemy_finder.lua
+└── health.lua
+```
+
+Das angehängte `.script` wird zum zentralen Koordinator. Die Lua-Module enthalten wiederverwendbare Logik, ähnlich wie kleine `MonoBehaviour`-Skripte in Unity oft jeweils eine Zuständigkeit abdecken.
+
+```lua
+local movement = require "modules.player_movement"
+local attack = require "modules.player_attack"
+local finder = require "modules.enemy_finder"
+local health = require "modules.health"
+
+function init(self)
+    self.movement = movement.new(self)
+    self.attack = attack.new(self)
+    self.finder = finder.new(self)
+    self.health = health.new(self)
+end
+
+function update(self, dt)
+    self.movement:update(dt)
+    self.attack:update(dt)
+    self.finder:update(dt)
+end
+
+function on_message(self, message_id, message, sender)
+    self.health:on_message(message_id, message, sender)
+    self.attack:on_message(message_id, message, sender)
+end
+```
+
+Der wichtige Unterschied besteht nicht darin, dass Defold modulare Architektur verhindert, sondern darin, wo die Komposition stattfindet und wie Gameplay-Code kommuniziert:
+
+| Unity | Defold |
+|---|---|
+| Hänge mehrere `MonoBehaviour`-Skripte im Inspector an | Hänge ein `.script` an und setze Lua-Module im Code zusammen |
+| Verwende `GetComponent<T>()` oder serialisierte Felder, um Verhalten zu verbinden | Speichere Modulinstanzen in `self` und verwende Adressen/Nachrichten zwischen Objekten |
+| Jede Komponente kann eigene Lebenszyklusmethoden haben | Das zentrale Skript leitet `init()`, `update()`, `on_message()`, `final()` usw. weiter |
+| Viele Architekturstile sind möglich | Nachrichtenorientierte, explizite Komposition im Code ist die übliche Praxis |
+
+Das kann sich anfangs ungewohnt anfühlen, insbesondere wenn du Verhalten gewöhnlich durch das Hinzufügen von Komponenten im Inspector konfigurierst. In Defold lassen sich viele Dinge, die du in Unity vielleicht visuell konfigurierst, stattdessen über Code erstellen, verbinden, aktivieren, deaktivieren oder aktualisieren. Defolds Nachrichtensystem hilft, Logik zu entkoppeln: Der Absender sendet Daten an eine Adresse, und der Empfänger entscheidet, was er damit macht.
+
+Obwohl dieser Ansatz empfohlen wird, ist er nicht vorgeschrieben. Du kannst deine Skripte weiterhin so schreiben, wie du möchtest, einschließlich mehrerer Skripte pro Spielobjekt oder eines stärker objektorientierten Programmierstils. Es gibt sogar Bibliotheken, die dich dabei unterstützen ([defold-oop](https://github.com/xiyoo0812/defold-oop) oder [lua-class](https://github.com/d954mas/lua-class)).
+
+Bei vielen Objekten desselben Typs, etwa Geschossen, Gegnern, Partikeln, Kacheln oder einfachen interaktiven Elementen, ist es oft besser, sie aus einem System- oder Verwaltungsskript zu steuern, statt jedem Objekt ein separates Skript zu geben. Verwende eigene Skripte pro Objekt, wenn ein Objekt einen eigenen relevanten Zustand und eigenes Verhalten hat. Verwende Module für wiederverwendbare Logik. Verwende Systemskripte, wenn ein Skript viele Objekte effizient steuern kann.
+
+Ein Beispiel dafür, wie du Skripteigenschaften, Fabriken, Adressierung und Nachrichten in Defold zur Steuerung mehrerer Einheiten nutzt, findest du [hier](https://defold.com/examples/factory/spawn_manager/).
+
+Nützliche Handbücher zum Schreiben von Code:
+- [Skripthandbuch](/manuals/script/)
+- [Code schreiben](/manuals/writing-code/)
+- [Debugging](/manuals/debugging/)
+
+
+### Integrierter Code-Editor {#built-in-code-editor}
+
+Der Defold-Editor enthält einen integrierten Code-Editor mit Codevervollständigung, Syntaxhervorhebung, schnellem Nachschlagen in der Dokumentation, statischer Codeprüfung und einem integrierten Debugger.
+
+![Defold-Code-Editor](/images/editor/code-editor.png)
+
+### VS Code und andere Editoren {#vs-code-and-other-editors}
+
+Du kannst weiterhin deinen eigenen externen Editor verwenden, wenn du das bevorzugst. Alle Defold-Komponenten und zugehörigen Dateien sind textbasiert, sodass du sie mit jedem Texteditor bearbeiten kannst. Du musst jedoch die korrekte Formatierung und Elementstruktur einhalten, da sie auf Protobuf basieren.
+
+Wenn du VS Code gewohnt bist und damit den Code deines Spiels schreiben möchtest, empfehlen wir, [Defold Kit](https://marketplace.visualstudio.com/items?itemName=astronachos.defold) oder [Defold Buddy](https://marketplace.visualstudio.com/items?itemName=mikatuo.vscode-defold-ide) aus dem Visual Studio Marketplace zu installieren.
+
+Du kannst die Einstellungen des Defold-Editors auch so konfigurieren, dass Textdateien standardmäßig in VS Code (oder einem anderen externen Editor) geöffnet werden. Weitere Informationen findest du unter [Editoreinstellungen](/manuals/editor-preferences/).
+
+### Shader - GLSL {#shaders-glsl}
+
+Defold verwendet ähnlich wie Unity GLSL (die OpenGL Shading Language) für Shader: `Vertex Programs` und `Fragment Programs`. Obwohl Defold keinen Shader Graph wie Unity bietet (was ein Nachteil sein kann), kannst du durch das Schreiben von Code trotzdem entsprechende Shader erstellen.
+
+Lies mehr über Shader im [Shader-Handbuch](/manuals/shader).
+
+#### Materialien {#materials}
+
+Defold verwendet das Konzept `Material`, das `.fp`- und `.vp`-Shader, Sampler (Texturen) und weitere Dinge wie Vertex-Attribute oder Konstanten verbindet.
+
+Lies mehr über Materialien im [Materialhandbuch](/manuals/material).
+
+---
+
+## Nachrichtensystem {#messaging-system}
+
+In Defold halten Objekte keine direkten Referenzen aufeinander. Es gibt kein `GetComponent`, keine objektübergreifenden Methodenaufrufe zwischen Skripten und keinen globalen Szenenzugriff wie in Unity.
+
+Stattdessen kommunizieren Skripte über Nachrichtenübermittlung: Du sendest Nachrichten an andere Skripte, anstatt Methoden aufzurufen oder direkt auf Komponenten zuzugreifen. Was diese Objekte mit den Nachrichten tun, entscheiden sie selbst.
+
+Das kann sich anfangs ungewohnt anfühlen, fördert aber lose Kopplung und verringert enge gegenseitige Abhängigkeiten.
+
+
+### Eine Nachricht senden {#sending-a-message}
+
+In Unity sieht die Kommunikation normalerweise so aus:
+
+```c#
+var enemy = GameObject.Find("Enemy");
+enemy.GetComponent<EnemyAI>().TakeDamage(10);
+```
+
+Objekte können also direkt aufeinander verweisen und Methoden in anderen Skripten aufrufen. Alles befindet sich in einem gemeinsamen Szenenraum.
+
+In Defold sendest du eine Nachricht von einem Skript an ein anderes Skript (oder eine andere Komponente):
+
+```lua
+msg.post("#my_component", "my_message", { my_name = "Defold" })
+```
+
+Und du kannst diese Nachrichten im Skript verarbeiten:
+
+```lua
+function on_message(self, message_id, messsage)
+    if message_id == hash("my_message") then
+        print("Hello ", message.my_name)
+    end
+end
+```
+
+Ignoriere `#` und `hash` vorerst, darauf kommen wir später zurück. Der Rest sollte verständlich sein. Du kannst eine Nachricht an jede Komponente (sogar an dasselbe Skript) eines beliebigen instanziierten Spielobjekts senden.
+
+#### Andere Komponenten als Skripte {#components-other-than-scripts}
+
+Manchmal sendest du Nachrichten beispielsweise an Komponenten vom Typ `Sprite` oder `Collision`, um sie etwa zu aktivieren oder zu deaktivieren. Manchmal senden `Components` Nachrichten an dein Skript, zum Beispiel bei einer Kollision, damit du sie verarbeiten kannst. Defold verwendet intern dasselbe Nachrichtensystem für Engine-Ereignisse und Gameplay-Kommunikation. 
+
+Das Nachrichtensystem ähnelt etwas Unitys SendMessage oder Ereignissystemen, allerdings unterscheiden sich die Adressierung und die Konventionen.
+
+Weitere Informationen findest du im [Handbuch zur Nachrichtenübermittlung](/manuals/message-passing/).
+
+### Adressierung {#addressing}
+
+Objekte und Komponenten in Defold werden durch Adressen identifiziert, die als URLs bezeichnet werden.
+
+Jedes instanziierte Objekt und jede Komponente hat eine eigene eindeutige Adresse, und du musst keinen Szenengraphen durchlaufen, um sie zu finden. Dadurch ist die Adressierung explizit und direkt.
+
+Eine einfache URL in Defold könnte so aussehen:
+```lua
+"/player"
+```
+
+Dies ist *konzeptionell* ähnlich wie:
+```c#
+GameObject.Find("player")
+```
+
+Nun erklären wir, warum `"/"` oder `"#"` in Adressen verwendet wurden.
+
+Eine Defold-URL besteht ähnlich wie eine [URL](https://en.wikipedia.org/wiki/URL) aus drei Teilen:
+
+```yaml
+socket: /path #fragment
+```
+
+Oder stärker an Defolds Bezeichnungen angelehnt:
+
+```yaml
+collection: /gameobject #component 
+```
+Die Leerzeichen in den obigen Beschreibungen dienen nur dazu, diese 3 Teile optisch zu trennen.
+
+Vereinfacht gesagt:
+1. `collection:` identifiziert den Sammlungskontext, mit `:` am Ende.
+2. `/path` identifiziert das Spielobjekt, mit `/` vor der ID.
+3. `#fragment` identifiziert die bestimmte Komponente an diesem Objekt (etwa eine Skript-, Sprite- oder Kollisionskomponente), mit `#` vor der ID.
+
+#### Statische Adresse {#static-address}
+
+Diese Bezeichner werden beim Erstellen des jeweiligen Elements festgelegt und ändern sich nie, auch wenn du die Eltern-Kind-Beziehungen änderst. Du kannst sie in Dateien über die Eigenschaft `Id` festlegen oder erhältst sie zur Laufzeit beim Instanziieren durch Aufrufe von `factory.create` oder `collectionfactory.create`.
+
+#### Relative Adressierung {#relative-addressing}
+
+Du musst nicht immer eine vollständige URL verwenden.
+
+Wenn du Nachrichten innerhalb derselben Sammlung (derselben *Welt*) sendest, kannst du den Socket-Teil weglassen:
+
+```yaml
+/gameobject #component
+```
+Wenn du an eine Komponente innerhalb desselben Spielobjekts sendest, kannst du auch den Spielobjekt-Teil weglassen:
+
+```yaml
+#component
+```
+
+Zwei nützliche Kurzformen sind:
+- `#` zum Senden an diese *Skriptkomponente*
+- `.` zum Senden an alle Komponenten in diesem *Spielobjekt*
+
+Mit relativer Adressierung und Kurzformen kannst du URLs schreiben, die in unterschiedlichen Kontexten und Spielobjekten wiederverwendbar sind, ohne vollständige Pfade anzugeben.
+
+### Nachrichten an GUI und Rendering {#messaging-to-gui-and-render}
+
+Da Defold die GUI-Welt von der Welt der Spielobjekte trennt, kannst du auch Nachrichten aus den `.scripts` deiner Spielobjekte an `.gui_scripts` senden.
+
+Du kannst außerdem Nachrichten an spezielle Systemnamensräume senden, indem du einen Bezeichner verwendest, der mit `@` beginnt. Das Render-System lässt sich beispielsweise über `@render`: adressieren. Damit kannst du bestimmte integrierte Rendering-Funktionen steuern, etwa die Projektion im Standard-Render-Skript ändern:
+
+```lua
+msg.post("@render:", "use_stretch_projection", { near = -1, far = 1 })
+```
+
+Weitere Informationen findest du im [Handbuch zur Adressierung](/manuals/addressing/).
+
+---
+
+## Prefabs und Instanzen {#prefabs-and-instances}
+
+Unity kann alles in der Szene statisch oder dynamisch instanziieren, und Defold kann das ebenfalls. In Unity nimmst du ein Prefab und rufst `Instantiate(prefab)` auf. In Defold stehen dir 3 Komponenten zum Instanziieren von Inhalten zur Verfügung:
+
+- `Factory` - instanziiert ein **einzelnes Spielobjekt** aus einem vorgegebenen Prototyp: einer `*.go`-Datei (Prefab).
+- `Collection Factory` - instanziiert eine **Gruppe von Spielobjekten** mit Eltern-Kind-Beziehungen aus einem vorgegebenen Prototyp: einer `*.collection`-Datei.
+- `Collection Proxy` - **lädt** und instanziiert eine neue *Welt* aus einer `*.collection`-Datei.
+
+### Fabrik {#factory}
+
+Sobald du eine Komponente vom Typ `Factory` definiert und ihre Eigenschaft `Prototype` auf die passende Spielobjektdatei gesetzt hast, genügt zum Erzeugen einer Instanz folgender Codeaufruf:
+
+```lua
+factory.create("#my_factory")
+```
+
+Dieser verwendet die Adresse der Komponente, in diesem Fall einen relativen Pfad mit dem Bezeichner `"#my_factory"`.
+
+Er gibt den Bezeichner der neu erstellten Instanz zurück. Wenn du ihn später verwenden möchtest, lohnt es sich daher, ihn in einer Variablen zu speichern:
+
+```lua
+local new_instance_id = factory.create("#my_factory")
+```
+
+Denk daran, dass du Objekte in Defold nicht manuell in Pools verwalten musst. Die Engine übernimmt das Pooling intern für dich.
+
+Weitere Informationen findest du im [Handbuch zu Fabriken](/manuals/factory/). 
+
+### Sammlungsfabrik {#collection-factory}
+
+Der Unterschied zwischen den Komponenten `Factory` und `Collection Factory` besteht darin, dass eine Sammlungsfabrik **mehrere** Spielobjekte gleichzeitig erzeugen und beim Erstellen die Eltern-Kind-Beziehungen entsprechend der `*.collection`-Datei festlegen kann.
+
+Diese Unterscheidung gibt es in Unity nicht; es hat kein eigenes Konzept, das Defolds Sammlungsfabrik entspricht. Die ähnlichste Entsprechung ist ein verschachteltes Prefab, das eine Hierarchie von Objekten enthält.
+
+Sie gibt eine **Tabelle** mit den IDs aller erzeugten Instanzen zurück:
+
+```lua
+local spawned_instances = collectionfactory.create("#my_collectionfactory")
+```
+
+Weitere Informationen findest du im [Handbuch zu Sammlungsfabriken](/manuals/collection-factory/).
+
+#### Benutzerdefinierte Eigenschaften von Instanzen {#custom-properties-of-instances}
+
+Beim Aufruf von `factory.create()` oder `collectionfactory.create()` kannst du auch optionale Parameter wie Position, Drehung, Skalierung und Skripteigenschaften angeben. So kannst du genau steuern, wie und wo die Instanz erscheint und wie sie sich verhält, zum Beispiel:
+
+```lua
+local scale_2d = vmath.vector3(0.5, 0.5, 1.0)
+factory.create("#my_factory", my_position, my_rotation, my_properties, scale_2d)
+```
+
+Bei den optionalen Argumenten stehen die Eigenschaften vor der Skalierung. Verwende einen `vector3`, dessen Z-Wert ausdrücklich auf `1.0` gesetzt ist, wenn du nur die X- und Y-Achse eines 2D-Objekts skalierst; ein numerischer Skalierungsfaktor wird gleichmäßig auf alle drei Achsen angewendet.
+
+#### Dynamisches Laden {#dynamic-loading}
+
+Sowohl in Komponenten vom Typ `Factory` als auch vom Typ `Collection Factory` kannst du einen Prototyp für das dynamische Laden von Ressourcen markieren. Seine umfangreichen Assets werden dann nur bei Bedarf in den Speicher geladen und entladen, wenn sie nicht mehr verwendet werden.
+
+Weitere Informationen findest du im [Handbuch zur Ressourcenverwaltung](/manuals/resource/). 
+
+### Sammlungs-Proxy {#collection-proxy}
+
+Der `Collection Proxy` verweist auf eine bestimmte `*.collection`-Datei. Statt die Objekte wie Fabriken in die *aktuelle Welt* einzufügen, **lädt und instanziiert er eine neue Spielwelt**. Das ähnelt dem Laden einer vollständigen Szene in Unity, allerdings mit strikterer Trennung.
+
+In Unity könntest du eine additive Szene so laden:
+
+```c#
+SceneManager.LoadSceneAsync("Level2", LoadSceneMode.Additive);
+```
+
+In Defold lädst du die neue Sammlung, indem du einfach eine Nachricht an die Komponente `Collection Proxy` sendest:
+
+```lua
+msg.post("#myproxy", "load")
+```
+
+1. Wenn du dem Proxy die Nachricht `"load"` sendest (oder `"async_load"` zum asynchronen Laden), weist die Engine Speicher für eine neue Welt zu, instanziiert dort alles aus dieser Sammlung und hält die Welt isoliert.
+2. Nach dem Laden sendet der Proxy eine Nachricht `"proxy_loaded"` zurück, die anzeigt, dass die Welt bereit ist.
+3. Anschließend sendest du normalerweise die Nachrichten `"init"` und `"enable"`, damit die Objekte in dieser neuen Welt ihren normalen Lebenszyklus beginnen.
+
+Für die Kommunikation zwischen den geladenen Welten musst du explizite Nachrichtenübermittlung mit URLs verwenden, die den Weltnamen enthalten (`collection:`, den ersten Teil der URL).
+
+Diese Isolation kann bei der Implementierung von Levelübergängen, Minispielen oder großen modularen Systemen ein großer Vorteil sein: Sie verhindert unbeabsichtigte Interaktionen und ermöglicht bei Bedarf außerdem eine separate Steuerung des zeitlichen Ablaufs der Aktualisierungen (z. B. für Pausen oder Zeitlupe).
+
+Wenn du in Unity schon einmal mehrere Szenen verwendet hast, die sich unabhängig voneinander verhalten mussten, kannst du dir einen `Collection Proxy` als Möglichkeit vorstellen, dieses Konzept direkt in Defold umzusetzen.
+
+Weitere Informationen findest du im [Handbuch zu Sammlungs-Proxys](/manuals/collection-proxy/).
+
+---
+
+## Anwendungslebenszyklus {#application-lifecycle}
+
+Du kennst bereits eine Reihe von Unity-Lebenszyklusereignissen: `Awake`, `Start`, `Update`, `FixedUpdate`, `LateUpdate`, `OnDestroy` oder `OnApplicationQuit`.
+
+Defold hat ebenfalls einen klar definierten Anwendungslebenszyklus, aber die Konzepte und Begriffe unterscheiden sich. Defold stellt die Lebenszyklusphasen über eine Reihe vordefinierter Lua-Callbacks bereit, die von der Engine während der Initialisierung, in jedem Frame und bei der Finalisierung aufgerufen werden.
+
+Hier ein Vergleich:
+
+| Defold | Unity | Anmerkung |
+|-|-|-|
+| `init()` | `Awake()` / `Start()` / `OnEnable()`| Defold hat einen einzigen Einstiegspunkt und Callback für die Initialisierung: init(). Er wird beim Erstellen jeder Komponente aufgerufen. |
+| `on_input` | Eingabemethoden | Defold empfängt Eingaben, wenn [der Eingabefokus für das Skript gesetzt ist](/manuals/input/#input-focus). Wird in der Aktualisierungsschleife zuerst verarbeitet. |
+| `fixed_update()` | `FixedUpdate()` | Wird mit festem Zeitschritt aufgerufen. Um dies in Defold zu aktivieren, musst du `Use Fixed Timestep` einschalten; siehe [Details](https://defold.com/manuals/project-settings/#use-fixed-timestep). Seit 1.12.0 wird es vor `update()` ausgeführt. |
+| `update()` | `Update()` | Wird einmal pro Frame mit der Zeitdifferenz aufgerufen. |
+| `late_update()` | `LateUpdate()` | Wird nach `update()` aufgerufen, unmittelbar bevor der Frame gerendert wird. Seit 1.12.0 verfügbar. |
+| `on_message` | Nachrichtenempfänger | Defolds zentraler Callback zum Empfangen von Nachrichten. Wird verarbeitet, wenn sich eine Nachricht in einer Warteschlange befindet. |
+| `final` | `OnDisable` / `OnDestroy` / `OnApplicationQuit` | Defold ruft den Callback `final()` für jede Komponente auf, wenn ihr Spielobjekt zur Laufzeit zerstört wird (mit `go.delete()`) oder die Welt/Sammlung entladen wird, und beim Beenden der Anwendung für alle verbleibenden Objekte. |
+
+::: sidenote
+Denk daran, dass Defold keine Ausführungsreihenfolge zwischen Komponenten garantiert, wenn mehrere gleichzeitig initialisiert/aktualisiert/entfernt werden. Ein entkoppelter Aufbau wird empfohlen.
+:::
+
+### Initialisierung {#initialization}
+
+Stell dir Defolds `init()` so vor, dass es Elemente von Unitys `Awake()`, `Start()` und `OnEnable()` in einem einzigen Einstiegspunkt vereint. Dort hat die Engine bereits alles eingerichtet, und du kannst den Zustand deiner Komponente sicher vorbereiten.
+
+### Wann werden Nachrichten verarbeitet? {#when-messages-are-handled}
+
+Da du bereits in `init()` Nachrichten senden kannst, werden Nachrichten erstmals direkt nach der Initialisierung zugestellt.
+
+Anschließend werden Nachrichten nach jeder internen Verarbeitungsschleife verarbeitet, sobald sich etwas in einer Warteschlange befindet. Daher kann `on_message()` zum Beispiel auch mehrmals in einer Aktualisierungsschleife aufgerufen werden.
+
+### Aktualisierungsschleife {#update-loop}
+
+In jedem Frame durchläuft Defold eine Folge von Vorgängen: Eingaben verarbeiten, Nachrichten zustellen, Skript- und GUI-Aktualisierungen auslösen, Physik und Transformationen anwenden und zum Schluss die Grafik rendern.
+
+### Finalisierung {#finalization}
+
+In Defold ist das Aufräumen immer an das Löschen oder Entladen der Welt gebunden, und der einzige Ausstiegspunkt pro Komponente ist `final()`.
+
+Ein subtiler Unterschied zum Modell von Unity besteht darin, dass nicht zwischen dem Deaktivieren einer Komponente und dem Beenden der gesamten Anwendung unterschieden wird.
+
+### Rendering
+
+Das Render-Skript (`*.render_script`) ist ein Teil der Rendering-Pipeline, der mit eigenen Callbacks für `init()`, `update()` und `on_message()` ebenfalls am Lebenszyklus teilnimmt. Diese laufen jedoch im Render-Thread und sind von der Logik der Spielobjekt- und GUI-Skripte getrennt.
+
+Weitere Informationen findest du im [Handbuch zum Anwendungslebenszyklus](/manuals/application-lifecycle/).
+
+---
+
+## GUI
+
+Defolds GUI ist ein einziges eigenständiges Framework für Benutzeroberflächen: Menüs, Overlays, Dialoge und andere Elemente, ähnlich wie UI Toolkit oder uGUI mit Canvas.
+
+GUI ist eine Komponente und von Spielobjekten und Sammlungen getrennt. Anstelle von Spielobjekten arbeitest du mit GUI-Knoten, die in einer Hierarchie angeordnet sind und von einem GUI-Skript gesteuert werden.
+
+### GUI-Knoten {#gui-nodes}
+
+Wenn du in Defold eine Komponentendatei vom Typ `*.gui` öffnest, siehst du eine Zeichenfläche, auf der du `"GUI-Knoten"` platzierst. Dies sind die Bausteine der GUI. Du kannst GUI-Knoten der folgenden Typen hinzufügen:
+
+- Box (rechteckige Form mit einer Textur)
+- Text (mit beliebiger Schriftart)
+- Pie (radial gefülltes Kreissektorelement mit einer Textur)
+- ParticleFX
+- Template (eine weitere vollständige verschachtelte `.gui`-Datei, ähnlich einem GUI-Prefab)
+- und Spine-Knoten, wenn du die Spine-Erweiterung verwendest.
+
+### GUI-Skript {#gui-script}
+
+GUI-Komponenten haben eine spezielle Eigenschaft für GUI-Skripte: Du weist jeder Komponente eine `*.gui_script`-Datei zu, mit der sich das Verhalten der Komponente ändern lässt. Das ähnelt gewöhnlichen Skripten, allerdings wird nicht der Namensraum `go.*` verwendet (der für Spielobjekt-Skripte vorgesehen ist). Stattdessen wird die API des speziellen Namensraums `gui.*` verwendet, die nur innerhalb von GUI-Skripten (`*.gui_script`) funktioniert. Du kannst dir das wie eine separate Szene vorstellen. Unity UI (uGUI) mit Canvas.
+
+### GUI-Rendering
+
+GUI-Elemente werden unabhängig von der Spielkamera gerendert, üblicherweise im Bildschirmkoordinatensystem. Dieses Verhalten lässt sich jedoch in benutzerdefinierten Rendering-Pipelines ändern.
+
+Weitere Informationen findest du im [GUI-Handbuch](/manuals/gui/).
+
+## Wo sind die Sorting Layers? {#where-are-sorting-layers}
+
+Dies ist eine sehr häufige Ursache für Verwirrung beim Umstieg von Unity.
+
+GUI-Komponenten haben `Layers`, was fast genauso funktioniert wie „Sorting Layers“ in Unity. Für andere Komponenten wie `Sprites`, `Tilemaps`, `Models` usw. gibt es aber keine direkte Entsprechung.
+
+Stattdessen kombinierst du normalerweise:
+- Eine feine Sortierung über die Z-Achse bei Verwendung einer Standardkamera oder über die Tiefe bei Verwendung einer Kamerakomponente.
+- Eine grobe Sortierung über das Render-Skript mit Render-Prädikaten, um anhand von Material-Tags auszuwählen, was gezeichnet werden soll.
+
+Du solltest Unitys Sorting Layers jedoch nicht mit vielen Tags nachahmen, da Tags in Defold ein Mechanismus auf Rendering-Ebene sind. Übermäßige Verwendung kann die Bündelung von Zeichenoperationen (Batching) verhindern und den zusätzlichen Aufwand beim Zeichnen erhöhen.
+
+---
+
+## Wie geht es weiter? {#where-to-go-from-here}
+
+- [Defold-Beispiele](/examples)
+- [Tutorials](/tutorials)
+- [Handbücher](/manuals)
+- [API-Referenzen](/ref/go)
+- [FAQ](/faq/faq)
+
+Wenn du Fragen hast oder nicht weiterkommst, sind das [Defold-Forum](//forum.defold.com) oder [Discord](https://defold.com/discord/) gute Anlaufstellen für Hilfe.

--- a/docs/de/manuals/version-control.md
+++ b/docs/de/manuals/version-control.md
@@ -1,0 +1,22 @@
+---
+title: Versionsverwaltung
+brief: Dieses Handbuch beschreibt, wie du Git mit Defold-Projekten verwendest und lokale Änderungen im Editor überprüfst.
+---
+
+# Versionsverwaltung {#version-control}
+
+Defold-Projekte lassen sich gut mit [Git](https://git-scm.com) verwenden, die Synchronisierung erfolgt jedoch außerhalb des Editors. Verwende deinen bevorzugten Git-Client oder die Befehlszeile zum Klonen sowie für fetch, pull, commit, push, das Erstellen von Branches und das Lösen von Konflikten.
+
+## Geänderte Dateien {#changed-files}
+
+Wenn das Projektverzeichnis das Stammverzeichnis eines Git-Worktrees mit mindestens einem Commit ist, listet Defold im Editorbereich *Changed Files* nicht ignorierte Dateien auf, die als hinzugefügt, geändert, gelöscht oder umbenannt erkannt wurden. Defold ermittelt diese Einträge durch einen direkten Vergleich der Dateien auf dem Datenträger mit dem aktuellen Commit (`HEAD`), sodass das Vormerken einer Änderung im Index die Liste nicht verändert. Löse Merge-Konflikte in einem externen Git-Client.
+
+![Geänderte Dateien](images/workflow/changed_files.png)
+
+Wähle genau eine geänderte oder umbenannte Datei aus und klicke auf <kbd>Diff</kbd>, um ihre Textunterschiede anzuzeigen. Klicke auf <kbd>Revert</kbd>, um die ausgewählten Änderungen im Worktree und im Index zu verwerfen. Nachverfolgte Dateien werden auf den Stand von `HEAD` zurückgesetzt; Dateien, die in `HEAD` fehlen, werden gelöscht, unabhängig davon, ob sie als neu hinzugefügte Dateien im Index vorgemerkt sind; bei Umbenennungen wird der neue Pfad gelöscht und der alte Pfad wiederhergestellt. Dies kann im Editor nicht rückgängig gemacht werden. Erstelle daher einen Commit oder eine Sicherungskopie von Arbeit, die du möglicherweise noch benötigst.
+
+## Git
+
+Git speichert die textbasierten Projektdateien von Defold effizient. Häufige Änderungen an großen binären Assets, etwa PSD-Dateien oder Dateien aus der Audioproduktion, können den Verlauf des Repositorys dennoch schnell anwachsen lassen. Ziehe für große Arbeitsdateien Git LFS oder eine separate Speicher- und Sicherungslösung in Betracht.
+
+Der Bereich *Changed Files* bietet ausschließlich lokale Funktionen zum Anzeigen des Status und von Unterschieden sowie zum Verwerfen von Änderungen. Er weiß nicht, ob Commits bereits an ein entferntes Repository übertragen wurden, und führt weder fetch noch pull, commit oder push aus. Führe diese Vorgänge in einem externen Git-Client oder über die Befehlszeile aus. Standardmäßig lädt Defold externe Änderungen neu und aktualisiert den Bereich, sobald die Anwendung wieder den Fokus erhält. Wenn *Load External Changes on App Focus* deaktiviert ist, wähle *File ▸ Load External Changes*.

--- a/docs/de/manuals/websocket-connections.md
+++ b/docs/de/manuals/websocket-connections.md
@@ -1,0 +1,5 @@
+---
+title: WebSocket-Verbindungen
+brief: Dieses Handbuch erklärt, wie du WebSocket-Verbindungen verwendest.
+---
+Verschoben in das [Handbuch zur WebSocket-Erweiterung](/extension-websocket).

--- a/docs/de/manuals/webview.md
+++ b/docs/de/manuals/webview.md
@@ -1,0 +1,6 @@
+---
+title: WebViews in Defold
+brief: Mit WebViews kannst du Webseiten laden und als Einblendungen in deinen Spielen anzeigen. Außerdem können sie von dir bereitgestellten JavaScript-Code im Hintergrund ausführen. Dieses Handbuch erläutert die offizielle WebView-Erweiterung von Defold, ihre API und ihre Funktionen.
+---
+
+Die WebView-Dokumentation [wurde verschoben](/extension-webview).

--- a/docs/de/manuals/windows.md
+++ b/docs/de/manuals/windows.md
@@ -1,0 +1,43 @@
+---
+title: Defold-Entwicklung für die Windows-Plattform
+brief: Dieses Handbuch beschreibt, wie du unter Windows Builds von Defold-Anwendungen erstellst und diese ausführst
+---
+
+# Entwicklung für Windows {#windows-development}
+
+Die Entwicklung von Defold-Anwendungen für die Windows-Plattform ist unkompliziert und erfordert nur wenige besondere Überlegungen.
+
+## Projekteinstellungen {#project-settings}
+
+Die Windows-spezifische Konfiguration der Anwendung erfolgt im [Windows-Abschnitt](/manuals/project-settings/#windows) der Einstellungsdatei *game.project*.
+
+## Anwendungssymbol {#application-icon}
+
+Das Anwendungssymbol für ein Windows-Spiel muss im .ico-Format vorliegen. Du kannst mit einem Online-Werkzeug wie [ICOConvert](https://www.icoconverter.com/) oder [AConvert](https://www.aconvert.com/icon/png-to-ico/) ganz einfach eine .ico-Datei aus einer .png-Datei erstellen. Lade ein Bild hoch und verwende mindestens die folgenden Symbolgrößen: 16x16, 24x24, 32x32, 48x48, 256x256.
+
+Quelle: [Microsoft - Erstellen von Windows-Anwendungssymbolen](https://learn.microsoft.com/en-us/windows/apps/design/style/iconography/app-icon-construction#icon-sizes-win32)
+
+### Eine .ico-Datei lokal mit der Softwaresammlung ImageMagick erstellen. {#creating-ico-file-locally-using-imagemagick-software-suite}
+[ImageMagick](https://www.imagemagick.org/) ist eine kostenlose Open-Source-Softwaresammlung zum Bearbeiten und Verändern digitaler Bilder.
+
+1. Installiere ImageMagick
+  * Linux: Installiere es mit `apt`
+```
+sudo apt install imagemagick
+```
+  * Windows: Lade es von [https://imagemagick.org/script/download.php#windows](https://imagemagick.org/script/download.php#windows) herunter:
+  * macOS: Installiere es mit `brew`:
+```
+brew install imagemagick
+```
+
+2. Bereite dein PNG-Symbol vor.
+3. Wandle die PNG-Datei mit dem Werkzeug [convert](https://www.imagemagick.org/script/convert.php) in eine ICO-Datei um:
+```bash
+magick icon_256x256px.png -compress None -define icon:auto-resize=256,128,96,64,48,32,24,16 favicon.ico
+```
+
+
+
+## FAQ
+:[Windows FAQ](../shared/windows-faq.md)

--- a/docs/de/manuals/working-offline.md
+++ b/docs/de/manuals/working-offline.md
@@ -1,0 +1,55 @@
+---
+title: Offline arbeiten
+brief: Dieses Handbuch beschreibt, wie du in Projekten mit Abhängigkeiten und insbesondere nativen Erweiterungen offline arbeitest.
+---
+
+# Offline arbeiten {#working-offline}
+
+Defold benötigt in den meisten Fällen keine Internetverbindung, um zu funktionieren. In einigen Situationen ist jedoch eine Internetverbindung erforderlich:
+
+* Automatische Updates
+* Probleme melden
+* Abhängigkeiten herunterladen
+* Builds für native Erweiterungen erstellen
+
+
+## Automatische Updates {#automatic-updates}
+
+Defold prüft regelmäßig, ob neue Updates verfügbar sind. Dazu fragt Defold die [offizielle Download-Seite](https://d.defold.com) ab. Wenn ein Update gefunden wird, wird es automatisch heruntergeladen.
+
+Wenn du nur zeitweise eine Internetverbindung hast und nicht warten möchtest, bis das automatische Update startet, kannst du neue Versionen von Defold manuell von der [offiziellen Download-Seite](https://d.defold.com) herunterladen.
+
+
+## Probleme melden {#reporting-issues}
+
+Wenn im Editor ein Problem erkannt wird, kannst du es an die Problemverwaltung von Defold melden. Die Problemverwaltung wird [auf GitHub gehostet](https://www.github.com/defold/editor2-issues), sodass du eine Internetverbindung benötigst, um das Problem zu melden.
+
+Wenn du offline auf ein Problem stößt, kannst du es später manuell über die [Option Report Issue im Menü Help](/manuals/getting-help/#report-a-problem-from-the-editor) des Editors melden.
+
+
+## Abhängigkeiten herunterladen {#fetching-dependencies}
+
+Defold unterstützt ein System, mit dem Entwickler Code und Assets über sogenannte [Bibliotheksprojekte (Library Projects)](/manuals/libraries/) teilen können. Bibliotheken sind ZIP-Dateien, die überall im Internet gehostet werden können. Du findest Defold-Bibliotheksprojekte üblicherweise auf GitHub und in anderen Online-Repositorys für Quellcode.
+
+Du kannst eine Bibliothek als [Projektabhängigkeit in den Projekteinstellungen](/manuals/project-settings/#dependencies) hinzufügen. Abhängigkeiten werden heruntergeladen oder aktualisiert, wenn das Projekt geöffnet wird oder wenn du die Option *Fetch Libraries* im Menü *Project* auswählst.
+
+Wenn du offline und in mehreren Projekten arbeiten musst, kannst du Abhängigkeiten im Voraus herunterladen und sie anschließend über einen lokalen Server gemeinsam nutzen. Abhängigkeiten auf GitHub findest du üblicherweise auf der Registerkarte Releases des Projekt-Repositorys:
+
+![URL einer Bibliothek auf GitHub](images/libraries/libraries_library_url_github.png)
+
+Mit Python kannst du ganz einfach einen lokalen Server erstellen:
+
+    python -m SimpleHTTPServer
+
+Dadurch wird im aktuellen Verzeichnis ein Server erstellt, der Dateien unter `localhost:8000` bereitstellt. Wenn das aktuelle Verzeichnis heruntergeladene Abhängigkeiten enthält, kannst du sie deiner Datei *game.project* hinzufügen:
+
+    http://localhost:8000/extension-fbinstant-4.1.1.zip
+
+
+## Builds für native Erweiterungen erstellen {#building-native-extensions}
+
+Defold unterstützt ein System namens [native Erweiterungen (Native Extensions)](/manuals/extensions/), mit dem Entwickler nativen Code hinzufügen können, um die Funktionalität der Engine zu erweitern. Mit einer cloudbasierten Build-Lösung ermöglicht Defold den Einstieg in native Erweiterungen ohne Einrichtungsaufwand.
+
+Wenn du zum ersten Mal einen Build eines Projekts erstellst und das Projekt eine native Erweiterung enthält, wird der native Code auf den Build-Servern von Defold zu einer angepassten Game-Engine von Defold kompiliert und an deinen PC zurückgesendet. Die angepasste Engine wird in deinem Projekt zwischengespeichert und für nachfolgende Builds wiederverwendet, solange du keine nativen Erweiterungen hinzufügst, entfernst oder änderst und den Editor nicht aktualisierst.
+
+Wenn du offline arbeiten musst und dein Projekt native Erweiterungen enthält, musst du sicherstellen, dass du mindestens einmal erfolgreich einen Build erstellst, damit dein Projekt eine zwischengespeicherte Kopie der angepassten Engine enthält.

--- a/docs/de/manuals/writing-code.md
+++ b/docs/de/manuals/writing-code.md
@@ -1,0 +1,93 @@
+---
+title: Code schreiben
+brief: Dieses Handbuch gibt einen kurzen Überblick über die Arbeit mit Code in Defold.
+---
+
+# Code schreiben {#writing-code}
+
+Defold ermöglicht dir zwar, viele Spielinhalte mit visuellen Werkzeugen wie den Editoren für Kachelkarten (tile maps) und Partikeleffekte zu erstellen, deine Spiellogik schreibst du jedoch weiterhin in einem Code-Editor. Die Spiellogik wird in der [Programmiersprache Lua](https://www.lua.org/) geschrieben, während Erweiterungen der Engine selbst in den nativen Programmiersprachen der Zielplattform geschrieben werden.
+
+## Lua-Code schreiben {#writing-lua-code}
+
+Defold verwendet Lua 5.1 und LuaJIT (je nach Zielplattform). Beim Schreiben deiner Spiellogik musst du die Sprachspezifikation dieser jeweiligen Lua-Versionen einhalten. Weitere Einzelheiten zur Arbeit mit Lua in Defold findest du in unserem [Handbuch zu Lua in Defold](/manuals/lua).
+
+## Andere Sprachen verwenden, die nach Lua transpilieren {#using-other-languages-that-transpile-to-lua}
+
+Defold unterstützt Transpiler, die Lua-Code erzeugen. Wenn eine Transpiler-Erweiterung installiert ist, kannst du alternative Sprachen wie [Teal](https://github.com/defold/extension-teal) verwenden, um statisch geprüften Lua-Code zu schreiben. Diese Vorschaufunktion hat Einschränkungen: Die derzeitige Transpiler-Unterstützung stellt keine Informationen über Module und Funktionen bereit, die in der Lua-Laufzeitumgebung von Defold definiert sind. Wenn du Defold-APIs wie `go.animate` verwenden möchtest, musst du die externen Definitionen dafür daher selbst schreiben.
+
+## Nativen Code schreiben {#writing-native-code}
+
+Defold ermöglicht dir, die Game-Engine mit nativem Code zu erweitern, um auf plattformspezifische Funktionen zuzugreifen, die die Engine selbst nicht bereitstellt. Du kannst nativen Code auch verwenden, wenn die Leistung von Lua nicht ausreicht (ressourcenintensive Berechnungen, Bildverarbeitung usw.). Weitere Informationen findest du in unseren [Handbüchern zu nativen Erweiterungen (native extensions)](/manuals/extensions/).
+
+## Den integrierten Code-Editor verwenden {#using-the-built-in-code-editor}
+
+Defold verfügt über einen integrierten Code-Editor, mit dem du Lua-Dateien (.lua), Defold-Skriptdateien (.script, .gui_script und .render_script) sowie alle anderen Dateien öffnen und bearbeiten kannst, deren Dateierweiterung der Editor nicht von Haus aus verarbeitet. Außerdem bietet der Editor Syntaxhervorhebung für Lua- und Skriptdateien.
+
+![](/images/editor/code-editor.png)
+
+### Codevervollständigung {#code-completion}
+
+Der integrierte Code-Editor zeigt beim Schreiben von Code Vorschläge zur Vervollständigung von Funktionen an:
+
+![](/images/editor/codecompletion.png)
+
+Wenn du <kbd>CTRL</kbd> + <kbd>Space</kbd> drückst, werden zusätzliche Informationen zu Funktionen, Argumenten und Rückgabewerten angezeigt:
+
+![](/images/editor/apireference.png)
+
+Der mitgelieferte Lua-Sprachserver enthält Typannotationen für die Defold-APIs. Die Vervollständigung, Informationen beim Überfahren mit dem Mauszeiger und die Diagnosefunktionen berücksichtigen Defold-Typen wie Hashwerte, URLs, Vektoren und Quaternionen sowie Funktionsargumente und Rückgabewerte. Der Editor stellt Annotationen für Spielskripte und für die `editor.*`-APIs bereit, die in `.editor_script`-Dateien verwendet werden. Wenn du den Code-Editor von Defold verwendest, benötigst du für die integrierten APIs keine separate Annotationsbibliothek.
+
+APIs von Erweiterungen Dritter benötigen möglicherweise eigene Annotationen.
+
+### Code formatieren {#formatting-code}
+
+Wähle <kbd>Edit ▸ Format Document/Selection</kbd> oder drücke <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd>, um den Formatierer des Sprachservers auszuführen. Wenn eine Auswahl vorhanden ist, formatiert der Editor die ausgewählten Zeilen; andernfalls formatiert er das Dokument. Dafür ist ein Sprachserver erforderlich, der den jeweiligen Formatierungsvorgang unterstützt.
+
+Um geänderte geöffnete Dateien beim Speichern zu formatieren, aktiviere **Format on save** unter <kbd>Preferences ▸ Code</kbd>. Diese Einstellung ist standardmäßig deaktiviert und erfordert einen Sprachserver, der die Formatierung von Dokumenten unterstützt. Siehe [Einstellungen für Code](/manuals/editor-preferences/#code).
+
+### Zu einem Symbol springen {#jump-to-symbol}
+
+Der integrierte Code-Editor kann eine durchsuchbare Liste der Symbole in der aktuellen Codedatei anzeigen, beispielsweise Funktionen, Objekte und Variablen. Wähle <kbd>View ▸ Jump to Symbol…</kbd> oder drücke unter Windows und Linux <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>O</kbd> beziehungsweise unter macOS <kbd>⌘ Cmd</kbd> + <kbd>Shift</kbd> + <kbd>O</kbd>.
+
+Beginne zu tippen, um die Symbole mit einer unscharfen Suche zu durchsuchen. Verwende die Pfeiltasten, um durch die Ergebnisse zu navigieren und ihre Positionen im Editor in der Vorschau zu sehen. Drücke anschließend <kbd>Enter</kbd>, um zum ausgewählten Symbol zu springen. Drücke <kbd>Esc</kbd>, um das Dialogfeld zu schließen und zur vorherigen Cursor- und Scrollposition zurückzukehren.
+
+![](/images/editor/jump-to-symbol.png)
+
+### Statische Codeprüfung konfigurieren {#linting-configuration}
+
+Der integrierte Code-Editor führt mit [Luacheck](https://luacheck.readthedocs.io/en/stable/index.html) und dem [Lua-Sprachserver](https://luals.github.io/wiki/diagnostics/) eine statische Codeprüfung durch. Um Luacheck zu konfigurieren, erstelle eine Datei namens `.luacheckrc` im Stammverzeichnis des Projekts. Eine Liste der verfügbaren Optionen findest du auf der [Seite zur Konfiguration von Luacheck](https://luacheck.readthedocs.io/en/stable/config.html). Defold verwendet die folgenden Standardeinstellungen für die Luacheck-Konfiguration:
+
+```lua
+unused_args = false      -- don't warn on unused arguments (common for .script files)
+max_line_length = false  -- don't warn on long lines
+ignore = {
+    "611",               -- line contains only whitespace
+    "612",               -- line contains trailing whitespace
+    "614"                -- trailing whitespace in a comment
+},
+```
+
+## Einen externen Code-Editor verwenden {#using-an-external-code-editor}
+
+Der Code-Editor in Defold bietet die grundlegenden Funktionen, die du zum Schreiben von Code benötigst. Für anspruchsvollere Anwendungsfälle oder wenn du als erfahrener Nutzer einen bevorzugten Code-Editor hast, kannst du Defold Dateien in einem externen Editor öffnen lassen. Im [Fenster Preferences auf der Registerkarte Code](/manuals/editor-preferences/#code) kannst du einen externen Editor festlegen, der zum Bearbeiten von Code verwendet werden soll.
+
+### Visual Studio Code - Defold Kit
+
+Defold Kit ist ein Plugin für Visual Studio Code mit den folgenden Funktionen:
+
+* Installation empfohlener Erweiterungen
+* Syntaxhervorhebung, automatische Vervollständigung und statische Codeprüfung für Lua
+* Anwendung relevanter Einstellungen auf den Arbeitsbereich
+* Lua-Annotationen für die Defold-API
+* Lua-Annotationen für Abhängigkeiten
+* Builds erstellen und starten
+* Debuggen mit Haltepunkten
+* Bundles für alle Plattformen erstellen
+* Bereitstellung auf verbundenen Mobilgeräten
+
+Weitere Informationen und die Möglichkeit, Defold Kit zu installieren, findest du im [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astronachos.defold).
+
+
+## Dokumentationssoftware {#documentation-software}
+
+Von der Community erstellte API-Referenzpakete sind für [Dash und Zeal](https://forum.defold.com/t/defold-docset-for-dash/2417) verfügbar.

--- a/docs/de/manuals/zerobrane.md
+++ b/docs/de/manuals/zerobrane.md
@@ -1,0 +1,99 @@
+---
+title: Debugging mit ZeroBrane Studio
+brief: Dieses Handbuch erklärt, wie du mit ZeroBrane Studio Lua-Code in Defold debuggen kannst.
+---
+
+# Lua-Skripte mit ZeroBrane Studio debuggen {#debugging-lua-scripts-with-zerobrane-studio}
+
+Defold enthält einen integrierten Debugger. Du kannst aber auch die kostenlose Open-Source-Lua-IDE _ZeroBrane Studio_ als externen Debugger verwenden. ZeroBrane Studio muss installiert sein, damit du die Debugging-Funktionen nutzen kannst. Das Programm ist plattformübergreifend und läuft sowohl unter macOS als auch unter Windows.
+
+Lade „ZeroBrane Studio“ von http://studio.zerobrane.com herunter
+
+## ZeroBrane konfigurieren {#zerobrane-configuration}
+
+Damit ZeroBrane die Dateien in deinem Projekt findet, musst du den Pfad zu deinem Defold-Projektverzeichnis angeben. Du kannst diesen Pfad bequem ermitteln, indem du bei einer Datei im Stammverzeichnis deines Defold-Projekts die Option <kbd>Show in Desktop</kbd> verwendest.
+
+1. Klicke mit der rechten Maustaste auf *game.project*
+2. Wähle <kbd>Show in Desktop</kbd>
+
+![Im Finder anzeigen](images/zerobrane/show_in_desktop.png)
+
+## ZeroBrane einrichten {#to-set-up-zerobrane}
+
+Um ZeroBrane einzurichten, wähle <kbd>Project ▸ Project Directory ▸ Choose...</kbd>:
+
+![Einrichtung](images/zerobrane/setup.png)
+
+Sobald du hier das Verzeichnis deines aktuellen Defold-Projekts eingestellt hast, solltest du den Verzeichnisbaum des Defold-Projekts in ZeroBrane sehen sowie darin navigieren und Dateien öffnen können.
+
+Weitere empfohlene, aber nicht erforderliche Konfigurationsänderungen findest du weiter unten in diesem Dokument.
+
+## Den Debugging-Server starten {#starting-the-debugging-server}
+
+Bevor du eine Debugging-Sitzung beginnst, musst du den in ZeroBrane integrierten Debugging-Server starten. Den Menüeintrag dafür findest du im Menü <kbd>Project</kbd>. Wähle <kbd>Project ▸ Start Debugger Server</kbd>:
+
+![Debugger starten](images/zerobrane/startdebug.png)
+
+## Deine Anwendung mit dem Debugger verbinden {#connecting-your-application-to-the-debugger}
+
+Du kannst das Debugging jederzeit während der Ausführung der Defold-Anwendung starten, musst es aber ausdrücklich aus einem Lua-Skript heraus einleiten. Der Lua-Code zum Starten einer Debugging-Sitzung sieht so aus:
+
+::: sidenote
+Wenn sich dein Spiel beim Aufruf von `dbg.start()` beendet, kann das daran liegen, dass ZeroBrane ein Problem erkannt hat und den Befehl zum Beenden an das Spiel sendet. Aus irgendeinem Grund muss in ZeroBrane eine Datei geöffnet sein, damit die Debugging-Sitzung gestartet werden kann. Andernfalls gibt ZeroBrane Folgendes aus:
+"Can't start debugging without an opened file or with the current file not being saved 'untitled.lua')."
+Öffne in ZeroBrane die Datei, in die du `dbg.start()` eingefügt hast, um diesen Fehler zu beheben.
+:::
+
+```lua
+dbg = require "builtins.scripts.mobdebug"
+dbg.start()
+```
+
+Wenn du den obigen Code in die Anwendung einfügst, verbindet sie sich mit dem Debugging-Server von ZeroBrane (standardmäßig über "localhost") und hält bei der nächsten auszuführenden Anweisung an.
+
+```txt
+Debugger server started at localhost:8172.
+Mapped remote request for '/' to '/Users/my_user/Documents/Projects/Defold_project/'.
+Debugging session started in '/Users/my_user/Documents/Projects/Defold_project'.
+```
+
+Jetzt kannst du die Debugging-Funktionen von ZeroBrane nutzen: Du kannst den Code schrittweise ausführen, Werte untersuchen, Haltepunkte hinzufügen und entfernen usw.
+
+::: sidenote
+Das Debugging wird nur für den Lua-Kontext aktiviert, aus dem es gestartet wird. Wenn du "shared_state" in *game.project* aktivierst, kannst du deine gesamte Anwendung debuggen, unabhängig davon, wo du das Debugging gestartet hast.
+:::
+
+![Schrittweise Ausführung](images/zerobrane/code.png)
+
+Falls der Verbindungsversuch fehlschlägt (möglicherweise weil der Debugging-Server nicht läuft), läuft deine Anwendung nach dem Verbindungsversuch wie gewohnt weiter.
+
+## Remote-Debugging
+
+Da das Debugging über gewöhnliche Netzwerkverbindungen (TCP) erfolgt, kannst du auch aus der Ferne debuggen. So kannst du deine Anwendung debuggen, während sie auf einem Mobilgerät läuft.
+
+Du musst dazu nur den Befehl ändern, der das Debugging startet. Standardmäßig versucht `start()`, eine Verbindung zu localhost herzustellen. Für das Remote-Debugging musst du jedoch die Adresse des Debugging-Servers von ZeroBrane manuell angeben, etwa so:
+
+```lua
+dbg = require "builtins.scripts.mobdebug"
+dbg.start("192.168.5.101")
+```
+
+Deshalb musst du sicherstellen, dass vom entfernten Gerät aus eine Netzwerkverbindung möglich ist und alle Firewalls oder ähnliche Programme TCP-Verbindungen über Port 8172 zulassen. Andernfalls kann die Anwendung beim Start hängen bleiben, wenn sie versucht, eine Verbindung zu deinem Debugging-Server herzustellen.
+
+## Weitere empfohlene ZeroBrane-Einstellung {#other-recommended-zerobrane-setting}
+
+Du kannst ZeroBrane so einstellen, dass es während des Debuggings Lua-Skriptdateien automatisch öffnet. Dadurch kannst du in Funktionen in anderen Quelldateien einsteigen, ohne diese Dateien manuell öffnen zu müssen.
+
+Öffne zunächst die Konfigurationsdatei des Editors. Es wird empfohlen, die benutzerspezifische Version dieser Datei zu ändern.
+
+- Wähle <kbd>Edit ▸ Preferences ▸ Settings: User</kbd>
+- Füge Folgendes zur Konfigurationsdatei hinzu:
+
+  ```txt
+  - to automatically open files requested during debugging
+  editor.autoactivate = true
+  ```
+
+- Starte ZeroBrane neu
+
+![Weitere empfohlene Einstellungen](images/zerobrane/otherrecommended.png)

--- a/docs/de/shared/android-adb.md
+++ b/docs/de/shared/android-adb.md
@@ -1,0 +1,33 @@
+Das Kommandozeilenwerkzeug `adb` ist ein einfach zu bedienendes und vielseitiges Programm, mit dem du mit Android-Geräten interagieren kannst. Du kannst `adb` als Teil der Android SDK Platform-Tools für Mac, Linux oder Windows herunterladen und installieren.
+
+Lade die Android SDK Platform-Tools hier herunter: https://developer.android.com/studio/releases/platform-tools. Das Werkzeug *adb* findest du unter */platform-tools/*. Alternativ kannst du plattformspezifische Pakete über die jeweiligen Paketmanager installieren.
+
+Unter Ubuntu Linux:
+
+```
+$ sudo apt-get install android-tools-adb
+```
+
+Unter Fedora 18/19:
+
+```
+$ sudo yum install android-tools
+```
+
+Unter macOS (Homebrew)
+
+```
+$ brew cask install android-platform-tools
+```
+
+Du kannst überprüfen, ob `adb` funktioniert, indem du dein Android-Gerät per USB mit deinem Computer verbindest und den folgenden Befehl ausführst:
+
+```
+$ adb devices
+List of devices attached
+31002535c90ef000    device
+```
+
+Wenn dein Gerät nicht angezeigt wird, prüfe, ob du *USB debugging* auf dem Android-Gerät aktiviert hast. Öffne auf dem Gerät *Settings* und suche nach *Developer options* (oder *Development*).
+
+![USB-Debugging aktivieren](images/android/usb_debugging.png)

--- a/docs/de/shared/android-faq.md
+++ b/docs/de/shared/android-faq.md
@@ -1,0 +1,30 @@
+#### Q: Kann ich die Navigations- und Statusleiste unter Android ausblenden? {#q-is-it-possible-to-hide-the-navigation-and-status-bars-on-android}
+A: Ja, aktiviere die Einstellung *immersive_mode* im Abschnitt *Android* deiner Datei *game.project*. Dadurch kann deine App den gesamten Bildschirm nutzen und alle Ereignisse für Berührungseingaben auf dem Bildschirm erfassen.
+
+
+#### Q: Warum erhalte ich „Failure [INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES]“, wenn ich ein Defold-Spiel auf einem Gerät installiere? {#q-why-am-im-getting-failure-install_parse_failed_inconsistent_certificates-when-installing-a-defold-game-on-device}
+A: Android erkennt, dass du versuchst, die App mit einem neuen Zertifikat zu installieren. Wenn du Bundles für Debug-Builds erstellst, wird jeder Build mit einem temporären Zertifikat signiert. Deinstalliere die alte App, bevor du die neue Version installierst:
+
+```
+$ adb uninstall com.defold.examples
+Success
+$ adb install Defold\ examples.apk
+4826 KB/s (18774344 bytes in 3.798s)
+      pkg: /data/local/tmp/Defold examples.apk
+Success
+```
+
+
+#### Q: Warum erhalte ich beim Erstellen eines Builds mit bestimmten Erweiterungen Fehlermeldungen zu widersprüchlichen Eigenschaften in AndroidManifest.xml? {#q-why-am-i-getting-errors-about-conflicting-properties-in-androidmanifestxml-when-building-with-certain-extensions}
+A: Das kann passieren, wenn zwei oder mehr Erweiterungen jeweils einen Stub eines Android-Manifests bereitstellen, der dasselbe property-Tag mit unterschiedlichen Werten enthält. Das ist beispielsweise bei Firebase und AdMob aufgetreten. Der Build-Fehler sieht etwa so aus:
+
+```
+SEVERE: /tmp/job4531953598647135356/upload/AndroidManifest.xml:32:13-58
+Error: Attribute property#android.adservices.AD_SERVICES_CONFIG@resource
+value=(@xml/ga_ad_services_config) from AndroidManifest.xml:32:13-58 is also
+present at AndroidManifest.xml:92:13-59 value=(@xml/gma_ad_services_config).
+Suggestion: add 'tools:replace="android:resource"' to <property> element at
+AndroidManifest.xml to override. 
+```
+
+Mehr über das Problem und die Übergangslösung erfährst du im gemeldeten Defold-Issue [#9453](https://github.com/defold/defold/issues/9453#issuecomment-2367367269) und im Google-Issue [#327696048](https://issuetracker.google.com/issues/327696048?pli=1).

--- a/docs/de/shared/apple-privacy-manifest.md
+++ b/docs/de/shared/apple-privacy-manifest.md
@@ -1,0 +1,8 @@
+
+## Datenschutzmanifest von Apple {#apple-privacy-manifest}
+
+Das Datenschutzmanifest ist eine Eigenschaftsliste, die die von deiner App oder einem SDK eines Drittanbieters erfassten Datenarten sowie die von deiner App oder dem SDK verwendeten APIs auflistet, deren Nutzung eine Begründung erfordert. Für jede erfasste Datenart und jede verwendete Kategorie solcher APIs muss deine App oder das SDK eines Drittanbieters die Gründe in der im Bundle enthaltenen Datenschutzmanifestdatei festhalten.
+
+Defold stellt über das Feld Privacy Manifest in der Datei *game.project* ein standardmäßiges Datenschutzmanifest bereit. Beim Erstellen eines Anwendungsbundles wird das Datenschutzmanifest mit allen Datenschutzmanifesten in den Projektabhängigkeiten zusammengeführt und in das Anwendungsbundle aufgenommen.
+
+Weitere Informationen zu Datenschutzmanifesten findest du in der [offiziellen Dokumentation von Apple](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files?language=objc).

--- a/docs/de/shared/blend-modes.md
+++ b/docs/de/shared/blend-modes.md
@@ -1,0 +1,13 @@
+Die Eigenschaft *Blend Mode* legt fest, wie die Grafik einer Komponente (component) mit der dahinterliegenden Grafik gemischt wird. Dies sind die verfügbaren Mischmodi und ihre Berechnungen:
+
+Alpha
+: Normale Mischung: `src.a * src.rgb + (1 - src.a) * dst.rgb`
+
+Add
+: Hellt den Hintergrund mit den Farbwerten der entsprechenden Pixel der Komponente auf: `src.rgb + dst.rgb`
+
+Multiply
+: Dunkelt den Hintergrund mit den Werten der entsprechenden Pixel der Komponente ab: `src.rgb * dst.rgb`
+
+Screen
+: Gegenteil von Multiply. Erhöht die Helligkeit des Hintergrunds und die Werte der entsprechenden Pixel der Komponente: `src.rgb - dst.rgb * dst.rgb`

--- a/docs/de/shared/build-variants.md
+++ b/docs/de/shared/build-variants.md
@@ -1,0 +1,37 @@
+## Build-Varianten {#build-variants}
+
+Wenn du ein Bundle für ein Spiel erstellst, musst du auswählen, welche Art von Engine du verwenden möchtest. Du hast drei grundlegende Optionen:
+
+  * Debug
+  * Release
+  * Headless
+
+Diese verschiedenen Versionen werden auch als `Build-Varianten` (Build variants) bezeichnet.
+
+::: sidenote
+Wenn du <kbd>Project ▸ Build</kbd> wählst, erhältst du immer die Debug-Version.
+:::
+
+
+### Debug
+
+Diese Art von ausführbarer Datei wird üblicherweise während der Entwicklung eines Spiels verwendet, da sie mehrere nützliche Debugging-Funktionen enthält:
+
+* Profiler - Dient zum Erfassen von Leistungs- und Nutzungszählern. Wie du den Profiler verwendest, erfährst du im [Profiling-Handbuch](/manuals/profiling/).
+* Protokollierung - Die Engine protokolliert Systeminformationen, Warnungen und Fehler, wenn die Protokollierung aktiviert ist. Die Engine gibt außerdem Protokollmeldungen der Lua-Funktion `print()` sowie von nativen Erweiterungen (native extensions) aus, die mit `dmLogInfo()`, `dmLogError()` und ähnlichen Funktionen protokollieren. Wie du diese Protokolle liest, erfährst du im [Handbuch zu Spiel- und Systemprotokollen](https://defold.com/manuals/debugging-game-and-system-logs/).
+* Hot Reload - Hot Reload ist eine leistungsfähige Funktion, mit der du während der Entwicklung Ressourcen (resources) neu laden kannst, während das Spiel läuft. Wie du diese Funktion verwendest, erfährst du im [Hot-Reload-Handbuch](https://defold.com/manuals/hot-reload/).
+* Engine-Dienste - Du kannst über verschiedene offene TCP-Ports und Dienste eine Verbindung zu einer Debug-Version eines Spiels herstellen und mit ihr interagieren. Zu diesen Diensten gehören die Hot-Reload-Funktion, der Fernzugriff auf Protokolle und der oben erwähnte Profiler, aber auch weitere Dienste zur Ferninteraktion mit der Engine. Mehr über die Engine-Dienste erfährst du [in der Entwicklerdokumentation](https://github.com/defold/defold/blob/dev/engine/docs/DEBUG_PORTS_AND_SERVICES.md).
+
+
+### Release
+
+Bei dieser Variante sind die Debugging-Funktionen deaktiviert. Du solltest diese Option wählen, wenn das Spiel zur Veröffentlichung im App Store oder zur Weitergabe an Spieler auf anderem Wege bereit ist. Aus mehreren Gründen wird davon abgeraten, ein Spiel mit aktivierten Debugging-Funktionen zu veröffentlichen:
+
+* Die Debugging-Funktionen beanspruchen etwas Platz in der Binärdatei, und [es ist bewährte Praxis, die Binärdatei eines veröffentlichten Spiels so klein wie möglich zu halten](https://defold.com/manuals/optimization/#optimize-application-size).
+* Die Debugging-Funktionen beanspruchen auch etwas CPU-Zeit. Das kann die Leistung des Spiels beeinträchtigen, wenn ein Nutzer leistungsschwache Hardware verwendet. Auf Mobiltelefonen trägt die erhöhte CPU-Auslastung außerdem zur Erwärmung und zum Akkuverbrauch bei.
+* Die Debugging-Funktionen können Informationen über das Spiel offenlegen, die nicht für die Augen der Spieler bestimmt sind, sei es im Hinblick auf Sicherheit, Schummeln oder Betrug.
+
+
+### Headless
+
+Diese ausführbare Datei läuft ohne Grafik und Ton. Das bedeutet, dass du die Unit- und Smoke-Tests des Spiels auf einem CI-Server ausführen oder das Spiel sogar als Spielserver in der Cloud betreiben kannst.

--- a/docs/de/shared/bundle-resources.md
+++ b/docs/de/shared/bundle-resources.md
@@ -1,0 +1,20 @@
+Bundle-Ressourcen (bundle resources) sind zusätzliche Dateien und Ordner, die du über das [Feld *Bundle Resources*](/manuals/project-settings/#bundle-resources) in *game.project* in das Bundle deiner Anwendung aufnimmst.
+
+Das Feld *Bundle Resources* sollte eine durch Kommas getrennte Liste von Verzeichnissen enthalten. In diesen Verzeichnissen liegen die Ressourcendateien und Ordner, die bei der Bundle-Erstellung unverändert in das resultierende Paket kopiert werden sollen. Die Verzeichnisse müssen mit einem absoluten Pfad vom Projektstamm aus angegeben werden, zum Beispiel `/res`. Das Ressourcenverzeichnis muss Unterordner enthalten, die nach dem Schema `platform` oder `architecture-platform` benannt sind.
+
+Unterstützte Plattformen sind `ios`, `android`, `osx`, `win32`, `linux`, `web`, `switch`. Ein Unterordner namens `common` ist ebenfalls zulässig und enthält Ressourcendateien, die für alle Plattformen gemeinsam verwendet werden. Beispiel:
+
+```
+res
+├── win32
+│   └── mywin32file.txt
+├── common
+│   └── mycommonfile.txt
+└── android
+    ├── myandroidfile.txt
+    └── res
+        └── xml
+            └── filepaths.xml
+```
+
+Du kannst [`sys.get_application_path()`](/ref/stable/sys/#sys.get_application_path:) verwenden, um den Pfad zu ermitteln, unter dem die Anwendung gespeichert ist. Verwende diesen Basispfad der Anwendung, um den vollständigen absoluten Pfad zu den Dateien zu bilden, auf die du zugreifen musst. Sobald du den absoluten Pfad dieser Dateien hast, kannst du mit den Funktionen `io.*` und `os.*` auf die Dateien zugreifen.

--- a/docs/de/shared/component-max-count-optimizations.md
+++ b/docs/de/shared/component-max-count-optimizations.md
@@ -1,0 +1,10 @@
+## Optimierungen der maximalen Komponentenanzahl {#component-max-count-optimizations}
+Die Einstellungsdatei *game.project* enthält viele Werte, die angeben, wie viele Ressourcen eines bestimmten Typs höchstens gleichzeitig existieren können. Häufig wird diese Anzahl pro geladener Sammlung (collection), auch als Welt bezeichnet, gezählt. Die Defold-Engine verwendet diese Höchstwerte, um Speicher für die jeweilige Anzahl im Voraus zu reservieren und so dynamische Speicherzuweisungen und Speicherfragmentierung während der Ausführung des Spiels zu vermeiden.
+
+Die Datenstrukturen, die Defold zur Darstellung von Komponenten (components) und anderen Ressourcen verwendet, sind auf einen möglichst geringen Speicherverbrauch optimiert. Dennoch solltest du die Werte sorgfältig festlegen, um nicht mehr Speicher als tatsächlich nötig zu reservieren.
+
+Um den Speicherverbrauch weiter zu optimieren, analysiert der Build-Vorgang von Defold die Inhalte des Spiels und überschreibt die Höchstwerte, wenn sich die genaue Anzahl mit Sicherheit bestimmen lässt:
+
+* Wenn eine Sammlung keine Fabrikkomponenten (factory components) enthält, wird Speicher für die genaue Anzahl jeder Komponente und der Spielobjekte (game objects) reserviert. Die festgelegten Höchstwerte werden dabei ignoriert.
+* Wenn eine Sammlung eine Fabrikkomponente enthält, werden die dynamisch erzeugten Objekte analysiert. Für Komponenten, die durch die Fabriken dynamisch erzeugt werden können, und für Spielobjekte wird der Höchstwert verwendet.
+* Wenn eine Sammlung eine Fabrik oder eine Sammlungsfabrik (collection factory) mit aktivierter Option "Dynamic Prototype" enthält, verwendet diese Sammlung die Höchstwerte.

--- a/docs/de/shared/components.md
+++ b/docs/de/shared/components.md
@@ -1,0 +1,24 @@
+Komponenten (components) verleihen Spielobjekten (game objects) eine bestimmte Darstellung und/oder Funktionalität. Komponenten müssen in Spielobjekten enthalten sein und werden durch die Position, Drehung und Skalierung des Spielobjekts beeinflusst, das sie enthält:
+
+![Komponenten](../shared/images/components.png)
+
+Viele Komponenten haben typspezifische Eigenschaften, die du ändern kannst. Außerdem gibt es typspezifische Funktionen für die Interaktion mit ihnen zur Laufzeit:
+
+```lua
+-- disable the can "body" sprite
+msg.post("can#body", "disable")
+
+-- play "hoohoo" sound on "bean" in 1 second
+sound.play("bean#hoohoo", { delay = 1, gain = 0.5 } )
+```
+
+Komponenten werden entweder direkt in ein Spielobjekt eingefügt (in-place) oder einem Spielobjekt als Referenz auf eine Komponentendatei hinzugefügt:
+
+<kbd>Klicke mit der rechten Maustaste</kbd> auf das Spielobjekt in der Ansicht *Outline* und wähle <kbd>Add Component</kbd> (direkt einfügen) oder <kbd>Add Component File</kbd> (als Dateireferenz einfügen).
+
+In den meisten Fällen ist es am sinnvollsten, Komponenten direkt im Spielobjekt zu erstellen. Die folgenden Komponententypen müssen jedoch in separaten Ressourcendateien erstellt werden, bevor du sie einem Spielobjekt als Referenz hinzufügst:
+
+* Script
+* GUI
+* Particle FX
+* Tile Map

--- a/docs/de/shared/consoles-faq.md
+++ b/docs/de/shared/consoles-faq.md
@@ -1,0 +1,8 @@
+#### Q: Muss ich zusätzliche Werkzeuge installieren, um Builds für Konsolen zu erstellen? {#q-do-i-need-to-install-additional-tools-to-build-for-consoles}
+
+A: Du wirst Anwendungs-Bundles mit dem Editor und den Kommandozeilenwerkzeugen erstellen können. Informationen dazu, wie du auf PlayStation®4-, PlayStation®5- und Nintendo Switch-Hardware testen kannst, erhältst du, wenn dir Zugang zu den jeweiligen Plattformen gewährt wird.
+
+
+#### Q: Ist es weiterhin einfach, eine gemeinsame Codebasis zu verwenden, wenn ich mich entscheide, auch Konsolen als Zielplattformen zu unterstützen? {#q-is-it-still-easy-to-use-a-single-code-base-if-i-decide-to-also-target-consoles}
+
+A: Ja, alle Standardfunktionen der Defold-API sind auch für die Konsolenplattformen verfügbar. Zusätzlich zum Standardfunktionsumfang erhältst du auch Zugriff auf einige spezifische Funktionen für PlayStation®4, PlayStation®5 und Nintendo Switch. Im Allgemeinen sollte der Code jedoch auf mehreren Plattformen genau gleich bleiben können.

--- a/docs/de/shared/custom-resources.md
+++ b/docs/de/shared/custom-resources.md
@@ -1,0 +1,3 @@
+Benutzerdefinierte Ressourcen (custom resources) werden über das [Feld *Custom Resources*](https://defold.com/manuals/project-settings/#custom-resources) in *game.project* in das Hauptarchiv des Spiels aufgenommen.
+
+Das Feld *Custom Resources* sollte eine durch Kommas getrennte Liste der Ressourcen enthalten, die in das Hauptarchiv des Spiels aufgenommen werden. Wenn Verzeichnisse angegeben sind, werden alle Dateien und Verzeichnisse im jeweiligen Verzeichnis rekursiv aufgenommen. Du kannst die Dateien mit [`sys.load_resource()`](/ref/sys/#sys.load_resource) lesen.

--- a/docs/de/shared/editor-faq.md
+++ b/docs/de/shared/editor-faq.md
@@ -1,0 +1,26 @@
+#### Q: Welche Systemanforderungen hat der Editor? {#q-what-are-the-system-requirements-for-the-editor}
+A: Der Editor verwendet bis zu 75 % des verfügbaren Arbeitsspeichers des Systems. Auf einem Computer mit 4 GB RAM sollte dies für kleinere Defold-Projekte ausreichen. Für mittelgroße oder große Projekte werden mindestens 6 GB RAM empfohlen.
+
+
+#### Q: Werden Defold-Betaversionen automatisch aktualisiert? {#q-are-defold-beta-versions-auto-updating}
+A: Ja. Der Defold-Editor in der Betaversion sucht beim Start nach Updates, genau wie die stabile Version von Defold.
+
+
+#### Q: Warum erhalte ich beim Starten des Editors die Fehlermeldung `java.awt.AWTError: Assistive Technology not found`? {#q-why-am-i-getting-an-error-saying-javaawtawterror-assistive-technology-not-found-when-launching-the-editor}
+A: Dieser Fehler hängt mit Problemen mit assistiven Technologien in Java zusammen, etwa mit dem [Screenreader NVDA](https://www.nvaccess.org/download/). Wahrscheinlich befindet sich in deinem Benutzerordner eine Datei namens `.accessibility.properties`. Entferne die Datei und versuche erneut, den Editor zu starten. (Hinweis: Wenn du assistive Technologien verwendest und diese Datei benötigst, wende dich bitte unter info@defold.se an uns, um alternative Lösungen zu besprechen).
+
+Eine Diskussion dazu findest du [hier im Defold-Forum](https://forum.defold.com/t/editor-endless-loading-windows-10-1-2-169-solved/65481/3).
+
+
+#### Q: Warum erhalte ich beim Starten des Editors die Fehlermeldung `sun.security.validator.ValidatorException: PKIX path building failed`? {#q-why-am-i-getting-an-error-saying-sunsecurityvalidatorvalidatorexception-pkix-path-building-failed-when-launching-the-editor}
+A: Diese Ausnahme tritt auf, wenn der Editor versucht, eine HTTPS-Verbindung herzustellen, die vom Server bereitgestellte Zertifikatskette aber nicht überprüft werden kann.
+
+Weitere Informationen zu diesem Fehler findest du unter [diesem Link](https://github.com/defold/defold/blob/master/editor/README_TROUBLESHOOTING_PKIX.md).
+
+
+#### Q: Warum erhalte ich bei bestimmten Vorgängen die Fehlermeldung `java.lang.OutOfMemoryError: Java heap space`? {#q-why-am-i-am-getting-a-javalangoutofmemoryerror-java-heap-space-when-performing-certain-operations}
+A: Der Defold-Editor wurde mit Java entwickelt. In manchen Fällen reicht die standardmäßige Speicherkonfiguration von Java möglicherweise nicht aus. In diesem Fall kannst du den Editor manuell so konfigurieren, dass er mehr Speicher reserviert, indem du seine Konfigurationsdatei bearbeitest. Die Konfigurationsdatei heißt `config` und befindet sich unter macOS im Ordner `Defold.app/Contents/Resources/`. Unter Windows befindet sie sich neben der ausführbaren Datei `Defold.exe` und unter Linux neben der ausführbaren Datei `Defold`. Öffne die Datei `config` und füge `-Xmx6gb` zur Zeile hinzu, die mit `vmargs` beginnt. Mit `-Xmx6gb` setzt du die maximale Heap-Größe auf 6 Gigabyte (der Standardwert ist normalerweise 4Gb). Das sollte ungefähr so aussehen:
+
+```
+vmargs = -Xmx6gb,-Dfile.encoding=UTF-8,-Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Ddefold.archive.domain=${build.archive_domain},-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false,--illegal-access=warn,--add-opens=java.base/java.lang=ALL-UNNAMED,--add-opens=java.desktop/sun.awt=ALL-UNNAMED,--add-opens=java.desktop/sun.java2d.opengl=ALL-UNNAMED,--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED
+```

--- a/docs/de/shared/editor-versions.md
+++ b/docs/de/shared/editor-versions.md
@@ -1,0 +1,11 @@
+## Editor 1 und 2 {#editor-1-and-2}
+
+Das Defold-Team stellt derzeit auf den Defold-Editor 2 um, der momentan als Betaversion verfügbar ist. Die meisten neuen Dokumentationsartikel des Teams beziehen sich auf den neuen Editor. Nach und nach wird das Team die gesamte Dokumentation aktualisieren, aber dieser Vorgang wird Zeit brauchen. Anhand des Farbschemas in Bildschirmaufnahmen kannst du die Editorversion erkennen.
+
+Editor 2 bietet ein ansprechendes dunkles Farbschema:
+![Editor 2](../shared/images/editor2.png)
+
+Editor 1 hat ein standardmäßiges helles Farbschema:
+![Editor 1](../shared/images/editor1.png)
+
+Du bist herzlich eingeladen, [den neuen Editor auszuprobieren](https://www.defold.com/editor-two/).

--- a/docs/de/shared/graphics-api.md
+++ b/docs/de/shared/graphics-api.md
@@ -1,0 +1,9 @@
+| System   | Grafik-API                 | Hinweis                  |
+|----------|----------------------------|--------------------------|
+| macOS    | OpenGL 3.3 oder Metal      | Vulkan über MoltenVK     |
+| Windows  | OpenGL 3.3 oder Vulkan 1.1 |                          |
+| Linux x86-64 | OpenGL 3.3 oder Vulkan 1.1 |                      |
+| Linux ARM64  | OpenGL ES oder Vulkan 1.1 | EGL/GLES ist der Standard |
+| Android  | OpenGLES 3.0 oder Vulkan 1.1 | Rückgriff auf OpenGLES 2.0 |
+| iOS      | OpenGLES 3.0 oder Metal    | Vulkan über MoltenVK     |
+| HTML5    | WebGL 2.0 oder WebGPU      | Rückgriff auf WebGL 1.0  |

--- a/docs/de/shared/html5-faq.md
+++ b/docs/de/shared/html5-faq.md
@@ -1,0 +1,12 @@
+#### Q: Warum bleibt meine HTML5-App in Chrome beim Startbildschirm hängen? {#q-why-does-my-html5-app-freeze-at-the-splash-screen-in-chrome}
+
+A: In manchen Fällen lässt sich ein Spiel nicht lokal aus dem Dateisystem im Browser ausführen. Wenn du das Spiel aus dem Editor startest, wird es von einem lokalen Webserver bereitgestellt. Du kannst beispielsweise `SimpleHTTPServer` in Python verwenden:
+
+```sh
+$ python -m SimpleHTTPServer [port]
+```
+
+
+#### Q: Warum stürzt mein Spiel beim Laden mit dem Fehler "Unexpected data size" ab? {#q-why-does-my-game-crash-with-error-unexpected-data-size-while-loading}
+
+A: Das passiert normalerweise, wenn du unter Windows einen Build erstellst und ihn in Git committest. Wenn die Zeilenenden in Git falsch konfiguriert sind, ändert Git deine Zeilenenden und damit auch die Datengröße. Befolge diese Anleitung, um das Problem zu beheben: [https://docs.github.com/en/free-pro-team@latest/github/using-git/configuring-git-to-handle-line-endings](https://docs.github.com/en/free-pro-team@latest/github/using-git/configuring-git-to-handle-line-endings)

--- a/docs/de/shared/install.md
+++ b/docs/de/shared/install.md
@@ -1,0 +1,51 @@
+## Herunterladen {#downloading}
+
+Rufe die [Defold-Downloadseite](https://defold.com/download/) auf. Dort findest du Download-Schaltflächen für macOS, Windows und Linux (Ubuntu):
+
+![Editor herunterladen](../shared/images/editor_download.png)
+
+## Installation
+
+Installation unter macOS
+: Die heruntergeladene Datei ist ein DMG-Abbild, das das Programm enthält.
+
+  1. Suche die Datei "Defold-x86_64-macos.dmg" und doppelklicke darauf, um das Abbild zu öffnen.
+  2. Ziehe die Anwendung "Defold" auf die Verknüpfung zum Ordner "Applications".
+
+  Um den Editor zu starten, öffne deinen Ordner "Applications" und <kbd>doppelklicke</kbd> auf die Datei "Defold".
+
+  ![Defold unter macOS](../shared/images/macos_content.png)
+
+Installation unter Windows
+: Die heruntergeladene Datei ist ein ZIP-Archiv, das entpackt werden muss:
+
+  1. Suche die Archivdatei "Defold-x86_64-win32.zip", <kbd>halte den Ordner gedrückt</kbd> (oder <kbd>klicke mit der rechten Maustaste darauf</kbd>), wähle *Extract All* und folge dann den Anweisungen, um das Archiv in einen Ordner namens "Defold" zu entpacken.
+  2. Verschiebe den Ordner "Defold" an den gewünschten Speicherort (z. B. `D:\Defold`). Du solltest Defold nicht nach `C:\Program Files (x86)\` oder `C:\Program Files\` verschieben, da dies die Aktualisierung des Editors verhindert.
+
+  Um den Editor zu starten, öffne den Ordner "Defold" und <kbd>doppelklicke</kbd> auf die Datei "Defold.exe".
+
+  ![Defold unter Windows](../shared/images/windows_content.png)
+
+Installation unter Linux
+: Die heruntergeladene Datei ist ein ZIP-Archiv, das entpackt werden muss:
+
+  1. Suche im Terminal die Archivdatei "Defold-x86_64-linux.zip" und entpacke sie in ein Zielverzeichnis namens "Defold".
+
+     ```bash
+     $ unzip Defold-x86_64-linux.zip -d Defold
+     ```
+
+  Um den Editor zu starten, wechsle in das Verzeichnis, in das du die Anwendung entpackt hast, und führe dann die ausführbare Datei `Defold` aus oder <kbd>doppelklicke</kbd> auf deinem Desktop darauf.
+
+  ```bash
+  $ cd Defold
+  $ ./Defold
+  ```
+
+  Unter dem Menüpunkt `Help > Create Desktop Entry` findest du eine Hilfsfunktion zum Installieren eines Desktop-Eintrags.
+
+  Falls beim Starten des Editors, beim Öffnen eines Projekts oder beim Ausführen eines Defold-Spiels Probleme auftreten, lies den [Linux-Abschnitt der FAQ](/faq/faq#linux-questions).
+
+## Eine ältere Version installieren {#install-an-old-version}
+
+Jede Betaversion und jede stabile Version von Defold ist auch [auf GitHub verfügbar](https://github.com/defold/defold/releases).

--- a/docs/de/shared/ios-faq.md
+++ b/docs/de/shared/ios-faq.md
@@ -1,0 +1,16 @@
+#### Q: Ich kann mein Defold-Spiel mit einem kostenlosen Konto bei Apple Developer nicht installieren. {#q-i-am-unable-to-install-my-defold-game-using-a-free-apple-developer-account}
+A: Stelle sicher, dass die Bundle-ID in deinem Defold-Projekt mit der Bundle-ID übereinstimmt, die du im Xcode-Projekt beim Erstellen des mobilen Bereitstellungsprofils verwendet hast.
+
+#### Q: Wie kann ich die Berechtigungen einer als Bundle erstellten Anwendung prüfen? {#q-how-can-i-check-the-entitlements-of-a-bundled-application}
+A: Aus [Berechtigungen einer erstellten App prüfen](https://developer.apple.com/library/archive/technotes/tn2415/_index.html#//apple_ref/doc/uid/DTS40016427-CH1-APPENTITLEMENTS):
+
+```sh
+codesign -d --ent :- /path/to/the.app
+```
+
+#### Q: Wie kann ich die Berechtigungen eines Bereitstellungsprofils prüfen {#q-how-can-i-check-the-entitlements-of-a-provisioning-profile}
+A: Aus [Berechtigungen eines Profils prüfen](https://developer.apple.com/library/archive/technotes/tn2415/_index.html#//apple_ref/doc/uid/DTS40016427-CH1-PROFILESENTITLEMENTS):
+
+```sh
+security cms -D -i /path/to/iOSTeamProfile.mobileprovision
+```

--- a/docs/de/shared/linux-faq.md
+++ b/docs/de/shared/linux-faq.md
@@ -1,0 +1,150 @@
+#### Q: Warum ist der Defold-Editor auf einem 4k- oder HiDPI-Monitor winzig klein? {#q-why-is-the-defold-editor-super-small-when-run-on-a-4k-or-hidpi-monitor}
+
+A: Wenn du GNOME verwendest, kannst du den Skalierungsfaktor vor dem Start von Defold ändern. [Quelle](https://unix.stackexchange.com/a/552411)
+
+```bash
+$ gsettings set org.gnome.desktop.interface scaling-factor 2
+$ ./Defold
+```
+
+A: Eine alternative Lösung, insbesondere wenn du um einen nicht ganzzahligen Faktor vergrößern möchtest, besteht darin, die Datei `Defold/config` zu ändern und in der Zeile `vmargs` den Eintrag `glass.gtk.uiScale` hinzuzufügen: [Quelle](https://forum.defold.com/t/4k-hidpi-monitor-support-solved/64108/12?u=britzl)
+
+```
+vmargs = -Dglass.gtk.uiScale=1.5,-Dfile.encoding=UTF-8,...
+vmargs = -Dglass.gtk.uiScale=175%,-Dfile.encoding=UTF-8,...
+vmargs = -Dglass.gtk.uiScale=192dpi,-Dfile.encoding=UTF-8,...
+```
+
+Mehr zu diesem Wert findest du im [HiDPI-Wiki-Artikel von Arch Linux](https://wiki.archlinux.org/title/HiDPI#JavaFX).
+
+A: Wenn du KDE verwendest, kannst du `GDK_SCALE` setzen:
+
+```bash
+$ GDK_SCALE=2 ./Defold
+```
+
+#### Q: Warum gehen Mausklicks unter Elementary OS durch den Editor hindurch an das, was darunter liegt? {#q-why-does-mouse-clicks-on-elementary-os-go-through-the-editor-onto-whatever-is-below}
+
+A: Starte den Editor wie folgt:
+
+```bash
+$ GTK_CSD=0 ./Defold
+```
+
+
+#### Q: Der Defold-Editor stürzt beim Öffnen einer Sammlung (collection) oder eines Spielobjekts (game object) ab, und die Absturzmeldung verweist auf `com.jogamp.opengl` {#q-the-defold-editor-crashes-when-opening-a-collection-or-game-object-and-the-crash-refers-to-comjogampopengl}
+
+A: Bei bestimmten Distributionen (wie Ubuntu 18) gibt es ein Problem zwischen der von Defold verwendeten Version von `jogamp`/`jogl` und der Version von [Mesa](https://docs.mesa3d.org/) auf dem System. Du kannst überschreiben, welche GL-Version beim Aufruf von `glGetString(GL_VERSION)` gemeldet wird, indem du `MESA_GL_VERSION_OVERRIDE` auf 2.1 oder einen größeren Wert setzt, der aber kleiner oder gleich der von deinem Treiber unterstützten Version ist. Mit `glxinfo` kannst du prüfen, welche OpenGL-Version dein Treiber maximal unterstützt:
+
+```bash
+glxinfo | grep version
+```
+
+Beispielausgabe (suche nach "OpenGL version string: x.y"):
+
+```
+server glx version string: 1.4
+client glx version string: 1.4
+GLX version: 1.4
+Max core profile version: 4.6
+Max compat profile version: 4.6
+Max GLES1 profile version: 1.1
+Max GLES[23] profile version: 3.2
+OpenGL core profile version string: 4.6 (Core Profile) Mesa 20.2.6
+OpenGL core profile shading language version string: 4.60
+OpenGL version string: 4.6 (Compatibility Profile) Mesa 20.2.6
+OpenGL shading language version string: 4.60
+OpenGL ES profile version string: OpenGL ES 3.2 Mesa 20.2.6
+OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
+GL_EXT_shader_implicit_conversions, GL_EXT_shader_integer_mix,
+```
+
+Verwende Version 2.1 oder die zu deinem Grafiktreiber passende Version:
+
+```bash
+$ MESA_GL_VERSION_OVERRIDE=2.1 ./Defold
+```
+
+```bash
+$ MESA_GL_VERSION_OVERRIDE=4.6 ./Defold
+```
+
+
+#### Q: Warum erhalte ich beim Starten von Defold die Meldung "`com.jogamp.opengl.GLException: Graphics configuration failed`"? {#q-why-am-i-getting-comjogampopenglglexception-graphics-configuration-failed-when-launching-defold}
+
+A: Bei bestimmten Distributionen (beispielsweise Ubuntu 20.04) gibt es beim Ausführen von Defold ein Problem mit den neuen [Mesa](https://docs.mesa3d.org/)-Treibern (Iris). Du kannst versuchen, Defold mit einer älteren Treiberversion auszuführen:
+
+```bash
+$ MESA_LOADER_DRIVER_OVERRIDE=i965 ./Defold
+```
+
+
+#### Q: Der Defold-Editor stürzt beim Öffnen einer Sammlung oder eines Spielobjekts ab, und die Absturzmeldung verweist auf `libffi.so` {#q-the-defold-editor-crashes-when-opening-a-collection-or-game-object-and-the-crash-refers-to-libffiso}
+
+A: Die [libffi](https://sourceware.org/libffi/)-Version deiner Distribution stimmt nicht mit der von Defold benötigten Version (Version 6 oder 7) überein. Stelle sicher, dass `libffi.so.6` oder `libffi.so.7` unter `/usr/lib/x86_64-linux-gnu` installiert ist. Du kannst `libffi.so.7` wie folgt herunterladen:  
+
+```bash
+$ wget http://ftp.br.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb
+$ sudo dpkg -i libffi7_3.3-6_amd64.deb
+```
+
+Gib anschließend beim Ausführen von Defold den Pfad zu dieser Version in der Umgebungsvariablen `LD_PRELOAD` an:
+
+```bash
+$ LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libffi.so.7 ./Defold
+```
+
+
+#### Q: Meine OpenGL-Treiber sind veraltet. Kann ich Defold trotzdem verwenden? {#q-my-opengl-drivers-are-outdated-can-i-still-use-defold}
+
+A: Ja, möglicherweise kannst du Defold verwenden, wenn du Software-Rendering aktivierst. Du kannst Software-Rendering aktivieren, indem du die Umgebungsvariable `LIBGL_ALWAYS_SOFTWARE` auf 1 setzt:
+
+```bash
+$ LIBGL_ALWAYS_SOFTWARE=1 ./Defold
+```
+
+
+#### Q: Warum startet mein Defold-Spiel nicht, wenn ich versuche, es unter Linux auszuführen? {#q-why-doesnt-my-defold-game-start-when-i-try-to-run-it-on-linux}
+
+A: Prüfe die Konsolenausgabe im Editor. Wenn du die folgende Meldung erhältst:
+
+```
+dmengine: error while loading shared libraries: libopenal.so.1: cannot open shared object file: No such file or directory
+```
+
+Dann musst du *`libopenal1`* installieren. Der Paketname unterscheidet sich je nach Distribution, und in manchen Fällen musst du möglicherweise die Pakete *`openal`* und *`openal-dev`* oder *`openal-devel`* installieren.
+
+```bash
+$ apt-get install libopenal-dev
+```
+
+#### Q: Warum schließt sich das obere Menü, bevor ich etwas auswählen kann? {#q-why-does-the-top-menu-close-before-i-can-select-something}
+
+A: Dies wird wahrscheinlich durch den verwendeten Fenstermanager verursacht (beispielsweise `Qtile` oder i3). Es handelt sich um ein [bekanntes Problem in JavaFX](https://bugs.openjdk.org/browse/JDK-8251240?focusedCommentId=14362084&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14362084), das sich entweder lösen lässt, indem du die Umgebungsvariable `GDK_DISPLAY` auf 1 setzt:¨
+
+```bash
+$ GDK_DISPLAY=1 ./Defold
+
+D=2
+
+```
+
+Oder indem du die Datei `Defold/config` änderst und in der Zeile `vmargs` den Eintrag `-Djdk.gtk.version=2` hinzufügst:
+
+```
+vmargs = -Djdk.gtk.version=2,-Dfile.encoding=UTF-8,...
+```
+
+
+#### Q: Warum kann ich nicht alle verfügbaren Speicherorte durchsuchen, wenn ich Open From Disk auswähle? {#q-why-am-i-not-able-to-browse-all-available-file-locations-when-i-select-open-from-disk}
+
+A: Wenn du Defold über [Steam als Flatpak](https://flathub.org/apps/com.valvesoftware.Steam) ausführst, musst du Steam die Berechtigung erteilen, auf deine anderen Laufwerke zuzugreifen. Du kannst die Berechtigungen deiner Flatpak-Anwendungen mit [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) oder einem ähnlichen Werkzeug ändern.
+
+
+#### Q: Warum kann ich den Web-Profiler oder andere Menüoptionen, die einen Browser erfordern, nicht öffnen? {#q-why-am-i-not-able-to-open-the-web-profiler-or-any-other-menu-option-which-requires-a-browser}
+
+A: Wahrscheinlich schlägt ein interner Aufruf von `Desktop.getDesktop().browse(new URI(url));` fehl, da auf Systemen ohne Gnome kein Browser erkannt wird. Versuche, `libgnome` zu installieren.
+
+```bash
+$ apt-get install libgnome
+```

--- a/docs/de/shared/material-constants.md
+++ b/docs/de/shared/material-constants.md
@@ -1,0 +1,6 @@
+
+Das Standardmaterial für {{ include.component }} hat die folgenden Konstanten, die du mit [go.set()](/ref/stable/go/#go.set) oder [go.animate()](/ref/stable/go/#go.animate) ändern kannst (weitere Details findest du im [Handbuch zu Materialien](/manuals/material/#vertex-and-fragment-constants)). Beispiele:
+```lua
+go.set("#{{ include.component }}", "{{ include.variable }}", vmath.vector4(1,0,0,1))
+go.animate("#{{ include.component }}", "{{ include.variable }}", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,0,0,1), go.EASING_LINEAR, 2)
+```

--- a/docs/de/shared/optimization-memory-html5.md
+++ b/docs/de/shared/optimization-memory-html5.md
@@ -1,0 +1,21 @@
+## Heap-Größe (HTML5) {#heap-size-html5}
+Die Heap-Größe eines HTML5-Spiels von Defold lässt sich über das [Feld `heap_size`](/manuals/project-settings/#heap-size) in *game.project* konfigurieren. Achte darauf, den Speicherverbrauch deines Spiels zu optimieren und eine möglichst kleine Heap-Größe festzulegen.
+
+Für kleine Spiele ist eine Heap-Größe von 32 MB erreichbar. Für größere Spiele solltest du 64–128 MB anstreben. Wenn du beispielsweise bei 58 MB liegst und weitere Optimierungen nicht machbar sind, kannst du dich ohne langes Grübeln für 64 MB entscheiden. Es gibt keine feste Zielgröße — sie hängt vom Spiel ab. Strebe möglichst kleine Größen an, idealerweise in Stufen, die Zweierpotenzen entsprechen. 
+
+Um den aktuellen Heap-Verbrauch zu prüfen, kannst du dein Spiel starten, im „ressourcenintensivsten“ Level oder Abschnitt spielen und dabei den Speicherverbrauch beobachten:
+
+```lua
+if html5 then
+    local mem = tonumber(html5.run("HEAP8.length") / 1024 / 1024)
+    print(mem)
+end
+```
+
+Du kannst auch die Entwicklerwerkzeuge deines Browsers öffnen und Folgendes in die Konsole eingeben:
+
+```js
+HEAP8.length / 1024 / 1024
+```
+
+Wenn der Speicherverbrauch bei 32 MB bleibt, ist das großartig! Andernfalls befolge die Schritte, um [die Größe der Engine selbst und großer Assets wie Audiodateien und Texturen zu optimieren](/manuals/optimization-size).

--- a/docs/de/shared/platforms.md
+++ b/docs/de/shared/platforms.md
@@ -1,0 +1,3 @@
+Unterstützte Plattformen sind `ios`, `android`, `osx`, `win32`, `linux`, `web`.
+
+Unterstützte `arc-platform`-Paare sind `arm64-ios`, `arm64_sim-ios`, `armv7-android`, `arm64-android`, `x86_64-android`, `arm64-osx`, `x86_64-osx`, `x86-win32`, `x86_64-win32`, `arm64-linux`, `x86_64-linux`, `wasm-web` und `wasm_pthread-web`.

--- a/docs/de/shared/slice-9-texturing.md
+++ b/docs/de/shared/slice-9-texturing.md
@@ -1,0 +1,41 @@
+## Texturierung mit Neun-Segment-Skalierung {#slice-9-texturing}
+
+GUI-Box-Knoten (box nodes) und Sprite-Komponenten (sprite components) stellen manchmal Elemente dar, deren Größe vom jeweiligen Kontext abhängt: Bereiche und Dialogfelder, deren Größe an den enthaltenen Inhalt angepasst werden muss, oder eine Lebensanzeige, deren Größe die verbleibende Gesundheit eines Gegners widerspiegeln muss. Dabei können Darstellungsprobleme entstehen, wenn du den in seiner Größe angepassten Knoten oder das Sprite mit einer Textur versiehst.
+
+Normalerweise skaliert die Engine die Textur so, dass sie in die rechteckigen Grenzen passt. Durch das Festlegen von Randbereichen für die Neun-Segment-Skalierung (9-slice) kannst du jedoch einschränken, welche Teile der Textur skaliert werden sollen:
+
+![GUI-Skalierung](../shared/images/gui_slice9_scaling.png)
+
+Die Einstellung *Slice9* des Box-Knotens besteht aus 4 Zahlen. Sie geben jeweils die Anzahl der Pixel für den linken, oberen, rechten und unteren Rand an, die nicht auf die übliche Weise skaliert werden sollen:
+
+![Eigenschaften der Neun-Segment-Skalierung](../shared/images/gui_slice9_properties.png)
+
+Die Ränder werden im Uhrzeigersinn festgelegt, beginnend am linken Rand:
+
+![Bereiche der Neun-Segment-Skalierung](../shared/images/gui_slice9.png)
+
+- Ecksegmente werden niemals skaliert.
+- Randsegmente werden entlang einer einzelnen Achse skaliert. Die linken und rechten Randsegmente werden vertikal skaliert. Die oberen und unteren Randsegmente werden horizontal skaliert.
+- Der mittlere Texturbereich wird nach Bedarf horizontal und vertikal skaliert.
+
+Die oben beschriebene Texturskalierung mit *Slice9* wird nur angewendet, wenn du die Größe des Box-Knotens oder des Sprites änderst:
+
+![Größe des GUI-Box-Knotens](../shared/images/gui_slice9_size.png)
+
+![Größe des Sprites](../shared/images/sprite_slice9_size.png)
+
+::: important
+Wenn du den Skalierungsparameter des Box-Knotens, des Sprites oder des Spielobjekts (game object) änderst, werden der Knoten oder das Sprite und die Textur skaliert, ohne die Parameter von *Slice9* anzuwenden.
+:::
+
+::: important
+Wenn du die Texturierung mit Neun-Segment-Skalierung für Sprites verwendest, muss [Sprite Trim Mode des Bildes](https://defold.com/manuals/atlas/#image-properties) auf Off gesetzt sein.
+:::
+
+
+### Mipmaps und Neun-Segment-Skalierung {#mipmaps-and-slice-9}
+Aufgrund der Funktionsweise von Mipmapping im Renderer können beim Skalieren von Textursegmenten manchmal Artefakte auftreten. Das geschieht, wenn du Segmente gegenüber der ursprünglichen Texturgröße _verkleinerst_. Der Renderer wählt dann für das Segment eine Mipmap mit geringerer Auflösung aus, was zu sichtbaren Artefakten führt.
+
+![Mipmapping bei der Neun-Segment-Skalierung](../shared/images/gui_slice9_mipmap.png)
+
+Um dieses Problem zu vermeiden, stelle sicher, dass die zu skalierenden Segmente der Textur klein genug sind, sodass sie niemals verkleinert, sondern nur vergrößert werden müssen.

--- a/docs/de/shared/test.md
+++ b/docs/de/shared/test.md
@@ -1,0 +1,5 @@
+Mit dieser Datei kannst du die Transklusion testen. Die gesamte Datei wird unverändert eingebunden, wobei die Leerraumzeichen erhalten bleiben.
+
+Beachte, dass alle Dateireferenzen relativ zu dem Dokument sind, in das die Datei eingefügt wird.
+
+![Gemeinsam genutztes Bild](../shared/images/logo.png)

--- a/docs/de/shared/url-shorthands.md
+++ b/docs/de/shared/url-shorthands.md
@@ -1,0 +1,17 @@
+  `.`
+  : Kurzform, die auf das aktuelle Spielobjekt (game object) verweist.
+
+  `#`
+  : Kurzform, die auf die aktuelle Komponente (component) verweist.
+
+  Zum Beispiel:
+
+  ```lua
+   -- Let this game object acquire input focus
+   msg.post(".", "acquire_input_focus")
+  ```
+
+  ```lua
+   -- Post "reset" to the current script
+   msg.post("#", "reset")
+  ```

--- a/docs/de/shared/windows-faq.md
+++ b/docs/de/shared/windows-faq.md
@@ -1,0 +1,27 @@
+#### Q: Warum sind GUI-Box-Knoten (GUI box nodes) ohne Textur im Editor transparent, werden aber wie erwartet angezeigt, wenn ich einen Build erstelle und ausführe? {#q-why-are-gui-box-nodes-without-a-texture-transparent-in-the-editor-but-show-up-as-expected-when-i-build-and-run}
+
+A: Dieser Fehler kann auf [Computern mit AMD Radeon-GPUs](https://github.com/defold/editor2-issues/issues/2723) auftreten. Stelle sicher, dass du deine Grafiktreiber aktualisierst.
+
+#### Q: Warum erhalte ich beim Öffnen eines Atlas oder einer Szenenansicht die Fehlermeldung `com.sun.jna.Native.open.class java.lang.Error: Access is denied`? {#q-why-am-i-getting-comsunjnanativeopenclass-javalangerror-access-is-denied-when-opening-an-atlas-or-a-scene-view}
+
+A: Versuche, Defold als Administrator auszuführen. Klicke mit der rechten Maustaste auf die ausführbare Defold-Datei und wähle "Run as Administrator".
+
+#### Q: Warum wird mein Spiel unter Windows mit einer integrierten Intel UHD-GPU nicht richtig gerendert (obwohl mein HTML5-Build funktioniert)? {#q-why-is-my-game-not-rendering-properly-on-windows-using-an-intel-uhd-integrated-gpu-but-my-html5-build-works}
+
+A: Stelle sicher, dass du deinen Treiber auf Version 27.20.100.8280 oder höher aktualisierst. Prüfe dies mit dem [Intel Driver Support Assistant](https://www.intel.com/content/www/us/en/search.html?ws=text#t=Downloads&layout=table&cf:Downloads=%5B%7B%22actualLabel%22%3A%22Graphics%22%2C%22displayLabel%22%3A%22Graphics%22%7D%2C%7B%22actualLabel%22%3A%22Intel%C2%AE%20UHD%20Graphics%20Family%22%2C%22displayLabel%22%3A%22Intel%C2%AE%20UHD%20Graphics%20Family%22%7D%2C%7B%22actualLabel%22%3A%22Intel%C2%AE%20UHD%20Graphics%20630%22%2C%22displayLabel%22%3A%22Intel%C2%AE%20UHD%20Graphics%20630%22%7D%5D). Weitere Informationen findest du in [diesem Forumsbeitrag](https://forum.defold.com/t/sprite-game-object-is-not-rendering/69198/35?u=britzl).
+
+#### Q: Der Defold-Editor stürzt ab und im Protokoll steht `AWTError: Assistive Technology not found` {#q-the-defold-editor-is-crashing-and-the-log-shows-awterror-assistive-technology-not-found}
+
+Wenn der Editor abstürzt und im Protokoll `Caused by: java.awt.AWTError: Assistive Technology not found: com.sun.java.accessibility.AccessBridge` steht, führe die folgenden Schritte aus:
+
+* Navigiere zu `C:\Users\<username>`
+* Öffne die Datei `.accessibility.properties` mit einem gewöhnlichen Texteditor (Notepad ist geeignet)
+* Suche in der Konfiguration nach den folgenden Zeilen:
+
+```
+assistive_technologies=com.sun.java.accessibility.AccessBridge
+screen_magnifier_present=true
+```
+
+* Füge am Anfang dieser Zeilen ein Rautezeichen (`#``) hinzu
+* Speichere deine Änderungen an der Datei und starte Defold neu

--- a/docs/de/translation-guidelines.txt
+++ b/docs/de/translation-guidelines.txt
@@ -1,0 +1,286 @@
+---
+title: Richtlinien für die deutsche Übersetzung
+brief: Sprache, Terminologie und Formatregeln für die deutsche Dokumentation von Defold.
+---
+
+# Richtlinien für die deutsche Übersetzung
+
+Diese Richtlinien gelten für deutsche Handbücher, Tutorials, FAQ und gemeinsame Textbausteine von Defold. Verwende sie zusammen mit dem [Glossar](glossary.txt). Erstellt und Quellen geprüft am: 2026-09-12.
+
+Bei Beginn der Untersuchung gab es noch keinen deutschen Dokumentationsbestand unter `docs/de`. Die folgenden Regeln legen deshalb eine Grundlage für neue Übersetzungen fest. Sie beruhen auf den vorhandenen Übersetzungsmaterialien, dem [README](../../README.md), den englischen Defold-Handbüchern und deutschsprachigen Dokumentationen auf offiziellen Projekt- und Herstellerseiten.
+
+## Untersuchte Übersetzungsmaterialien
+
+Untersucht wurden alle neun vorhandenen Paare aus `glossary.txt` und `translation-guidelines.txt`, insgesamt 18 Dateien. Ihre Themen, Terminologielisten und Übersetzungsregeln dienen als Vorlage für Umfang und Aufbau. Die deutschen Begriffe werden nach ihrer Bedeutung im englischen Original gewählt.
+
+| Sprache | Dateien | Für die deutsche Fassung besonders relevant |
+|---|---|---|
+| Spanisch (`es`) | [Glossar](../es/glossary.txt), [Richtlinien](../es/translation-guidelines.txt) | Grundbegriffe, englischer Begriff bei der ersten Nennung, FAQ und Bedienhandlungen |
+| Französisch (`fr`) | [Glossar](../fr/glossary.txt), [Richtlinien](../fr/translation-guidelines.txt) | Erhaltung technischer Zeichenfolgen, unterschiedliche Bedeutungen von runtime, HTTP und Automatisierung |
+| Griechisch (`gr`) | [Glossar](../gr/glossary.txt), [Richtlinien](../gr/translation-guidelines.txt) | Mehrdeutige Begriffe wie translation, unterschiedliche Hierarchien, Umgang mit alten Übersetzungsfehlern |
+| Italienisch (`it`) | [Glossar](../it/glossary.txt), [Richtlinien](../it/translation-guidelines.txt) | Build, Kompilierung und Bundle als getrennte Vorgänge; Tests und KI-Werkzeuge |
+| Japanisch (`ja`) | [Glossar](../ja/glossary.txt), [Richtlinien](../ja/translation-guidelines.txt) | Vergleich offizieller Quellen, breite Themenabdeckung, nachvollziehbare redaktionelle Entscheidungen |
+| Koreanisch (`ko`) | [Glossar](../ko/glossary.txt), [Richtlinien](../ko/translation-guidelines.txt) | Komponenten, Ressourcen, GUI, Eingabe und Rendering; Trennung von Begriffen und UI-Beschriftungen |
+| Polnisch (`pl`) | [Glossar](../pl/glossary.txt), [Richtlinien](../pl/translation-guidelines.txt) | Detaillierter Wortschatz aus 86 zusammengeführten Teilglossaren; Wiederholungen nach Begriffen zusammenfassen |
+| Portugiesisch (`pt`) | [Glossar](../pt/glossary.txt), [Richtlinien](../pt/translation-guidelines.txt) | Plattformen und Veröffentlichung; überprüfte UI-Lokalisierung von erklärenden Übersetzungen unterscheiden |
+| Ukrainisch (`uk`) | [Glossar](../uk/glossary.txt), [Richtlinien](../uk/translation-guidelines.txt) | Adressierung, Nachrichten, Lebenszyklus, Automatisierung und Überprüfung |
+
+Die Regeln sind teilweise widersprüchlich: `es`, `ko`, `pl` und `pt` erlauben übersetzte Codekommentare. Das README verlangt dagegen, Codebeispiele einschließlich ihrer Kommentare unverändert zu lassen. Die deutsche Fassung folgt hier dem README, ebenso wie `fr`, `gr`, `it`, `ja` und `uk`. Auch bei Include-Beschriftungen und FAQ-Kürzeln gibt es Unterschiede; für Deutsch gelten die unten festgelegten Regeln.
+
+## Grundregel und Rangfolge der Quellen
+
+Übersetze Erklärungen und Handlungsanweisungen in natürliches, präzises Deutsch. Erhalte Zeichenfolgen exakt, wenn die lesende Person sie auf dem Bildschirm finden, eingeben, aufrufen oder kopieren muss.
+
+1. Für Bedeutung, Verhalten, Voraussetzungen, Einschränkungen und Reihenfolge gilt die entsprechende Datei unter `docs/en`. Lies zunächst den gesamten englischen Artikel.
+2. Für Struktur und besondere Auszeichnungen gelten das README und die Konventionen dieses Repositorys.
+3. Für deutsche Begriffe und Schreibweisen gelten dieses Dokument und `docs/de/glossary.txt`.
+4. Für UI-Beschriftungen gelten die tatsächlich beschriebene Version, Anzeigesprache und Abbildung des Produkts.
+5. Für noch nicht erfasste Fachbegriffe dienen passende deutschsprachige Primärquellen als sprachliche Orientierung.
+
+Die Dokumentation anderer Produkte belegt Sprachgebrauch. Sie ändert keine Defold-Spezifikation. Wenn eine Erklärung im englischen Original unklar erscheint, halte die Frage für eine technische Prüfung fest, statt nur in der Übersetzung ein anderes Verhalten zu beschreiben.
+
+## Sprachvariante, Ansprache und Ton
+
+Verwende heutiges Standarddeutsch mit der in Deutschland üblichen Rechtschreibung, einschließlich Umlauten und `ß`. Das Verzeichnis bleibt `docs/de`; es wird keine regionale Variante im Dateinamen ergänzt.
+
+- Sprich die lesende Person mit kleingeschriebenem `du`, `dir`, `dich` und `dein` an. Schreibe in Anleitungen beispielsweise `Öffne`, `Wähle`, `Klicke`, `Ziehe` und `Prüfe`.
+- Verwende vollständige, direkte Sätze. `Du kannst die Position ändern` ist klarer als `Es besteht die Möglichkeit einer Positionsänderung`.
+- Benenne das handelnde System: `Die Engine lädt die Ressource`, `Der Editor zeigt die Vorschau`.
+- Teile lange englische Sätze bei Bedarf auf. Erhalte Bedingungen, Verneinungen, Begründungen und die Reihenfolge der Schritte.
+- Übersetze `we` passend zum Zusammenhang: `In diesem Beispiel erstellen wir ...` bei einer gemeinsamen Demonstration; benenne das Defold-Team, wenn dessen Aussage gemeint ist.
+- Verwende natürliche neutrale Formulierungen wie `das Entwicklungsteam` oder die direkte Ansprache, wo sie passen. Füge dem Original keine Aussagen über Personengruppen hinzu.
+- Übernimm keine zusätzlichen Wertungen wie `einfach`, `offensichtlich` oder `garantiert`, wenn das Original sie nicht enthält.
+
+Die Du-Ansprache ist eine redaktionelle Entscheidung für diese Dokumentation. Offizielle Quellen verwenden verschiedene Formen: [Godot][G1] und [Visual Studio][M1] verwenden auf den untersuchten Seiten `Sie`, die [Blueprint-Grundlagen von Unreal Engine][E2] verwenden `du`.
+
+| Englischer Ausgangssatz | Deutsche Form |
+|---|---|
+| Select Add Game Object. | Wähle <kbd>Add Game Object</kbd>. |
+| You can change the position at runtime. | Du kannst die Position zur Laufzeit ändern. |
+| The editor displays the resource properties. | Der Editor zeigt die Eigenschaften der Ressource an. |
+| Do not modify this value. | Ändere diesen Wert nicht. |
+
+## Verpflichtung, Empfehlung und Möglichkeit
+
+Erhalte die Verbindlichkeit einer Aussage und die Reichweite ihrer Verneinung.
+
+| Bedeutung im Original | Deutsche Form |
+|---|---|
+| must / required | muss / erforderlich |
+| must not | darf nicht |
+| should / recommended | sollte / empfohlen |
+| should not | sollte nicht |
+| can, bei einer Fähigkeit | kann |
+| may, bei einer Erlaubnis | darf |
+| may / might, bei einer Möglichkeit | kann / möglicherweise |
+| cannot / unsupported | kann nicht / wird nicht unterstützt |
+
+`May not` kann ein Verbot oder die Möglichkeit ausdrücken, dass etwas nicht geschieht. Entscheide anhand des Zusammenhangs. Erhalte Einschränkungen wie `nur`, `alle`, `jeweils`, `mindestens`, `höchstens`, `vor` und `nach`. `Mehr als` und `mindestens` bezeichnen unterschiedliche Grenzen. Zahlen, Einheiten, Standardwerte und Versionsbedingungen behalten ihren Wert.
+
+## Grundbegriffe und erste Nennung
+
+Führe wichtige Defold-Begriffe bei der ersten erklärenden Nennung eines Artikels auf Deutsch mit dem englischen Begriff in Klammern ein:
+
+- `Spielobjekt (game object)`
+- `Komponente (component)`
+- `Sammlung (collection)`
+- `Startsammlung (bootstrap collection)`
+- `Fabrik (factory)`
+- `Sammlungsfabrik (collection factory)`
+- `Sammlungs-Proxy (collection proxy)`
+- `Eingabebindung (input binding)`
+
+Danach genügt die deutsche Form. Eine genaue UI-Beschriftung wie <kbd>Collection Factory</kbd>, eine Erweiterung wie `.collectionfactory` oder ein Aufruf wie `collectionfactory.create()` bleibt unverändert. Gib den englischen Begriff in einem eigenständig lesbaren Artikel bei Bedarf erneut an, aber nicht bei jeder Wiederholung.
+
+Allgemeine Überschriften werden übersetzt. Verwende beispielsweise `Sammlungen` und erläutere den englischen Begriff im ersten Absatz. Eine Überschrift mit einem API-Namen oder einer exakten Einstellung behält diesen Namen.
+
+`Sammlung`, `Startsammlung`, `Fabrik`, `Sammlungsfabrik` und `Sammlungs-Proxy` sind hier festgelegte deutsche Erklärbegriffe für Defold. Sie sind keine aus Godot oder Unreal Engine übernommenen Typnamen und keine bestätigten deutschen Editorbeschriftungen.
+
+## Vergleich der offiziellen deutschsprachigen Quellen
+
+Die Tabelle trennt nachgewiesene Wörter von den Entscheidungen für Defold. Auch offizielle Übersetzungen enthalten wechselnde Schreibweisen oder englische Resttexte. Übernimm daraus keine Fehler und prüfe stets den eigentlichen deutschsprachigen Absatz.
+
+| Bereich | Beobachteter Sprachgebrauch | Entscheidung für die deutsche Defold-Dokumentation |
+|---|---|---|
+| Engine, Editor, Instanz | [Godot][G1] verwendet diese Fachwörter | Engine, Editor und Instanz übernehmen |
+| node | [Godot][G1] verwendet Node; [Unreal Engine][E2] verwendet auch Knoten | Für Defold-GUI-Elemente `Knoten` und `GUI-Knoten`; Godots Typ `Node` bleibt bei Produktvergleichen erhalten |
+| property | [Godot 4.5][G1] verwendet Propertys; [Unreal Engine][E2] verwendet Eigenschaften | Im erklärenden Text `Eigenschaft` |
+| transform / translation | [Godot][G2] verwendet Transformation, Verschiebung, Drehung und Skalierung | `Transformation` als Oberbegriff; räumliche translation heißt `Verschiebung` |
+| material / shader / texture | [Unreal Engine][E1] verwendet Material, Shader und Textur | Diese Begriffe übernehmen und ihre unterschiedlichen Aufgaben erhalten |
+| asset / mesh / component | [Unreal Engine][E2] verwendet Asset, Mesh und Komponente | Asset für Produktionsmaterial, Mesh für Geometrie, Komponente für den Defold-Baustein |
+| layer / opacity / transparency | [GIMP][I1] verwendet Ebene, Deckkraft und Transparenz | Diese Wörter verwenden; GIMP-Ebenen und Defold-GUI-Ebenen behalten ihre produktspezifische Bedeutung |
+| build / compile | [Visual Studio][M1] verwendet Erstellen, Build und Kompilieren | Build als Gesamtvorgang oder Ergebnis, Kompilierung als Teilvorgang |
+| breakpoint / debugging | [Visual Studio][M2] verwendet Haltepunkt und Debuggen | `Haltepunkt`, `debuggen`, `Debugger`; allgemein auch `Fehlersuche` |
+| unit test / integration test | [Microsoft .NET][M3] verwendet Komponententest und Integrationstest | `Unit-Test` und `Integrationstest`; Unit-Test hält die getestete Softwareeinheit sprachlich von einer Defold-Komponente getrennt |
+| HTTP request / response | [MDN][W1] verwendet Anfrage, Antwort und Statuscode | `HTTP-Anfrage`, `HTTP-Antwort`, `Statuscode`; Methoden, Header und Datenfelder bleiben exakt |
+
+## Bedeutungen, die getrennt bleiben müssen
+
+- Eine Sammlung definiert die Anordnung und Hierarchie von Spielobjekten in einer Datei. Die Datei, ihre instanziierten Inhalte und eine geladene Spielwelt sind unterschiedliche Dinge.
+- Eine Fabrik erzeugt Spielobjekte. Eine Sammlungsfabrik erzeugt die Inhalte einer Sammlung in der aktuellen Spielwelt. Ein Sammlungs-Proxy lädt eine eigene Spielwelt einschließlich einer eigenen Physikwelt. Maßgeblich sind die Handbücher zu [Sammlungsfabriken](../en/manuals/collection-factory.md) und [Sammlungs-Proxys](../en/manuals/collection-proxy.md).
+- Die Sammlungshierarchie bestimmt den Kontext der Adressierung. Die Eltern-Kind-Hierarchie bestimmt die Weitergabe von Transformationen. Das Ändern der Elternzuordnung verändert die Adresse des untergeordneten Spielobjekts nicht; siehe [Bausteine](../en/manuals/building-blocks.md).
+- Ein GUI-Knoten ist kein Spielobjekt. Ein Godot-Node, ein Unreal-Actor und ein Defold-Spielobjekt behalten ihre jeweiligen Bedeutungen.
+- Ein Prototyp ist im Defold-Kontext die Definition, auf der Instanzen beruhen. Die Metapher `blueprint` darf als `Bauplan` erklärt werden; die Unreal-Funktion `Blueprint` behält ihren Namen.
+- `Ressource` bezeichnet Daten im Defold-Ressourcensystem. `Asset` bezeichnet Produktionsmaterial wie Bilder, Modelle oder Audiodateien. Wende keine pauschale Ersetzung zwischen beiden an.
+- `Eigenschaft` bezeichnet eine property; ein Vertex-Attribut bleibt ein Attribut. Ein URL-Fragment und ein Fragment beim Rendern haben unterschiedliche Bedeutungen.
+- `Runtime` als Softwareumgebung heißt `Laufzeitumgebung`; `at runtime` heißt `zur Laufzeit`. Die Dauer einer Berechnung heißt `Ausführungszeit`.
+- Build, Kompilierung, Bundle-Erstellung, Start und Veröffentlichung sind getrennte Vorgänge. Schreibe `einen Build erstellen`, `Code kompilieren` und `ein Bundle erstellen` entsprechend dem Original.
+- Hot Reload beim Entwickeln und Live Update für Spielinhalte sind unterschiedliche Funktionen. Ebenso unterscheiden sich Editorvorschau und Aufnahme des laufenden Spiels sowie Editorserver und Engine-Dienst.
+- Aktivieren, sichtbar machen, initialisieren, löschen, finalisieren und entladen bezeichnen unterschiedliche Zustandsänderungen. Erhalte auch die Unterscheidung zwischen Ereignis, Nachricht und Callback.
+
+## Englische Fachwörter, Grammatik und Zusammensetzungen
+
+Verwende etablierte Fachwörter wie `Engine`, `Editor`, `Sprite`, `Shader`, `Mesh`, `Asset`, `Build`, `Bundle`, `Callback`, `Debugger`, `Profiler` und `Cache`, wie im Glossar festgelegt. Gib bei Bedarf eine kurze deutsche Erklärung. Verwende `Skript` mit `k` in der Prosa; `Script` als genaue UI-Beschriftung und `.script` als Dateierweiterung bleiben erhalten.
+
+Die folgenden Formen legen Artikel und Plural für diese Dokumentation fest:
+
+| Singular | Plural |
+|---|---|
+| die Engine | die Engines |
+| der Editor | die Editoren |
+| das Skript | die Skripte |
+| das Sprite | die Sprites |
+| der Shader | die Shader |
+| das Mesh | die Meshes |
+| das Asset | die Assets |
+| der Build | die Builds |
+| das Bundle | die Bundles |
+| der Atlas | die Atlanten |
+| der Proxy | die Proxys |
+| der Cache | die Caches |
+| das Token | die Tokens |
+| der Callback | die Callbacks |
+| die API | die APIs |
+| die GUI | die GUIs |
+| die URL | die URLs |
+
+Schreibe Substantive auch in Überschriften groß und Verben wie `rendern`, `kompilieren` und `debuggen` klein. Überschriften folgen der deutschen Satzschreibung: `Ein neues Spielobjekt erstellen`.
+
+Deutsche Zusammensetzungen stehen zusammen: `Spielobjekt`, `Sammlungsdatei`, `Projekteinstellungen`, `Texturfilterung`, `Bildschirmauflösung`. Bei Abkürzungen und zur besseren Lesbarkeit mit englischen Fachwörtern verwende Bindestriche: `GUI-Knoten`, `Lua-Skript`, `HTTP-Anfrage`, `2D-Grafik`, `3D-Modell`, `Build-Bericht`, `Sprite-Komponente`, `Vertex-Shader`, `Defold-Editor`.
+
+Füge Bindestriche oder deutsche Endungen nicht innerhalb eines Literals ein. Schreibe beispielsweise: der Wert von `message_id`, die Datei `game.project`. Plurale erhalten keinen Apostroph: `Sprites`, `Builds`, `APIs`.
+
+## Benutzeroberfläche, Aktionen und Tastatur
+
+Bei Anleitungen für eine englische Oberfläche und bei englischen Bildschirmabbildungen bleiben die Beschriftungen englisch. Übersetze den Satz um die Beschriftung herum:
+
+- `Wähle <kbd>Add Game Object</kbd>.`
+- `Wähle das Spielobjekt in der Ansicht <kbd>Outline</kbd>.`
+- `Ändere den Wert im Bereich <kbd>Properties</kbd>.`
+- `Wähle <kbd>Edit ▸ World Space</kbd>.`
+
+Wenn ein Artikel ausdrücklich eine deutsche Produktoberfläche beschreibt, verwende deren für die betreffende Version überprüfte offizielle Beschriftung. Prüfe sie im Produkt oder in dessen offizieller Lokalisierungsdatei. Bei englischen Abbildungen hilft die englische Beschriftung in Klammern. Die Wörter im Glossar allein belegen keine deutsche Defold-UI.
+
+In Einstellungsreferenzen bleiben Kategorien, Feldnamen und Werte genau wie in der beschriebenen Oberfläche oder Konfigurationsdatei. Erläutere beispielsweise `Max Nodes` als `maximale Anzahl der Knoten`, ohne den Feldnamen zu ersetzen.
+
+Erhalte vorhandene `<kbd>`-Tags und Hervorhebungen. Verwende für neu formulierte Menüpfade `▸`. Ändere beim Übersetzen nicht pauschal jede andere Menüschreibweise oder Hervorhebung des Originals.
+
+Beschreibt der Inhalt eines `<kbd>`-Tags eine normale Handlung, wird diese übersetzt: `<kbd>right-click</kbd>` → `<kbd>Rechtsklick</kbd>`, `<kbd>drag</kbd>` → `<kbd>ziehen</kbd>`, `<kbd>drop</kbd>` → `<kbd>ablegen</kbd>`. Entscheidend ist die Funktion des Textes, nicht allein das Tag.
+
+Tastennamen, Kombinationen und Unterschiede zwischen Betriebssystemen bleiben wie im Original: `Ctrl`, `Cmd`, `Shift`, `Alt`, `Enter`. Ersetze `Ctrl` nicht automatisch durch `Strg` und passe Kürzel nicht anhand einer vermuteten deutschen Tastaturbelegung an.
+
+## Code, API und genaue Zeichenfolgen
+
+Lasse Codeblöcke einschließlich ihrer Kommentare, Einrückung, Leerzeichen und Zeichenfolgen unverändert, wie im README vorgegeben. Das gilt auch für Shell-Beispiele, JSON, Konfigurationen und Konsolenausgaben. Übersetze die zugehörige Erklärung außerhalb des Blocks.
+
+Erhalte insbesondere:
+
+- Funktionen, Namespaces und Callbacks: `msg.post()`, `go.animate()`, `gui.get_node()`, `init()`, `on_input()`.
+- Nachrichten, Konstanten und Felder: `set_parent`, `proxy_loaded`, `PLAYBACK_LOOP_PINGPONG`, `self`, `message_id`.
+- Beispielnamen und Adressen: `bean`, `buddy`, `controller`, `team_1`, `main:/manager#controller`, `@render`.
+- Dateien, Erweiterungen, Pfade und Schlüssel: `game.project`, `main.collection`, `.gui_script`, `.internal/editor.port`, `display.width`.
+- Befehle, Optionen und Umgebungsvariablen: `build-html5`, `--variant`, `PATH`.
+- HTTP-Methoden, Routen, Header und Ergebniswerte: `GET /ping`, `POST /eval`, `/openapi.json`, `Authorization: Bearer`, `success`, `duration_ms`.
+- Fehlermeldungen und erwartete Ausgaben, einschließlich ihrer Großschreibung und Satzzeichen.
+
+Verwende Backticks für technische Literale in der Prosa. Ersetze ASCII-Anführungszeichen, Bindestriche, Punkte oder andere Zeichen innerhalb von Code und Eingabewerten nicht durch typografische Varianten. Ein englischer Codekommentar ist kein Übersetzungsrest.
+
+## Markdown, Metadaten und Links
+
+- Erhalte die YAML-Begrenzer und Schlüssel des Front Matter. Übersetze die beschreibenden Werte von `title` und `brief`; erhalte Pfade, IDs, boolesche Werte und andere technische Metadaten.
+- Erhalte Reihenfolge und Ebenen der Überschriften sowie die Struktur von Listen, Tabellen und Definitionslisten. Fasse keine Anleitungsschritte zusammen und lasse keine Tabellenzeilen aus.
+- Erhalte explizite Anker wie `{#the-editor-views}` oder `<a id="example">`. Prüfe Verweise auf automatisch aus Überschriften erzeugte Anker nach der Übersetzung.
+- Erhalte `::: sidenote`, `::: important` und die schließenden `:::`. Übersetze den Text innerhalb dieser Blöcke.
+- Erhalte Include-Anweisungen wie `:[components](../shared/components.md)` einschließlich Beschriftung und Pfad. Behandle sie getrennt von gewöhnlichen Markdown-Links.
+- Erhalte Codezäune, Sprachkennungen, HTML-Tags, technische Attribute, Klassen und Template-Ausdrücke.
+- Übersetze beschreibende Linktexte und alternative Bildtexte. Namen von APIs, Produkten und genauen UI-Elementen bleiben darin erhalten.
+- Erhalte Linkziele, Referenz-IDs, Bildpfade, Dateinamen, Abfrageparameter, Fragmente und abschließende Schrägstriche. Ergänze nicht eigenständig `/de/` in URLs.
+- Prüfe, ob kopierte relative Pfade auch vom deutschen Dateistandort aus auflösbar sind. Fehlende Übersetzungen oder Bilddateien müssen ausdrücklich geklärt werden.
+- Setze Leerzeilen um Überschriften, Listen, Tabellen und Codeblöcke. Vermeide Leerzeichen direkt innerhalb von Hervorhebungsmarkierungen.
+
+Beispiele:
+
+- `[Project settings](/manuals/project-settings/#debug)` → `[Projekteinstellungen](/manuals/project-settings/#debug)`.
+- `[gui.clone()](/ref/gui/#gui.clone:node)` bleibt unverändert.
+- `![Editor overview](images/introduction/editor.png)` → `![Übersicht des Editors](images/introduction/editor.png)`.
+
+## Deutsche Zeichensetzung, Zahlen und Einheiten
+
+Diese Regeln gelten für erklärenden Text. Technische Zeichenfolgen behalten die Schreibweise des Originals.
+
+- Verwende `„…“` für gewöhnliche Zitate und `‚…‘` für Zitate darin; Backticks für Literale.
+- Vor Punkt, Komma, Doppelpunkt, Semikolon, Fragezeichen und Ausrufezeichen steht kein Leerzeichen. Nach Satzzeichen folgt ein Leerzeichen, soweit die Markdown-Syntax nichts anderes verlangt.
+- Setze Kommas bei Nebensätzen, beispielsweise mit `wenn`, `weil`, `dass` und `damit`. Übernimm die englische Kommasetzung nicht mechanisch.
+- Verwende echte Umlaute und `ß`: `größer`, `schließen`, `auswählen`. Schreibungen wie `groesser` sind nur Teil eines unveränderten Literals zulässig.
+- Schreibe in gewöhnlichem Fließtext Dezimalzahlen mit Komma, beispielsweise `0,5 Sekunden`. Ein einzugebender Wert, Code, eine Koordinate in Codeformat, eine Version oder ein API-Beispiel behält den Punkt: `0.5`, `vmath.vector3(0.5, 1, 0)`, `1.2.3`.
+- Trenne Zahl und Einheit durch ein Leerzeichen: `60 Hz`, `16 ms`, `128 MB`, `50 %`. Ändere weder Größenordnung noch Präzision und verwechsle `MB` nicht mit `MiB`.
+- Schreibe beschreibende Bildmaße als `1280 × 720`. Literale wie `1280x720` bleiben erhalten.
+- Verwende für technische Werte Ziffern. Portnummern, IDs und Versionsnummern erhalten keine Tausendertrennzeichen. Gruppiere bei Bedarf große Mengen im Fließtext mit Leerzeichen, beispielsweise `10 000 Spielobjekte`.
+- Schreibe Datumsangaben in der Prosa eindeutig, etwa `12. September 2026`. Maschinenlesbare Datumswerte und Metadaten bleiben im Originalformat.
+
+## Produktnamen, Abkürzungen und FAQ
+
+Erhalte die offizielle Schreibweise von `Defold`, `Defold Foundation`, `Lua`, `LuaJIT`, `JavaScript`, `OpenAPI`, `GitHub`, `macOS`, `iOS`, `Spine`, `Rive` und `Automation Bridge`. Schreibe in der Prosa `Defold`, `die Defold-Engine` und `der Defold-Editor`.
+
+API, GUI, HTTP, JSON, HTML5, CPU, GPU, SDK, CI, LLM und MCP bleiben erhalten. Allgemeines `artificial intelligence / AI` heißt `künstliche Intelligenz (KI)`; Produktnamen, API-Felder und exakte englische Titel behalten `AI`. Führe unbekannte Abkürzungen bei der ersten Nennung ein, beispielsweise `großes Sprachmodell (Large Language Model, LLM)`.
+
+Erhalte in FAQ die Kürzel `Q:` und `A:`, die Überschriftenebenen und die Reihenfolge des englischen Originals. Übersetze Frage und Antwort sowie beschreibende Abschnittstitel:
+
+- `#### Q: Ist Defold kostenlos?`
+- `A: Ja, ...`
+- `General questions` → `Allgemeine Fragen`.
+- `Publishing games` → `Spiele veröffentlichen`.
+
+Unterscheide bei Lizenz- und Veröffentlichungsfragen `kostenlos`, `Open Source`, `mit einsehbarem Quellcode` und `lizenzgebührenfrei` entsprechend der Aussage des Originals.
+
+## Glossar erweitern und Übersetzungen prüfen
+
+Suche vor einem neuen Eintrag nach Singular, Plural, Varianten mit Bindestrich und der englischen Schreibweise. Fasse dieselbe Bedeutung in einem Eintrag zusammen. Trenne unterschiedliche Bedeutungen wie räumliche und sprachliche translation ausdrücklich.
+
+Prüfe einen fehlenden Begriff zuerst im englischen Defold-Kontext und anschließend in einer fachlich passenden offiziellen deutschen Quelle. Halte den bevorzugten Ausdruck, die relevante Bedeutung, die URL und bei neuen Belegen das Prüfdatum fest. Eine URL mit `de` allein genügt nicht als Nachweis. Kennzeichne eigene Defold-Erklärbegriffe als redaktionelle Wahl.
+
+Vor Abschluss eines Artikels:
+
+1. Vergleiche den Inhalt mit dem englischen Original: Erklärungen, Voraussetzungen, Einschränkungen, Warnungen, Schritte und Tabellen müssen vollständig sein.
+2. Prüfe Verpflichtungen, Verneinungen, Mengen, Grenzwerte, Einheiten und Ausführungsreihenfolgen.
+3. Prüfe Glossarbegriffe, englische Erstnennungen, Du-Ansprache, Artikel, Plurale und deutsche Zusammensetzungen.
+4. Vergleiche Codeblöcke einschließlich ihrer Kommentare, technische Literale, UI-Beschriftungen, Tastenkürzel und Ausgaben mit dem Original.
+5. Prüfe Front Matter, Markdown, Anker, Includes, Linkziele und Bildpfade. Für übersetzte Markdown-Artikel stehen die [Werkzeuge zur Konsistenzprüfung](../../scripts/README.md) zur Verfügung.
+6. Suche nach unübersetzten Erklärungen, doppelten zweisprachigen Überschriften, beschädigten Zeichen und Git-Konfliktmarkierungen. Bewusst erhaltene Literale bleiben davon ausgenommen.
+7. Lies den deutschen Text eigenständig: Sind Handlung, Bezug und technischer Sinn ohne Rückübersetzung verständlich?
+
+## Geprüfte offizielle Quellen
+
+Die folgenden neun Seiten enthalten die für die Entscheidungen herangezogenen deutschen Textstellen. Sie stammen von zwei Game-Engine-Projekten sowie GIMP, Microsoft Learn und MDN. Versionsangaben bezeichnen die untersuchten Dokumentationsfassungen. Prüfdatum: 2026-09-12.
+
+- [G1: Godot 4.5 — Nodes und Szenen][G1]. Engine, Editor, Instanz, Node und Property; teilweise englische Abschnitte.
+- [G2: Godot 4.5 — Viewport- und Canvas-Transformationen][G2]. Transformation, Verschiebung, Drehung, Skalierung und Koordinatensystem.
+- [E1: Unreal Engine — Materialien][E1]. Material, Shader, Textur und Arbeitsablauf.
+- [E2: Unreal Engine — Blueprint-Grundlagen][E2]. Komponente, Eigenschaft, Knoten, Asset, Mesh und Du-Ansprache.
+- [I1: GIMP 3.0 — Bilder kombinieren][I1]. Ebene, Deckkraft, Transparenz, Alphakanal und Sichtbarkeit; teilweise englische Abschnitte.
+- [M1: Visual Studio — Kompilieren und Erstellen][M1]. Build, Erstellen, Kompilieren und Zielplattform.
+- [M2: Visual Studio — Übersicht über den Debugger][M2]. Haltepunkt, Debugger und schrittweise Ausführung.
+- [M3: .NET — Testen in .NET][M3]. Automatisierte Tests, Komponententests und Integrationstests.
+- [W1: MDN — Überblick über HTTP][W1]. Anfrage, Antwort, Header und Statuscode.
+
+Die Quellen belegen einzelne deutsche Verwendungen. Die daraus abgeleiteten Empfehlungen, insbesondere Ansprache, Artikel, zusammengesetzte Begriffe und Defold-spezifische Übersetzungen, sind redaktionelle Festlegungen dieser deutschen Fassung.
+
+[G1]: https://docs.godotengine.org/de/4.5/getting_started/step_by_step/nodes_and_scenes.html
+[G2]: https://docs.godotengine.org/de/4.5/tutorials/2d/2d_transforms.html
+[E1]: https://dev.epicgames.com/documentation/de-de/unreal-engine/unreal-engine-materials
+[E2]: https://dev.epicgames.com/documentation/de-de/unreal-engine/blueprint-foundations
+[I1]: https://docs.gimp.org/3.0/de/gimp-image-combining.html
+[M1]: https://learn.microsoft.com/de-de/visualstudio/ide/compiling-and-building-in-visual-studio?view=visualstudio
+[M2]: https://learn.microsoft.com/de-de/visualstudio/debugger/debugger-feature-tour?view=visualstudio
+[M3]: https://learn.microsoft.com/de-de/dotnet/core/testing/
+[W1]: https://developer.mozilla.org/de/docs/Web/HTTP/Guides/Overview

--- a/docs/de/tutorials/15-puzzle.md
+++ b/docs/de/tutorials/15-puzzle.md
@@ -1,0 +1,394 @@
+---
+title: Ein 15-Puzzle in Defold erstellen
+brief: Wenn du neu bei Defold bist, hilft dir diese Anleitung, mit einigen Bausteinen von Defold zu experimentieren und Skriptlogik auszuführen.
+---
+
+# Das klassische 15-Puzzle {#the-classic-15-puzzle}
+
+Dieses bekannte Puzzle wurde in Amerika in den 1870er-Jahren populär. Ziel des Puzzles ist es, die Kacheln auf dem Spielbrett durch horizontales und vertikales Verschieben in die richtige Reihenfolge zu bringen. Das Puzzle beginnt mit einer Anordnung, in der die Kacheln durcheinandergewürfelt sind.
+
+Bei der gängigsten Version des Puzzles stehen auf den Kacheln die Zahlen 1--15. Du kannst das Puzzle jedoch etwas anspruchsvoller machen, indem die Kacheln Teile eines Bildes darstellen. Versuche, das Puzzle zu lösen, bevor wir beginnen. Klicke auf eine Kachel neben dem leeren Feld, um sie auf die leere Position zu schieben.
+
+## Das Projekt erstellen {#creating-the-project}
+
+1. Starte Defold.
+2. Wähle links *New Project*.
+3. Wähle den Tab *From Template*.
+4. Wähle *Empty Project*
+5. Wähle einen Speicherort für das Projekt auf deinem lokalen Laufwerk.
+6. Klicke auf *Create New Project*.
+
+Öffne die Einstellungsdatei *game.project* und setze die Abmessungen des Spiels auf 512 × 512. Diese Abmessungen entsprechen dem Bild, das du verwenden wirst.
+
+![Anzeigeeinstellungen](images/15-puzzle/display_settings.png)
+
+Lade als Nächstes ein geeignetes Bild für das Puzzle herunter. Wähle ein beliebiges quadratisches Bild und achte darauf, es auf 512 mal 512 Pixel zu skalieren. Wenn du nicht nach einem Bild suchen möchtest, kannst du dieses verwenden:
+
+![Mona Lisa](images/15-puzzle/monalisa.png)
+
+Lade das Bild herunter und ziehe es dann in den Ordner *main* deines Projekts.
+
+## Das Raster darstellen {#representing-the-grid}
+
+Defold enthält die eingebaute Komponente (component) *Kachelkarte* (tile map), die sich perfekt zur Darstellung des Spielbretts eignet. Mit Kachelkarten kannst du einzelne Kacheln setzen und auslesen, und mehr brauchst du für dieses Projekt nicht.
+
+Bevor du die Kachelkarte erstellst, benötigst du jedoch eine *Kachelquelle* (tile source), aus der die Kachelkarte ihre Kachelbilder bezieht.
+
+Mache einen <kbd>Rechtsklick</kbd> auf den Ordner *main* und wähle <kbd>New ▸ Tile Source</kbd>. Nenne die neue Datei `monalisa.tilesource`.
+
+Setze die Kacheleigenschaften *Width* und *Height* auf 128. Dadurch wird das 512 × 512 Pixel große Bild in 16 Kacheln aufgeteilt. Die Kacheln werden mit 1--16 nummeriert, wenn du sie auf der Kachelkarte platzierst.
+
+![Kachelquelle](images/15-puzzle/tilesource.png)
+
+Mache als Nächstes einen <kbd>Rechtsklick</kbd> auf den Ordner *main* und wähle <kbd>New ▸ Tile Map</kbd>. Nenne die neue Datei "grid.tilemap".
+
+Defold erfordert, dass du das Raster initialisierst. Wähle dazu die Ebene "layer1" und male das 4 × 4 große Kachelraster direkt oberhalb und rechts vom Ursprung. Es ist dabei nicht entscheidend, welche Kacheln du setzt. Du wirst gleich Code schreiben, der den Inhalt dieser Kacheln automatisch festlegt.
+
+![Kachelkarte](images/15-puzzle/tilemap.png)
+
+## Die Teile zusammenfügen {#putting-the-pieces-together}
+
+Öffne die Sammlung (collection) *main.collection*. Mache einen <kbd>Rechtsklick</kbd> auf den Wurzelknoten in der Ansicht *Outline* und wähle <kbd>Add Game Object</kbd>. Setze die Eigenschaft *Id* des neuen Spielobjekts (game object) auf "game".
+
+Mache einen <kbd>Rechtsklick</kbd> auf das Spielobjekt und wähle <kbd>Add Component File</kbd>. Wähle die Datei *grid.tilemap*. Setze die Eigenschaft *Id* auf "tilemap".
+
+Mache einen <kbd>Rechtsklick</kbd> auf das Spielobjekt und wähle <kbd>Add Component ▸ Label</kbd>. Setze die Eigenschaft *Id* der Beschriftungskomponente (label) auf "done" und ihre Eigenschaft *Text* auf "Well done". Verschiebe die Beschriftung in die Mitte der Kachelkarte.
+
+Setze die Z-Position der Beschriftung auf 1, damit sie über dem Raster gezeichnet wird.
+
+![Hauptsammlung](images/15-puzzle/main_collection.png)
+
+Erstelle als Nächstes eine Lua-Skriptdatei für die Puzzlelogik: Mache einen <kbd>Rechtsklick</kbd> auf den Ordner *main* und wähle <kbd>New ▸ Script</kbd>. Nenne die neue Datei "game.script".
+
+Mache dann einen <kbd>Rechtsklick</kbd> auf das Spielobjekt namens "game" in *main.collection* und wähle <kbd>Add Component File</kbd>. Wähle die Datei *game.script*.
+
+Starte das Spiel. Du solltest das Raster so sehen, wie du es gezeichnet hast, und darüber die Beschriftung mit der Meldung "Well done".
+
+## Die Puzzlelogik {#the-puzzle-logic}
+
+Jetzt sind alle Teile an ihrem Platz, sodass sich der Rest des Tutorials dem Aufbau der Puzzlelogik widmet.
+
+Das Skript verwaltet eine eigene Darstellung der Kacheln des Spielbretts, getrennt von der Kachelkarte. So lässt sich die Verarbeitung erleichtern. Statt die Kacheln in einem zweidimensionalen Array zu speichern, werden sie als eindimensionale Liste in einer Lua-Tabelle gespeichert. Die Liste enthält die Kachelnummern in ihrer Reihenfolge, beginnend in der oberen linken Ecke des Rasters bis hin zur unteren rechten Ecke:
+
+```lua
+-- The completed board looks like this:
+self.board = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0}
+```
+
+Der Code, der eine solche Kachelliste auf unserer Kachelkarte zeichnet, ist recht einfach. Er muss jedoch die Position in der Liste in eine x- und eine y-Position umrechnen:
+
+```lua
+-- Draw a table list of tiles onto a 4x4 tilemap
+local function draw(t)
+    for i=1, #t do
+        local y = 5 - math.ceil(i/4) -- <1>
+        local x = i - (math.ceil(i/4) - 1) * 4
+        tilemap.set_tile("#tilemap","layer1",x,y,t[i])
+    end
+end
+```
+1. In Kachelkarten befindet sich die Kachel mit dem x-Wert 1 und dem y-Wert 1 unten links. Deshalb muss die y-Position umgekehrt werden.
+
+Du kannst prüfen, ob die Funktion wie beabsichtigt arbeitet, indem du zum Testen eine `init()`-Funktion erstellst:
+
+```lua
+function init(self)
+    -- An inverted board, for test
+    self.board = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+    draw(self.board)
+end
+```
+
+Da die Kacheln als Liste in einer Lua-Tabelle vorliegen, lässt sich ihre Reihenfolge sehr leicht mischen. Der Code durchläuft einfach jedes Element der Liste und vertauscht jede Kachel mit einer anderen, zufällig ausgewählten Kachel:
+
+```lua
+-- Swap two items in a table list
+local function swap(t, i, j)
+    local tmp = t[i]
+    t[i] = t[j]
+    t[j] = tmp
+    return t
+end
+
+-- Randomize the order of a the elements in a table list
+local function scramble(t)
+    local n = #t
+    for i = 1, n - 1 do
+        t = swap(t, i, math.random(i, n))
+    end
+    return t
+end
+```
+
+Bevor du fortfährst, musst du eine Besonderheit des 15-Puzzles beachten: Wenn du die Kacheln wie oben zufällig anordnest, besteht eine Wahrscheinlichkeit von 50 %, dass das Puzzle *unmöglich* zu lösen ist.
+
+Das ist eine schlechte Nachricht, denn du möchtest dem Spieler auf keinen Fall ein unlösbares Puzzle vorsetzen.
+
+Glücklicherweise lässt sich feststellen, ob eine Anordnung lösbar ist. Das geht so:
+
+## Lösbarkeit {#solvability}
+
+Um herauszufinden, ob eine Anordnung in einem 4 × 4 großen Puzzle lösbar ist, benötigst du zwei Informationen:
+
+1. Die Anzahl der „Inversionen“ in der Anordnung. Eine Inversion liegt vor, wenn eine Kachel vor einer anderen Kachel mit einer kleineren Zahl steht. Die Liste `{1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 11, 10, 13, 14, 15, 0}` hat beispielsweise 3 Inversionen:
+
+    - Auf die Zahl 12 folgen 11 und 10, was 2 Inversionen ergibt.
+    - Auf die Zahl 11 folgt 10, was 1 weitere Inversion ergibt.
+
+    (Beachte, dass der gelöste Zustand des Puzzles keine Inversionen hat.)
+
+2. Die Zeile, in der sich das leere Feld befindet (in der Liste durch `0` dargestellt).
+
+Diese beiden Zahlen lassen sich mit den folgenden Funktionen berechnen:
+
+```lua
+-- Count the number of inversions in a list of tiles
+local function inversions(t)
+    local inv = 0
+    for i=1, #t do
+        for j=i+1, #t do
+            if t[i] > t[j] and t[j] ~= 0 then -- <1>
+                inv = inv + 1
+            end
+        end
+    end
+    return inv
+end
+```
+1. Beachte, dass das leere Feld nicht mitgezählt wird.
+
+```lua
+-- Find the x and y position of a given tile
+local function find(t, tile)
+    for i=1, #t do
+        if t[i] == tile then
+            local y = 5 - math.ceil(i/4) -- <1>
+            local x = i - (math.ceil(i/4) - 1) * 4
+            return x,y
+        end
+    end
+end
+```
+1. Die y-Position, von unten gezählt.
+
+Anhand dieser beiden Zahlen lässt sich nun feststellen, ob ein Zustand des Puzzles lösbar ist. Ein Zustand eines 4 × 4 großen Spielbretts ist *lösbar*, wenn:
+
+- das leere Feld in einer *ungeraden* Zeile liegt (1 oder 3, von unten gezählt) und die Anzahl der Inversionen *gerade* ist.
+- das leere Feld in einer *geraden* Zeile liegt (2 oder 4, von unten gezählt) und die Anzahl der Inversionen *ungerade* ist.
+
+## Wie funktioniert das? {#how-does-this-work}
+
+Bei jedem erlaubten Zug wird eine Kachel verschoben, indem sie horizontal oder vertikal ihren Platz mit dem leeren Feld tauscht.
+
+Wird eine Kachel horizontal verschoben, ändert sich weder die Anzahl der Inversionen noch die Zeilennummer des leeren Feldes.
+
+Wird eine Kachel dagegen vertikal verschoben, ändert sich die Parität der Anzahl der Inversionen (von ungerade zu gerade oder von gerade zu ungerade). Außerdem ändert sich die Parität der Zeilennummer des leeren Feldes.
+
+Zum Beispiel:
+
+![Eine Kachel verschieben](images/15-puzzle/slide.png)
+
+Dieser Zug ändert die Kachelreihenfolge von:
+
+`{ ... 0, 11, 2, 13, 6 ... }`
+
+zu
+
+`{ ... 6, 11, 2, 13, 0 ... }`
+
+Die Gesamtzahl der Inversionen verringert sich dabei um 1:
+
+- Die Zahl 6 fügt 1 Inversion hinzu (die Zahl 2 steht jetzt nach der 6).
+- Die Zahl 11 verliert 1 Inversion (die Zahl 6 steht jetzt vor der 11).
+- Die Zahl 13 verliert 1 Inversion (die Zahl 6 steht jetzt vor der 13).
+
+Durch vertikales Verschieben kann sich die Anzahl der Inversionen um ±1 oder ±3 ändern.
+
+Die Zeilennummer des leeren Feldes kann sich durch vertikales Verschieben um ±1 ändern.
+
+Im Endzustand des Puzzles befindet sich das leere Feld in der unteren rechten Ecke (der *ungeraden* Zeile 1), und die Anzahl der Inversionen hat den *geraden* Wert 0. Jeder erlaubte Zug lässt diese beiden Werte entweder unverändert (horizontales Verschieben) oder kehrt ihre Parität um (vertikales Verschieben). Kein erlaubter Zug kann jemals dazu führen, dass die Parität der Inversionsanzahl und der Zeilennummer des leeren Feldes *ungerade*, *ungerade* oder *gerade*, *gerade* ist.
+
+Ein Zustand des Puzzles, in dem beide Zahlen ungerade oder beide gerade sind, ist daher unmöglich zu lösen.
+
+Hier ist der Code, der die Lösbarkeit prüft:
+
+```lua
+-- Is the given table list of 4x4 tiles solvable?
+local function solvable(t)
+    local x,y = find(t, 0)
+    if y % 2 == 1 and inversions(t) % 2 == 0 then
+        return true
+    end
+    if y % 2 == 0 and inversions(t) % 2 == 1 then
+        return true
+    end
+    return false    
+end
+```
+
+## Benutzereingaben {#user-input}
+
+Jetzt musst du nur noch dafür sorgen, dass sich das Puzzle bedienen lässt.
+
+Erstelle eine `init()`-Funktion, die mithilfe der oben erstellten Funktionen alle Vorbereitungen zur Laufzeit trifft:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus") -- <1>
+    math.randomseed(socket.gettime()) -- <2>
+    self.board = scramble({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0}) -- <3>
+    while not solvable(self.board) do -- <4>
+        self.board = scramble(self.board)
+    end
+    draw(self.board) -- <5>
+    self.done = false -- <6>
+    msg.post("#done", "disable") -- <7>
+end
+```
+1. Teile der Engine mit, dass dieses Spielobjekt Eingaben empfangen soll.
+2. Initialisiere den Zufallszahlengenerator mit einem Startwert.
+3. Erstelle einen zufälligen Anfangszustand für das Spielbrett.
+4. Wenn der Zustand unlösbar ist, mische erneut.
+5. Zeichne das Spielbrett.
+6. Setze ein Abschluss-Flag, um festzuhalten, ob das Puzzle gelöst ist.
+7. Deaktiviere die Beschriftung mit der Abschlussmeldung.
+
+Öffne */input/game.input_bindings* und füge einen neuen *Mouse Trigger* hinzu. Setze den Namen der Aktion auf "press":
+
+![Eingabe](images/15-puzzle/input.png)
+
+Kehre zum Skript zurück und erstelle eine `on_input()`-Funktion.
+
+```lua
+-- Deal with user input
+function on_input(self, action_id, action)
+    if action_id == hash("press") and action.pressed and not self.done then -- <1>
+        local x = math.ceil(action.x / 128) -- <2>
+        local y = math.ceil(action.y / 128)
+        local ex, ey = find(self.board, 0) -- <3>
+        if math.abs(x - ex) + math.abs(y - ey) == 1 then -- <4>
+            self.board = swap(self.board, (4-ey)*4+ex, (4-y)*4+x) -- <5>
+            draw(self.board) -- <6>
+        end
+        ex, ey = find(self.board, 0)
+        if inversions(self.board) == 0 and ex == 4 then -- <7>
+            self.done = true
+            msg.post("#done", "enable")
+        end
+    end
+end
+```
+1. Wenn eine Maustaste gedrückt wird und das Spiel noch läuft, führe Folgendes aus.
+2. Berechne die x- und y-Koordinaten des Feldes, auf das der Benutzer geklickt hat.
+3. Ermittle die aktuelle Position des leeren Feldes (0).
+4. Wenn das angeklickte Feld direkt über, unter, links oder rechts neben dem leeren Feld liegt, führe Folgendes aus:
+5. Vertausche die Kacheln auf dem angeklickten und dem leeren Feld.
+6. Zeichne das aktualisierte Spielbrett neu.
+7. Wenn die Anzahl der Inversionen auf dem Spielbrett 0 ist, also alles in der richtigen Reihenfolge steht, und sich das leere Feld in der äußersten rechten Spalte befindet (es muss in der letzten Zeile liegen, damit die Anzahl der Inversionen 0 ist), dann ist das Puzzle gelöst. Führe daher Folgendes aus:
+8. Setze das Abschluss-Flag.
+9. Aktiviere beziehungsweise zeige die Abschlussmeldung an.
+
+Und das war's! Du bist fertig, das Puzzlespiel ist vollständig!
+
+## Das vollständige Skript {#the-complete-script}
+
+Hier ist der vollständige Skriptcode zum Nachschlagen:
+
+```lua
+local function inversions(t)
+    local inv = 0
+    for i=1, #t do
+        for j=i+1, #t do
+            if t[i] > t[j] and t[j] ~= 0 then
+                inv = inv + 1
+            end
+        end
+    end
+    return inv
+end
+
+local function find(t, tile)
+    for i=1, #t do
+        if t[i] == tile then
+            local y = 5 - math.ceil(i/4)
+            local x = i - (math.ceil(i/4) - 1) * 4
+            return x,y
+        end
+    end
+end
+
+local function solvable(t)
+    local x,y = find(t, 0)
+    if y % 2 == 1 and inversions(t) % 2 == 0 then
+        return true
+    end
+    if y % 2 == 0 and inversions(t) % 2 == 1 then
+        return true
+    end
+    return false    
+end
+
+local function scramble(t)
+    for i=1, #t do
+        local tmp = t[i]
+        local r = math.random(#t)
+        t[i] = t[r]
+        t[r] = tmp
+    end
+    return t
+end
+
+local function swap(t, i, j)
+    local tmp = t[i]
+    t[i] = t[j]
+    t[j] = tmp
+    return t
+end
+
+local function draw(t)
+    for i=1, #t do
+        local y = 5 - math.ceil(i/4)
+        local x = i - (math.ceil(i/4) - 1) * 4
+        tilemap.set_tile("#tilemap","layer1",x,y,t[i])
+    end
+end
+
+function init(self)
+    msg.post(".", "acquire_input_focus")
+    math.randomseed(socket.gettime())
+    self.board = scramble({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0})   
+    while not solvable(self.board) do
+        self.board = scramble(self.board)
+    end
+    draw(self.board)
+    self.done = false
+    msg.post("#done", "disable")
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("press") and action.pressed and not self.done then
+        local x = math.ceil(action.x / 128)
+        local y = math.ceil(action.y / 128)
+        local ex, ey = find(self.board, 0)
+        if math.abs(x - ex) + math.abs(y - ey) == 1 then
+            self.board = swap(self.board, (4-ey)*4+ex, (4-y)*4+x)
+            draw(self.board)
+        end
+        ex, ey = find(self.board, 0)
+        if inversions(self.board) == 0 and ex == 4 then
+            self.done = true
+            msg.post("#done", "enable")
+        end
+    end
+end
+
+function on_reload(self)
+    self.done = false
+    msg.post("#done", "disable")
+end
+```
+
+## Weitere Übungen {#further-exercises}
+
+1. Erstelle ein 5 × 5 großes Puzzle und anschließend eines mit 6 × 5 Feldern. Achte darauf, dass die Lösbarkeitsprüfungen allgemein funktionieren.
+2. Füge Verschiebeanimationen hinzu. Kacheln lassen sich nicht unabhängig von der Kachelkarte bewegen, also musst du dir dafür eine Lösung überlegen. Vielleicht eine separate Kachelkarte, die nur die gerade verschobene Kachel enthält?

--- a/docs/de/tutorials/astronaut.md
+++ b/docs/de/tutorials/astronaut.md
@@ -1,0 +1,34 @@
+---
+title: Tutorial zur Bewegung in der Draufsicht
+brief: In diesem Tutorial für Einsteiger lernst du, wie du Spielereingaben erfasst und eine Spielfigur bewegst und animierst. Außerdem lernst du Spielobjekte (game objects), Komponenten (components) und Sammlungen (collections) kennen.
+github: https://github.com/defold/tutorial-astronaut
+difficulty: Beginner
+---
+
+# Tutorial zur Bewegung in der Draufsicht {#top-down-movement-tutorial}
+
+In diesem Tutorial für Einsteiger lernst du, wie du in Defold eine einfache Steuerung für eine Spielfigur in der Draufsicht erstellst. Du beginnst mit einem eigens vorbereiteten Projekt, sodass du dich nicht um die Assets und die grundlegende Einrichtung kümmern musst und dich auf die Spielmechanik konzentrieren kannst.
+
+Du erkundest die grundlegende Struktur eines Defold-Projekts, einschließlich Sammlungen, Spielobjekten, Sprites, Skripten, Kachelkarten (tile map), Atlanten und Kameras. Du fügst der Spielfigur Laufanimationen hinzu, verarbeitest Spielereingaben, bewegst das Spielobjekt mit Lua, normalisierst die diagonale Bewegung und wechselst die Animationen je nach Bewegungsrichtung.
+
+Am Ende hast du eine funktionsfähige, animierte Spielfigur, die sich durch einen kleinen, mit einer Kachelkarte aufgebauten Level bewegt. Dann kannst du das Projekt um Funktionen wie eine WASD-Steuerung, eine der Spielfigur folgende Kamera oder eine größere Karte erweitern.
+
+## Direkt in Defold starten {#run-it-from-the-defold-directly}
+
+Das Tutorial ist in den Defold-Editor integriert und lässt sich bequem über den Defold-Willkommensbildschirm aufrufen:
+
+1. Wähle links *Create From* -> <kbd>Tutorials</kbd>.
+2. Wähle <kbd>Top-down Movement Tutorial</kbd>.
+3. Gib unter *Title* einen Titel für dein Projekt ein.
+4. Wähle unter *Location* einen Speicherort für das Projekt auf deinem lokalen Laufwerk.
+5. Klicke auf <kbd>Create New Project</kbd>.
+
+![Neues Projekt](images/top-down-start.webp)
+
+Der Editor öffnet automatisch die Datei „README“ aus dem Stammverzeichnis des Projekts. Sie enthält den vollständigen Tutorialtext, dem du folgen kannst.
+
+![Symbol](images/icon-tutorial.svg){.icon} [Du kannst den vollständigen Tutorialtext auch auf GitHub lesen](https://github.com/defold/tutorial-astronaut)
+
+Wenn du nicht weiterkommst, besuche das [Defold-Forum](//forum.defold.com). Dort helfen dir das Defold-Team und viele freundliche Nutzer.
+
+Viel Spaß mit Defold!

--- a/docs/de/tutorials/car.md
+++ b/docs/de/tutorials/car.md
@@ -1,0 +1,439 @@
+---
+title: Ein einfaches Auto in Defold bauen.
+brief: Wenn du neu bei Defold bist, hilft dir diese Anleitung dabei, dich im Editor zurechtzufinden. Sie erklärt außerdem die Grundideen und die häufigsten Bausteine von Defold – Spielobjekte, Sammlungen, Skripte und Sprites.
+---
+
+# Ein Auto bauen {#building-a-car}
+
+Wenn du neu bei Defold bist, hilft dir diese Anleitung dabei, dich im Editor zurechtzufinden. Sie erklärt außerdem die Grundideen und die häufigsten Bausteine von Defold: Spielobjekte (game objects), Sammlungen (collections), Skripte (scripts) und Sprites.
+
+Wir beginnen mit einem leeren Projekt und arbeiten uns Schritt für Schritt zu einer sehr kleinen, spielbaren Anwendung vor. Am Ende hast du hoffentlich ein Gefühl dafür, wie Defold funktioniert, und bist bereit, ein umfangreicheres Tutorial anzugehen oder direkt in die Handbücher einzusteigen.
+
+::: sidenote
+Im gesamten Tutorial sind ausführliche Beschreibungen von Konzepten und einzelnen Arbeitsschritten wie dieser Absatz gekennzeichnet. Wenn dir diese Abschnitte zu sehr ins Detail gehen, kannst du sie überspringen.
+:::
+
+## Ein neues Projekt erstellen {#creating-a-new-project}
+
+![Neues Projekt](images/new_empty.png)
+
+1. Starte Defold.
+2. Wähle links *New Project*.
+3. Wähle die Registerkarte *From Template*.
+4. Wähle *Empty Project*
+5. Wähle einen Speicherort für das Projekt auf deinem lokalen Laufwerk.
+6. Klicke auf *Create New Project*.
+
+## Der Editor {#the-editor}
+
+Erstelle zunächst ein [neues Projekt](/manuals/project-setup/) und öffne es im Editor. Wenn du auf die Datei *main/main.collection* doppelklickst, wird sie geöffnet:
+
+![Übersicht des Editors](../manuals/images/editor/editor2_overview.png)
+
+Der Editor besteht aus den folgenden Hauptbereichen:
+
+Assets pane
+: Diese Ansicht zeigt alle Dateien in deinem Projekt. Unterschiedliche Dateitypen haben unterschiedliche Symbole. Doppelklicke auf eine Datei, um sie in dem für diesen Dateityp vorgesehenen Editor zu öffnen. Der besondere, schreibgeschützte Ordner *builtins* ist für alle Projekte gemeinsam verfügbar und enthält nützliche Elemente wie ein Standard-Render-Skript, eine Schriftart, Materialien zum Rendern verschiedener Komponenten (components) und weitere Dinge.
+
+Main Editor View
+: Je nachdem, welchen Dateityp du bearbeitest, zeigt diese Ansicht den passenden Editor an. Am häufigsten wird der Szeneneditor verwendet, den du hier siehst. Jede geöffnete Datei wird in einer eigenen Registerkarte angezeigt.
+
+Changed Files
+: Enthält Dateien, die im Vergleich zum aktuellen Git-Commit lokal hinzugefügt, geändert, umbenannt oder gelöscht wurden. Hier kannst du Textunterschiede anzeigen und lokale Änderungen rückgängig machen. Verwende einen externen Git-Client oder die Befehlszeile, um mit einem entfernten Repository zu synchronisieren.
+
+Outline
+: Der Inhalt der gerade bearbeiteten Datei in einer hierarchischen Ansicht. Über diese Ansicht kannst du Objekte und Komponenten hinzufügen, löschen, ändern und auswählen.
+
+Properties
+: Die Eigenschaften, die für das aktuell ausgewählte Objekt oder die ausgewählte Komponente festgelegt sind.
+
+Console
+: Wenn das Spiel läuft, erfasst diese Ansicht Ausgaben der Spiel-Engine (Protokollmeldungen, Fehler, Debug-Informationen usw.) sowie alle eigenen Debug-Meldungen aus deinen Skripten, die mit `print()` und `pprint()` ausgegeben werden. Wenn deine Anwendung oder dein Spiel nicht startet, solltest du zuerst die Konsole prüfen. Hinter der Konsole befinden sich mehrere Registerkarten mit Fehlerinformationen sowie ein Kurveneditor, der beim Erstellen von Partikeleffekten verwendet wird.
+
+## Das Spiel ausführen {#running-the-game}
+
+Die Projektvorlage "Empty" ist tatsächlich vollständig leer. Wähle trotzdem <kbd>Project ▸ Build</kbd>, um einen Build des Projekts zu erstellen und das Spiel zu starten.
+
+![Build erstellen](images/car/start_build_and_launch.png)
+
+Ein schwarzer Bildschirm ist vielleicht nicht besonders aufregend, aber dahinter läuft eine Defold-Spielanwendung, die wir leicht in etwas Interessanteres verwandeln können. Also machen wir das.
+
+::: sidenote
+Der Defold-Editor arbeitet mit Dateien. Wenn du im *Assets pane* auf eine Datei doppelklickst, öffnest du sie in einem passenden Editor. Anschließend kannst du den Inhalt der Datei bearbeiten.
+
+Wenn du mit der Bearbeitung einer Datei fertig bist, musst du sie speichern. Wähle im Hauptmenü <kbd>File ▸ Save</kbd>. Der Editor weist auf ungespeicherte Änderungen hin, indem er in der Registerkarte der jeweiligen Datei ein Sternchen '\*' an den Dateinamen anhängt.
+
+![Datei mit ungespeicherten Änderungen](images/car/file_changed.png)
+:::
+
+## Das Auto zusammensetzen {#assembling-the-car}
+
+Als Erstes erstellen wir eine neue Sammlung. Eine Sammlung ist ein Behälter für Spielobjekte, die du eingefügt und positioniert hast. Sammlungen werden meist zum Erstellen von Spiellevels verwendet. Sie sind aber immer dann sehr nützlich, wenn du Gruppen und/oder Hierarchien zusammengehöriger Spielobjekte wiederverwenden musst. Es kann hilfreich sein, sich Sammlungen als eine Art Prefab vorzustellen.
+
+Klicke im *Assets pane* auf den Ordner *main*, klicke dann mit der rechten Maustaste und wähle <kbd>New ▸ Collection File</kbd>. Du kannst auch im Hauptmenü <kbd>File ▸ New ▸ Collection File</kbd> auswählen.
+
+![Neue Sammlungsdatei](images/car/start_new_collection.png)
+
+Nenne die neue Sammlungsdatei *car.collection* und öffne sie. Wir verwenden diese neue, leere Sammlung, um aus einigen Spielobjekten ein kleines Auto zu bauen. Ein Spielobjekt ist ein Behälter für Komponenten (wie Sprites, Sounds, Logikskripte usw.), mit denen du dein Spiel aufbaust. Jedes Spielobjekt wird im Spiel durch seine ID eindeutig identifiziert. Spielobjekte können durch den Austausch von Nachrichten miteinander kommunizieren, aber dazu später mehr.
+
+Außerdem ist es möglich, ein Spielobjekt direkt in einer Sammlung zu erstellen, wie wir es hier getan haben. Dadurch entsteht ein eigenständiges Objekt. Du kannst dieses Objekt kopieren, aber jede Kopie ist unabhängig – Änderungen an einer Kopie wirken sich nicht auf die anderen aus. Wenn du also 10 Kopien eines Spielobjekts erstellst und feststellst, dass du sie alle ändern möchtest, musst du alle 10 Instanzen des Objekts bearbeiten. Daher solltest du direkt in der Sammlung erstellte Spielobjekte für Objekte verwenden, von denen du nicht viele Kopien anlegen möchtest.
+
+Ein Spielobjekt, das in einer _Datei_ gespeichert ist, dient dagegen als Prototyp (in anderen Engines auch als „Prefabs“ oder „Blueprints“ bekannt). Wenn du Instanzen eines in einer Datei gespeicherten Spielobjekts in einer Sammlung platzierst, wird jedes Objekt _als Referenz_ eingefügt – es ist ein Klon, der auf dem Prototyp basiert. Wenn du den Prototyp ändern musst, wird jedes einzelne platzierte Spielobjekt, das auf diesem Prototyp basiert, sofort aktualisiert.
+
+![Auto-Spielobjekt hinzufügen](images/car/start_add_car_gameobject.png)
+
+Wähle in der Ansicht *Outline* den obersten Knoten "Collection", klicke mit der rechten Maustaste und wähle <kbd>Add Game Object</kbd>. Ein neues Spielobjekt mit der ID "go" erscheint in der Sammlung. Wähle es aus und setze seine ID in der Ansicht *Properties* auf "car". Bisher ist "car" noch sehr uninteressant. Es ist leer und hat weder eine visuelle Darstellung noch Logik. Um eine visuelle Darstellung hinzuzufügen, müssen wir eine Sprite-_Komponente_ hinzufügen.
+
+Komponenten erweitern Spielobjekte um wahrnehmbare Inhalte (Grafik, Sound) und Funktionalität (Fabriken (factories) zum dynamischen Erzeugen von Objekten, Kollisionen, skriptgesteuertes Verhalten). Eine Komponente kann nicht allein existieren, sondern muss sich in einem Spielobjekt befinden. Komponenten werden normalerweise direkt in derselben Datei wie das Spielobjekt definiert. Wenn du eine Komponente wiederverwenden möchtest, kannst du sie jedoch in einer separaten Datei speichern (wie auch Spielobjekte) und als Referenz in eine beliebige Spielobjektdatei einbinden. Einige Komponententypen (zum Beispiel Lua-Skripte) müssen in einer separaten Komponentendatei liegen und dann als Referenz in deine Objekte eingebunden werden.
+
+Beachte, dass du Komponenten nicht direkt veränderst – du kannst Spielobjekte, die ihrerseits Komponenten enthalten, verschieben, drehen und skalieren sowie ihre Eigenschaften animieren.
+
+![Komponente zum Auto hinzufügen](images/car/start_add_car_component.png)
+
+Wähle das Spielobjekt "car", klicke mit der rechten Maustaste und wähle <kbd>Add Component</kbd>. Wähle dann *Sprite* und klicke auf *Ok*. Wenn du das Sprite in der Ansicht *Outline* auswählst, siehst du, dass noch einige Eigenschaften festgelegt werden müssen:
+
+Image
+: Hier wird eine Bildquelle für das Sprite benötigt. Erstelle eine Atlas-Bilddatei, indem du in der Ansicht *Assets pane* "main" auswählst, mit der rechten Maustaste klickst und <kbd>New ▸ Atlas File</kbd> wählst. Nenne die neue Atlasdatei *sprites.atlas* und doppelklicke darauf, um sie im Atlas-Editor zu öffnen. Speichere die folgenden beiden Bilddateien auf deinem Computer und ziehe sie in der Ansicht *Assets pane* nach *main*. Nun kannst du den obersten Knoten Atlas im Atlas-Editor auswählen, mit der rechten Maustaste klicken und <kbd>Add Images</kbd> wählen. Füge das Auto- und das Reifenbild zum Atlas hinzu und speichere ihn. Jetzt kannst du *sprites.atlas* als Bildquelle für die Sprite-Komponente im Spielobjekt "car" in der Sammlung "car" auswählen.
+
+Bilder für unser Spiel:
+
+![Autobild](images/car/start_car.png)
+![Reifenbild](images/car/start_tire.png)
+
+Füge diese Bilder zum Atlas hinzu:
+
+![Sprite-Atlas](images/car/start_sprites_atlas.png)
+
+![Sprite-Eigenschaften](images/car/start_sprite_properties.png)
+
+Default Animation
+: Setze dies auf "car" (oder den Namen, den du dem Autobild gegeben hast). Jedes Sprite benötigt eine Standardanimation, die abgespielt wird, wenn es im Spiel angezeigt wird. Wenn du Bilder zu einem Atlas hinzufügst, erstellt Defold praktischerweise für jede Bilddatei eine Animation mit einem einzigen Frame (ein Standbild).
+
+## Das Auto vervollständigen {#completing-the-car}
+
+Füge als Nächstes zwei weitere Spielobjekte zur Sammlung hinzu. Nenne sie "left_wheel" und "right_wheel" und füge in jedes eine Sprite-Komponente ein, die das Reifenbild zeigt, das wir zu *sprites.atlas* hinzugefügt haben. Ziehe dann die Spielobjekte der Räder auf "car" und lege sie dort ab, damit sie "car" untergeordnet werden. Spielobjekte, die anderen Spielobjekten untergeordnet sind, bewegen sich mit ihrem übergeordneten Objekt mit. Sie können auch einzeln bewegt werden, aber jede Bewegung erfolgt relativ zum übergeordneten Objekt. Für die Reifen ist das ideal, denn sie sollen am Auto bleiben, und beim Lenken können wir sie einfach leicht nach links und rechts drehen. Eine Sammlung kann beliebig viele Spielobjekte enthalten, die nebeneinander stehen, in komplexen Eltern-Kind-Bäumen angeordnet sind oder beides kombinieren.
+
+Bringe die Reifen-Spielobjekte in Position, indem du sie auswählst und dann <kbd>Scene ▸ Move Tool</kbd> wählst. Ziehe an den Pfeilgriffen oder am grünen Quadrat in der Mitte, um das Objekt an eine passende Stelle zu bewegen. Als Letztes müssen wir sicherstellen, dass die Reifen unter dem Auto gezeichnet werden. Dazu setzen wir die Z-Komponente der Position auf -0.5. Jedes sichtbare Element in einem Spiel wird nach seinem Z-Wert sortiert von hinten nach vorne gezeichnet. Ein Objekt mit dem Z-Wert 0 wird über einem Objekt mit dem Z-Wert -0.5 gezeichnet. Da der Standard-Z-Wert des Auto-Spielobjekts 0 ist, werden die Reifenobjekte durch den neuen Wert unter dem Autobild platziert.
+
+![Fertige Autosammlung](images/car/start_car_collection_complete.png)
+
+## Das Autoskript {#the-car-script}
+
+Das letzte Puzzleteil ist ein _Skript_, das das Auto steuert. Ein Skript ist eine Komponente mit einem Programm, das das Verhalten von Spielobjekten definiert. Mit Skripten kannst du die Regeln deines Spiels festlegen und bestimmen, wie Objekte auf verschiedene Interaktionen reagieren sollen (sowohl mit der spielenden Person als auch mit anderen Objekten). Alle Skripte werden in der Programmiersprache Lua geschrieben. Um mit Defold arbeiten zu können, musst du oder jemand in deinem Team lernen, in Lua zu programmieren.
+
+Wähle im *Assets pane* "main", klicke mit der rechten Maustaste und wähle <kbd>New ▸ Script File</kbd>. Nenne die neue Datei *car.script* und füge sie dann zum Spielobjekt "car" hinzu, indem du "car" in der Ansicht *Outline* auswählst, mit der rechten Maustaste klickst und <kbd>Add Component File</kbd> wählst. Wähle *car.script* und klicke auf *OK*. Speichere die Sammlungsdatei.
+
+Doppelklicke auf *car.script*, um die Datei zu öffnen.
+
+::: sidenote
+Defold stellt mehrere Lebenszyklusfunktionen bereit, mit denen du Spiellogik programmieren kannst. Mehr darüber erfährst du im [Skript-Handbuch](/manuals/script).
+:::
+
+Entferne zunächst die Funktionen `final`, `on_message` und `on_reload`, da wir sie
+für dieses Tutorial nicht benötigen.
+
+Füge als Nächstes die folgenden Codezeilen vor dem Beginn der Funktion `init` ein.
+
+```lua
+-- Constants
+local turn_speed = 0.1                           									  -- Slerp factor
+local max_steer_angle_left = vmath.quat_rotation_z(math.pi / 6)     -- 30 degrees
+local max_steer_angle_right = vmath.quat_rotation_z(-math.pi / 6)   -- -30 degrees
+local steer_angle_zero = vmath.quat_rotation_z(0)									  -- Zero degrees
+local wheels_vector = vmath.vector3(0, 72, 0)         		        	-- Vector from center of back and front wheel pairs
+
+local acceleration = 100 																						-- The acceleration of the car
+
+-- prehash the inputs
+local left = hash("left")
+local right = hash("right")
+local accelerate = hash("accelerate")
+local brake = hash("brake")
+```
+
+Die Änderungen hier sind recht einfach: Wir haben unserem Skript nur eine Reihe von Konstanten (`constants`) hinzugefügt, die wir später verwenden werden, um unser Auto zu programmieren.
+
+::: sidenote
+Beachte, wie wir die Hashwerte vorab in Variablen speichern. Das ist eine gute Vorgehensweise, da sie deinen Code lesbarer und leistungsfähiger macht.
+:::
+
+Bearbeite als Nächstes die Funktion `init` so, dass sie Folgendes enthält:
+
+```lua
+function init(self)
+	-- Send a message to the render script (see builtins/render/default.render_script) to set the clear color.
+	-- This changes the background color of the game. The vector4 contains color information
+	-- by channel from 0-1: Red = 0.2. Green = 0.2, Blue = 0.2 and Alpha = 1.0
+	msg.post("@render:", "clear_color", { color = vmath.vector4(0.2, 0.2, 0.2, 1.0) } )		--<1>
+
+	-- Acquire input focus so we can react to input
+	msg.post(".", "acquire_input_focus")		-- <2>
+
+	-- Some variables
+	self.steer_angle = vmath.quat()				 -- <3>
+	self.direction = vmath.quat()
+
+	-- Velocity and acceleration are car relative (not rotated)
+	self.velocity = vmath.vector3()
+	self.acceleration = vmath.vector3()
+
+	-- Input vector. This is modified later in the on_input function
+	-- to store the input.
+	self.input = vmath.vector3()
+end
+```
+
+Fragst du dich, was wir gerade geändert haben? Hier ist die Erklärung.
+
+1. Wir senden eine Nachricht an unser Render-Skript mit der Aufforderung, die Hintergrundfarbe auf Grau zu setzen. Render-Skripte sind spezielle Skripte in Defold, die steuern, wie Objekte auf dem Bildschirm angezeigt werden.
+2. Um in einer Skriptkomponente oder einem GUI-Skript auf Eingabeaktionen zu reagieren, muss die Nachricht `acquire_input_focus` an das Spielobjekt gesendet werden, das die Komponente enthält. In unserem Fall senden wir diese Nachricht an das Spielobjekt mit dem Autoskript.
+3. Dann deklarieren wir einige Variablen, mit denen wir den aktuellen Zustand unseres Autos festhalten.
+
+Das war doch einfach, oder? Nun bearbeiten wir die Funktion `update` so, dass sie Folgendes enthält:
+
+```lua
+function update(self, dt)
+	-- Set acceleration to the y input
+	self.acceleration.y = self.input.y * acceleration				-- <1>
+
+	-- Calculate the new positions of front and back wheels
+	local front_vel = vmath.rotate(self.steer_angle, self.velocity)
+	local new_front_pos = vmath.rotate(self.direction, wheels_vector + front_vel)
+	local new_back_pos = vmath.rotate(self.direction, self.velocity)								-- <2>
+
+	-- Calculate the car's new direction
+	local new_dir = vmath.normalize(new_front_pos - new_back_pos)
+	self.direction = vmath.quat_rotation_z(math.atan2(new_dir.y, new_dir.x) - math.pi / 2)			-- <3>
+
+	-- Calculate new velocity based on current acceleration
+	self.velocity = self.velocity + self.acceleration * dt			-- <4>
+
+	-- Update position based on current velocity and direction
+	local pos = go.get_position()
+	pos = pos + vmath.rotate(self.direction, self.velocity)
+	go.set_position(pos)																			-- <5>
+
+	-- Interpolate the wheels using vmath.slerp
+	if self.input.x > 0 then																		-- <6>
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, max_steer_angle_right)
+	elseif self.input.x < 0 then
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, max_steer_angle_left)
+	else
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, steer_angle_zero)
+	end
+
+	-- Update the wheel rotation
+	go.set_rotation(self.steer_angle, "left_wheel")					-- <7>
+	go.set_rotation(self.steer_angle, "right_wheel")
+
+	-- Set the game object's rotation to the direction
+	go.set_rotation(self.direction)
+
+	-- reset acceleration and input
+	self.acceleration = vmath.vector3()								-- <8>
+	self.input = vmath.vector3()
+end
+```
+
+Das war eine riesige Funktion! Aber keine Sorge, so funktioniert das Ganze:
+
+1. Zuerst legen wir unseren Beschleunigungsvektor anhand unseres Eingabevektors fest. Dadurch wird sichergestellt, dass das Auto in Richtung der Eingabe beschleunigt.
+2. Als Nächstes wird die Verschiebung beider Räder berechnet. Dabei gilt die einfache Überlegung, dass sich die Hinterräder des Autos immer vorwärts bewegen, während sich die Vorderräder in die Richtung bewegen, in die sie eingeschlagen sind.
+3. Anhand der Verschiebung beider Räder wird die neue Bewegungsrichtung unseres Autos berechnet.
+4. Hier addieren wir die berechnete Beschleunigung zur Geschwindigkeit.
+5. Schließlich aktualisieren wir die Position des Autos anhand unserer aktuellen Geschwindigkeit.
+6. Wir interpolieren den Lenkwinkel mit Slerp anhand unserer Eingabe nach links oder rechts. Dadurch springen die Räder bei einer Änderung der Eingabe nicht sofort in die neue Stellung.
+7. Die Drehung der Räder wird dann anhand des aktuellen Lenkwinkels des Autos festgelegt. Ebenso wird die Drehung des Autos anhand seiner aktuellen Bewegungsrichtung festgelegt.
+8. Abschließend setzen wir die Beschleunigungs- und Eingabevektoren zurück.
+
+Zum Schluss bringen wir unser Auto dazu, auf Eingaben zu reagieren. Aktualisiere die Funktion `on_input` wie folgt:
+
+```lua
+function on_input(self, action_id, action)
+	-- set the input vector to correspond to the key press
+	if action_id == left then
+		self.input.x = -1
+	elseif action_id == right then
+		self.input.x = 1
+	elseif action_id == accelerate then
+		self.input.y = 1
+	elseif action_id == brake then
+		self.input.y = -1
+	end
+end
+```
+
+Diese Funktion ist recht einfach: Wir nehmen lediglich die Eingabe entgegen und setzen unseren Eingabevektor.
+
+Vergiss nicht, deine Änderungen zu speichern.
+
+## Eingabe {#input}
+
+Es sind noch keine Eingabeaktionen eingerichtet, also holen wir das nach. Öffne die Datei */input/game.input_bindings* und füge Eingabebindungen (input bindings) vom Typ *key_trigger* für "accelerate", "brake", "left" und "right" hinzu. Wir legen sie auf die Pfeiltasten (KEY_LEFT, KEY_RIGHT, KEY_UP und KEY_DOWN):
+
+![Eingabebindungen](images/car/start_input_bindings.png)
+
+## Das Auto zum Spiel hinzufügen {#adding-the-car-to-the-game}
+
+Jetzt ist das Auto fahrbereit. Wir haben es in "car.collection" erstellt, aber im Spiel existiert es noch nicht. Das liegt daran, dass die Engine beim Start derzeit "main.collection" lädt. Um das zu ändern, müssen wir einfach *car.collection* zu *main.collection* hinzufügen. Öffne *main.collection*, wähle den obersten Knoten "Collection" in der Ansicht *Outline*, klicke mit der rechten Maustaste und wähle <kbd>Add Collection From File</kbd>. Wähle *car.collection* und klicke auf *OK*. Nun werden die Inhalte von *car.collection* als neue Instanzen in *main.collection* platziert. Wenn du den Inhalt von *car.collection* änderst, wird jede Instanz der Sammlung beim Erstellen des Spiel-Builds automatisch aktualisiert.
+
+![Die Autosammlung hinzufügen](images/car/start_adding_car_collection.png)
+
+Wähle nun <kbd>Project ▸ Build</kbd> und drehe eine Runde mit deinem neuen Auto!
+Du wirst feststellen, dass du das Auto jetzt nach Belieben bewegen kannst. Aber etwas stimmt noch nicht. Wenn du die Steuerung loslässt, hält das Auto nicht an, obwohl es das sollte. Zeit, das einzubauen!
+
+## Der Widerstand hilft {#drag-to-the-rescue}
+
+Immer wenn sich ein Objekt in der realen Welt bewegt, wirkt ihm eine Widerstandskraft entgegen, die es abbremst. Diese Kraft ist annähernd proportional zum Quadrat der Geschwindigkeit des bewegten Objekts und kann daher als `D = k * |V| * V` beschrieben werden. Dabei ist `k` eine Konstante, `V` die Geschwindigkeit und `|V|` ihr Betrag (das Tempo). Fügen wir das hinzu.
+
+Füge im Abschnitt mit den Konstanten am Anfang des Skripts die folgende Konstante hinzu
+
+```lua
+local drag = 1.1	        --the drag constant <1>
+```
+
+Füge dann in der Funktion `update` direkt über dieser Zeile die folgenden Zeilen ein und speichere die Datei.
+
+```lua
+function update(self, dt)
+	...
+  -- Calculate new velocity based on current acceleration
+	self.velocity = self.velocity + self.acceleration * dt
+	...
+end
+```
+
+```lua
+function update(self, dt)
+	...
+	-- Speed is the magnitude of the velocity
+	local speed = vmath.length_sqr(self.velocity)
+
+	-- Apply drag
+	self.acceleration = self.acceleration - speed * self.velocity * drag
+
+	-- Stop if we are already slow enough
+	if speed < 0.5 then self.velocity = vmath.vector3(0) end
+	...
+end
+```
+
+1. Deklariere den Widerstandswert als Konstante.
+2. Berechne das Tempo, mit dem wir uns bewegen.
+3. Wende den Widerstand anhand der Formel auf die aktuelle Beschleunigung an
+4. Halte an, wenn das Auto bereits langsam genug ist.
+
+## Das vollständige Autoskript {#the-complete-car-script}
+
+Nachdem du die obigen Schritte ausgeführt hast, sollte deine Datei *car.script* so aussehen:
+
+```lua
+local turn_speed = 0.1                           				          	-- Slerp factor
+local max_steer_angle_left = vmath.quat_rotation_z(math.pi / 6)	    -- 30 degrees
+local max_steer_angle_right = vmath.quat_rotation_z(-math.pi / 6)   -- -30 degrees
+local steer_angle_zero = vmath.quat_rotation_z(0)				          	-- Zero degrees
+local wheels_vector = vmath.vector3(0, 72, 0)         				      -- Vector from center of back and front wheel pairs
+
+local acceleration = 100 		                      									-- The acceleration of the car
+local drag = 1.1                                                  	-- the drag constant
+
+function init(self)
+	-- Send a message to the render script (see builtins/render/default.render_script) to set the clear color.
+	-- This changes the background color of the game. The vector4 contains color information
+	-- by channel from 0-1: Red = 0.2. Green = 0.2, Blue = 0.2 and Alpha = 1.0
+	msg.post("@render:", "clear_color", { color = vmath.vector4(0.2, 0.2, 0.2, 1.0) } )
+
+	-- Acquire input focus so we can react to input
+	msg.post(".", "acquire_input_focus")
+
+	-- Some variables
+	self.steer_angle = vmath.quat()
+	self.direction = vmath.quat()
+
+	-- Velocity and acceleration are car relative (not rotated)
+	self.velocity = vmath.vector3()
+	self.acceleration = vmath.vector3()
+
+	-- Input vector. This is modified later in the on_input function
+	-- to store the input.
+	self.input = vmath.vector3()
+end
+
+function update(self, dt)
+	-- Set acceleration to the y input
+	self.acceleration.y = self.input.y * acceleration
+
+	-- Calculate the new positions of front and back wheels
+	local front_vel = vmath.rotate(self.steer_angle, self.velocity)
+	local new_front_pos = vmath.rotate(self.direction, wheels_vector + front_vel)
+	local new_back_pos = vmath.rotate(self.direction, self.velocity)
+
+	-- Calculate the car's new direction
+	local new_dir = vmath.normalize(new_front_pos - new_back_pos)
+	self.direction = vmath.quat_rotation_z(math.atan2(new_dir.y, new_dir.x) - math.pi / 2)
+
+	-- Speed is the magnitude of the velocity
+	local speed = vmath.length(self.velocity)
+
+	-- Apply drag
+	self.acceleration = self.acceleration - speed * self.velocity * drag
+
+	-- Stop if we are already slow enough
+	if speed < 0.5 then self.velocity = vmath.vector3() end
+
+	-- Calculate new velocity based on current acceleration
+	self.velocity = self.velocity + self.acceleration * dt
+
+	-- Update position based on current velocity and direction
+	local pos = go.get_position()
+	pos = pos + vmath.rotate(self.direction, self.velocity)
+	go.set_position(pos)
+
+	-- Interpolate the wheels using vmath.slerp
+	if self.input.x > 0 then
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, max_steer_angle_right)
+	elseif self.input.x < 0 then
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, max_steer_angle_left)
+	else
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, steer_angle_zero)
+	end
+
+	-- Update the wheel rotation
+	go.set_rotation(self.steer_angle, "left_wheel")
+	go.set_rotation(self.steer_angle, "right_wheel")
+
+	-- Set the game object's rotation to the direction
+	go.set_rotation(self.direction)
+
+	-- reset acceleration and input
+	self.acceleration = vmath.vector3()
+	self.input = vmath.vector3()
+end
+
+function on_input(self, action_id, action)
+	-- set the input vector to correspond to the key press
+	if action_id == hash("left") then
+		self.input.x = -1
+	elseif action_id == hash("right") then
+		self.input.x = 1
+	elseif action_id == hash("accelerate") then
+		self.input.y = 1
+	elseif action_id == hash("brake") then
+		self.input.y = -1
+	end
+end
+```
+
+## Das fertige Spiel ausprobieren {#trying-the-final-game}
+
+Wähle nun im Hauptmenü <kbd>Project ▸ Build</kbd> und drehe eine Runde mit deinem neuen Auto!
+
+Damit ist dieses Einführungstutorial abgeschlossen. Hier sind einige Herausforderungen, die du vielleicht selbstständig angehen möchtest:
+
+1. Derzeit bewegt sich das Auto vorwärts und rückwärts mit derselben Beschleunigung. Du könntest dies so ändern, dass das Auto beim Rückwärtsfahren langsamer fährt.
+2. Mache einige der Konstanten (wie die Beschleunigung) zu Eigenschaften (`properties`), damit sie für verschiedene Instanzen des Autos geändert werden können.
+3. Füge deinem Auto Sounds hinzu und lass es brummen! ([Tipp](/manuals/sound/))
+
+Jetzt kannst du dich weiter mit Defold beschäftigen. Wir haben viele [Handbücher und Tutorials](/learn) vorbereitet, die dich dabei begleiten. Und wenn du nicht weiterkommst, bist du im [Forum](//forum.defold.com) herzlich willkommen.
+
+Viel Spaß mit Defold!

--- a/docs/de/tutorials/colorslide.md
+++ b/docs/de/tutorials/colorslide.md
@@ -1,0 +1,28 @@
+---
+title: Colorslide-Tutorial
+brief: In diesem Tutorial mit mittlerem Schwierigkeitsgrad erstellst du eine GUI im Spiel, einen GUI-Bildschirm zur Levelauswahl und einen Startbildschirm für ein einfaches Spiel mit mehreren Levels für Mobilgeräte.
+github: https://github.com/defold/tutorial-colorslide
+---
+
+# Colorslide-Tutorial
+
+In diesem Tutorial mit mittlerem Schwierigkeitsgrad erstellst du eine GUI im Spiel, einen GUI-Bildschirm zur Levelauswahl und einen Startbildschirm für ein einfaches Spiel mit mehreren Levels für Mobilgeräte.
+
+Das Tutorial ist in den Defold-Editor integriert und leicht zugänglich:
+
+1. Starte Defold.
+2. Wähle links *New Project*.
+3. Wähle die Registerkarte *From Tutorial*.
+4. Wähle „Colorslide tutorial“
+5. Wähle einen Speicherort für das Projekt auf deinem lokalen Laufwerk und klicke auf *Create New Project*.
+
+![Neues Projekt](images/new-colorslide.png)
+
+Der Editor öffnet automatisch die Datei „README“ aus dem Stammverzeichnis des Projekts, die den vollständigen Text des Tutorials enthält.
+
+![Symbol](images/icon-tutorial.svg){.icon} [Du kannst den vollständigen Text des Tutorials auch auf GitHub lesen](https://github.com/defold/tutorial-colorslide)
+
+Wenn du nicht weiterkommst, besuche das [Defold-Forum](//forum.defold.com). Dort helfen dir das Defold-Team und viele freundliche Nutzer.
+
+Viel Spaß mit Defold!
+

--- a/docs/de/tutorials/getting-started.md
+++ b/docs/de/tutorials/getting-started.md
@@ -1,0 +1,35 @@
+---
+title: Erste Schritte mit Defold
+brief: Dieses Tutorial erklärt, wie du mit den Tutorials in Defold beginnst.
+---
+
+# Erste Schritte {#getting-started}
+
+Die Defold-Engine und der Editor sind leistungsfähige Werkzeuge mit vielen Funktionen, deren Bedienung du erlernen kannst. Um dir den Einstieg zu erleichtern, haben wir eine Reihe von Tutorials erstellt. Viele davon sind direkt im Editor verfügbar, sodass du ganz einfach damit beginnen kannst.
+
+## Ein Tutorial im Editor starten {#starting-a-tutorial-from-the-editor}
+
+Wenn du den Defold-Editor startest, erscheint ein Fenster zum Auswählen und Erstellen von Projekten. Hier kannst du ganz einfach das Tutorial auswählen, das du ausprobieren möchtest:
+
+1. Starte Defold.
+2. Wähle links *New Project*.
+3. Wähle die Registerkarte *From Tutorial*.
+4. Wähle ein Tutorial, das dich interessiert.
+5. Wähle einen Speicherort für das Projekt auf deinem lokalen Laufwerk.
+6. Klicke auf *Create New Project*.
+
+![Projekt erstellen](images/getting-started/new-project.png)
+
+Der Editor lädt nun automatisch das Tutorial-Projekt herunter, öffnet es im Editor und öffnet den Tutorial-Text (die Datei „README“ im Stammverzeichnis des Projekts).
+
+![Tutorial-Text](images/getting-started/tutorial-text.png)
+
+Folge nun dem Tutorial-Text! Wenn du zum Text zurückkehren möchtest, öffne die Datei „README“ mit einem <kbd>Doppelklick</kbd> in der Ansicht *Assets*. Du kannst auch einen <kbd>Rechtsklick</kbd> auf die Registerkarte einer geöffneten Datei ausführen und <kbd>Move to Other Tab Pane</kbd> auswählen, um den Tutorial-Text neben der Datei anzuzeigen, an der du gerade arbeitest.
+
+![Ansichten nebeneinander](images/getting-started/side-by-side.png)
+
+Wenn du gerade erst mit Defold anfängst, lohnt sich auch ein Blick in die [Einführung in den Editor](/manuals/editor).
+
+Wenn du einmal nicht weiterkommst, besuche das [Defold-Forum](//forum.defold.com). Dort helfen dir die Defold-Entwickler und viele freundliche Nutzer weiter.
+
+Viel Spaß mit Defold!

--- a/docs/de/tutorials/grading.md
+++ b/docs/de/tutorials/grading.md
@@ -1,0 +1,456 @@
+---
+title: Tutorial zu einem Shader für Farbkorrektur
+brief: In diesem Tutorial erstellst du in Defold einen Nachbearbeitungseffekt für den gesamten Bildschirm.
+---
+
+# Tutorial zur Farbkorrektur {#grading-tutorial}
+
+In diesem Tutorial erstellen wir einen Nachbearbeitungseffekt zur Farbkorrektur (color grading) für den gesamten Bildschirm. Die zugrunde liegende Rendertechnik lässt sich vielseitig für verschiedene Nachbearbeitungseffekte wie Unschärfe, Nachzieheffekte, Leuchten, Farbanpassungen und andere verwenden.
+
+Wir gehen davon aus, dass du dich im Defold-Editor zurechtfindest und grundlegende Kenntnisse über GL-Shader und die Rendering-Pipeline von Defold hast. Wenn du dich in diese Themen einlesen möchtest, sieh dir [unser Shader-Handbuch](/manuals/shader/) und das [Render-Handbuch](/manuals/render/) an.
+
+## Renderziele {#render-targets}
+
+Mit dem Standard-Render-Skript (render script) wird jede visuelle Komponente (component), etwa ein Sprite, eine Kachelkarte (tile map), ein Partikeleffekt oder eine GUI, direkt in den *Bildpuffer (frame buffer)* der Grafikkarte gerendert. Die Hardware sorgt dann dafür, dass die Grafik auf dem Bildschirm erscheint. Das eigentliche Zeichnen der Pixel einer Komponente übernimmt ein GL-*Shader-Programm (shader program)*. Defold enthält für jeden Komponententyp ein Standard-Shader-Programm, das die Pixeldaten unverändert auf den Bildschirm zeichnet. Normalerweise ist genau dieses Verhalten erwünscht: Deine Bilder sollen so auf dem Bildschirm erscheinen, wie sie ursprünglich gestaltet wurden.
+
+Du kannst das Shader-Programm einer Komponente durch eines ersetzen, das die Pixeldaten verändert oder völlig neue Pixelfarben programmgesteuert erzeugt. Im [Shadertoy-Tutorial](/tutorials/shadertoy) erfährst du, wie das geht.
+
+Nehmen wir nun an, du möchtest dein gesamtes Spiel in Schwarz-Weiß rendern. Eine mögliche Lösung besteht darin, das jeweilige Shader-Programm für jeden Komponententyp so zu ändern, dass jeder Shader die Pixelfarben entsättigt. Derzeit enthält Defold 6 integrierte Materialien und 6 Paare aus Vertex- und Fragment-Shader-Programmen. Das ist also mit einigem Aufwand verbunden. Außerdem müssen alle späteren Änderungen oder zusätzlichen Effekte in jedem Shader-Programm vorgenommen werden.
+
+Ein wesentlich flexiblerer Ansatz besteht darin, das Rendering in zwei getrennten Schritten durchzuführen:
+
+![Renderziel](images/grading/render_target.png)
+
+1. Zeichne alle Komponenten wie gewohnt, aber in einen Puffer außerhalb des Bildschirms statt in den üblichen Bildpuffer. Dazu zeichnest du in ein sogenanntes *Renderziel (render target)*.
+2. Zeichne ein quadratisches Polygon in den Bildpuffer und verwende die im Renderziel gespeicherten Pixeldaten als Texturquelle für das Polygon. Achte außerdem darauf, dass das quadratische Polygon so gestreckt wird, dass es den gesamten Bildschirm bedeckt.
+
+Mit dieser Methode können wir die entstandenen Bilddaten auslesen und verändern, bevor sie auf dem Bildschirm erscheinen. Indem wir Schritt 2 oben um Shader-Programme ergänzen, können wir leicht Effekte für den gesamten Bildschirm erzielen. Sehen wir uns an, wie wir das in Defold einrichten.
+
+## Einen eigenen Renderer einrichten {#setting-up-a-custom-renderer}
+
+Wir müssen das integrierte Render-Skript ändern und die neue Renderfunktion hinzufügen. Das Standard-Render-Skript ist ein guter Ausgangspunkt. Kopiere es daher zunächst:
+
+1. Kopiere */builtins/render/default.render_script*: Klicke in der Ansicht *Asset* mit der rechten Maustaste auf *default.render_script* und wähle <kbd>Copy</kbd>. Klicke dann mit der rechten Maustaste auf *main* und wähle <kbd>Paste</kbd>. Klicke mit der rechten Maustaste auf die Kopie, wähle <kbd>Rename...</kbd> und gib ihr einen passenden Namen, etwa „grade.render_script“.
+2. Erstelle eine neue Renderdatei namens */main/grade.render*, indem du in der Ansicht *Asset* mit der rechten Maustaste auf *main* klickst und <kbd>New ▸ Render</kbd> auswählst.
+3. Öffne *grade.render* und setze ihre Eigenschaft *Script* auf „/main/grade.render_script“.
+
+   ![grade.render](images/grading/grade_render.png)
+
+4. Öffne *game.project* und setze *Render* auf „/main/grade.render“.
+
+   ![game.project](images/grading/game_project.png)
+
+Das Spiel ist jetzt so eingerichtet, dass es eine neue Rendering-Pipeline verwendet, die wir ändern können. Um zu prüfen, ob die Engine unsere Kopie des Render-Skripts verwendet, starte dein Spiel, nimm am Render-Skript eine Änderung mit sichtbarem Ergebnis vor und lade das Skript anschließend neu. Du kannst beispielsweise das Zeichnen von Kacheln und Sprites deaktivieren und dann <kbd>⌘ + R</kbd> drücken, um das „defekte“ Render-Skript per Hot Reload in das laufende Spiel zu laden:
+
+```lua
+...
+
+render.set_projection(vmath.matrix4_orthographic(0, render.get_width(), 0, render.get_height(), -1, 1))
+
+-- render.draw(self.tile_pred) -- <1>
+render.draw(self.particle_pred)
+render.draw_debug3d()
+
+...
+```
+1. Kommentiere das Zeichnen des Prädikats „tile“ aus, das alle Sprites und Kacheln umfasst. Diese Codezeile findest du ungefähr bei Zeile 33 in der Render-Skript-Datei.
+
+Wenn die Sprites und Kacheln bei diesem einfachen Test verschwinden, weißt du, dass das Spiel dein Render-Skript ausführt. Wenn alles wie erwartet funktioniert, kannst du die Änderung am Render-Skript rückgängig machen.
+
+## In ein Renderziel außerhalb des Bildschirms zeichnen {#drawing-to-an-off-screen-target}
+
+Ändern wir nun das Render-Skript so, dass es in das Renderziel außerhalb des Bildschirms statt in den Bildpuffer zeichnet. Zuerst müssen wir das Renderziel erstellen:
+
+```lua
+function init(self)
+    self.tile_pred = render.predicate({"tile"})
+    self.gui_pred = render.predicate({"gui"})
+    self.text_pred = render.predicate({"text"})
+    self.particle_pred = render.predicate({"particle"})
+
+    self.clear_color = vmath.vector4(0, 0, 0, 1)
+    self.clear_color.x = sys.get_config_number("render.clear_color_red", 0)
+    self.clear_color.y = sys.get_config_number("render.clear_color_green", 0)
+    self.clear_color.z = sys.get_config_number("render.clear_color_blue", 0)
+    self.clear_color.w = sys.get_config_number("render.clear_color_alpha", 1)
+
+    self.view = vmath.matrix4()
+
+    local color_params = { format = graphics.TEXTURE_FORMAT_RGBA,
+                       width = render.get_width(),
+                       height = render.get_height() } -- <1>
+    local target_params = {[graphics.BUFFER_TYPE_COLOR0_BIT] = color_params }
+
+    self.target = render.render_target("original", target_params) -- <2>
+end
+```
+1. Lege die Farbpufferparameter für das Renderziel fest. Wir verwenden die Zielauflösung des Spiels.
+2. Erstelle das Renderziel mit den Farbpufferparametern.
+
+Jetzt müssen wir nur noch den ursprünglichen Rendercode mit Aufrufen von `render.set_render_target()` umschließen:
+
+```lua
+function update(self)
+  render.set_render_target(self.target) -- <1>
+
+  render.set_depth_mask(true)
+  render.set_stencil_mask(0xff)
+  render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = self.clear_color, [graphics.BUFFER_TYPE_DEPTH_BIT] = 1, [graphics.BUFFER_TYPE_STENCIL_BIT] = 0})
+
+  render.set_viewport(0, 0, render.get_width(), render.get_height()) -- <2>
+  render.set_view(self.view)
+  ...
+
+  render.set_render_target(render.RENDER_TARGET_DEFAULT) -- <3>
+end
+```
+1. Aktiviere das Renderziel. Von nun an zeichnet jeder Aufruf von `render.draw()` in die Puffer unseres Renderziels außerhalb des Bildschirms.
+2. Der gesamte ursprüngliche Zeichencode in `update()` bleibt unverändert, abgesehen vom Ansichtsbereich (viewport), der auf die Auflösung des Renderziels gesetzt wird.
+3. An dieser Stelle wurde die gesamte Grafik des Spiels in das Renderziel gezeichnet. Jetzt ist es also an der Zeit, es durch den Wechsel zum Standard-Renderziel zu deaktivieren.
+
+Mehr müssen wir nicht tun. Wenn du das Spiel jetzt ausführst, zeichnet es alles in das Renderziel. Da wir aber nichts mehr in den Bildpuffer zeichnen, sehen wir nur einen schwarzen Bildschirm.
+
+## Etwas, das den Bildschirm füllt {#something-to-fill-the-screen-with}
+
+Um die Pixel im Farbpuffer des Renderziels auf den Bildschirm zu zeichnen, brauchen wir etwas, das wir mit den Pixeldaten texturieren können. Dazu verwenden wir ein flaches, quadratisches 3D-Modell.
+
+1. Öffne *`main.collection`* und erstelle ein neues Spielobjekt (game object) namens „`grade`“.
+2. Füge dem Spielobjekt „`grade`“ eine Modellkomponente (Model) hinzu.
+3. Setze die Eigenschaft *Mesh* der Modellkomponente auf die Datei *`quad.gltf`*, die du unter `builtins/assets/meshes` findest.
+
+Lass das Spielobjekt unskaliert am Ursprung. Wenn wir das Quad später rendern, projizieren wir es so, dass es den gesamten Bildschirm ausfüllt. Zuerst brauchen wir aber ein Material und Shader-Programme für das Quad:
+
+1. Erstelle ein neues Material namens *`grade.material`*, indem du mit der rechten Maustaste auf *main* in der Ansicht *Asset* klickst und <kbd>New ▸ Material</kbd> auswählst.
+2. Erstelle ein Vertex-Shader-Programm namens *`grade.vp`* und ein Fragment-Shader-Programm namens *`grade.fp`*, indem du mit der rechten Maustaste auf *main* in der Ansicht *Asset* klickst und <kbd>New ▸ Vertex program</kbd> sowie <kbd>New ▸ Fragment program</kbd> auswählst.
+3. Öffne *grade.material* und setze die Eigenschaften *Vertex program* und *Fragment program* auf die neuen Shader-Programmdateien.
+4. Füge eine *Vertex constant* namens „`view_proj`“ vom Typ `CONSTANT_TYPE_VIEWPROJ` hinzu. Das ist die kombinierte Ansichts- und Projektionsmatrix, die im Vertex-Programm für die Vertices des Quads verwendet wird.
+5. Füge einen *Sampler* namens „`original`“ hinzu. Mit ihm werden Pixel aus dem Farbpuffer des Renderziels außerhalb des Bildschirms ausgelesen.
+6. Füge ein *Tag* namens „`grade`“ hinzu. Wir erstellen im Render-Skript ein neues *Render-Prädikat (render predicate)*, das diesem Tag entspricht, um das Quad zu zeichnen.
+
+   ![grade.material](images/grading/grade_material.png)
+
+7. Öffne *`main.collection`*, wähle die Modellkomponente im Spielobjekt „`grade`“ aus und setze ihre Eigenschaft *Material* auf „`/main/grade.material`“.
+
+   ![Modelleigenschaften](images/grading/model_properties.png)
+
+8. Das Vertex-Shader-Programm kann so bleiben, wie es aus der Grundvorlage erstellt wurde:
+
+    ```glsl
+    // grade.vp
+    uniform mediump mat4 view_proj;
+
+    // positions are in world space
+    attribute mediump vec4 position;
+    attribute mediump vec2 texcoord0;
+
+    varying mediump vec2 var_texcoord0;
+
+    void main()
+    {
+      gl_Position = view_proj * vec4(position.xyz, 1.0);
+      var_texcoord0 = texcoord0;
+    }
+    ```
+
+9. Im Fragment-Shader-Programm führen wir eine einfache Farbänderung durch, anstatt `gl_FragColor` direkt auf den ausgelesenen Farbwert zu setzen. Damit wollen wir vor allem sicherstellen, dass bisher alles wie erwartet funktioniert:
+
+    ```glsl
+    // grade.fp
+    varying mediump vec4 position;
+    varying mediump vec2 var_texcoord0;
+
+    uniform lowp sampler2D original;
+
+    void main()
+    {
+      vec4 color = texture2D(original, var_texcoord0.xy);
+      // Desaturate the color sampled from the original texture
+      float grey = color.r * 0.3 + color.g * 0.59 + color.b * 0.11;
+      gl_FragColor = vec4(grey, grey, grey, 1.0);
+    }
+    ```
+
+Jetzt ist das Quad-Modell mit seinem Material und seinen Shadern eingerichtet. Wir müssen es nur noch in den Bildpuffer des Bildschirms zeichnen.
+
+## Mit dem Puffer außerhalb des Bildschirms texturieren {#texturing-with-the-off-screen-buffer}
+
+Wir müssen dem Render-Skript ein Render-Prädikat hinzufügen, damit wir das Quad-Modell zeichnen können. Öffne *`grade.render_script`* und bearbeite die Funktion `init()`:
+
+```lua
+function init(self)
+    self.tile_pred = render.predicate({"tile"})
+    self.gui_pred = render.predicate({"gui"})
+    self.text_pred = render.predicate({"text"})
+    self.particle_pred = render.predicate({"particle"})
+    self.grade_pred = render.predicate({"grade"}) -- <1>
+
+    ...
+end
+```
+1. Füge ein neues Prädikat hinzu, das dem Tag „grade“ entspricht, das wir in *`grade.material`* festgelegt haben.
+
+Nachdem der Farbpuffer des Renderziels in `update()` gefüllt wurde, richten wir eine Ansicht und eine Projektion ein, mit denen das Quad-Modell den gesamten Bildschirm ausfüllt. Anschließend verwenden wir den Farbpuffer des Renderziels als Textur des Quads:
+
+```lua
+function update(self)
+  render.set_render_target(self.target)
+
+  ...
+
+  render.set_render_target(render.RENDER_TARGET_DEFAULT)
+
+  render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = self.clear_color}) -- <1>
+
+  render.set_viewport(0, 0, render.get_window_width(), render.get_window_height()) -- <2>
+  render.set_view(vmath.matrix4()) -- <3>
+  render.set_projection(vmath.matrix4())
+
+  render.enable_texture(0, self.target, graphics.BUFFER_TYPE_COLOR0_BIT) -- <4>
+  render.draw(self.grade_pred) -- <5>
+  render.disable_texture(0, self.target) -- <6>
+end
+```
+1. Leere den Bildpuffer. Beachte, dass der vorherige Aufruf von `render.clear()` das Renderziel beeinflusst, nicht den Bildpuffer des Bildschirms.
+2. Passe den Ansichtsbereich an die Fenstergröße an.
+3. Setze die Ansicht auf die Einheitsmatrix. Das bedeutet, dass die Kamera am Ursprung liegt und gerade entlang der Z-Achse blickt. Setze auch die Projektion auf die Einheitsmatrix, wodurch das Quad flach über den gesamten Bildschirm projiziert wird.
+4. Setze den Texturplatz 0 auf den Farbpuffer des Renderziels. In unserem *`grade.material`* befindet sich der Sampler „original“ auf Platz 0, daher liest der Fragment-Shader aus dem Renderziel.
+5. Zeichne das erstellte Prädikat, das auf alle Materialien mit dem Tag „grade“ passt. Das Quad-Modell verwendet *`grade.material`*, das dieses Tag setzt, daher wird das Quad gezeichnet.
+6. Deaktiviere nach dem Zeichnen den Texturplatz 0, da wir mit dem Zeichnen über diesen Platz fertig sind.
+
+Starten wir nun das Spiel und sehen uns das Ergebnis an:
+
+![Entsättigtes Spiel](images/grading/desaturated_game.png)
+
+## Farbkorrektur {#color-grading}
+
+Farben werden durch drei Komponentenwerte ausgedrückt, wobei jede Komponente den Anteil von Rot, Grün oder Blau in einer Farbe angibt. Das gesamte Farbspektrum von Schwarz über Rot, Grün, Blau, Gelb und Pink bis Weiß lässt sich in einem Würfel darstellen:
+
+![Farbwürfel](images/grading/color_cube.png)
+
+Jede Farbe, die auf dem Bildschirm dargestellt werden kann, ist in diesem Farbwürfel enthalten. Die Grundidee der Farbkorrektur besteht darin, einen solchen Farbwürfel mit veränderten Farben als dreidimensionale *Nachschlagetabelle (lookup table)* zu verwenden.
+
+Für jedes Pixel:
+
+1. Ermittle die Position seiner Farbe im Farbwürfel anhand der Rot-, Grün- und Blauwerte.
+2. *Lies aus*, welche Farbe der farbkorrigierte Würfel an dieser Position gespeichert hat.
+3. Zeichne das Pixel in der ausgelesenen Farbe statt in der ursprünglichen Farbe.
+
+Das können wir in unserem Fragment-Shader tun:
+
+1. Lies den Farbwert jedes Pixels im Puffer außerhalb des Bildschirms aus.
+2. Schlage die Farbposition des ausgelesenen Pixels in einem farbkorrigierten Farbwürfel nach.
+3. Setze die Ausgabefarbe des Fragments auf den nachgeschlagenen Wert.
+
+![Farbkorrektur mit Renderziel](images/grading/render_target_grading.png)
+
+## Die Nachschlagetabelle darstellen {#representing-the-lookup-table}
+
+Open GL ES 2.0 unterstützt keine 3D-Texturen, daher müssen wir einen anderen Weg finden, den 3D-Farbwürfel darzustellen. Ein gängiges Verfahren besteht darin, den Würfel entlang der Z-Achse (Blau) in Scheiben zu schneiden und diese in einem zweidimensionalen Raster nebeneinander anzuordnen. Jede der 16 Scheiben enthält ein Raster aus 16 × 16 Pixeln. Wir speichern es in einer Textur, aus der wir im Fragment-Shader mit einem Sampler lesen können:
+
+![Nachschlagetextur](images/grading/lut.png)
+
+Die entstandene Textur enthält 16 Zellen, eine für jede Intensität von Blau. Innerhalb jeder Zelle liegen 16 Rottöne entlang der X-Achse und 16 Grüntöne entlang der Y-Achse. Die Textur stellt den gesamten RGB-Farbraum mit 16 Millionen Farben in nur 4096 Farben dar, also mit gerade einmal 4 Bit Farbtiefe. Nach den meisten Maßstäben ist das dürftig, aber dank einer Funktion der GL-Grafikhardware können wir wieder eine sehr hohe Farbgenauigkeit erreichen. Sehen wir uns an, wie das geht.
+
+## Farben nachschlagen {#looking-up-colors}
+
+Um eine Farbe nachzuschlagen, prüfen wir die Blaukomponente und ermitteln, aus welcher Zelle die Rot- und Grünwerte stammen sollen. Die Formel, mit der wir die Zelle mit dem passenden Rot-Grün-Farbsatz finden, ist einfach:
+
+```math
+cell = \left \lfloor{B \times (N - 1)} \right \rfloor
+```
+
+Hier ist `B` der Wert der Blaukomponente zwischen 0 und 1 und `N` die Gesamtzahl der Zellen. In unserem Fall liegt die Zellnummer im Bereich `0`--`15`, wobei Zelle `0` alle Farben mit der Blaukomponente `0` und Zelle `15` alle Farben mit der Blaukomponente `1` enthält.
+
+Der RGB-Wert `(0.63, 0.83, 0.4)` liegt beispielsweise in der Zelle, die alle Farben mit einem Blauwert von `0.4` enthält, also in Zelle 6. Mit diesem Wissen lassen sich die endgültigen Texturkoordinaten anhand der Grün- und Rotwerte leicht ermitteln:
+
+![Nachschlagetabelle](images/grading/lut_lookup.png)
+
+Beachte, dass wir die Rot- und Grünwerte `(0, 0)` als Position in der *Mitte* des Pixels unten links und die Werte `(1.0, 1.0)` als Position in der *Mitte* des Pixels oben rechts behandeln müssen.
+
+::: sidenote
+Wir lesen von der Mitte des Pixels unten links bis zur Mitte des Pixels oben rechts, weil keine Pixel außerhalb der aktuellen Zelle den ausgelesenen Wert beeinflussen sollen. Siehe dazu die Erklärung zur Filterung weiter unten.
+:::
+
+Wenn wir die Textur an diesen bestimmten Koordinaten abtasten, stellen wir fest, dass wir genau zwischen 4 Pixeln landen. Welchen Farbwert wird GL uns also für diesen Punkt liefern?
+
+![Filterung der Nachschlagetabelle](images/grading/lut_filtering.png)
+
+Die Antwort hängt davon ab, wie wir die *Filterung* des Samplers im Material festgelegt haben.
+
+- Wenn die Sampler-Filterung auf `NEAREST` gesetzt ist, gibt GL den Farbwert des nächstgelegenen Pixels zurück; dabei wird der Positionswert abgerundet. Im obigen Fall gibt GL den Farbwert an der Position `(0.60, 0.80)` zurück. Für unsere Nachschlagetextur mit 4 Bit bedeutet das, dass wir die Farbwerte auf insgesamt nur 4096 Farben quantisieren.
+
+- Wenn die Sampler-Filterung auf `LINEAR` gesetzt ist, gibt GL den *interpolierten* Farbwert zurück. GL mischt eine Farbe anhand der Abstände zu den Pixeln um die Abtastposition. Im obigen Fall gibt GL eine Farbe zurück, die sich zu jeweils 25 % aus den 4 Pixeln um den Abtastpunkt zusammensetzt.
+
+Mit linearer Filterung beseitigen wir also die Farbquantisierung und erzielen mit einer recht kleinen Nachschlagetabelle eine sehr gute Farbgenauigkeit.
+
+## Das Nachschlagen implementieren {#implementing-the-lookup}
+
+Implementieren wir das Nachschlagen in der Textur im Fragment-Shader:
+
+1. Öffne *`grade.material`*.
+2. Füge einen zweiten Sampler namens „`lut`“ hinzu, kurz für lookup table, also Nachschlagetabelle.
+3. Setze die Eigenschaft *`Filter min`* auf `FILTER_MODE_MIN_LINEAR` und die Eigenschaft *`Filter mag`* auf `FILTER_MODE_MAG_LINEAR`.
+
+    ![Sampler der Nachschlagetabelle](images/grading/material_lut_sampler.png)
+
+4. Lade die folgende Textur der Nachschlagetabelle (*`lut16.png`*) herunter und füge sie deinem Projekt hinzu.
+
+    ![Nachschlagetabelle mit 16 Farben](images/grading/lut16.png)
+
+5. Öffne *`main.collection`* und setze die Textureigenschaft *`lut`* auf die heruntergeladene Nachschlagetextur.
+
+    ![Nachschlagetabelle des Quad-Modells](images/grading/quad_lut.png)
+
+6. Öffne schließlich *`grade.fp`*, damit wir die Unterstützung für das Nachschlagen von Farben hinzufügen können:
+
+    ```glsl
+    varying mediump vec4 position;
+    varying mediump vec2 var_texcoord0;
+
+    uniform lowp sampler2D original;
+    uniform lowp sampler2D lut; // <1>
+
+    #define MAXCOLOR 15.0 // <2>
+    #define COLORS 16.0
+    #define WIDTH 256.0
+    #define HEIGHT 16.0
+
+    void main()
+    {
+        vec4 px = texture2D(original, var_texcoord0.xy); // <3>
+
+        float cell = floor(px.b * MAXCOLOR); // <4>
+
+        float half_px_x = 0.5 / WIDTH; // <5>
+        float half_px_y = 0.5 / HEIGHT;
+
+        float x_offset = half_px_x + px.r / COLORS * (MAXCOLOR / COLORS);
+        float y_offset = half_px_y + px.g * (MAXCOLOR / COLORS); // <6>
+
+        vec2 lut_pos = vec2(cell / COLORS + x_offset, y_offset); // <7>
+
+        vec4 graded_color = texture2D(lut, lut_pos); // <8>
+
+        gl_FragColor = graded_color; // <9>
+    }
+    ```
+    1. Deklariere den Sampler `lut`.
+    2. Konstanten für den maximalen Farbwert (15, da wir bei 0 beginnen), die Anzahl der Farben pro Kanal sowie Breite und Höhe der Nachschlagetextur.
+    3. Lies eine Pixelfarbe (namens `px`) aus der ursprünglichen Textur aus, also dem Farbpuffer des Renderziels außerhalb des Bildschirms.
+    4. Berechne anhand des Blaukanalwerts von `px`, aus welcher Zelle die Farbe gelesen werden soll.
+    5. Berechne Versätze um ein halbes Pixel, damit wir aus den Pixelmitten lesen.
+    6. Berechne den X- und Y-Versatz auf der Textur anhand der Rot- und Grünwerte von `px`.
+    7. Berechne die endgültige Abtastposition auf der Nachschlagetextur.
+    8. Lies die resultierende Farbe aus der Nachschlagetextur aus.
+    9. Setze die Farbe auf der Textur des Quads auf die resultierende Farbe.
+
+Derzeit gibt die Textur der Nachschlagetabelle lediglich dieselben Farbwerte zurück, die wir nachschlagen. Das bedeutet, dass das Spiel mit seiner ursprünglichen Farbgebung gerendert werden sollte:
+
+![Spielwelt mit ursprünglicher Farbgebung](images/grading/world_original.png)
+
+Bisher sieht es so aus, als hätten wir alles richtig gemacht. Unter der Oberfläche lauert jedoch ein Problem. Sieh dir an, was passiert, wenn wir ein Sprite mit einer Testtextur mit Farbverläufen hinzufügen:
+
+![Streifenbildung im Blauverlauf](images/grading/blue_banding.png)
+
+Der blaue Farbverlauf zeigt eine wirklich unschöne Streifenbildung. Woran liegt das?
+
+## Den Blaukanal interpolieren {#interpolating-the-blue-channel}
+
+Die Streifenbildung im Blaukanal entsteht, weil GL beim Auslesen der Farbe aus der Textur keine Interpolation des Blaukanals durchführen kann. Wir wählen anhand des Blauwerts vorab eine bestimmte Zelle zum Auslesen aus, und dabei bleibt es. Wenn der Blaukanal beispielsweise einen beliebigen Wert im Bereich `0.400`--`0.466` enthält, spielt der genaue Wert keine Rolle: Wir lesen die endgültige Farbe immer aus Zelle 6 aus, in der der Blaukanal auf `0.400` gesetzt ist.
+
+Um eine bessere Auflösung des Blaukanals zu erhalten, können wir die Interpolation selbst implementieren. Liegt der Blauwert zwischen den Werten zweier benachbarter Zellen, können wir beide Zellen auslesen und anschließend die Farben mischen. Wenn der Blauwert beispielsweise `0.420` ist, sollten wir Zelle 6 *und* Zelle 7 auslesen und anschließend die Farben mischen.
+
+Wir sollten also aus zwei Zellen lesen:
+
+```math
+cell_{low} = \left \lfloor{B \times (N - 1)} \right \rfloor
+```
+
+und:
+
+```math
+cell_{high} = \left \lceil{B \times (N - 1)} \right \rceil
+```
+
+Anschließend lesen wir Farbwerte aus beiden Zellen aus und interpolieren die Farben linear nach folgender Formel:
+
+```math
+color = color_{low} \times (1 - C_{frac}) + color_{high} \times C_{frac}
+```
+
+Hier ist `color`~low~ die aus der niedrigeren (linken) Zelle ausgelesene Farbe und `color`~high~ die aus der höheren (rechten) Zelle ausgelesene Farbe. Die GLSL-Funktion `mix()` führt diese lineare Interpolation für uns aus.
+
+Der Wert `C~frac~` oben ist der Nachkommaanteil des Blaukanalwerts, nachdem dieser auf den Farbbereich `0`--`15` skaliert wurde:
+
+```math
+C_{frac} = B \times (N - 1) - \left \lfloor{B \times (N - 1)} \right \rfloor
+```
+
+Auch hierfür gibt es eine GLSL-Funktion, die den Nachkommaanteil eines Werts liefert. Sie heißt `frac()`. Die endgültige Implementierung im Fragment-Shader (*`grade.fp`*) ist recht unkompliziert:
+
+```glsl
+varying mediump vec4 position;
+varying mediump vec2 var_texcoord0;
+
+uniform lowp sampler2D original;
+uniform lowp sampler2D lut;
+
+#define MAXCOLOR 15.0
+#define COLORS 16.0
+#define WIDTH 256.0
+#define HEIGHT 16.0
+
+void main()
+{
+  vec4 px = texture2D(original, var_texcoord0.xy);
+
+    float cell = px.b * MAXCOLOR;
+
+    float cell_l = floor(cell); // <1>
+    float cell_h = ceil(cell);
+
+    float half_px_x = 0.5 / WIDTH;
+    float half_px_y = 0.5 / HEIGHT;
+    float r_offset = half_px_x + px.r / COLORS * (MAXCOLOR / COLORS);
+    float g_offset = half_px_y + px.g * (MAXCOLOR / COLORS);
+
+    vec2 lut_pos_l = vec2(cell_l / COLORS + r_offset, g_offset); // <2>
+    vec2 lut_pos_h = vec2(cell_h / COLORS + r_offset, g_offset);
+
+    vec4 graded_color_l = texture2D(lut, lut_pos_l); // <3>
+    vec4 graded_color_h = texture2D(lut, lut_pos_h);
+
+    // <4>
+    vec4 graded_color = mix(graded_color_l, graded_color_h, fract(cell));
+
+    gl_FragColor = graded_color;
+}
+```
+
+1. Berechne die beiden benachbarten Zellen, aus denen gelesen werden soll.
+2. Berechne zwei getrennte Nachschlagepositionen, eine für jede Zelle.
+3. Lies die beiden Farben an den Positionen in den Zellen aus.
+3. Mische die Farben linear entsprechend dem Nachkommaanteil von `cell`, dem skalierten Blauwert.
+
+Wenn wir das Spiel erneut mit der Testtextur ausführen, erhalten wir nun deutlich bessere Ergebnisse. Die Streifenbildung im Blaukanal ist verschwunden:
+
+![Blauverlauf ohne Streifenbildung](images/grading/blue_no_banding.png)
+
+## Die Nachschlagetextur farbkorrigieren {#grading-the-lookup-texture}
+
+Gut, das war viel Arbeit, um etwas zu zeichnen, das genauso aussieht wie die ursprüngliche Spielwelt. Aber dieser Aufbau ermöglicht uns etwas wirklich Tolles. Jetzt wird es spannend!
+
+1. Erstelle eine Bildschirmaufnahme des Spiels in seiner unveränderten Form.
+2. Öffne die Bildschirmaufnahme in deinem bevorzugten Bildbearbeitungsprogramm.
+3. Wende beliebig viele Farbanpassungen an, etwa Helligkeit, Kontrast, Farbkurven, Weißabgleich, Belichtung und weitere.
+
+![Spielwelt in Affinity](images/grading/world_graded_affinity.png)
+
+4. Wende dieselben Farbanpassungen auf die Texturdatei der Nachschlagetabelle (*`lut16.png`*) an.
+5. Speichere die farblich angepasste Texturdatei der Nachschlagetabelle.
+6. Ersetze die in deinem Defold-Projekt verwendete Textur *`lut16.png`* durch die farblich angepasste Version.
+7. Starte das Spiel!
+
+![Farbkorrigierte Spielwelt](images/grading/world_graded.png)
+
+Juhu!

--- a/docs/de/tutorials/hud.md
+++ b/docs/de/tutorials/hud.md
@@ -1,0 +1,164 @@
+---
+title: HUD-Codebeispiel
+brief: In diesem Beispielprojekt lernst du Effekte für das Hochzählen von Punkten kennen.
+---
+# HUD - Beispielprojekt {#hud-sample-project}
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NoPHHG2kbOk" frameborder="0" allowfullscreen></iframe>
+
+In diesem Beispielprojekt, das du [im Editor öffnen](/manuals/project-setup/) oder [von GitHub herunterladen](https://github.com/defold/sample-hud) kannst, zeigen wir Effekte für das Hochzählen von Punkten. Die Punktanzeigen erscheinen an zufälligen Stellen auf dem Bildschirm und simulieren so ein Spiel, in dem der Spieler an verschiedenen Positionen Punkte erhält.
+
+Die Punktanzeigen schweben nach ihrem Erscheinen eine Weile. Dazu setzen wir die Punktanzeigen zunächst auf transparent und blenden dann ihre Farbe ein. Außerdem animieren wir sie nach oben. Das geschieht weiter unten in `on_message()`.
+
+Anschließend bewegen sie sich nach oben zur Gesamtpunktzahl am oberen Bildschirmrand, wo sie aufaddiert werden.
+Während sie sich nach oben bewegen, werden sie auch leicht ausgeblendet. Das geschieht in `float_done()`.
+
+Wenn sie die Gesamtpunktzahl oben erreicht haben, werden ihre Werte zu einer Zielpunktzahl addiert, bis zu der die Gesamtpunktzahl hochzählt. Das geschieht in `swoosh_done()`.
+
+Wenn das Skript aktualisiert wird, prüft es, ob die Zielpunktzahl erhöht wurde und die Gesamtpunktzahl hochgezählt werden muss. Trifft dies zu, wird die Gesamtpunktzahl um einen kleineren Schritt erhöht.
+Anschließend wird die Skalierung der Gesamtpunktzahl animiert, um einen Hüpfeffekt zu erzeugen. Das geschieht in `update()`.
+
+Jedes Mal, wenn die Gesamtpunktzahl erhöht wird, erzeugen wir mehrere kleinere Sterne und animieren sie von der Gesamtpunktzahl weg. Die Sterne werden in `spawn_stars()`, `fade_out_star()` und `delete_star()` erzeugt, animiert und gelöscht.
+
+```lua
+-- file: hud.gui_script
+-- how fast the score counts up per second
+local score_inc_speed = 1000
+
+function init(self)
+    -- the target score is the current score in the game
+    self.target_score = 0
+    -- the current score being counted up towards the target score
+    self.current_score = 0
+    -- the score as displayed in the hud
+    self.displayed_score = 0
+    -- keep a reference to the node displaying the score for later use below
+    self.score_node = gui.get_node("score")
+end
+
+local function delete_star(self, star)
+    -- star has finished animation, delete it
+    gui.delete_node(star)
+end
+
+local function fade_out_star(self, star)
+    -- fade out the star before deletion
+    gui.animate(star, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 0), gui.EASING_INOUT, 0.2, 0.0, delete_star)
+end
+
+local function spawn_stars(self, amount)
+    -- position of the score node, to be used for placing the stars
+    local p = gui.get_position(self.score_node)
+    -- distance from the position where the star is spawned
+    local start_distance = 0
+    -- distance where the star stops
+    local end_distance = 240
+    -- angle distance between each star in the star circle
+    local angle_step = 2 * math.pi / amount
+    -- randomize start angle
+    local angle = angle_step * math.random()
+    for i=1,amount do
+        -- increment the angle by the step to get an even distribution of stars
+        angle = angle + angle_step
+        -- direction of the star movement
+        local dir = vmath.vector3(math.cos(angle), math.sin(angle), 0)
+        -- start/end positions of the star
+        local start_p = p + dir * start_distance
+        local end_p = p + dir * end_distance
+        -- create the star node
+        local star = gui.new_box_node(vmath.vector3(start_p.x, start_p.y, 0), vmath.vector3(30, 30, 0))
+        -- set its texture
+        gui.set_texture(star, "star")
+        -- set to transparent
+        gui.set_color(star, vmath.vector4(1, 1, 1, 0))
+        -- fade in
+        gui.animate(star, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_OUT, 0.2, 0.0, fade_out_star)
+        -- animate position
+        gui.animate(star, gui.PROP_POSITION, end_p, gui.EASING_NONE, 0.55)
+    end
+end
+
+function update(self, dt)
+    -- check if the score needs to be updated
+    if self.current_score < self.target_score then
+        -- increment the score for this timestep to grow towards the target score
+        self.current_score = self.current_score + score_inc_speed * dt
+        -- clamp the score so it doesn't grow past the target score
+        self.current_score = math.min(self.current_score, self.target_score)
+        -- floor the score so it can be displayed without decimals
+        local floored_score = math.floor(self.current_score)
+        -- check if the displayed score should be updated
+        if self.displayed_score ~= floored_score then
+            -- update displayed score
+            self.displayed_score = floored_score
+            -- update the text of the score node
+            gui.set_text(self.score_node, string.format("%d p", self.displayed_score))
+            -- set the scale of the score node to be slightly bigger than normal
+            local s = 1.3
+            gui.set_scale(self.score_node, vmath.vector3(s, s, s))
+            -- then animate the scale back to the original value
+            s = 1.0
+            gui.animate(self.score_node, gui.PROP_SCALE, vmath.vector3(s, s, s), gui.EASING_OUT, 0.2)
+            -- spawn stars
+            spawn_stars(self, 4)
+        end
+    end
+end
+
+-- this function stores the added score so that the displayed score can be counted up in the update function
+local function swoosh_done(self, node)
+    -- retrieve score from node
+    local amount = tonumber(gui.get_text(node))
+    -- increase the target score, see the update function for how the score is updated to match the target score
+    self.target_score = self.target_score + amount
+    -- remove the temp score
+    gui.delete_node(node)
+end
+
+-- this function animates the node from having floated first to swoosh away towards the displayed total score
+local function float_done(self, node)
+    local duration = 0.2
+    -- swoosh away towards the displayed score
+    gui.animate(node, gui.PROP_POSITION, gui.get_position(self.score_node), gui.EASING_IN, duration, 0.0, swoosh_done)
+    -- also fade out partially during the swoosh
+    gui.animate(node, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 0.6), gui.EASING_IN, duration)
+end
+
+function on_message(self, message_id, message, sender)
+    -- register added score, this message could be sent by anyone wanting to increment the score
+    if message_id == hash("add_score") then
+        -- create a new temporary score node
+        local node = gui.new_text_node(message.position, tostring(message.amount))
+        -- use the small font for it
+        gui.set_font(node, "small_score")
+        -- initially transparent
+        gui.set_color(node, vmath.vector4(1, 1, 1, 0))
+        gui.set_outline(node, vmath.vector4(0, 0, 0, 0))
+        -- fade in
+        gui.animate(node, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_OUT, 0.3)
+        gui.animate(node, gui.PROP_OUTLINE, vmath.vector4(0, 0, 0, 1), gui.EASING_OUT, 0.3)
+        -- float
+        local offset = vmath.vector3(0, 20, 0)
+        gui.animate(node, gui.PROP_POSITION, gui.get_position(node) + offset, gui.EASING_NONE, 0.5, 0.0, float_done)
+    end
+end
+```
+
+In main.script verarbeiten wir Berührungs- und Mauseingaben und senden anschließend eine Nachricht an das GUI-Skript (GUI script), das an der Berührungsposition neue Punktanzeigen erstellt.
+
+```lua
+-- On click/touch get touch position and send it via message to hud gui script as well as the scored point amount.
+
+function init(self)
+    msg.post(".", "acquire_input_focus")
+end
+
+function on_input(self, action_id, action)
+    local pos = vmath.vector3(action.x, action.y, 0) -- use input action.x & action.y as x & y positions of touch
+    if action_id == hash("touch") then
+        if action.pressed then
+            msg.post("main:/hud#hud", "add_score" , { position = pos, amount = 1500})
+        end
+    end
+end
+```

--- a/docs/de/tutorials/level-complete.md
+++ b/docs/de/tutorials/level-complete.md
@@ -1,0 +1,226 @@
+---
+title: Codebeispiel zum Levelabschluss
+brief: In diesem Beispielprojekt lernst du Effekte kennen, mit denen sich das Hochzählen der Punktzahl nach Abschluss eines Levels darstellen lässt.
+---
+# Levelabschluss - Beispielprojekt {#level-complete-sample-project}
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/tSdTSvku1o8" frameborder="0" allowfullscreen></iframe>
+
+In diesem Beispielprojekt, das du [im Editor öffnen](/manuals/project-setup/) oder [von GitHub herunterladen](https://github.com/defold/sample-levelcomplete) kannst, zeigen wir Effekte, mit denen sich das Hochzählen der Punktzahl nach Abschluss eines Levels darstellen lässt. Eine Gesamtpunktzahl wird hochgezählt, und drei Sterne erscheinen, sobald verschiedene Punkteschwellen erreicht werden. Das Beispiel nutzt außerdem Hot Reload, damit du Änderungen an Werten schnell ausprobieren kannst.
+
+Die Szene wird durch eine Nachricht aus dem Spiel ausgelöst.
+Die Nachricht enthält die erreichte Gesamtpunktzahl und die Punkteschwellen, bei denen die drei Sterne erscheinen sollen.
+Wenn dies geschieht, wird der Überschriftentext ("Level completed!") eingeblendet und dabei auf seine normale Größe (100 %) verkleinert. Dies geschieht unten in `on_message()`.
+
+Sobald die Animation des Überschriftentextes abgeschlossen ist, beginnt das Hochzählen der Gesamtpunktzahl. Bei jedem Schritt wird die aktuelle Punktzahl um einen kleinen Betrag erhöht. Dann prüfen wir, ob eine der Punkteschwellen für die Sterne überschritten wurde. Ist dies der Fall, beginnt die Animation eines Sterns (siehe unten). Solange wir die Zielpunktzahl noch nicht erreicht haben, wird die Anzeige der Gesamtpunktzahl mit einem federnden Effekt animiert.
+Je näher die aktuelle Punktzahl an der Gesamtpunktzahl liegt, desto größer wird die Anzeige, bis sie ihre maximale Skalierung erreicht. Auf dieselbe Weise wechselt ihre Farbe allmählich von Weiß zu Grün. Dies geschieht in `inc_score()`.
+
+Jedes Mal, wenn ein Stern erscheint, wird er eingeblendet und auf seine normale Größe verkleinert. Dies geschieht in `animate_star()`.
+
+Sobald die Animation des Sterns abgeschlossen ist, werden die kleineren Sterne in einem Kreis um den größeren Stern dynamisch erzeugt. Dies geschieht in `spawn_small_stars()`.
+
+Anschließend werden sie so animiert, dass sie zufällig vom Stern nach außen schießen. Dabei variieren sowohl ihre Geschwindigkeit als auch ihre Skalierung zufällig, während sie sich nach außen bewegen. Dann werden sie ausgeblendet und schließlich gelöscht. Dies geschieht in `animate_small_star()` und `delete_small_star()`.
+
+Wenn die Punktzahl die Gesamtpunktzahl erreicht hat, wird der Highscore-Stempel eingeblendet und auf seine normale Größe an der vorgesehenen Stelle verkleinert. Dies wird am Ende von `inc_score()` gestartet und in `animate_imprint()` ausgeführt.
+
+Die Funktion `setup()` stellt sicher, dass die Knoten (nodes) die richtigen Anfangswerte haben. Indem wir `setup()` aus `on_reload()` aufrufen, stellen wir sicher, dass bei jedem Neuladen des Skripts aus dem Defold-Editor alles korrekt eingerichtet ist.
+
+```lua
+-- file: level_complete.gui_script
+
+-- how fast the score is incremented per second
+local score_inc_speed = 51100
+-- how long time between each update of the score
+local dt = 0.03
+-- scale of the score at the start of counting
+local score_start_scale = 0.7
+-- scale of the score when the target score has been reached
+local score_end_scale = 1.0
+-- how much the score "bounces" at each increment
+local score_bounce_factor = 1.1
+-- how many small stars to spawn for each big star
+local small_star_count = 16
+
+local function setup(self)
+    -- make heading color transparent
+    local c = gui.get_color(self.heading)
+    c.w = 0
+    gui.set_color(self.heading, c)
+    -- make heading shadow transparent
+    c = gui.get_shadow(self.heading)
+    c.w = 0
+    gui.set_shadow(self.heading, c)
+    -- set heading to twice the scale initially
+    local s = 2
+    gui.set_scale(self.heading, vmath.vector3(s, s, s))
+    -- set initial score (0)
+    gui.set_text(self.score, "0")
+    -- set score color to opaque white
+    gui.set_color(self.score, vmath.vector4(1, 1, 1, 1))
+    -- set scale so the score can grow while counting
+    gui.set_scale(self.score, vmath.vector4(score_start_scale, score_start_scale, 1, 0))
+
+    -- make all big stars transparent
+    for i=1,#self.stars do
+        gui.set_color(self.stars[i], vmath.vector4(1, 1, 1, 0))
+    end
+    -- make the imprint transparent
+    gui.set_color(self.imprint, vmath.vector4(1, 1, 1, 0))
+    -- the score currently being displayed
+    self.current_score = 0
+    -- the target score when counting
+    self.target_score = 0
+end
+
+function init(self)
+    -- retrieve nodes for easier access
+    self.heading = gui.get_node("heading")
+    self.stars = {gui.get_node("star_left"), gui.get_node("star_mid"), gui.get_node("star_right")}
+    self.score = gui.get_node("score")
+    self.imprint = gui.get_node("imprint")
+    -- start color of the score
+    self.score_start_color = vmath.vector4(1, 1, 1, 1)
+    -- save score color and animate towards it during counting later
+    self.score_end_color = gui.get_color(self.score)
+    setup(self)
+end
+
+-- delete a small star, called when the star has finished animating
+local function delete_small_star(self, small_star)
+    gui.delete_node(small_star)
+end
+
+-- animate a small star according to the given initial position and angle
+local function animate_small_star(self, pos, angle)
+    -- direction of travel for the small star
+    local dir = vmath.vector3(math.cos(angle), math.sin(angle), 0, 0)
+    -- create a small star
+    local small_star = gui.new_box_node(pos + dir * 20, vmath.vector3(64, 64, 0))
+    -- set its texture
+    gui.set_texture(small_star, "small_star")
+    -- set its color to full white
+    gui.set_color(small_star, vmath.vector4(1, 1, 1, 1))
+    -- set start scale low
+    local start_s = 0.3
+    gui.set_scale(small_star, vmath.vector3(start_s, start_s, 1))
+    -- variation in scale of each small star
+    local end_s_var = 1
+    -- actual end scale of this star
+    local end_s = 0.5 + math.random() * end_s_var
+    gui.animate(small_star, gui.PROP_SCALE, vmath.vector4(end_s, end_s, 1, 0), gui.EASING_NONE, 0.5)
+    -- variation in distance traveled (essentially speed of the star)
+    local dist_var = 300
+    -- actual distance the star will travel
+    local dist = 400 + math.random() * dist_var
+    gui.animate(small_star, gui.PROP_POSITION, pos + dir * dist, gui.EASING_NONE, 0.5)
+    gui.animate(small_star, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 0), gui.EASING_OUT, 0.3, 0.2, delete_small_star)
+end
+
+-- spawn a number of small stars
+local function spawn_small_stars(self, star)
+    -- position of the big star the small star will spawn around
+    local p = gui.get_position(star)
+    for i = 1,small_star_count do
+        -- calculate the angle of the particular small star
+        local angle = 2 * math.pi * i/small_star_count
+        -- as well as position
+        local pos = vmath.vector3(p.x, p.y, 0)
+        -- spawn and animate the small star
+        animate_small_star(self, pos, angle)
+    end
+end
+
+-- start the animation of a big star fading in
+local function animate_star(self, star)
+    -- fade in duration
+    local fade_in = 0.2
+    -- make it transparent
+    gui.set_color(star, vmath.vector4(1, 1, 1, 0))
+    -- fade in
+    gui.animate(star, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_IN, fade_in)
+    -- initial scale
+    local scale = 5
+    gui.set_scale(star, vmath.vector3(scale, scale, 1))
+    -- shrink back into place
+    gui.animate(star, gui.PROP_SCALE, vmath.vector4(1, 1, 1, 0), gui.EASING_IN, fade_in, 0, spawn_small_stars)
+end
+
+-- start the animation of the imprint fading in
+local function animate_imprint(self)
+    -- wait a bit before the imprint appears
+    local delay = 0.8
+    -- fade in duration
+    local fade_in = 0.2
+    -- initial scale
+    local scale = 4
+    gui.set_scale(self.imprint, vmath.vector4(scale, scale, 1, 0))
+    -- shrink back into place
+    gui.animate(self.imprint, gui.PROP_SCALE, vmath.vector4(1, 1, 1, 0), gui.EASING_IN, fade_in, delay)
+    -- also fade in
+    gui.animate(self.imprint, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_IN, fade_in, delay)
+end
+
+-- increment the score one step towards the target
+local function inc_score(self, node)
+    -- how much the score is incremented this step
+    local score_inc = score_inc_speed * dt
+    -- new score after increment
+    local new_score = self.current_score + score_inc
+    for i = 1,#self.stars do
+        -- start animating a big star if we cross the level in score for it to appear
+        if self.current_score < self.star_levels[i] and new_score >= self.star_levels[i] then
+            animate_star(self, self.stars[i])
+        end
+    end
+    -- update score, but clamp at target
+    self.current_score = math.min(new_score, self.target_score)
+    -- update the score on screen
+    gui.set_text(self.score, tostring(self.current_score))
+    -- if we are not yet done, keep animating and incrementing
+    if self.current_score < self.target_score then
+        -- how close we are to the target
+        local f = self.current_score / self.target_score
+        -- blend the color to get a slow fade
+        local c = vmath.lerp(f, self.score_start_color, self.score_end_color)
+        gui.animate(self.score, gui.PROP_COLOR, c, gui.EASING_NONE, dt, 0, inc_score)
+        -- new scale for this step
+        local s = vmath.lerp(f, score_start_scale, score_end_scale)
+        -- increase the scale by the bounce factor
+        local sp = s * score_bounce_factor
+        -- animate from bounced scale back to the appropriate scale
+        gui.set_scale(self.score, vmath.vector4(sp, sp, 1, 0))
+        gui.animate(self.score, gui.PROP_SCALE, vmath.vector4(s, s, 1, 0), gui.EASING_NONE, dt)
+    else
+        -- we are done, fade in the imprint
+        -- NOTE! this should in a real case be checked against the actual stored high score
+        animate_imprint(self)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    -- someone tells us that we should display the level completed scene
+    if message_id == hash("level_completed") then
+        -- retrieve the obtained score and at which score levels the stars should be displayed
+        self.target_score = message.score
+        self.star_levels = message.star_levels
+        -- fade in heading ("level completed")
+        local c = gui.get_color(self.heading)
+        c.w = 1
+        gui.animate(self.heading, gui.PROP_COLOR, c, gui.EASING_IN, dt, 0.0, inc_score)
+        c = gui.get_shadow(self.heading)
+        c.w = 1
+        gui.animate(self.heading, gui.PROP_SHADOW, c, gui.EASING_IN, dt, 0.0)
+        -- shrink it into place
+        gui.animate(self.heading, gui.PROP_SCALE, vmath.vector4(1, 1, 1, 0), gui.EASING_IN, 0.2, 0.0)
+    end
+end
+
+-- this function is called when the script is reloaded
+-- by setting up the scene and simulating level complete, we get a really fast workflow for tweaking
+function on_reload(self)
+    -- make sure any setup changes are taken into account
+    setup(self)
+    -- simulate that the level has been completed
+    msg.post("#gui", "level_completed", {score = 102000, star_levels = {40000, 70000, 100000}})
+end
+```

--- a/docs/de/tutorials/magic-link.md
+++ b/docs/de/tutorials/magic-link.md
@@ -1,0 +1,1338 @@
+---
+title: Magic Link-Tutorial
+brief: In diesem Tutorial erstellst du ein vollständiges kleines Puzzlespiel mit einem Startbildschirm, der Spielmechanik und einem einfachen Levelfortschritt in Form zunehmender Schwierigkeit.
+---
+
+# Magic Link-Tutorial
+
+Dieses Spiel ist eine Variante klassischer Kombinationsspiele wie _Bejeweled_ und _Candy Crush_. Durch Ziehen verbindet der Spieler Blöcke derselben Farbe, um sie zu entfernen. Das Ziel ist allerdings nicht, lange Reihen gleichfarbiger Blöcke zu entfernen, das Spielfeld zu leeren oder Punkte zu sammeln, sondern mehrere besondere „magische Blöcke“, die über das Spielfeld verteilt sind, miteinander zu verbinden.
+
+Dieses Tutorial ist eine Schritt-für-Schritt-Anleitung, in der wir das Spiel auf Grundlage eines fertigen Designs erstellen. In der Praxis kostet es viel Zeit und Mühe, ein funktionierendes Design zu finden. Vielleicht beginnst du mit einer Grundidee und suchst dann nach einer Möglichkeit, sie als Prototyp umzusetzen, um ihr Potenzial besser zu verstehen. Selbst ein einfaches Spiel wie „Magic Link“ erfordert einiges an Designarbeit. Dieses Spiel durchlief mehrere Überarbeitungen und Experimente, bis es seine endgültige (und immer noch längst nicht perfekte) Form und seine Spielregeln hatte. Für dieses Tutorial überspringen wir diesen Prozess aber und beginnen direkt mit der Umsetzung des fertigen Designs.
+
+## Erste Schritte {#getting-started}
+
+Zunächst musst du ein neues Projekt erstellen und das Asset-Paket importieren:
+
+* Erstelle ein [neues Projekt](/manuals/project-setup/#creating-a-new-project) aus der Vorlage „Empty Project“
+* Lade das vollständige „Magic Link“-Projekt [magic-link.zip](https://github.com/defold/defold-examples/releases/latest) als Referenz herunter. Das vollständige Projekt enthält alle Assets, falls du das Projekt von Grund auf erstellen möchtest.
+
+## Spielregeln {#game-rules}
+
+![Schematische Darstellung der Spielregeln](images/magic-link/linker_rules.png)
+
+Das Spielfeld wird in jeder Runde zufällig mit farbigen Blöcken und mehreren magischen Blöcken gefüllt. Für die farbigen Blöcke gelten diese Regeln:
+
+* Sie verschwinden, wenn der Spieler sie durch Ziehen mit gleichfarbigen Blöcken verbindet.
+* Wenn Blöcke verschwinden, hinterlassen sie Lücken. Farbige Blöcke fallen einfach senkrecht nach unten in die Lücken, die sich unter ihnen geöffnet haben.
+* Der untere Bildschirmrand verhindert, dass Blöcke weiter nach unten fallen.
+
+Die magischen Blöcke verhalten sich anders. Für sie gelten diese Regeln:
+
+* Magische Blöcke bewegen sich _seitwärts_, wenn auf einer der beiden Seiten eine Lücke entsteht.
+* Wenn unter ihnen eine Lücke entsteht, fallen sie stattdessen wie gewöhnliche farbige Blöcke nach unten.
+
+Für die Interaktion des Spielers mit dem Spiel gelten die folgenden Regeln:
+
+* Der Spieler kann farbige Blöcke durch Ziehen verbinden, wenn sie waagerecht, senkrecht oder diagonal aneinandergrenzen.
+* Verbundene Blöcke verschwinden, sobald der Spieler die Berührungseingabe beendet (den Finger anhebt).
+* Magische Blöcke reagieren nicht auf Ziehen und können nicht manuell verbunden werden.
+* Magische Blöcke reagieren jedoch darauf, wenn sie waagerecht oder senkrecht aneinandergrenzen. Unter diesen Umständen verbinden sie sich also automatisch.
+* Das Level ist abgeschlossen, wenn es dem Spieler gelingt, alle magischen Blöcke auf dem Spielfeld automatisch miteinander zu verbinden.
+
+Der Schwierigkeitsgrad bestimmt die Anzahl der magischen Blöcke, die auf dem Spielfeld platziert werden.
+
+## Überblick {#overview}
+
+Wie bei jedem Projekt brauchen wir einen groben Plan für die Umsetzung. Es gibt viele Möglichkeiten, das Spiel zu strukturieren und aufzubauen. Technisch könnten wir das gesamte Spiel im GUI-System umsetzen, wenn wir wollten. Meist ist es jedoch naheliegend, ein Spiel mit Spielobjekten (game objects) und Sprites aufzubauen und die GUI-APIs für die Bildschirmoberfläche und eingeblendete Spielinformationen zu verwenden. Diesen Weg gehen wir hier.
+
+Da wir mit einer recht geringen Anzahl von Dateien rechnen, halten wir die Ordnerstruktur des Projekts sehr einfach:
+
+![Ordnerstruktur](images/magic-link/linker_folders.png)
+
+*main*
+: Dieser Ordner enthält die gesamte Spiellogik. Hier liegen alle Skripte, Spielobjektdateien, Sammlungsdateien, GUI-Dateien und so weiter. Du kannst diesen Ordner auch in mehrere Ordner aufteilen oder Unterordner verwenden.
+
+*images*
+: In diesem Ordner liegen alle Bild-Assets.
+
+*fonts*
+: Hier werden die Schriftarten für das Rendern von Text aufbewahrt.
+
+*input*
+: In diesem Ordner liegen die Eingabebindungen (input bindings).
+
+## Das Projekt einrichten {#setting-up-the-project}
+
+Die Datei *game.project* behält größtenteils ihre Standardeinstellungen, aber einige Einstellungen müssen wir festlegen. Zunächst brauchen wir eine Auflösung für das Spiel. Die Auflösung lässt sich später recht leicht ändern. Für ein fertiges Spiel müssen wir außerdem dafür sorgen, dass es unabhängig von der Auflösung und dem Seitenverhältnis des Zielgeräts gut aussieht.
+
+Wir haben uns für eine Auflösung von 640 × 960 Pixeln entschieden, die native Auflösung des iPhone 4. Diese Auflösung passt auch auf viele Monitore, was Spieltests am Computer angenehm macht. Wenn du mit einer anderen Auflösung arbeiten möchtest, musst du nur einige Werte entsprechend anpassen.
+
+![Projekteinstellungen](images/magic-link/linker_project_settings.png)
+
+Außerdem müssen wir die maximale Anzahl gerenderter Sprites erhöhen. Wenn du möchtest, kannst du zum nächsten Abschnitt springen und hierher zurückkehren, sobald dich die Konsole darauf hinweist, dass du die Sprite-Grenze erreicht hast.
+
+![Aufteilung und Größenverhältnisse des Spielfelds](images/magic-link/linker_layout.png)
+
+Wir können die maximal benötigte Anzahl an Sprites berechnen:
+
+* Das Spielfeld enthält 7 × 9 Blöcke. An den Rändern braucht es etwas Abstand und oben Platz für einige GUI-Elemente. Die Blöcke sind deshalb etwa 90 × 90 Pixel groß. Kleinere Blöcke wären zu winzig, um auf dem kleinen Bildschirm eines Telefons mit ihnen zu interagieren.
+* Jeder Block besteht aus einem Sprite. Wir verwenden Animationen mit einem einzelnen Bild, um die Farbe des Blocks festzulegen.
+* Einige Blöcke sind magische Blöcke, und für jeden davon verwenden wir 4 Sprites für Spezialeffekte.
+* Die Verbindungsgrafiken benötigen ein Sprite pro Element. Im ungünstigsten Fall sind das 61 zusätzliche Sprites, wenn der Spieler es irgendwie schafft, das gesamte Spielfeld zu verbinden (abzüglich 2 magischer Blöcke, die sich nicht durch Ziehen verbinden lassen).
+
+Nehmen wir also an, dass wir höchstens 30 magische Blöcke haben. Das Spielfeld besteht aus 63 Blöcken (Sprites). Bei den 30 magischen Blöcken kommen jeweils 4 Sprites für Spezialeffekte hinzu. Das sind 120 zusätzliche Sprites. Zusammen mit den Verbindungsgrafiken (in diesem Fall höchstens 33) müssen wir also in jedem Frame mindestens 120 + 33 = 153 Sprites zeichnen. Die nächste Zweierpotenz ist 256.
+
+Es reicht jedoch nicht aus, das Maximum auf 256 zu setzen. Jedes Mal, wenn wir das Spielfeld leeren und zurücksetzen, löschen wir alle aktuellen Spielobjekte und erzeugen neue. Die Sprite-Anzahl muss alle Objekte berücksichtigen, die während des Frames existieren. Dazu gehören auch gelöschte Objekte, da sie erst am Ende des Frames entfernt werden. Es genügt daher, die maximale Anzahl an Sprites auf 512 zu setzen.
+
+![Maximale Sprite-Anzahl](images/magic-link/linker_sprite_max_count.png)
+
+## Die Grafik-Assets hinzufügen {#adding-the-graphics-assets}
+
+Alle für das Spiel benötigten Assets wurden im Voraus vorbereitet. Wir fügen sie als Bilder mit 512 × 512 Pixeln hinzu und lassen die Engine sie auf die Zielgröße verkleinern.
+
+::: sidenote
+Wenn du *hidpi* in den Projekteinstellungen aktivierst, erhält der Backbuffer eine hohe Auflösung. Große Bilder, die verkleinert gezeichnet werden, erscheinen auf Retina-Bildschirmen dadurch sehr scharf.
+:::
+
+![Bilder hinzufügen](images/magic-link/linker_add_images.png)
+
+Neben den Blöcken sind ein „connector“-Bild und Effekt-Sprites enthalten. Außerdem gibt es zwei Hintergrundbilder: eines als Hintergrund für das Spielfeld und eines für das Hauptmenü. Füge alle Bilder zum Ordner *images* hinzu und erstelle dann eine Atlasdatei namens *sprites.atlas*. Öffne die Atlasdatei und füge alle Bilder hinzu.
+
+![Bilder zum Atlas hinzufügen](images/magic-link/linker_add_to_atlas.png)
+
+Es gibt außerdem einige GUI-Bilder, mit denen GUI-Elemente wie Schaltflächen und Popups erstellt werden. Diese fügen wir einem separaten Atlas namens *gui.atlas* hinzu.
+
+## Das Spielfeld erzeugen {#generating-the-board}
+
+Im ersten Schritt erstellen wir die Spielfeldlogik. Das Spielfeld liegt in einer eigenen Sammlung (collection), die alles enthält, was während des Spiels auf dem Bildschirm zu sehen ist. Fürs Erste benötigen wir nur die Komponente (component) „blockfactory“ vom Typ Fabrik (factory) und das Skript. Später ergänzen wir eine Fabrik für Verbindungen, eine GUI-Komponente für das Hauptmenü und schließlich die Lademechanik, um das Spiel vom Hauptmenü aus zu starten, sowie eine Möglichkeit, zum Menü zurückzukehren.
+
+1. Erstelle *`board.collection`* im Ordner *`main`*. Gib der Sammlung den Namen „board“, damit wir sie später adressieren können. Wenn du die Sprite-Komponente für den Hintergrund hinzufügst, setze ihre Z-Position unbedingt auf -1. Andernfalls wird sie nicht hinter all den Blöcken gezeichnet, die wir später erzeugen.
+2. Setze *Main Collection* (unter *Bootstrap*) in *game.project* vorübergehend auf `/main/board.collection`, damit wir leicht testen können.
+
+![Sammlung für das Spielfeld](images/magic-link/linker_board_collection.png)
+
+![Spielfeldsammlung als Startsammlung](images/magic-link/linker_bootstrap_board.png)
+
+Die Skriptdatei *board.script* enthält die gesamte Logik für das Spielfeld selbst und die Blöcke darauf. Erstelle zunächst die Funktion zum Aufbau des Spielfelds und rufe sie (vorübergehend) aus `init()` auf. Wir fügen außerdem zwei Funktionen hinzu, die wir jetzt noch nicht verwenden, die später aber nützlich sind:
+
+`filter()`
+: Mit dieser Funktion können wir Listen von Elementen (Blöcken) filtern.
+
+`build_blocklist()`
+: Erstellt eine flache Liste aller Blöcke auf dem Spielfeld, die sich dadurch filtern lässt.
+
+Nach dem Aufbau des Spielfelds verwenden wir zwei verschiedene Datenbestände mit allen Blöcken, `self.blocks` und `self.board`:
+
+```lua
+-- board.script
+go.property("timer", 0)     -- Use to time events
+local blocksize = 80        -- Distance between block centers
+local edge = 40             -- Left and right edge.
+local bottom_edge = 50      -- Bottom edge.
+local boardwidth = 7        -- Number of columns
+local boardheight = 9       -- Number of rows
+local centeroff = vmath.vector3(8, -8, 0) -- Center offset for connector gfx since there's shadow below in the block img
+local dropamount = 3        -- The number of blocks dropped on a "drop"
+local colors = { hash("orange"), hash("pink"), hash("blue"), hash("yellow"), hash("green") }
+
+--
+-- filter(function, table)
+-- e.g: filter(is_even, {1,2,3,4}) -> {2,4}
+--
+local function filter(func, tbl)
+    local new = {}
+    for i, v in pairs(tbl) do
+        if func(v) then
+            new[i] = v
+        end
+    end
+    return new
+end
+
+--
+-- Build a list of blocks in 1 dimension for easy filtering
+--
+local function build_blocklist(self)
+    self.blocks = {}
+    for x, l in pairs(self.board) do
+        for y, b in pairs(self.board[x]) do
+            table.insert(self.blocks, { id = b.id, color = b.color, x = b.x, y = b.y })
+        end
+    end
+end
+
+--
+-- INIT
+--
+function init(self)
+    self.board = {}             -- Contains the board structure
+    self.blocks = {}            -- List of all blocks. Used for easy filtering on selection.
+    self.chain = {}             -- Current selection chain
+    self.connectors = {}        -- Connector elements to mark the selection chain
+    self.num_magic = 3          -- Number of magic blocks on the board
+    self.drops = 1              -- Number of drops you have available
+    self.magic_blocks = {}      -- Magic blocks that are lined up
+    self.dragging = false       -- Drag touch input
+    msg.post(".", "acquire_input_focus")
+    msg.post("#", "start_level")
+end
+
+local function build_board(self)
+    math.randomseed(os.time())
+    local pos = vmath.vector3()
+    local c
+    local x = 0
+    local y = 0
+    for x = 0,boardwidth-1 do
+        pos.x = edge + blocksize / 2 + blocksize * x
+        self.board[x] = {}
+        for y = 0,boardheight-1 do
+            pos.y = bottom_edge + blocksize / 2 + blocksize * y
+            -- Calc z
+            pos.z = x * -0.1 + y * 0.01 -- <1>
+            c = colors[math.random(#colors)]    -- Pick a random color
+            local id = factory.create("#blockfactory", pos, null, { color = c })
+            self.board[x][y] = { id = id, color = c,  x = x, y = y }
+        end
+    end
+
+    -- Build 1d list that we can easily filter.
+    build_blocklist(self)
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("start_level") then
+        build_board(self)
+    end
+end
+```
+1. Da sich die Blockgrafiken überlappen, müssen wir sie in der richtigen Reihenfolge zeichnen. Dazu setzen wir die Z-Koordinate jedes Blocks. Der Wert bleibt deutlich über -1, wo sich das Hintergrund-Sprite befindet.
+
+Die Spielfeldlogik erzeugt „`block`“-Spielobjekte über die Fabrikkomponente „`blockfactory`“. Damit das funktioniert, müssen wir das Spielobjekt für den Block erstellen. Der Block besitzt ein Skript und ein Sprite. Wir setzen die Standardanimation des Sprites auf einen beliebigen farbigen Block in *`sprites.atlas`* und ergänzen dann *`block.script`* um Code, damit der Block beim Erzeugen die richtige Farbe annimmt:
+
+![Spielobjekt für einen Block](images/magic-link/linker_block.png)
+
+```lua
+-- block.script
+go.property("color", hash("none"))
+
+function init(self)
+    go.set_scale_xy(0.18)     -- render scaled down without changing Z
+
+    if self.color ~= nil then
+        sprite.play_flipbook("#sprite", self.color)
+    else
+        msg.post("#sprite", "disable")
+    end
+end
+```
+
+Setze *Prototype* der Fabrikkomponente „blockfactory“ auf die neue Spielobjektdatei *block.go*.
+
+![Fabrik für Blöcke](images/magic-link/linker_blockfactory.png)
+
+Jetzt solltest du das Spiel starten können und ein Spielfeld sehen, das mit zufällig gefärbten Blöcken gefüllt ist:
+
+![Erste Bildschirmaufnahme](images/magic-link/linker_first_screenshot.png)
+
+## Interaktionen {#interactions}
+
+Jetzt haben wir ein Spielfeld und sollten die Interaktion mit dem Spieler hinzufügen. Zunächst definieren wir die Eingabebindungen in *game.input_binding* im Ordner *input*. Stelle sicher, dass die Einstellungen in *game.project* deine Eingabebindungsdatei verwenden.
+
+![Eingabebindungen](images/magic-link/linker_input_bindings.png)
+
+Wir benötigen nur eine Bindung und weisen `MOUSE_BUTTON_LEFT` dem Aktionsnamen „touch“ zu. Dieses Spiel verwendet keine Mehrfacheingabe per Berührung. Praktischerweise übersetzt Defold Berührungseingaben mit einem Finger in Klicks mit der linken Maustaste.
+
+Das Spielfeld übernimmt die Verarbeitung der Eingaben, deshalb müssen wir den entsprechenden Code in *board.script* ergänzen:
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.value == 1 then
+        -- What block was touched or dragged over?
+        local x = math.floor((action.x - edge) / blocksize)
+        local y = math.floor((action.y - bottom_edge) / blocksize)
+
+        if x < 0 or x >= boardwidth or y < 0 or y >= boardheight or self.board[x][y] == nil then
+            -- outside board.
+            return
+        end
+
+        if action.pressed then
+            -- Player started touch
+            msg.post(self.board[x][y].id, "make_orange")
+
+            self.dragging = true
+        elseif self.dragging then
+            -- then drag
+            msg.post(self.board[x][y].id, "make_green")
+        end
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+    end
+end
+```
+
+Die Nachrichten `make_orange` und `make_green` dienen nur vorübergehend als sichtbare Rückmeldung, dass der Code funktioniert. Wir müssen *block.script* um Code ergänzen, der diese Nachrichten verarbeitet:
+
+```lua
+-- block.script
+function on_message(self, message_id, message, sender)
+    if message_id == hash("make_orange") then
+        sprite.play_flipbook("#sprite", hash("orange"))
+    elseif message_id == hash("make_green") then
+        sprite.play_flipbook("#sprite", hash("green"))
+    end
+end
+```
+
+Jetzt erhalten die Blöcke zuerst eine `make_orange`-Nachricht und danach `make_green`-Nachrichten, solange du den Bildschirm berührst (oder die Maustaste gedrückt hältst). Daher flackern die Blöcke wahrscheinlich nur kurz orange auf (wenn überhaupt), bevor sie grün werden. Aber wir wissen nun, welchen Block der Spieler berührt! Wenn du die Verarbeitung der Eingabe genauer verfolgen möchtest, füge `print()`- oder `pprint()`-Aufrufe in den Code ein.
+
+## Verbindungen markieren {#mark-links}
+
+Jetzt brauchen wir Assets für die Markierung, die anzeigt, wenn der Spieler Blöcke miteinander verbindet. Die Idee ist, einfach eine Grafik über jeden Block zu legen, um seine Verbindung anzuzeigen.
+
+Wir müssen ein Spielobjekt namens „connector“ erstellen, das das Sprite-Bild für die Verbindungen enthält, sowie eine Fabrikkomponente namens „connector factory“ im Spielobjekt „board“:
+
+![Spielobjekt für eine Verbindung](images/magic-link/linker_connector.png)
+
+![Fabrik für Verbindungen](images/magic-link/linker_connector_factory.png)
+
+Das Skript für dieses Spielobjekt ist minimal. Es muss nur die Grafik passend zum restlichen Spiel skalieren und die Z-Reihenfolge richtig einstellen.
+
+```lua
+-- connector.script
+function init(self)
+    go.set_scale_xy(0.18)           -- Scale in 2D without changing Z.
+    go.set(".", "position.z", 1)    -- Put on top.
+end
+```
+
+Die Funktion `same_color_neighbors()` gibt eine Liste von Blöcken zurück, die an einen bestimmten Block (an der Position x, y) angrenzen und dieselbe Farbe haben. Sie verwendet die Funktion `filter()`, die auf die vollständige flache Liste der Blöcke in `self.blocks` angewendet wird.
+
+```lua
+-- board.script
+--
+-- Returns a list of neighbor blocks of the same color as the
+-- block on x, y
+--
+local function same_color_neighbors(self, x, y)
+    local f = function (v)
+        return (v.id ~= self.board[x][y].id) and
+               (v.x == x or v.x == x - 1 or v.x == x + 1) and
+               (v.y == y or v.y == y - 1 or v.y == y + 1) and
+               (v.color == self.board[x][y].color)
+    end
+    return filter(f, self.blocks)
+end
+```
+
+Die Hilfsfunktion `in_blocklist()` prüft, ob ein Block in einer Liste von Blöcken vorhanden ist:
+
+```lua
+-- board.script
+--
+-- Does the block exist in the list of blocks?
+--
+local function in_blocklist(blocks, block)
+    for i, b in pairs(blocks) do
+        if b.id == block then
+            return true
+        end
+    end
+    return false
+end
+```
+
+Wir verwenden diese Funktionen bei Berührungs- und Zieheingaben in `on_input()`, um die berührten Blöcke zu einer Verbindungskette zusammenzustellen. Dabei prüfen wir bereits auf magische Blöcke und ignorieren sie, obwohl es noch keine gibt:
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    -- If trying to manipulate magic blocks, ignore.
+    if self.board[x][y].color == hash("magic") then
+        return
+    end
+
+    if action.pressed then
+        -- List of neighbors of the same color as touched block
+        self.neighbors = same_color_neighbors(self, x, y)
+        self.chain = {}
+        table.insert(self.chain, self.board[x][y])
+
+        -- Mark block.
+        p = go.get_position(self.board[x][y].id)
+        local id = factory.create("#connectorfactory", p + centeroff)
+        table.insert(self.connectors, id)
+
+        self.dragging = true
+    elseif self.dragging then
+        -- then drag
+        if in_blocklist(self.neighbors, self.board[x][y].id) and not in_blocklist(self.chain, self.board[x][y].id) then
+            -- dragging over a same-colored neighbor
+            table.insert(self.chain, self.board[x][y])
+            self.neighbors = same_color_neighbors(self, x, y)
+
+            -- Mark block.
+            p = go.get_position(self.board[x][y].id)
+            local id = factory.create("#connectorfactory", p + centeroff)
+            table.insert(self.connectors, id)
+        end
+    end
+```
+
+Zum Schluss entfernen wir beim Beenden der Berührung alle sichtbaren Verbindungsmarkierungen.
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+
+        -- Empty chain of connector graphics.
+        for i, c in ipairs(self.connectors) do
+            go.delete(c)
+        end
+        self.connectors = {}
+    end
+end
+```
+
+![Verbindungen im Spiel](images/magic-link/linker_connector_screen.png)
+
+## Verbundene Blöcke entfernen {#remove-linked-blocks}
+
+Jetzt haben wir die Logik zum Verbinden gleichfarbiger Blöcke, und die verbundenen Blöcke zu entfernen ist einfach. Wir setzen die Position auf dem Spielfeld auf `hash("removing")` statt einfach auf `nil`, weil wir später bei der Logik für magische Blöcke sicherstellen müssen, dass diese nur an die Stellen gerade entfernter Blöcke gleiten. Wenn wir die Position auf dem Spielfeld hier auf `nil` setzen, können wir gerade entfernte Blöcke nicht von solchen unterscheiden, die schon zuvor entfernt wurden.
+
+```lua
+-- board.script
+-- Remove the currently selected block-chain
+--
+local function remove_chain(self)
+    -- Delete all chained blocks
+    for i, c in ipairs(self.chain) do
+        self.board[c.x][c.y] = hash("removing")
+        go.delete(c.id)
+    end
+    self.chain = {}
+end
+```
+
+Außerdem brauchen wir eine Funktion, die Positionen auf dem Spielfeld tatsächlich entfernt (auf `nil` setzt), wenn sie zuvor auf `hash("removing")` gesetzt wurden:
+
+```lua
+-- board.script
+--
+-- Set removed blocks to nil
+--
+local function nilremoved(self)
+    for y = 0,boardheight - 1 do
+        for x = 0,boardwidth - 1 do
+            if self.board[x][y] == hash("removing") then
+                self.board[x][y] = nil
+            end
+        end
+    end
+end
+```
+
+Wir erstellen auch eine Funktion, die die übrigen Blöcke nach unten gleiten lässt, wenn Blöcke darunter entfernt (auf `nil` gesetzt) werden. Wir durchlaufen das Spielfeld spaltenweise von links nach rechts und jede Spalte von unten nach oben. Wenn wir auf eine leere (`nil`) Position stoßen, lassen wir alle Blöcke darüber nach unten gleiten.
+
+```lua
+-- board.script
+--
+-- Apply shift-down logic to all blocks.
+--
+local function slide_board(self)
+    -- Slide all remaining blocks down into blank spots.
+    -- Going column by column makes this easy.
+    local dy = 0
+    local pos = vmath.vector3()
+    for x = 0,boardwidth - 1 do
+        dy = 0
+        for y = 0,boardheight - 1 do
+            if self.board[x][y] ~= nil then
+                if dy > 0 then
+                    -- Move down dy steps
+                    self.board[x][y - dy] = self.board[x][y]
+                    self.board[x][y] = nil
+                    -- Calc new position
+                    self.board[x][y - dy].y = self.board[x][y - dy].y - dy
+                    go.animate(self.board[x][y-dy].id, "position.y", go.PLAYBACK_ONCE_FORWARD, bottom_edge + blocksize / 2 + blocksize * (y - dy), go.EASING_OUTBOUNCE, 0.3)
+                    -- Calc new z
+                    go.set(self.board[x][y-dy].id, "position.z", x * -0.1 + (y-dy) * 0.01)
+                end
+            else
+                dy = dy + 1
+            end
+        end
+    end
+    -- blocklist needs updating
+    build_blocklist(self)
+end
+```
+
+![Blöcke nach unten gleiten lassen](images/magic-link/linker_blocks_slide.png)
+
+Jetzt können wir diese Funktionen einfach in `on_input()` aufrufen, wenn die Berührung beendet wurde und sich Blöcke in `self.chain` befinden.
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+
+        if #self.chain > 1 then
+            -- There is a chain of blocks. Remove it from board and slide the remaining blocks down.
+            remove_chain(self)
+            nilremoved(self)
+            slide_board(self)
+        end
+
+        -- Empty chain of connector graphics.
+        for i, c in ipairs(self.connectors) do
+            go.delete(c)
+        end
+        self.connectors = {}
+    end
+```
+
+## Logik für magische Blöcke {#magic-block-logic}
+
+Jetzt ist es Zeit, die magischen Blöcke hinzuzufügen. Zuerst ermöglichen wir es, einen Block in einen magischen Block umzuwandeln. So können wir das gefüllte Spielfeld in einem separaten Durchlauf bearbeiten und die gewünschten Blöcke in magische verwandeln. Um die magischen Blöcke etwas interessanter zu gestalten, erstellen wir zunächst einen animierten magischen Effekt als Spielobjekt *`magic_fx.go`*, das wir vom magischen Block aus erzeugen können.
+
+![Magic_fx.go](images/magic-link/linker_magic_fx.png)
+
+Dieses Spielobjekt enthält zwei Sprites. Eines stellt die Farbe „magic“ dar (ein Sprite mit dem Bild *`magic-sphere_layer2.png`*), das andere einen Lichteffekt namens „light“ (ein Sprite mit dem Bild *`magic-sphere_layer3.png`*). Das Objekt beginnt beim Erzeugen abhängig vom Wert der Eigenschaft `direction` zu rotieren. Außerdem reagiert es auf zwei Nachrichten: `lights_on` und `lights_off`, die das Sprite für den Lichteffekt steuern.
+
+Erstelle ein neues Skript und füge es als Skriptkomponente zu *`magic_fx.go`* hinzu:
+
+```lua
+-- magic_fx.script
+go.property("direction", hash("left"))
+
+function init(self)
+    msg.post("#", "lights_off")
+    if self.direction == hash("left") then
+        go.set(".", "euler.z", 0)
+        go.animate(".", "euler.z", go.PLAYBACK_LOOP_FORWARD, 360,  go.EASING_LINEAR, 3 + math.random())
+    else
+        go.set(".", "euler.z", 0)
+        go.animate(".", "euler.z", go.PLAYBACK_LOOP_FORWARD, -360,  go.EASING_LINEAR, 2 + math.random())
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("lights_on") then
+        msg.post("#light", "enable")
+    elseif message_id == hash("lights_off") then
+        msg.post("#light", "disable")
+    end
+end
+```
+
+Der magische Block erzeugt nun bei der Nachricht `make_magic` zwei `magic_fx`-Spielobjekte. Sie drehen sich in entgegengesetzte Richtungen und erzeugen dadurch ein schönes Farbenspiel im Inneren der Blöcke. Außerdem fügen wir *`block.go`* ein weiteres Sprite mit dem Bild *`magic-sphere_layer4.png`* hinzu. Dieses Bild erhält einen höheren Z-Wert als der erzeugte Effekt und zeichnet die Hülle oder Abdeckung („cover“) der magischen Kugel.
+
+![Sprite für die Abdeckung](images/magic-link/linker_cover.png)
+
+Beachte, dass wir dem Spielobjekt des Blocks eine *Factory*-Komponente hinzufügen und ihr unser Spielobjekt *`magic_fx.go`* als *Prototype* zuweisen müssen. Das Blockskript muss außerdem auf die Nachrichten `lights_on` und `lights_off` reagieren und sie an die erzeugten Objekte weiterleiten. Beachte auch, dass die erzeugten Objekte gelöscht werden müssen, wenn der Block gelöscht wird. Dafür sorgt die Funktion `final()` des Blocks. All das geschieht in *`block.script`*.
+
+```lua
+-- block.script
+function init(self)
+    go.set_scale_xy(0.18) -- render scaled down without changing Z
+
+    self.fx1 = nil
+    self.fx2 = nil
+
+    msg.post("#cover", "disable")
+
+    if self.color ~= nil then
+        sprite.play_flipbook("#sprite", self.color)
+    else
+        msg.post("#sprite", "disable")
+    end
+end
+
+function final(self)
+    if self.fx1 ~= nil then
+        go.delete(self.fx1)
+    end
+
+    if self.fx2 ~= nil then
+        go.delete(self.fx2)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("make_magic") then
+        self.color = hash("magic")
+        msg.post("#cover", "enable")
+        msg.post("#sprite", "enable")
+        sprite.play_flipbook("#sprite", hash("magic-sphere_layer1"))
+
+        self.fx1 = factory.create("#fxfactory", p, nil, { direction = hash("left") })
+        self.fx2 = factory.create("#fxfactory", p, nil, { direction = hash("right") })
+
+        go.set_parent(self.fx1, go.get_id())
+        go.set_parent(self.fx2, go.get_id())
+
+        go.set(self.fx1, "position.z", 0.01)
+        go.set(self.fx1, "scale.xy", 1)
+        go.set(self.fx2, "position.z", 0.02)
+        go.set(self.fx2, "scale.xy", 1)
+    elseif message_id == hash("lights_on") or message_id == hash("lights_off") then
+        msg.post(self.fx1, message_id)
+        msg.post(self.fx2, message_id)
+    end
+end
+```
+
+Jetzt können wir magische Blöcke erzeugen und sie auch aufleuchten lassen. Mit diesem Effekt zeigen wir an, dass ein magischer Block neben einem anderen magischen Block liegt.
+
+![Magischer Block ohne und mit Licht](images/magic-link/linker_magic_blocks.png)
+
+Den Code, der das Spielfeld mit Blöcken füllt, müssen wir nun so ändern, dass auch einige magische Blöcke darauf erscheinen:
+
+```lua
+-- board.script
+local function build_board(self)
+
+    ...
+
+    -- Distribute magic blocks.
+    local rand_x = 0
+    local rand_y
+    for y = 0, boardheight - 1, boardheight / self.num_magic do
+        local set = false
+        while not set do
+            rand_y = math.random(math.floor(y), math.min(boardheight - 1, math.floor(y + boardheight / self.num_magic)))
+            rand_x = math.random(0, boardwidth - 1)
+            if self.board[rand_x][rand_y].color ~= hash("magic") then
+                msg.post(self.board[rand_x][rand_y].id, "make_magic")
+                self.board[rand_x][rand_y].color = hash("magic")
+                set = true
+            end
+        end
+    end
+
+    -- Build 1d list that we can easily filter.
+    build_blocklist(self)
+end
+```
+
+Die wichtigste Mechanik der magischen Blöcke ist ihre Fähigkeit, seitwärts zu gleiten, wenn neben ihnen ein anderer Block verschwindet. Alle Einzelheiten dieser Mechanik setzen wir in der Funktion `slide_magic_blocks()` in *board.script* um. Der Algorithmus ist einfach:
+
+1. Erstelle für jede Zeile des Spielfelds eine Liste `M` der magischen Blöcke.
+2. Durchlaufe jeden magischen Block in der Liste `M` so lange, bis die Liste nicht mehr schrumpft. Für jeden Durchlauf gilt:
+    1. Wenn sich unter dem magischen Block eine mit `hash("removing")` markierte Blockposition befindet, entferne ihn einfach aus der Liste `M`.
+    2. Wenn sich neben dem magischen Block eine mit `hash("removing")` markierte Lücke befindet, lasse ihn dorthin gleiten, setze seine alte Position auf `hash("removing")` und entferne ihn dann aus der Liste `M`.
+
+```lua
+-- board.script
+-- Apply the shifting logic to magic blocks. Only slide to positions
+-- marked for removal with hash("removing")
+--
+local function slide_magic_blocks(self)
+    -- Slide all magic blocks to the side that should slide first.
+    -- This works best going row by row!
+    local row_m
+    for y = 0,boardheight - 1 do
+        row_m = {}
+        -- Build list of magic blocks on this row.
+        for x = 0,boardwidth - 1 do
+            if self.board[x][y] ~= nil and self.board[x][y] ~= hash("removing") and self.board[x][y].color == hash("magic") then
+                table.insert(row_m, self.board[x][y])
+            end
+        end
+
+        local mc = #row_m + 1
+        -- Go through list, slide and remove if possible. Reiterate until the list does not shrink.
+        while #row_m < mc do
+            mc = #row_m
+            for i, m in pairs(row_m) do
+                local x = m.x
+                if y > 0 and self.board[x][y-1] == hash("removing") then
+                    -- Hole below, do nothing.
+                    row_m[i] = nil
+                elseif x > 0 and self.board[x-1][y] == hash("removing") then
+                    -- Hole to the left! Slide magic block there
+                    self.board[x-1][y] = self.board[x][y]
+                    self.board[x-1][y].x = x - 1
+                    go.animate(self.board[x][y].id, "position.x", go.PLAYBACK_ONCE_FORWARD, edge + blocksize / 2 + blocksize * (x - 1), go.EASING_OUTBOUNCE, 0.3)
+                    -- Calc new z
+                    go.set(self.board[x][y].id, "position.z", (x - 1) * -0.1 + y * 0.01)
+                    self.board[x][y] = hash("removing") -- Will be nilled later
+                    row_m[i] = nil
+                elseif x < boardwidth - 1 and self.board[x + 1][y] == hash("removing") then
+                    -- Hole to the right. Slide magic block there
+                    self.board[x+1][y] = self.board[x][y]
+                    self.board[x+1][y].x = x + 1
+                    go.animate(self.board[x+1][y].id, "position.x", go.PLAYBACK_ONCE_FORWARD, edge + blocksize / 2 + blocksize * (x + 1), go.EASING_OUTBOUNCE, 0.3)
+                    -- Calc new z
+                    go.set(self.board[x+1][y].id, "position.z", (x + 1) * -0.1 + y * 0.01)
+                    self.board[x][y] = hash("removing") -- Will be nilled later
+                    row_m[i] = nil
+                end
+            end
+        end
+    end
+end
+```
+
+Wir können die Mechanik ausprobieren, indem wir in `on_input()` einen Aufruf der Funktion ergänzen:
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+
+        if #self.chain > 1 then
+            -- There is a chain of blocks. Remove it from board
+            remove_chain(self)
+            slide_magic_blocks(self)
+            nilremoved(self)
+            -- Slide remaining blocks down.
+            slide_board(self)
+        end
+        self.chain = {}
+        -- Empty chain clears connector graphics.
+        for i, c in ipairs(self.connectors) do
+            go.delete(c)
+        end
+        self.connectors = {}
+    end
+```
+
+Jetzt wird klar, warum wir beim Entfernen von Positionen die Zwischenmarkierung `hash("removing")` verwendet haben. Ohne sie würden magische Blöcke in jede freie Position neben ihnen hin- und hergleiten. Das wäre vielleicht eine interessante Mechanik, aber nicht die für dieses kleine Spiel vorgesehene.
+
+Nun brauchen wir Logik, die erkennt, ob magische Blöcke verbunden sind (links, rechts, über- oder untereinander liegen). Außerdem müssen wir wissen, ob alle magischen Blöcke auf dem Spielfeld miteinander verbunden sind. Der verwendete Algorithmus ist recht geradlinig:
+
+1. Erstelle eine Liste `M` aller magischen Blöcke auf dem Spielfeld.
+2. Für jeden Block in der Liste `M`:
+    1. Wenn für den Block keine `region` gesetzt ist, weise ihm die Regionsnummer `R` zu (anfangs `1`).
+    2. Markiere alle noch nicht markierten Nachbarn des Blocks mit derselben Regionsnummer `R` und gehe dann zu deren Nachbarn, den Nachbarn dieser Nachbarn und so weiter über.
+    3. Erhöhe die Regionsnummer `R` um `1`.
+
+![Regionen markieren](images/magic-link/linker_regions.png)
+
+Hier ist die Implementierung des Algorithmus:
+
+```lua
+-- board.script
+--
+-- Build list of all current magic blocks.
+--
+local function magic_blocks(self)
+    local magic = {}
+    for x = 0,boardwidth - 1 do
+        for y = 0,boardheight - 1 do
+            if self.board[x][y] ~= nil and self.board[x][y].color == hash("magic") then
+                table.insert(magic, self.board[x][y])
+            end
+        end
+    end
+    return magic
+end
+
+--
+-- Filter out adjacent magic blocks
+--
+local function adjacent_magic_blocks(blocks, block)
+    return filter(function (e)
+        return (block.x == e.x and math.abs(block.y - e.y) == 1) or
+            (block.y == e.y and math.abs(block.x - e.x) == 1)
+    end, blocks)
+end
+
+--
+-- Spread region to neighbors
+--
+local function mark_neighbors(blocks, block, region)
+    local neighbors = adjacent_magic_blocks(blocks, block)
+    for i, m in pairs(neighbors) do
+        if m.region == nil then
+            m.region = region
+            mark_neighbors(blocks, m, region)
+        end
+    end
+end
+
+--
+-- Mark all magic block regions
+--
+local function mark_magic_regions(self)
+    local m_blocks = magic_blocks(self)
+    -- 1. Clear all region marks and count neighbors
+    for i, m in pairs(m_blocks) do
+        m.region = nil
+        local n = 0
+        for _ in pairs(adjacent_magic_blocks(m_blocks, m)) do n = n + 1 end
+        m.neighbors = n
+    end
+
+    -- 2. Assign regions and spread them
+    local region = 1
+    for i, m in pairs(m_blocks) do
+        if m.region == nil then
+            m.region = region
+            mark_neighbors(m_blocks, m, region)
+            region = region + 1
+        end
+    end
+    return m_blocks
+end
+```
+
+Wir erstellen außerdem Funktionen, mit denen wir die Anzahl der Regionen unter den magischen Blöcken zählen können. Ist die Anzahl der Regionen 1, wissen wir, dass alle magischen Blöcke miteinander verbunden sind. Außerdem fügen wir eine Funktion hinzu, die das Licht in allen magischen Blöcken ausschaltet, und eine weitere, die die Lichteffekte in den magischen Blöcken einschaltet, die magische Nachbarblöcke haben:
+
+```lua
+-- board.script
+--
+-- Count the number of connected regions among the magic blocks.
+--
+local function count_magic_regions(blocks)
+    local maxr = 0
+    for i, m in pairs(blocks) do
+        if m.region > maxr then
+            maxr = m.region
+        end
+    end
+    return maxr
+end
+
+--
+-- Shut off lights on all listed magic blocks
+--
+local function shutdown_lined_up_magic(self)
+    for i, m in ipairs(self.lined_up_magic) do
+        msg.post(m.id, "lights_off")
+    end
+end
+
+--
+-- Set highlight for all magic blocks
+--
+local function highlight_magic(blocks)
+    for i, m in pairs(blocks) do
+        if m.neighbors > 0 then
+            msg.post(m.id, "lights_on")
+        else
+            msg.post(m.id, "lights_off")
+        end
+    end
+end
+```
+
+Jetzt können wir diese Teile der Logik in den Gesamtablauf einfügen. Da das Spielfeld zufällig erzeugt wird, besteht zunächst eine geringe Wahrscheinlichkeit, dass es bereits im Gewinnzustand beginnt. In diesem Fall verwerfen wir das Spielfeld einfach und bauen es erneut auf:
+
+```lua
+-- board.script
+--
+-- Clear the board
+--
+local function clear_board(self)
+    for y = 0,boardheight - 1 do
+        for x = 0,boardwidth - 1 do
+            if self.board[x][y] ~= nil then
+                go.delete(self.board[x][y].id)
+                self.board[x][y] = nil
+            end
+        end
+    end
+end
+
+local function build_board(self)
+
+    ...
+
+    -- Build 1d list that we can easily filter.
+    build_blocklist(self)
+
+    local magic_blocks = mark_magic_regions(self)
+    if count_magic_regions(magic_blocks) == 1 then
+        -- "Win" from start. Make new board.
+        clear_board(self)
+        build_board(self)
+    end
+    highlight_magic(magic_blocks)
+end
+```
+
+Die restliche Logik kommt in `on_input()`. Es gibt noch keinen Code, der die Nachricht `level_completed` verarbeitet, aber das genügt fürs Erste:
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+
+        if #self.chain > 1 then
+            -- There is a chain of blocks. Remove it from board and refill board.
+            remove_chain(self)
+            slide_magic_blocks(self)
+            nilremoved(self)
+            -- Slide remaining blocks down.
+            slide_board(self)
+
+            local magic_blocks = mark_magic_regions(self)
+            -- Highlight adjacent magic blocks.
+            if count_magic_regions(magic_blocks) == 1 then
+                -- Win!
+                msg.post("#", "level_completed")
+            end
+            highlight_magic(magic_blocks)
+        end
+        self.chain = {}
+        -- Empty chain clears connector graphics.
+        for i, c in ipairs(self.connectors) do
+            go.delete(c)
+        end
+        self.connectors = {}
+    end
+```
+
+Jetzt lässt sich das Spiel spielen und der Gewinnzustand erreichen, auch wenn noch nichts passiert, sobald du alle magischen Blöcke miteinander verbindest.
+
+![Erster Sieg](images/magic-link/linker_first_win.png)
+
+## Abwürfe {#drops}
+
+Die Idee hinter dem „Abwurf“ (drop) ist, eine einfache Mechanik für den Spielfortschritt hinzuzufügen. Der Spieler kann durch Drücken der Schaltfläche *DROP* eine begrenzte Anzahl von Abwürfen auslösen. Dabei fallen einfach einige neue zufällige Blöcke auf das Spielfeld. Der Spieler beginnt mit einem Abwurf und erhält jedes Mal, wenn er ein Level abschließt, einen weiteren. Der Code für die Abwurfmechanik passt in zwei Funktionen: Eine gibt eine Liste möglicher Stellen zurück, an denen abgeworfene Blöcke landen können, und die andere führt den eigentlichen Abwurf samt Animation aus.
+
+```lua
+-- board.script
+--
+-- Find spots for a drop.
+--
+local function dropspots(self)
+    local spots = {}
+    for x = 0, boardwidth - 1 do
+        for y = 0, boardheight - 1 do
+            if self.board[x][y] == nil then
+                table.insert(spots, { x = x, y = y })
+                break
+            end
+        end
+    end
+    -- If more than dropamount, randomly remove a slot until dropamount
+    for c = 1, #spots - dropamount do
+        table.remove(spots, math.random(#spots))
+    end
+    return spots
+end
+
+--
+-- Perform the drop
+--
+local function drop(self, spots)
+    for i, s in pairs(spots) do
+        local pos = vmath.vector3()
+        pos.x = edge + blocksize / 2 + blocksize * s.x
+        pos.y = 1000
+        c = colors[math.random(#colors)]    -- Pick a random color
+        local id = factory.create("#blockfactory", pos, null, { color = c })
+        go.animate(id, "position.y", go.PLAYBACK_ONCE_FORWARD, bottom_edge + blocksize / 2 + blocksize * s.y, go.EASING_OUTBOUNCE, 0.5)
+        -- Calc new z
+        go.set(id, "position.z", s.x * -0.1 + s.y * 0.01)
+
+        self.board[s.x][s.y] = { id = id, color = c,  x = s.x, y = s.y }
+    end
+
+    -- Rebuild blocklist
+    build_blocklist(self)
+end
+```
+
+Wir können Abwürfe testen, indem wir den folgenden Code beispielsweise in `on_reload()` ausführen oder ihn an eine vorübergehende Eingabeaktion binden:
+
+```lua
+s = dropspots(self)
+if #s > 0 then
+    -- Do the drop
+    drop(self, s)
+end
+```
+
+![Abwurf](images/magic-link/linker_drop.png)
+
+## Das Hauptmenü {#the-main-menu}
+
+Jetzt ist es Zeit, alles zusammenzufügen. Zuerst erstellen wir einen Startbildschirm und trennen ihn vom Spielfeld. Schritt 1 besteht darin, eine *main_menu.gui* zu erstellen und sie mit einer *Start*-Schaltfläche (einem Textknoten und einem texturierten Box-Knoten), einem Textknoten für den Titel und einigen dekorativen Blöcken (texturierten Box-Knoten) einzurichten. Das Skript *main_menu.gui_script*, das wir an die GUI anhängen, animiert die dekorativen Blöcke in `init()`. Es enthält außerdem eine Funktion `on_input()`, die eine `start_game`-Nachricht an ein Hauptskript sendet. Dieses Skript erstellen wir gleich.
+
+![GUI des Hauptmenüs](images/magic-link/linker_main_menu.png)
+
+```lua
+-- main_menu.gui_script
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    local bs = { "brick1", "brick2", "brick3", "brick4", "brick5", "brick6" }
+    for i, b in ipairs(bs) do
+        local n = gui.get_node(b)
+        local rt = (math.random() * 3) + 1
+        local a = math.random(-45, 45)
+        gui.set_color(n, vmath.vector4(1, 1, 1, 0))
+
+        gui.animate(n, "position.y", -100 - math.random(0, 50), gui.EASING_INSINE, 1 + rt, 0, nil, gui.PLAYBACK_LOOP_FORWARD)
+        gui.animate(n, "color.w", 1, gui.EASING_INSINE, 1 + rt, 0, nil, gui.PLAYBACK_LOOP_FORWARD)
+        gui.animate(n, "rotation.z", a, gui.EASING_INSINE, 1 + rt, 0, nil, gui.PLAYBACK_LOOP_FORWARD)
+    end
+
+    gui.animate(gui.get_node("start"), "color.x", 1, gui.EASING_INOUTSINE, 1, 0, nil, gui.PLAYBACK_LOOP_PINGPONG)
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local start = gui.get_node("start")
+
+        if gui.pick_node(start, action.x, action.y) then
+            msg.post("/main#script", "start_game")
+        end
+    end
+end
+```
+
+Da das Starten des Spiels bald das Skript des Hauptmenüs übernimmt, entferne den vorübergehenden Aufruf zum Aufbau des Spielfelds aus `init()` in *board.script*:
+
+```lua
+-- board.script
+--
+-- INIT
+--
+function init(self)
+    self.board = {}                -- Contains the board structure
+    self.blocks = {}            -- List of all blocks. Used for easy filtering on selection.
+
+    self.chain = {}                -- Current selection chain
+    self.connectors = {}        -- Connector elements to mark the selection chain
+    self.num_magic = 3            -- Number of magic blocks on the board
+
+    self.drops = 1                -- Number of drops you have available
+
+    self.magic_blocks = {}        -- Magic blocks that are lined up
+
+    self.dragging = false        -- Drag touch input
+end
+```
+
+Das Hauptskript verwaltet den gesamten Spielzustand und startet das Spiel auf Anforderung. Wir möchten hier erreichen, dass *main.collection* nur die Mindestmenge an Assets enthält, die wir beim Start anzeigen müssen. Dazu enthält *main.collection* ein Spielobjekt namens „main“ mit der GUI des Hauptmenüs, einer Skriptkomponente und vor allem einer *Collection Proxy*-Komponente.
+
+Mit dem Sammlungs-Proxy (collection proxy) können wir Sammlungen im laufenden Spiel dynamisch laden und entladen. Er handelt stellvertretend für eine angegebene Sammlungsdatei. Indem wir Nachrichten an den Proxy senden, laden, initialisieren, aktivieren, deaktivieren und entladen wir die dynamische Sammlung. Eine vollständige Beschreibung ihrer Verwendung findest du in der [Dokumentation zu Sammlungs-Proxys](/manuals/collection-proxy).
+
+In unserem Fall setzen wir die Eigenschaft *Collection* der Sammlungs-Proxy-Komponente auf *board.collection*, die das „Level“ enthält.
+
+![Hauptsammlung](images/magic-link/linker_main_collection.png)
+
+Öffne nun *game.project* und ändere die Startsammlung (bootstrap collection) *main_collection* auf `/main/main.collectionc`.
+
+![Hauptsammlung als Startsammlung](images/magic-link/linker_bootstrap_main.png)
+
+Ein Spiel zu starten bedeutet jetzt, unserem Sammlungs-Proxy Nachrichten zum Laden, Initialisieren und Aktivieren des Spielfelds zu senden und anschließend das Hauptmenü zu deaktivieren (damit es nicht angezeigt wird). Bei der Rückkehr zum Hauptmenü geschieht das Umgekehrte (vorausgesetzt, der Proxy hat die Sammlung geladen).
+
+```lua
+-- main.script
+function init(self)
+    msg.post("#", "to_main_menu")
+    self.state = "MAIN_MENU"
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("to_main_menu") then
+        if self.state ~= "MAIN_MENU" then
+            msg.post("#boardproxy", "unload")
+        end
+        msg.post("main:/main#menu", "enable") -- <1>
+        self.state = "MAIN_MENU"
+    elseif message_id == hash("start_game") then
+        msg.post("#boardproxy", "load")
+        msg.post("#menu", "disable")
+    elseif message_id == hash("proxy_loaded") then
+        -- Board collection has loaded...
+        msg.post(sender, "init")
+        msg.post("board:/board#script", "start_level", { difficulty = 1 }) -- <2>
+        msg.post(sender, "enable")
+        self.state = "GAME_RUNNING"
+    end
+end
+```
+1. Beachte, dass wir den Socket „main“ nennen. Stelle deshalb sicher, dass dieser Name auch für *main.collection* gesetzt ist. Wähle den obersten Knoten aus und prüfe, ob die Eigenschaft *Name* auf „main“ gesetzt ist.
+2. Ebenso senden wir Nachrichten an die geladene Sammlung über ihren Socket, dessen Name durch die Eigenschaft *Name* der Sammlung festgelegt wird.
+
+## Die GUI im Spiel {#the-in-game-gui}
+
+Bevor wir die letzten Teile der Logik zum Spielfeldskript hinzufügen, sollten wir das Spielfeld um einige GUI-Elemente ergänzen. Zuerst fügen wir oberhalb des Spielfelds eine Schaltfläche *RESTART* und eine Schaltfläche *DROP* hinzu.
+
+![GUI des Spielfelds](images/magic-link/linker_board_gui.png)
+
+Das Skript für die GUI des Spielfelds sendet bei einem Klick Nachrichten an den GUI-Dialog für den Neustart und beim Klicken auf *DROP* zurück an das Spielfeldskript selbst:
+
+```lua
+-- board.gui_script
+function init(self)
+    msg.post("#", "show")
+    msg.post("/restart#gui", "hide")
+    msg.post("/level_complete#gui", "hide")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+    elseif message_id == hash("show") then
+        msg.post("#", "enable")
+    elseif message_id == hash("set_drop_counter") then
+        local n = gui.get_node("drop_counter")
+        gui.set_text(n, message.drops .. " x")
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local restart = gui.get_node("restart")
+        local drop = gui.get_node("drop")
+
+        if gui.pick_node(restart, action.x, action.y) then
+            -- Show the restart dialog box.
+            msg.post("/restart#gui", "show")
+            msg.post("#", "hide")
+        elseif gui.pick_node(drop, action.x, action.y) then
+            msg.post("/board#script", "drop")
+        end
+    end
+end
+```
+
+Der Dialog *RESTART* ist einfach. Wir erstellen ihn als *restart.gui* und hängen ein einfaches Skript an, das bei einem Klick auf *NO* nichts tut, bei einem Klick auf *YES* eine `restart_level`-Nachricht an das Spielfeldskript sendet und bei einem Klick auf *Quit to main menu* eine `to_main_menu`-Nachricht an das Hauptskript:
+
+![GUI für den Neustart](images/magic-link/linker_restart_gui.png)
+
+```lua
+-- restart.gui_script
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+        msg.post(".", "release_input_focus")
+    elseif message_id == hash("show") then
+        msg.post("#", "enable")
+        msg.post(".", "acquire_input_focus")
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local yes = gui.get_node("yes")
+        local no = gui.get_node("no")
+        local quit = gui.get_node("quit")
+
+        if gui.pick_node(no, action.x, action.y) then
+            msg.post("#", "hide")
+            msg.post("/board#gui", "show")
+        elseif gui.pick_node(yes, action.x, action.y) then
+            msg.post("board:/board#script", "restart_level")
+            msg.post("/board#gui", "show")
+            msg.post("#", "hide")
+        elseif gui.pick_node(quit, action.x, action.y) then
+            msg.post("main:/main#script", "to_main_menu")
+            msg.post("#", "hide")
+        end
+    end
+    -- Consume all input until we're gone.
+    return true
+end
+```
+
+Wir erstellen außerdem in *level_complete.gui* einen einfachen GUI-Dialog für den Levelabschluss mit einem einfachen Skript, das eine `next_level`-Nachricht an das Spielfeldskript sendet, wenn der Spieler auf *CONTINUE* klickt:
+
+![Dialog für den Levelabschluss](images/magic-link/linker_level_complete_gui.png)
+
+```lua
+-- level_complete.gui_script
+function init(self)
+    msg.post("#", "hide")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+        msg.post(".", "release_input_focus")
+    elseif message_id == hash("show") then
+        msg.post("#", "enable")
+        msg.post(".", "acquire_input_focus")
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local continue = gui.get_node("continue")
+
+        if gui.pick_node(continue, action.x, action.y) then
+            msg.post("board#script", "next_level")
+            msg.post("#", "hide")
+        end
+    end
+    -- Consume all input until we're gone.
+    return true
+end
+```
+
+Ein Dialog stellt das aktuelle Level vor. Sein Skript enthält nur das Ausblenden und Anzeigen des Dialogs. Beim Anzeigen wird der Dialogtext auf eine Nachricht gesetzt, die den aktuellen Schwierigkeitsgrad enthält:
+
+![GUI zur Vorstellung des Levels](images/magic-link/linker_present_level_gui.png)
+
+```lua
+-- present_level.gui_script
+function init(self)
+    msg.post("#", "hide")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+    elseif message_id == hash("show") then
+        local n = gui.get_node("message")
+        gui.set_text(n, "Level " .. message.level)
+        msg.post("#", "enable")
+    end
+end
+```
+
+Wir fügen außerdem einen Dialog hinzu, der erscheint, wenn der Spieler einen Abwurf versucht, dafür aber kein Platz ist.
+
+![GUI bei fehlendem Platz für einen Abwurf](images/magic-link/linker_no_drop_room_gui.png)
+
+```lua
+-- no_drop_room.gui_script
+function init(self)
+    msg.post("#", "hide")
+    self.t = 0
+end
+
+function update(self, dt)
+    if self.t < 0 then
+        msg.post("#", "hide")
+    else
+        self.t = self.t - dt
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+    elseif message_id == hash("show") then
+        self.t = 1
+        msg.post("#", "enable")
+    end
+end
+```
+
+Zum Schluss fügen wir diese GUI-Komponenten zu *board.collection* hinzu und ergänzen den benötigten Code in *board.script*:
+
+![Fertige Spielfeldsammlung](images/magic-link/linker_board_collection_final.png)
+
+In `on_message()` brauchen wir Code für alle Nachrichten, die an das Spielfeld und von ihm gesendet werden.
+
+`start_level`
+: Setze die Anzahl der magischen Blöcke entsprechend dem Schwierigkeitsparameter, baue das Spielfeld auf und zeige dann den GUI-Dialog „present_level“ für 2 Sekunden an, bevor das Spiel beginnt (der Dialog entfernt und der Eingabefokus angefordert wird). Beachte, dass wir `go.animate()` als Zeitgeber verwenden, indem wir den Wert von „timer“ animieren, der sonst für nichts verwendet wird.
+
+`restart_level`
+: Dies geschieht, wenn der Spieler die GUI-Schaltfläche *RESTART* drückt und den Neustart bestätigt. Leere das Spielfeld, baue es neu auf und setze den Abwurfzähler zurück.
+
+`level_completed`
+: Wird gesendet, sobald sich das Spielfeld im Gewinnzustand befindet. Schalte die Eingabe aus, animiere die magischen Blöcke und zeige den GUI-Dialog „level_complete“ an. Der Dialog sendet eine `next_level`-Nachricht zurück, wenn der Spieler darin auf die Schaltfläche *CONTINUE* klickt.
+
+`next_level`
+: Wenn diese Nachricht empfangen wird, leere das Spielfeld, erhöhe den Abwurfzähler und sende `start_level` mit dem nächsten Schwierigkeitsgrad.
+
+`drop`
+: Prüfe, wo Abwürfe möglich sind. Wenn es keine möglichen Stellen gibt, zeige den GUI-Dialog „no_drop_room“ an. Führe andernfalls den Abwurf aus (wenn der Spieler noch Abwürfe übrig hat), verringere den Abwurfzähler und aktualisiere die Anzeige des Zählers.
+
+```lua
+-- board.script
+function on_message(self, message_id, message, sender)
+    if message_id == hash("start_level") then
+        self.num_magic = message.difficulty + 1
+        build_board(self)
+
+        msg.post("#gui", "set_drop_counter", { drops = self.drops } )
+
+        msg.post("present_level#gui", "show", { level = message.difficulty } )
+        -- Wait some...
+        go.animate("#", "timer", go.PLAYBACK_ONCE_FORWARD, 1, go.EASING_LINEAR, 2, 0, function ()
+            msg.post("present_level#gui", "hide")
+            msg.post(".", "acquire_input_focus")
+        end)
+    elseif message_id == hash("restart_level") then
+        clear_board(self)
+        build_board(self)
+        self.drops = 1
+        msg.post("#gui", "set_drop_counter", { drops = self.drops } )
+        msg.post(".", "acquire_input_focus")
+    elseif message_id == hash("level_completed") then
+        -- turn off input
+        msg.post(".", "release_input_focus")
+
+        -- Animate the magic!
+        for i, m in ipairs(magic_blocks(self)) do
+            go.set_scale_xy(0.17, m.id)
+            go.animate(m.id, "scale.xy", go.PLAYBACK_LOOP_PINGPONG, 0.19, go.EASING_INSINE, 0.5, 0)
+        end
+
+        -- Show completion screen
+        msg.post("level_complete#gui", "show")
+    elseif message_id == hash("next_level") then
+        clear_board(self)
+        self.drops = self.drops + 1
+        -- Difficulty level is number of magic blocks - 1
+        msg.post("#", "start_level", { difficulty = self.num_magic })
+    elseif message_id == hash("drop") then
+        s = dropspots(self)
+        if #s == 0 then
+            -- Can't perform drop
+            msg.post("no_drop_room#gui", "show")
+        elseif self.drops > 0 then
+            -- Do the drop
+            drop(self, s)
+            self.drops = self.drops - 1
+            msg.post("#gui", "set_drop_counter", { drops = self.drops } )
+        end
+    end
+end
+```
+
+Geschafft! Das Spiel und dieses Tutorial sind jetzt abgeschlossen! Viel Spaß beim Spielen!
+
+![Fertiges Spiel](images/magic-link/linker_game_finished.png)
+
+## Weiterführende Schritte {#moving-on}
+
+Dieses kleine Spiel hat einige interessante Eigenschaften. Experimentiere ruhig damit. Hier sind einige Übungen, mit denen du dich weiter mit Defold vertraut machen kannst:
+
+* Verdeutliche die Interaktion. Neuen Spielern fällt es möglicherweise schwer zu verstehen, wie das Spiel funktioniert und womit sie interagieren können. Nimm dir etwas Zeit, um das Spiel verständlicher zu machen, ohne Tutorial-Elemente einzubauen.
+* Füge Ton hinzu. Das Spiel ist derzeit völlig stumm und würde von einem schönen Soundtrack und Klängen bei Interaktionen profitieren.
+* Erkenne das Spielende automatisch.
+* Höchstpunktzahl. Füge eine Funktion für eine dauerhaft gespeicherte Höchstpunktzahl hinzu.
+* Implementiere das Spiel neu und verwende dabei ausschließlich die GUI-APIs.
+* Derzeit kommt bei jedem neuen Level ein magischer Block hinzu. Das lässt sich nicht beliebig lange fortsetzen. Finde eine zufriedenstellende Lösung für dieses Problem.
+* Optimiere das Spiel und senke die maximale Sprite-Anzahl, indem du Sprites wiederverwendest, statt sie zu löschen und neu zu erzeugen.
+* Implementiere ein von der Auflösung unabhängiges Rendering des Spiels, damit es auf Bildschirmen mit unterschiedlichen Auflösungen und Seitenverhältnissen gleichermaßen gut aussieht.

--- a/docs/de/tutorials/main-menu.md
+++ b/docs/de/tutorials/main-menu.md
@@ -1,0 +1,92 @@
+---
+title: Beispiel für die Animation eines Hauptmenüs
+brief: In diesem Beispielprojekt lernst du Effekte kennen, mit denen du ein Hauptmenü präsentieren kannst.
+---
+# Animation eines Hauptmenüs - Beispielprojekt {#main-menu-animation-sample-project}
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/dPQpSlt3ahw" frameborder="0" allowfullscreen></iframe>
+
+In diesem Beispielprojekt, das du [im Editor öffnen](/manuals/project-setup/) oder [von GitHub herunterladen](https://github.com/defold/sample-main-menu-animation) kannst, zeigen wir Effekte zur Präsentation eines Hauptmenüs. Das Menü enthält einen Hintergrund und zwei Menüeinträge.
+Das Projekt ist bereits mit den Dateien menu.gui und menu.gui_script sowie dem unten gezeigten Code eingerichtet. Die Bild-Assets sind einem Atlas namens images.atlas hinzugefügt und den Knoten (nodes) in menu.gui zugewiesen.
+
+Auf den Hintergrund und die beiden Menüeinträge werden jeweils dieselben Animationen angewendet, allerdings mit unterschiedlichen Verzögerungen. Dies wird unten in `init()` eingerichtet.
+
+Bei der ersten Animation wird jeder Knoten allmählich eingeblendet und dabei von 70 % auf 110 % skaliert.
+Dies geschieht in `anim1()`.
+
+Während der folgenden Animationen wechselt die Skalierung von 110 % auf 98 %, dann auf 106 % und schließlich auf 100 %. Dadurch entsteht der Federeffekt, der in `anim2()`, `anim3()` und `anim4()` umgesetzt wird.
+
+Der Hintergrund wird zum Schluss zusätzlich leicht ausgeblendet. Dies geschieht in `anim5()`.
+
+```lua
+-- file: menu.gui_script
+
+-- the functions animX represents the animation time-line
+-- first is anim1 executed, when finished anim2 is executed, etc
+-- anim1 to anim4 creates a bouncing rubber effect.
+-- anim5 fades down alpha and is only used for the background
+
+local function anim5(self, node)
+	if gui.get_node("background") == node then
+		-- special case for background. animate alpha to 60%
+		local to_color = gui.get_color(node)
+		to_color.w = 0.6
+		gui.animate(node, gui.PROP_COLOR, to_color, gui.EASING_OUTCUBIC, 2.4, 0.1)
+	end
+end
+
+local function anim4(self, node)
+	-- animate scale to 100%
+	local s = 1
+	gui.animate(node, gui.PROP_SCALE, vmath.vector4(s, s, s, 0), gui.EASING_INOUTCUBIC, 0.24, 0, anim5)
+end
+
+local function anim3(self, node)
+	-- animate scale to 106%
+	local s = 1.06
+	gui.animate(node, gui.PROP_SCALE, vmath.vector4(s, s, s, 0), gui.EASING_INOUTCUBIC, 0.24, 0, anim4)
+end
+
+local function anim2(self, node)
+	-- animate scale to 98%
+	local s = 0.98
+	gui.animate(node, gui.PROP_SCALE, vmath.vector4(s, s, s, 0), gui.EASING_INOUTCUBIC, 0.24, 0, anim3)
+end
+
+local function anim1(node, d)
+	-- set scale to 70%
+	local start_scale = 0.7
+	gui.set_scale(node, vmath.vector4(start_scale, start_scale, start_scale, 0))
+
+	-- get current color and set alpha to 0 to fade up
+	local from_color = gui.get_color(node)
+	local to_color = gui.get_color(node)
+	from_color.w = 0
+	gui.set_color(node, from_color)
+
+	-- animate alpha value from 0 to 1
+	gui.animate(node, gui.PROP_COLOR, to_color, gui.EASING_INOUTCUBIC, 0.4, d)
+
+	-- animate scale from %70 to 110%
+	local s = 1.1
+	gui.animate(node, gui.PROP_SCALE, vmath.vector4(s, s, s, 0), gui.EASING_INOUTCUBIC, 0.4, d, anim2)
+end
+
+function init(self)
+	-- start animations for all nodes
+	-- background, button-boxes and text are animated equally
+	-- d is the animation start delay
+	local d = 0.4
+	anim1(gui.get_node("new_game"), d)
+	anim1(gui.get_node("new_game_shadow"), d)
+	anim1(gui.get_node("new_game_button"), d)
+
+	d = 0.3
+	anim1(gui.get_node("quit"), d)
+	anim1(gui.get_node("quit_shadow"), d)
+	anim1(gui.get_node("quit_button"), d)
+
+	d = 0.1
+	anim1(gui.get_node("background"), d)
+end
+```

--- a/docs/de/tutorials/movement.md
+++ b/docs/de/tutorials/movement.md
@@ -1,0 +1,27 @@
+---
+title: Tutorial zu Bewegung
+brief: In diesem Tutorial für Einsteiger lernst du, wie du mit Vektoren und etwas einfacher Vektoralgebra realistische Bewegungen erzeugst.
+---
+
+# Tutorial zu Bewegung {#movement-tutorial}
+
+In diesem Tutorial für Einsteiger lernst du, wie du mit Vektoren und etwas einfacher Vektoralgebra realistische Bewegungen erzeugst.
+
+Das Tutorial ist in den Defold-Editor integriert und leicht zugänglich:
+
+1. Starte Defold.
+2. Wähle links *New Project*.
+3. Wähle die Registerkarte *From Tutorial*.
+4. Wähle „Movement tutorial“
+5. Wähle einen Speicherort für das Projekt auf deinem lokalen Laufwerk und klicke auf *Create New Project*.
+
+![Neues Projekt](images/new-movement.png)
+
+Der Editor öffnet automatisch die Datei „README“ aus dem Stammverzeichnis des Projekts. Sie enthält den vollständigen Text des Tutorials.
+
+![Symbol](images/icon-tutorial.svg){.icon} [Du kannst den vollständigen Text des Tutorials auch auf GitHub lesen](https://github.com/defold/tutorial-movement)
+
+Wenn du nicht weiterkommst, besuche das [Defold-Forum](//forum.defold.com). Dort helfen dir das Defold-Team und viele freundliche Nutzer.
+
+Viel Spaß mit Defold!
+

--- a/docs/de/tutorials/parallax.md
+++ b/docs/de/tutorials/parallax.md
@@ -1,0 +1,82 @@
+---
+title: Codebeispiel für Parallaxe
+brief: In diesem Beispiel lernst du, wie du mit einem Parallaxeneffekt Tiefe in der Spielwelt simulierst.
+---
+# Parallaxe - Beispielprojekt {#parallax-sample-project}
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/UdNA7kanRQE" frameborder="0" allowfullscreen></iframe>
+
+
+In diesem Beispielprojekt, das du [im Editor öffnen](/manuals/project-setup/) oder [von GitHub herunterladen](https://github.com/defold/sample-parallax) kannst, zeigen wir, wie du mit einem Parallaxeneffekt Tiefe in der Spielwelt simulierst.
+Es gibt zwei Wolkenebenen, von denen eine weiter hinten zu liegen scheint als die andere. Außerdem gibt es eine animierte fliegende Untertasse, die die Szene belebt.
+
+Die Wolkenebenen sind als zwei separate Spielobjekte (game objects) aufgebaut, die jeweils eine *Kachelkarte* (tile map) und ein *Skript* enthalten.
+Die Ebenen werden mit unterschiedlichen Geschwindigkeiten bewegt, um den Parallaxeneffekt zu erzeugen. Dies geschieht in `update()` in *background1.script* und *background2.script*, wie unten gezeigt.
+
+```lua
+-- file: background1.script
+
+function init(self)
+    msg.post("@render:", "clear_color", { color = vmath.vector4(0.52, 0.80, 1, 0) } )
+end
+
+-- the background is a tilemap in a gameobject
+-- we move the gameobject for the parallax effect
+
+function update(self, dt)
+    -- decrease x-position by 1 units per frame for parallax effect
+    local p = go.get_position()
+    p.x = p.x + 1
+    go.set_position(p)
+end
+```
+
+```lua
+-- file: background2.script
+
+-- the background is a tilemap in a gameobject
+-- we move the gameobject for the parallax effect
+
+function update(self, dt)
+    -- decrease x-position by 0.5 units per frame for parallax effect
+    local p = go.get_position()
+    p.x = p.x + 0.5
+    go.set_position(p)
+end
+```
+
+Die fliegende Untertasse ist ein separates Spielobjekt, das ein *Sprite* und ein *Skript* enthält.
+Sie wird mit konstanter Geschwindigkeit nach links bewegt. Die Auf-und-ab-Bewegung entsteht, indem ihre y-Komponente mithilfe der Lua-Sinusfunktion (`math.sin()`) um einen festen Wert herum animiert wird. Dies geschieht in `update()` in *spaceship.script*.
+
+
+```lua
+-- file: spaceship.script
+
+function init(self)
+    -- remeber initial y position such that we
+    -- can move the spaceship without changing the script
+    self.start_y = go.get_position().y
+    -- set counter to zero. use for sin-movement below
+    self.counter = 0
+end
+
+function update(self, dt)
+    -- decrease x-position by 2 units per frame
+    local p = go.get_position()
+    p.x = p.x - 2
+
+    -- move the y position around initial y
+    p.y = self.start_y + 8 * math.sin(self.counter * 0.08)
+
+    -- update position
+    go.set_position(p)
+
+    -- remove shaceship when outside of screen
+    if p.x < - 32 then
+        go.delete()
+    end
+
+    -- increase the counter
+    self.counter = self.counter + 1
+end
+```

--- a/docs/de/tutorials/platformer.md
+++ b/docs/de/tutorials/platformer.md
@@ -1,0 +1,416 @@
+---
+title: Plattformspiel-Tutorial für Defold
+brief: In diesem Artikel gehst du die Implementierung eines einfachen kachelbasierten 2D-Plattformspiels in Defold durch. Du lernst die Mechaniken für die Bewegung nach links und rechts, das Springen und das Fallen kennen.
+---
+
+# Plattformspiel {#platformer}
+
+In diesem Artikel gehen wir die Implementierung eines einfachen kachelbasierten 2D-Plattformspiels in Defold durch. Wir lernen die Mechaniken für die Bewegung nach links und rechts, das Springen und das Fallen kennen.
+
+Es gibt viele verschiedene Möglichkeiten, ein Plattformspiel zu erstellen. Rodrigo Monteiro hat [hier](http://higherorderfun.com/blog/2012/05/20/the-guide-to-implementing-2d-platformers/) eine ausführliche Analyse zu diesem Thema und weiteren Aspekten geschrieben.
+
+Wir empfehlen dir sehr, sie zu lesen, wenn du noch keine Erfahrung mit der Entwicklung von Plattformspielen hast, denn sie enthält viele wertvolle Informationen. Wir werden einige der beschriebenen Methoden und ihre Implementierung in Defold etwas genauer betrachten. Alles sollte sich jedoch leicht auf andere Plattformen und Sprachen übertragen lassen (in Defold verwenden wir Lua).
+
+Wir gehen davon aus, dass du dich ein wenig mit Vektorrechnung (linearer Algebra) auskennst. Falls nicht, solltest du dich damit beschäftigen, denn sie ist für die Spieleentwicklung unglaublich nützlich. David Rosen von Wolfire hat [hier](http://blog.wolfire.com/2009/07/linear-algebra-for-game-developers-part-1/) eine sehr gute Artikelreihe dazu geschrieben.
+
+Wenn du Defold bereits verwendest, kannst du ein neues Projekt auf Grundlage der Projektvorlage _Platformer_ erstellen und damit experimentieren, während du diesen Artikel liest.
+
+::: sidenote
+Einige Leser haben darauf hingewiesen, dass unsere vorgeschlagene Methode mit der Standardimplementierung von Box2D nicht möglich ist. Wir haben ein paar Änderungen an Box2D vorgenommen, damit sie funktioniert:
+
+Kollisionen zwischen kinematischen und statischen Objekten werden ignoriert. Ändere die Prüfungen in `b2Body::ShouldCollide` und `b2ContactManager::Collide`.
+
+Außerdem wird der Kontaktabstand (in Box2D als separation bezeichnet) nicht an die Callback-Funktion übergeben.
+Füge `b2ManifoldPoint` ein Abstandsfeld hinzu und stelle sicher, dass es in den Funktionen `b2Collide*` aktualisiert wird.
+:::
+
+## Kollisionserkennung {#collision-detection}
+
+Die Kollisionserkennung wird benötigt, damit sich die Spielfigur nicht durch die Levelgeometrie bewegt.
+Je nach deinem Spiel und seinen spezifischen Anforderungen gibt es verschiedene Möglichkeiten, dies zu lösen.
+Eine der einfachsten Möglichkeiten besteht darin, diese Aufgabe nach Möglichkeit einer Physik-Engine zu überlassen.
+In Defold verwenden wir für 2D-Spiele die Physik-Engine [Box2D](http://box2d.org/).
+Die Standardimplementierung von Box2D bietet nicht alle benötigten Funktionen. Am Ende dieses Artikels erfährst du, wie wir sie angepasst haben.
+
+Eine Physik-Engine speichert die Zustände der Physikobjekte zusammen mit ihren Formen, um physikalisches Verhalten zu simulieren. Während der Simulation meldet sie außerdem Kollisionen, damit das Spiel auf sie reagieren kann, sobald sie auftreten. In den meisten Physik-Engines gibt es drei Arten von Objekten: _statische_ (static), _dynamische_ (dynamic) und _kinematische_ (kinematic) Objekte (diese Namen können in anderen Physik-Engines abweichen). Es gibt noch weitere Arten von Objekten, aber die lassen wir vorerst außer Acht.
+
+- Ein *statisches* Objekt bewegt sich niemals (z. B. die Levelgeometrie).
+- Ein *dynamisches* Objekt wird von Kräften und Drehmomenten beeinflusst, die während der Simulation in Geschwindigkeiten umgewandelt werden.
+- Ein *kinematisches* Objekt wird von der Anwendungslogik gesteuert, beeinflusst aber trotzdem andere dynamische Objekte.
+
+In einem Spiel wie diesem wollen wir ein Verhalten, das dem physikalischen Verhalten in der realen Welt ähnelt. Eine reaktionsschnelle Steuerung und ausgewogene Mechaniken sind jedoch viel wichtiger. Ein Sprung, der sich gut anfühlt, muss weder physikalisch korrekt sein noch der Schwerkraft der realen Welt unterliegen. [Diese](http://hypertextbook.com/facts/2007/mariogravity.shtml) Analyse zeigt allerdings, dass die Schwerkraft in Mario-Spielen mit jeder Version näher an 9,8 m/s<sup>2</sup> heranrückt. :-)
+
+Es ist wichtig, dass wir die volle Kontrolle über das Geschehen haben, damit wir die Mechaniken so gestalten und anpassen können, dass das gewünschte Spielerlebnis entsteht. Deshalb entscheiden wir uns dafür, die Spielfigur als kinematisches Objekt zu modellieren. So können wir die Spielfigur nach Belieben bewegen, ohne uns mit physikalischen Kräften beschäftigen zu müssen. Das bedeutet, dass wir Überschneidungen zwischen der Spielfigur und der Levelgeometrie selbst auflösen müssen (mehr dazu später), aber diesen Nachteil nehmen wir in Kauf. Wir stellen die Spielfigur in der Physikwelt durch eine Rechteckform dar.
+
+## Bewegung {#movement}
+
+Nachdem wir entschieden haben, die Spielfigur als kinematisches Objekt darzustellen, können wir sie durch das Setzen ihrer Position frei bewegen. Beginnen wir mit der Bewegung nach links und rechts.
+
+Die Bewegung soll auf Beschleunigung beruhen, damit die Figur ein Gefühl von Gewicht vermittelt. Wie bei einem normalen Fahrzeug bestimmt die Beschleunigung, wie schnell die Spielfigur ihre Höchstgeschwindigkeit erreichen und die Richtung wechseln kann. Die Beschleunigung wirkt über den Zeitschritt des Frames---üblicherweise im Parameter `dt` (Delta-`t`) angegeben---und wird dann zur Geschwindigkeit addiert. Ebenso wirkt die Geschwindigkeit über den Frame, und die daraus resultierende Verschiebung wird zur Position addiert. In der Mathematik nennt man dies [Integration über die Zeit](http://en.wikipedia.org/wiki/Integral).
+
+![Näherungsweise Integration der Geschwindigkeit](images/platformer/integration.png)
+
+Die beiden senkrechten Linien markieren den Anfang und das Ende des Frames. Die Höhe der Linien entspricht der Geschwindigkeit, die die Spielfigur zu diesen beiden Zeitpunkten hat. Nennen wir diese Geschwindigkeiten `v0` und `v1`. `v1` ergibt sich, indem die Beschleunigung (die Steigung der Kurve) über den Zeitschritt `dt` angewendet wird:
+
+![Gleichung der Geschwindigkeit](images/platformer/equationofvelocity.png)
+
+Die orange Fläche entspricht der Verschiebung, die wir während des aktuellen Frames auf die Spielfigur anwenden sollen. Geometrisch können wir die Fläche wie folgt annähern:
+
+![Gleichung der Verschiebung](images/platformer/equationoftranslation.png)
+
+So integrieren wir die Beschleunigung und Geschwindigkeit, um die Figur in der Aktualisierungsschleife zu bewegen:
+
+1. Bestimme die Zielgeschwindigkeit anhand der Eingabe
+2. Berechne die Differenz zwischen unserer aktuellen Geschwindigkeit und der Zielgeschwindigkeit
+3. Richte die Beschleunigung so aus, dass sie in Richtung der Differenz wirkt
+4. Berechne die Geschwindigkeitsänderung für diesen Frame (`dv` steht für Delta-Geschwindigkeit), wie oben gezeigt:
+
+    ```lua
+    local dv = acceleration * dt
+    ```
+
+5. Prüfe, ob `dv` die beabsichtigte Geschwindigkeitsdifferenz überschreitet, und begrenze den Wert in diesem Fall
+6. Speichere die aktuelle Geschwindigkeit zur späteren Verwendung (`self.velocity`, die derzeit noch die im vorherigen Frame verwendete Geschwindigkeit enthält):
+
+    ```lua
+    local v0 = self.velocity
+    ```
+
+7. Berechne die neue Geschwindigkeit, indem du die Geschwindigkeitsänderung addierst:
+
+    ```lua
+    self.velocity = self.velocity + dv
+    ```
+
+8. Berechne die Verschiebung in x-Richtung für diesen Frame durch Integration der Geschwindigkeit, wie oben gezeigt:
+
+    ```lua
+    local dx = (v0 + self.velocity) * dt * 0.5
+    ```
+
+9. Wende sie auf die Spielfigur an
+
+Wenn du dir nicht sicher bist, wie du Eingaben in Defold verarbeitest, findest du [hier](/manuals/input) eine Anleitung dazu.
+
+Jetzt können wir die Figur nach links und rechts bewegen, und die Steuerung fühlt sich gewichtig und flüssig an. Fügen wir nun die Schwerkraft hinzu!
+
+Schwerkraft ist ebenfalls eine Beschleunigung, wirkt aber entlang der y-Achse auf die Spielfigur. Sie wird also genauso angewendet wie die oben beschriebene Bewegungsbeschleunigung. Wenn wir die obigen Berechnungen auf Vektoren umstellen und dafür sorgen, dass wir in Schritt 3) die Schwerkraft in die y-Komponente der Beschleunigung aufnehmen, funktioniert es bereits. Vektorrechnung muss man einfach lieben! :-)
+
+## Kollisionsreaktion {#collision-response}
+
+Unsere Spielfigur kann sich jetzt bewegen und fallen. Es ist also an der Zeit, uns die Kollisionsreaktionen anzusehen.
+Natürlich müssen wir auf der Levelgeometrie landen und uns an ihr entlangbewegen können. Wir verwenden die von der Physik-Engine bereitgestellten Kontaktpunkte, um sicherzustellen, dass wir niemals etwas überlappen.
+
+Ein Kontaktpunkt enthält eine _Normale_ des Kontakts (sie zeigt aus dem Objekt heraus, mit dem wir kollidieren; in anderen Engines kann dies anders sein) sowie einen _Abstand_, der angibt, wie weit wir in das andere Objekt eingedrungen sind. Das ist alles, was wir brauchen, um die Spielfigur von der Levelgeometrie zu trennen.
+Da wir ein Rechteck verwenden, können wir innerhalb eines Frames mehrere Kontaktpunkte erhalten. Das passiert zum Beispiel, wenn zwei Ecken des Rechtecks in den waagerechten Boden eindringen oder sich die Spielfigur in eine Ecke bewegt.
+
+![Kontaktnormalen, die auf die Spielfigur wirken](images/platformer/collision.png)
+
+Damit wir dieselbe Korrektur nicht mehrfach vornehmen, sammeln wir die Korrekturen in einem Vektor und stellen so sicher, dass wir nicht überkompensieren. Sonst wären wir am Ende zu weit von dem Objekt entfernt, mit dem wir kollidiert sind. Im Bild oben siehst du, dass wir derzeit zwei Kontaktpunkte haben, die durch die beiden Pfeile (Normalen) dargestellt werden. Die Eindringtiefe ist bei beiden Kontakten gleich. Würden wir sie jedes Mal ungeprüft verwenden, würden wir die Spielfigur am Ende um das Doppelte des beabsichtigten Betrags verschieben.
+
+::: sidenote
+Es ist wichtig, die gesammelten Korrekturen in jedem Frame auf den Nullvektor zurückzusetzen.
+Füge dazu etwa Folgendes am Ende der Funktion `update()` ein:
+`self.corrections = vmath.vector3()`
+:::
+
+Wenn es eine Callback-Funktion gibt, die für jeden Kontaktpunkt aufgerufen wird, können wir die Trennung in dieser Funktion so durchführen:
+
+```lua
+local proj = vmath.dot(self.correction, normal) -- <1>
+local comp = (distance - proj) * normal -- <2>
+self.correction = self.correction + comp -- <3>
+go.set_position(go.get_position() + comp) -- <4>
+```
+
+1. Projiziere den Korrekturvektor auf die Kontaktnormale (beim ersten Kontaktpunkt ist der Korrekturvektor der Nullvektor)
+2. Berechne die Kompensation, die wir für diesen Kontaktpunkt vornehmen müssen
+3. Addiere sie zum Korrekturvektor
+4. Wende die Kompensation auf die Spielfigur an
+
+Wir müssen außerdem den Anteil der Geschwindigkeit der Spielfigur aufheben, der zum Kontaktpunkt hin gerichtet ist:
+
+```lua
+proj = vmath.dot(self.velocity, message.normal) -- <1>
+if proj < 0 then
+    self.velocity = self.velocity - proj * message.normal -- <2>
+end
+```
+1. Projiziere die Geschwindigkeit auf die Normale
+2. Wenn die Projektion negativ ist, bedeutet das, dass ein Teil der Geschwindigkeit zum Kontaktpunkt hin gerichtet ist; entferne in diesem Fall diese Komponente
+
+## Springen {#jumping}
+
+Da wir jetzt auf der Levelgeometrie laufen und herunterfallen können, ist es Zeit zu springen! Sprünge in Plattformspielen lassen sich auf viele verschiedene Arten umsetzen. In diesem Spiel streben wir etwas Ähnliches wie in Super Mario Bros und Super Meat Boy an. Beim Springen wird die Spielfigur durch einen Impuls nach oben gestoßen, der im Grunde eine feste Geschwindigkeit ist.
+
+Die Schwerkraft zieht die Figur fortlaufend wieder nach unten, wodurch eine schöne Sprungkurve entsteht. Während die Figur in der Luft ist, kann der Spieler sie weiterhin steuern. Lässt der Spieler die Sprungtaste vor dem höchsten Punkt der Sprungkurve los, wird die Aufwärtsgeschwindigkeit verringert, um den Sprung vorzeitig zu beenden.
+
+1. Wenn die Eingabe gedrückt wird, führe Folgendes aus:
+
+    ```lua
+    -- jump_takeoff_speed is a constant defined elsewhere
+    self.velocity.y = jump_takeoff_speed
+    ```
+
+    Dies sollte nur geschehen, wenn die Eingabe _gedrückt_ wird, und nicht in jedem Frame, in dem sie weiterhin _gedrückt gehalten_ wird.
+
+2. Wenn die Eingabe losgelassen wird, führe Folgendes aus:
+
+    ```lua
+    -- cut the jump short if we are still going up
+    if self.velocity.y > 0 then
+        -- scale down the upwards speed
+        self.velocity.y = self.velocity.y * 0.5
+    end
+    ```
+
+ExciteMike hat einige schöne Diagramme der Sprungkurven in [Super Mario Bros 3](http://meyermike.com/wp/?p=175) und [Super Meat Boy](http://meyermike.com/wp/?p=160) erstellt, die einen Blick wert sind.
+
+## Levelgeometrie {#level-geometry}
+
+Die Levelgeometrie besteht aus den Kollisionsformen der Umgebung, mit denen die Spielfigur (und möglicherweise andere Dinge) kollidiert. In Defold gibt es zwei Möglichkeiten, diese Geometrie zu erstellen.
+
+Du kannst separate Kollisionsformen über den von dir erstellten Levels anlegen. Diese Methode ist sehr flexibel und ermöglicht eine genaue Positionierung der Grafiken. Sie ist besonders nützlich, wenn du sanfte Schrägen möchtest.
+Das Spiel [Braid](http://braid-game.com/) hat diese Methode zum Aufbau von Levels verwendet. Auch das Beispiellevel in diesem Tutorial wurde damit erstellt. So sieht es im Defold-Editor aus:
+
+![Der Defold-Editor mit der Levelgeometrie und der in der Welt platzierten Spielfigur](images/platformer/editor.png)
+
+Eine weitere Möglichkeit besteht darin, Levels aus Kacheln aufzubauen und den Editor die Physikformen automatisch anhand der Kachelgrafiken erzeugen zu lassen. Das bedeutet, dass die Levelgeometrie automatisch aktualisiert wird, wenn du die Levels änderst, was äußerst nützlich sein kann.
+
+Die Physikformen der platzierten Kacheln werden automatisch zu einer einzigen Form zusammengeführt, wenn sie aneinander anschließen.
+Dadurch entfallen Lücken, an denen deine Spielfigur hängen bleiben oder anstoßen könnte, wenn sie über mehrere waagerechte Kacheln gleitet. Dazu werden die Kachelpolygone beim Laden durch Kantenformen in Box2D ersetzt.
+
+![Mehrere kachelbasierte Polygone zu einem einzigen verbunden](images/platformer/stitching.png)
+
+Oben siehst du ein Beispiel, in dem wir fünf benachbarte Kacheln aus einem Teil der Plattformspielgrafik erstellt haben. Im Bild kannst du sehen, wie die platzierten Kacheln (oben) einer einzigen zusammengefügten Form entsprechen (graue Kontur unten).
+
+Weitere Informationen findest du in unseren Anleitungen zu [Physik](/manuals/physics) und [Kacheln](/manuals/2dgraphics).
+
+## Abschließende Worte {#final-words}
+
+Wenn du mehr über die Mechaniken von Plattformspielen erfahren möchtest, findest du hier eine beeindruckend große Menge an Informationen über die Physik in [Sonic](http://info.sonicretro.org/Sonic_Physics_Guide).
+
+Wenn du unser Vorlagenprojekt auf einem iOS-Gerät oder mit einer Maus ausprobierst, kann sich das Springen ziemlich unbeholfen anfühlen.
+Das ist nur unser schwacher Versuch, ein Plattformspiel mit einer einzigen Berührung zu steuern. :-)
+
+Wir haben nicht darüber gesprochen, wie wir die Animationen in diesem Spiel umgesetzt haben. Du kannst dir einen Eindruck davon verschaffen, indem du dir *player.script* unten ansiehst. Suche nach der Funktion `update_animations()`.
+
+Wir hoffen, dass diese Informationen für dich nützlich waren!
+Bitte entwickle ein großartiges Plattformspiel, damit wir es alle spielen können! <3
+
+## Code
+
+Hier ist der Inhalt von *player.script*:
+
+```lua
+-- player.script
+
+-- these are the tweaks for the mechanics, feel free to change them for a different feeling
+-- the acceleration to move right/left
+local move_acceleration = 3500
+-- acceleration factor to use when air-borne
+local air_acceleration_factor = 0.8
+-- max speed right/left
+local max_speed = 450
+-- gravity pulling the player down in pixel units
+local gravity = -1000
+-- take-off speed when jumping in pixel units
+local jump_takeoff_speed = 550
+-- time within a double tap must occur to be considered a jump (only used for mouse/touch controls)
+local touch_jump_timeout = 0.2
+
+-- prehashing ids improves performance
+local msg_contact_point_response = hash("contact_point_response")
+local msg_animation_done = hash("animation_done")
+local group_obstacle = hash("obstacle")
+local input_left = hash("left")
+local input_right = hash("right")
+local input_jump = hash("jump")
+local input_touch = hash("touch")
+local anim_run = hash("run")
+local anim_idle = hash("idle")
+local anim_jump = hash("jump")
+local anim_fall = hash("fall")
+
+function init(self)
+    -- this lets us handle input in this script
+    msg.post(".", "acquire_input_focus")
+
+    -- initial player velocity
+    self.velocity = vmath.vector3(0, 0, 0)
+    -- support variable to keep track of collisions and separation
+    self.correction = vmath.vector3()
+    -- if the player stands on ground or not
+    self.ground_contact = false
+    -- movement input in the range [-1,1]
+    self.move_input = 0
+    -- the currently playing animation
+    self.anim = nil
+    -- timer that controls the jump-window when using mouse/touch
+    self.touch_jump_timer = 0
+end
+
+local function play_animation(self, anim)
+    -- only play animations which are not already playing
+    if self.anim ~= anim then
+        -- tell the sprite to play the animation
+        sprite.play_flipbook("#sprite", anim)
+        -- remember which animation is playing
+        self.anim = anim
+    end
+end
+
+local function update_animations(self)
+    -- make sure the player character faces the right way
+    sprite.set_hflip("#sprite", self.move_input < 0)
+    -- make sure the right animation is playing
+    if self.ground_contact then
+        if self.velocity.x == 0 then
+            play_animation(self, anim_idle)
+        else
+            play_animation(self, anim_run)
+        end
+    else
+        if self.velocity.y > 0 then
+            play_animation(self, anim_jump)
+        else
+            play_animation(self, anim_fall)
+        end
+    end
+end
+
+function update(self, dt)
+    -- determine the target speed based on input
+    local target_speed = self.move_input * max_speed
+    -- calculate the difference between our current speed and the target speed
+    local speed_diff = target_speed - self.velocity.x
+    -- the complete acceleration to integrate over this frame
+    local acceleration = vmath.vector3(0, gravity, 0)
+    if speed_diff ~= 0 then
+        -- set the acceleration to work in the direction of the difference
+        if speed_diff < 0 then
+            acceleration.x = -move_acceleration
+        else
+            acceleration.x = move_acceleration
+        end
+        -- decrease the acceleration when air-borne to give a slower feel
+        if not self.ground_contact then
+            acceleration.x = air_acceleration_factor * acceleration.x
+        end
+    end
+    -- calculate the velocity change this frame (dv is short for delta-velocity)
+    local dv = acceleration * dt
+    -- check if dv exceeds the intended speed difference, clamp it in that case
+    if math.abs(dv.x) > math.abs(speed_diff) then
+        dv.x = speed_diff
+    end
+    -- save the current velocity for later use
+    -- (self.velocity, which right now is the velocity used the previous frame)
+    local v0 = self.velocity
+    -- calculate the new velocity by adding the velocity change
+    self.velocity = self.velocity + dv
+    -- calculate the translation this frame by integrating the velocity
+    local dp = (v0 + self.velocity) * dt * 0.5
+    -- apply it to the player character
+    go.set_position(go.get_position() + dp)
+
+    -- update the jump timer
+    if self.touch_jump_timer > 0 then
+        self.touch_jump_timer = self.touch_jump_timer - dt
+    end
+
+    update_animations(self)
+
+    -- reset volatile state
+    self.correction = vmath.vector3()
+    self.move_input = 0
+    self.ground_contact = false
+
+end
+
+local function handle_obstacle_contact(self, normal, distance)
+    -- project the correction vector onto the contact normal
+    -- (the correction vector is the 0-vector for the first contact point)
+    local proj = vmath.dot(self.correction, normal)
+    -- calculate the compensation we need to make for this contact point
+    local comp = (distance - proj) * normal
+    -- add it to the correction vector
+    self.correction = self.correction + comp
+    -- apply the compensation to the player character
+    go.set_position(go.get_position() + comp)
+    -- check if the normal points enough up to consider the player standing on the ground
+    -- (0.7 is roughly equal to 45 degrees deviation from pure vertical direction)
+    if normal.y > 0.7 then
+        self.ground_contact = true
+    end
+    -- project the velocity onto the normal
+    proj = vmath.dot(self.velocity, normal)
+    -- if the projection is negative, it means that some of the velocity points towards the contact point
+    if proj < 0 then
+        -- remove that component in that case
+        self.velocity = self.velocity - proj * normal
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    -- check if we received a contact point message
+    if message_id == msg_contact_point_response then
+        -- check that the object is something we consider an obstacle
+        if message.group == group_obstacle then
+            handle_obstacle_contact(self, message.normal, message.distance)
+        end
+    end
+end
+
+local function jump(self)
+    -- only allow jump from ground
+    -- (extend this with a counter to do things like double-jumps)
+    if self.ground_contact then
+        -- set take-off speed
+        self.velocity.y = jump_takeoff_speed
+        -- play animation
+        play_animation(self, anim_jump)
+    end
+end
+
+local function abort_jump(self)
+    -- cut the jump short if we are still going up
+    if self.velocity.y > 0 then
+        -- scale down the upwards speed
+        self.velocity.y = self.velocity.y * 0.5
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == input_left then
+        self.move_input = -action.value
+    elseif action_id == input_right then
+        self.move_input = action.value
+    elseif action_id == input_jump then
+        if action.pressed then
+            jump(self)
+        elseif action.released then
+            abort_jump(self)
+        end
+    elseif action_id == input_touch then
+        -- move towards the touch-point
+        local diff = action.x - go.get_position().x
+        -- only give input when far away (more than 10 pixels)
+        if math.abs(diff) > 10 then
+            -- slow down when less than 100 pixels away
+            self.move_input = diff / 100
+            -- clamp input to [-1,1]
+            self.move_input = math.min(1, math.max(-1, self.move_input))
+        end
+        if action.released then
+            -- start timing the last release to see if we are about to jump
+            self.touch_jump_timer = touch_jump_timeout
+        elseif action.pressed then
+            -- jump on double tap
+            if self.touch_jump_timer > 0 then
+                jump(self)
+            end
+        end
+    end
+end
+```

--- a/docs/de/tutorials/rpgmap.md
+++ b/docs/de/tutorials/rpgmap.md
@@ -1,0 +1,80 @@
+---
+title: Beispiel einer RPG-Karte
+brief: In diesem Beispielprojekt lernst du eine Methode kennen, mit der du sehr große RPG-Karten erstellst.
+---
+# RPG-Karte - Beispielprojekt {#rpg-map-sample-project}
+
+In diesem Beispielprojekt, das du [im Editor öffnen](/manuals/project-setup/) oder [von GitHub herunterladen](https://github.com/defold/sample-rpgmap) kannst, zeigen wir eine Methode zum Erstellen sehr großer RPG-Karten in Defold. Der Entwurf beruht auf den folgenden Annahmen:
+
+1. Die Welt wird Bildschirmabschnitt für Bildschirmabschnitt dargestellt. Dadurch kann das Spiel Gegner und NPC-Figuren auf natürliche Weise innerhalb der Grenzen eines einzelnen Bildschirmabschnitts halten. Der Leveldesigner hat volle Kontrolle darüber, wie die Welt auf dem Bildschirm des Spielers dargestellt wird.
+2. Die Spielfigur sollte beliebig weit reisen können, ohne dass im Spiel Probleme mit der Genauigkeit von Gleitkommazahlen auftreten. Diese führen typischerweise dazu, dass Objekte merkwürdig zittern, wenn sie sich weit vom Ursprung entfernen.
+3. Die Bewegung des Spielers wird durch Hindernisse auf der Karte eingeschränkt, sodass der Leveldesigner den Spieler mit Bäumen, Felsen, Wasser und anderen Hindernissen zwischen Bildschirmabschnitten führen kann.
+4. Es sollte möglich sein, Kachelkarten (tile maps), Sprites und andere visuelle Inhalte miteinander zu kombinieren.
+
+Starte zunächst das Beispiel und durchquere die 3x3 Bildschirmabschnitte große Welt, um ein Gefühl für den Aufbau des Beispiels zu bekommen. Du steuerst die Figur mit den Pfeiltasten.
+
+## Die Hauptsammlung {#the-main-collection}
+
+Öffne "/main/main.collection", um die Startsammlung (bootstrap collection) dieses Beispiels anzusehen.
+
+![](images/rpgmap/main_collection.png)
+
+Diese Sammlung (collection) enthält das Spielobjekt (game object) der Spielfigur, das mit den Pfeiltasten in 8 Richtungen gesteuert wird, sowie ein zweites Spielobjekt namens "game", das den Spielablauf steuert. Das Objekt "game" besteht aus einem Skript und einer Sammlungsfabrik (collection factory) für jeden Bildschirmabschnitt im Spiel. Die Sammlungsfabriken werden nach dem Benennungsschema des Bildschirmabschnittsrasters benannt.
+
+Das Skript "/main/game.script" verfolgt, in welchem Bildschirmabschnitt sich der Spieler gerade befindet. Das Skript reagiert außerdem auf eine benutzerdefinierte Nachricht namens "load_screen". Diese Nachricht lädt einen neuen Bildschirmabschnitt und tauscht ihn in der Bewegungsrichtung des Helden gegen den aktuellen Bildschirmabschnitt aus. Zu Beginn wird ein Bildschirmabschnitt in die Mitte des Bildschirms geladen, und es gibt keinen anderen Bildschirmabschnitt, mit dem er den Platz tauschen könnte.
+
+## Bildschirmabschnitte wechseln {#changing-screens}
+
+Der Held wird durch das Skript "/main/hero.script" gesteuert. Das Skript prüft, ob sich das Spielobjekt des Helden über eine obere, untere, linke oder rechte Linie nahe dem Bildschirmrand hinausbewegt:
+
+![](images/rpgmap/change_screen.png)
+
+1. Wenn sich der Held einem Bildschirmrand weit genug nähert, wird eine Nachricht an das Skript des Objekts "game" gesendet, um den nächsten Bildschirmabschnitt zu laden.
+2. Die Sammlung des nächsten Bildschirmabschnitts wird durch den Aufruf von `factory.create()` für die passende collectionfactory-Komponente (component) dynamisch erzeugt. Der Inhalt der Sammlung wird außerhalb des Bildschirms positioniert.
+3. Der nächste Bildschirmabschnitt wird in die Mitte des Sichtbereichs gescrollt und der aktuelle Bildschirmabschnitt in die entgegengesetzte Richtung hinausgescrollt. Auch die Spielfigur wird über dieselbe Strecke und mit derselben Geschwindigkeit gescrollt.
+4. Der bisherige aktuelle Bildschirmabschnitt, der sich nun außerhalb des Bildschirms befindet, wird gelöscht, und der nächste Bildschirmabschnitt wird zum neuen aktuellen Bildschirmabschnitt.
+5. Der Held bewegt sich mit einer Animation in den sichtbaren Bereich des neuen Bildschirmabschnitts, und der Spieler erhält die Kontrolle zurück.
+
+All dies geschieht innerhalb einer Sekunde, sodass der Übergang flüssig ist und den Spielablauf nicht unterbricht.
+
+## Bildschirmabschnitte {#screens}
+
+Jeder Bildschirmabschnitt der Spielwelt wird in einer separaten Sammlung aufgebaut, die die Kachelkarte, das Kollisionsobjekt (collision object) und weitere Spielobjekte enthält, die nur zu diesem Bildschirmabschnitt gehören. Um die Verwaltung und das Laden der Bildschirmabschnitte zu erleichtern, werden ihre Sammlungen nach einem einfachen Schema benannt:
+
+![](images/rpgmap/screens.png)
+
+Jede Sammlung eines Bildschirmabschnitts wird nach ihrer Position im Weltraster benannt. Die erste Zahl ist die X-Position im Raster und die zweite die Y-Position im Raster.
+
+Navigiere in der Ansicht *Assets* zur Sammlung "/main/screens/0-0.collection" und öffne sie. Sie beschreibt den Bildschirmabschnitt in der linken unteren Ecke der Karte:
+
+![](images/rpgmap/screen_collection.png)
+
+Beachte das Spielobjekt namens "root", dem alle Inhalte des Bildschirmabschnitts untergeordnet sind. Dies ist eine weitere Konvention des Beispiels, die einen sehr wichtigen Zweck erfüllt: Wenn ein Bildschirmabschnitt in den sichtbaren Bereich gebracht wird, muss nur das Spielobjekt "root" bewegt werden. Alle untergeordneten Objekte werden automatisch mit dem obersten übergeordneten Objekt mitbewegt. Besondere Spielobjekte in einem Bildschirmabschnitt können ebenfalls frei animiert werden, da ihre Bewegung relativ zu diesem obersten übergeordneten Objekt erfolgt. Wenn der Bildschirmabschnitt hinein- oder hinausgescrollt wird, bewegen sich diese untergeordneten Objekte mit ihm. Spezieller Code ist nur erforderlich, wenn sich ein Objekt zwischen Bildschirmabschnitten bewegen muss.
+
+Die Bienen im Bildschirmabschnitt 0-1 veranschaulichen diese Idee auf einfache Weise:
+
+![](images/rpgmap/bees.png)
+
+## Bildschirmabschnitte im Zusammenhang mit der Welt bearbeiten {#editing-screens-in-the-world-context}
+
+Jeder Bildschirmabschnitt hat eine eigene Kachelkarte, die im integrierten Kachelkarteneditor bearbeitet werden kann. Der größte Nachteil beim isolierten Bearbeiten einzelner Bildschirmabschnitte ist jedoch, dass sich nicht ohne Weiteres erkennen lässt, wie sie an ihre Nachbarabschnitte anschließen. Dies ist ein wichtiger Aspekt, um eine zusammenhängende Spielwelt zu schaffen.
+
+Aus diesem Grund wurde eine besondere Sammlung erstellt. Öffne "/main/map/test_layout.collection", um diese Sammlung mit dem Testlayout der Welt anzusehen:
+
+![](images/rpgmap/test_layout.png)
+
+Diese Sammlung dient ausschließlich als Bearbeitungswerkzeug während der Entwicklung. Wenn du einen bestimmten Bildschirmabschnitt neben der Sammlung mit dem Testlayout bearbeitest, siehst du ihn im Zusammenhang mit seiner Umgebung, und die Bearbeitung ist viel angenehmer:
+
+![](images/rpgmap/side_by_side.png)
+
+Alle Änderungen an der Kachelkarte des Bildschirmabschnitts (hier im rechten Bereich) werden sofort in der Testsammlung (im linken Bereich) angezeigt. Beachte außerdem, dass die Sammlung mit dem Testlayout nicht zur statischen Hierarchie hinzugefügt wird und deshalb automatisch von allen Builds ausgeschlossen ist.
+
+## Zusammenfassung {#summary}
+
+Wie du gesehen hast, wurde dieses Beispiel unter bestimmten Einschränkungen hinsichtlich der Spielwelt und der Bewegung des Helden durch diese Welt aufgebaut. Wenn dein Spiel andere Anforderungen hat, musst du wahrscheinlich eine andere Lösung finden. Soll sich die Kamera in deinem Spiel beispielsweise nahtlos über die Weltkarte bewegen, brauchst du eine andere Aufteilung deiner Inhalte, einen anderen Lademechanismus und auch andere Werkzeuge, die dir beim Erstellen deiner Spielwelt helfen.
+
+Damit endet die Einführung in das Beispiel einer RPG-Karte. Wie immer kannst du die Inhalte des Beispiels nach Belieben verwenden. Wenn du mehr über Defold erfahren möchtest, findest du auf unseren [Dokumentationsseiten](https://defold.com/learn) weitere Beispiele, Tutorials, Handbücher und API-Dokumentation.
+
+Wenn du auf Schwierigkeiten stößt oder Fragen hast, [besuche unser Forum](https://forum.defold.com/).
+
+Viel Spaß mit Defold!

--- a/docs/de/tutorials/runner.md
+++ b/docs/de/tutorials/runner.md
@@ -1,0 +1,942 @@
+---
+title: Tutorial für einen Endless Runner
+brief: In diesem Tutorial beginnst du mit einem leeren Projekt und entwickelst ein vollständiges Runner-Spiel mit einer animierten Figur, physikalischen Kollisionen, Sammelobjekten und einem Punktesystem.
+---
+
+# Runner-Tutorial
+
+In diesem Tutorial beginnen wir mit einem leeren Projekt und entwickeln ein vollständiges Runner-Spiel mit einer animierten Figur, physikalischen Kollisionen, Sammelobjekten und einem Punktesystem.
+
+Beim Erlernen einer neuen Game-Engine gibt es viel aufzunehmen. Deshalb haben wir dieses Tutorial erstellt, um dir den Einstieg zu erleichtern. Es ist ein recht umfassendes Tutorial, das dir zeigt, wie die Engine und der Editor funktionieren. Wir setzen voraus, dass du bereits etwas Erfahrung mit dem Programmieren hast.
+
+Wenn du eine Einführung in die Lua-Programmierung brauchst, lies unser [Handbuch zu Lua in Defold](/manuals/lua).
+
+Falls dir dieses Tutorial für den Anfang etwas zu umfangreich erscheint, sieh dir unsere [Tutorial-Seite](//www.defold.com/tutorials) an. Dort findest du eine Auswahl an Tutorials mit unterschiedlichen Schwierigkeitsgraden.
+
+Wenn du lieber Video-Tutorials ansiehst, schau dir [die Videoversion auf YouTube](https://www.youtube.com/playlist?list=PLXsXu5srjNlxtYPQ_YJQSxJG2AN9OVS5b) an.
+
+Wir verwenden Spiel-Assets aus zwei anderen Tutorials und nehmen daran einige kleine Änderungen vor. Dieses Tutorial ist in mehrere Schritte unterteilt, von denen uns jeder dem fertigen Spiel ein gutes Stück näherbringt.
+
+Am Ende entsteht ein Spiel, in dem du eine Heldenfigur steuerst, die durch eine Umgebung läuft, Münzen sammelt und Hindernissen ausweicht. Die Heldenfigur läuft mit einer festen Geschwindigkeit. Der Spieler steuert nur ihre Sprünge, indem er eine einzige Taste drückt (oder auf einem Mobilgerät den Bildschirm berührt). Das Level besteht aus einem endlosen Strom von Plattformen, auf die du springen kannst, und Münzen zum Einsammeln.
+
+Wenn du an irgendeiner Stelle dieses Tutorials oder beim Erstellen deines Spiels nicht weiterkommst, zögere nicht, uns im [Defold-Forum](//forum.defold.com) um Hilfe zu bitten. Im Forum kannst du dich über Defold austauschen, das Defold-Team um Hilfe bitten, sehen, wie andere Spieleentwickler ihre Probleme gelöst haben, und neue Anregungen finden. Leg jetzt los.
+
+::: sidenote
+Ausführliche Beschreibungen von Konzepten und bestimmten Arbeitsschritten sind im gesamten Tutorial so markiert wie dieser Absatz. Wenn dir diese Abschnitte zu sehr ins Detail gehen, überspringe sie.
+:::
+
+Fangen wir also an. Wir hoffen, dass dir dieses Tutorial viel Spaß macht und dir beim Einstieg in Defold hilft.
+
+> Lade die Assets für dieses Tutorial [hier](https://github.com/defold/sample-runner/tree/main/def-runner) herunter.
+
+## SCHRITT 1 - Installation und Einrichtung {#step-1-installation-and-setup}
+
+Lade als ersten Schritt [die folgenden Dateien herunter](https://github.com/defold/sample-runner/tree/main/def-runner).
+
+Wenn du den Defold-Editor noch nicht heruntergeladen und installiert hast, ist jetzt der richtige Zeitpunkt dafür:
+
+:[install](../shared/install.md)
+
+Nachdem der Editor installiert und gestartet ist, kannst du ein neues Projekt erstellen und vorbereiten. Erstelle ein [neues Projekt](/manuals/project-setup/#creating-a-new-project) mit der Vorlage "Empty Project".
+
+::: sidenote
+Dieses Tutorial verwendet Spine-Funktionen aus der [Spine-Erweiterung](https://github.com/defold/extension-spine). Füge die Erweiterung zum Abschnitt für Abhängigkeiten in *game.project* hinzu.
+:::
+
+## Der Editor {#the-editor}
+
+Beim ersten Start ist der Editor leer, ohne geöffnetes Projekt. Wähle deshalb <kbd>Open Project</kbd> im Menü und öffne dein gerade erstelltes Projekt. Du wirst außerdem aufgefordert, einen „Branch“ für das Projekt zu erstellen.
+
+Im Bereich *Assets pane* siehst du nun alle Dateien, die zum Projekt gehören. Wenn du auf die Datei "main/main.collection" doppelklickst, wird sie in der Editoransicht in der Mitte geöffnet:
+
+![Übersicht des Editors](images/runner/1/editor2_overview.png)
+
+Der Editor besteht aus den folgenden Hauptbereichen:
+
+Assets-Bereich
+: Diese Ansicht zeigt alle Dateien in deinem Projekt. Verschiedene Dateitypen haben unterschiedliche Symbole. Doppelklicke auf eine Datei, um sie in einem für diesen Dateityp vorgesehenen Editor zu öffnen. Der besondere schreibgeschützte Ordner *builtins* ist für alle Projekte verfügbar. Er enthält nützliche Dinge wie ein Standard-Render-Skript, eine Schriftart, Materialien zum Rendern verschiedener Komponenten (components) und weitere Ressourcen.
+
+Hauptansicht des Editors
+: Je nachdem, welchen Dateityp du bearbeitest, zeigt diese Ansicht den passenden Editor an. Am häufigsten kommt der Szeneneditor zum Einsatz, den du hier siehst. Jede geöffnete Datei wird in einem eigenen Tab angezeigt.
+
+Changed Files
+: Enthält Dateien, die im Vergleich zum aktuellen Git-Commit lokal hinzugefügt, geändert, umbenannt oder gelöscht wurden. Für jeweils eine geänderte oder umbenannte Textdatei kannst du die Unterschiede anzeigen lassen. Hier kannst du auch ausgewählte lokale Änderungen zurücknehmen. Verwende einen externen Git-Client oder die Befehlszeile, um mit einem entfernten Repository zu synchronisieren.
+
+Outline
+: Zeigt den Inhalt der gerade bearbeiteten Datei als Hierarchie an. Über diese Ansicht kannst du Objekte und Komponenten hinzufügen, löschen, ändern und auswählen.
+
+Properties
+: Die Eigenschaften des aktuell ausgewählten Objekts oder der aktuell ausgewählten Komponente.
+
+Console
+: Wenn das Spiel läuft, zeigt diese Ansicht Ausgaben der Game-Engine an (Protokollmeldungen, Fehler, Debug-Informationen usw.) sowie alle eigenen Debug-Meldungen, die deine Skripte mit `print()` und `pprint()` ausgeben. Wenn deine App oder dein Spiel nicht startet, solltest du zuerst die Konsole prüfen. Hinter der Konsole befinden sich mehrere Tabs mit Fehlerinformationen sowie ein Kurveneditor, der beim Erstellen von Partikeleffekten verwendet wird.
+
+## Das Spiel ausführen {#running-the-game}
+
+Die Projektvorlage "Empty" ist tatsächlich vollständig leer. Wähle trotzdem <kbd>Project ▸ Build</kbd>, um einen Build des Projekts zu erstellen und das Spiel zu starten.
+
+![Build erstellen](images/runner/1/build_and_launch.png)
+
+Ein schwarzer Bildschirm ist vielleicht nicht besonders aufregend, aber dahinter läuft eine Defold-Spielanwendung, die wir leicht zu etwas Interessanterem machen können. Machen wir das also.
+
+::: sidenote
+Der Defold-Editor arbeitet mit Dateien. Wenn du im Bereich *Assets pane* auf eine Datei doppelklickst, öffnest du sie in einem geeigneten Editor. Anschließend kannst du den Inhalt der Datei bearbeiten.
+
+Wenn du mit dem Bearbeiten einer Datei fertig bist, musst du sie speichern. Wähle dazu <kbd>File ▸ Save</kbd> im Hauptmenü. Der Editor weist auf ungespeicherte Änderungen hin, indem er im Tab der betreffenden Datei ein Sternchen '\*' an den Dateinamen anhängt.
+
+![Datei mit ungespeicherten Änderungen](images/runner/1/file_changed.png)
+:::
+
+## Das Projekt einrichten {#setting-up-the-project}
+
+Bevor wir beginnen, nehmen wir einige Projekteinstellungen vor. Öffne das Asset *game.project* im `Assets Pane` und scrolle zum Abschnitt Display. Setze `width` und `height` des Projekts auf `1280` beziehungsweise `720`.
+
+Außerdem musst du die Spine-Erweiterung zum Projekt hinzufügen, damit wir die Heldenfigur animieren können. Füge eine Version der Spine-Erweiterung hinzu, die mit deiner installierten Version des Defold-Editors kompatibel ist. Die verfügbaren Spine-Versionen findest du hier:
+
+[https://github.com/defold/extension-spine/releases](https://github.com/defold/extension-spine/releases)
+
+Klicke mit der rechten Maustaste auf den Link zur ZIP-Datei der Version, die du verwenden möchtest:
+
+![Mit der rechten Maustaste klicken und den Link zur Version kopieren](images/runner/extension-spine-releases.png)
+
+Füge den Link zur Version zu deiner Liste der [Abhängigkeiten in game.project](/manuals/libraries/#setting-up-library-dependencies) hinzu. Nachdem du die Spine-Erweiterung hinzugefügt hast, musst du den Editor neu starten, um die mitgelieferte Editorintegration zu aktivieren.
+
+
+## SCHRITT 2 - Den Boden erstellen {#step-2-creating-the-ground}
+
+Machen wir die ersten kleinen Schritte und erstellen eine Spielfläche für unsere Figur, genauer gesagt ein Stück scrollenden Boden. Dazu gehen wir in wenigen Schritten vor.
+
+1. Importiere die Bild-Assets in das Projekt, indem du die Bilddateien "ground01.png" und "ground02.png" aus dem Unterordner "level-images" des Asset-Pakets an eine geeignete Stelle im Projekt ziehst, zum Beispiel in einen Ordner "images" innerhalb des Ordners "main".
+2. Erstelle eine neue *Atlas*-Datei für die Bodentexturen. Klicke dazu im Bereich *Assets pane* mit der rechten Maustaste auf einen geeigneten Ordner, beispielsweise den Ordner *main*, und wähle <kbd>New ▸ Atlas File</kbd>. Nenne die Atlasdatei *level.atlas*.
+
+  ::: sidenote
+  Ein *Atlas* ist eine Datei, die mehrere einzelne Bilder in einer größeren Bilddatei zusammenfasst. Das spart Speicherplatz und verbessert die Leistung. Mehr über Atlanten und andere Funktionen für 2D-Grafik erfährst du in der [Dokumentation zur 2D-Grafik](/manuals/2dgraphics).
+  :::
+
+3. Füge die Bodenbilder zum neuen Atlas hinzu, indem du in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten des Atlas klickst und <kbd>Add Images</kbd> wählst. Wähle die importierten Bilder aus und klicke auf *OK*. Jedes Bild im Atlas steht jetzt als Animation mit einem Einzelbild (Standbild) für Sprites, Partikeleffekte und andere visuelle Elemente zur Verfügung. Speichere die Datei.
+
+  ![Einen neuen Atlas erstellen](images/runner/1/new_atlas.png)
+
+  ![Bilder zum Atlas hinzufügen](images/runner/1/add_images_to_atlas.png)
+
+  ::: sidenote
+  *Warum funktioniert das nicht!?* Ein häufiges Problem beim Einstieg in Defold ist, dass das Speichern vergessen wird! Nachdem du Bilder zu einem Atlas hinzugefügt hast, musst du die Datei speichern, bevor du auf die Bilder zugreifen kannst.
+  :::
+
+4. Erstelle für den Boden eine Datei *ground.collection* für eine Sammlung (collection) und füge ihr 7 Spielobjekte (game objects) hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten der Sammlung und wähle <kbd>Add Game Object</kbd>. Nenne die Objekte "ground0", "ground1", "ground2" usw., indem du die Eigenschaft *Id* in der Ansicht *Properties* änderst. Beachte, dass Defold neuen Spielobjekten automatisch einen eindeutigen Bezeichner zuweist.
+
+5. Füge jedem Objekt eine Sprite-Komponente hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf das Spielobjekt und wähle <kbd>Add Component</kbd>, dann *Sprite* und schließlich *OK*. Setze die Eigenschaft *Image* der Sprite-Komponente auf den gerade erstellten Atlas und die Standardanimation des Sprites auf eines der beiden Bodenbilder. Setze die X-Position der _Sprite-Komponente_ (nicht des Spielobjekts) auf 190 und die Y-Position auf 40. Das Bild ist 380 Pixel breit und wir verschieben es um die Hälfte dieser Pixelzahl zur Seite. Dadurch liegt der Bezugspunkt (pivot) des Spielobjekts am linken Rand des Sprite-Bildes.
+
+  ![Die Bodensammlung erstellen](images/runner/1/ground_collection.png)
+
+6. Die verwendete Grafik ist etwas zu groß. Skaliere deshalb jedes Spielobjekt auf 60 % (Skalierung von 0.6 in X und Y, wodurch 228 Pixel breite Bodenstücke entstehen).
+
+  ![Den Boden skalieren](images/runner/1/scale_ground.png)
+
+7. Ordne alle _Spielobjekte_ in einer Reihe an. Setze die X-Positionen der _Spielobjekte_ (nicht der Sprite-Komponenten) auf 0, 228, 456, 684, 912, 1140 und 1368 (Vielfache der Breite von 228 Pixeln).
+
+  ::: sidenote
+  Am einfachsten ist es wahrscheinlich, ein vollständiges, skaliertes Spielobjekt mit einer Sprite-Komponente zu erstellen und es anschließend zu kopieren. Markiere es in der Ansicht *Outline*, wähle <kbd>Edit ▸ Copy</kbd> und danach <kbd>Edit ▸ Paste</kbd>.
+
+  Wenn du größere oder kleinere Kacheln möchtest, kannst du einfach die Skalierung ändern. Dann musst du allerdings auch die X-Positionen aller Boden-Spielobjekte auf Vielfache der neuen Breite ändern.
+  :::
+
+8. Speichere die Datei und füge anschließend *ground.collection* zur Datei *main.collection* hinzu: Doppelklicke zuerst auf die Datei *main.collection*. Klicke dann in der Ansicht *Outline* mit der rechten Maustaste auf das oberste Objekt und wähle <kbd>Add Collection From File</kbd>. Wähle im Dialog *ground.collection* aus und klicke auf *OK*. Achte darauf, *ground.collection* an der Position 0, 0, 0 zu platzieren, sonst erscheint sie versetzt. Speichere die Datei.
+
+9. Starte das Spiel (<kbd>Project ▸ Build</kbd>), um zu sehen, ob alles an seinem Platz ist.
+
+  ![Unbewegter Boden](images/runner/1/still_ground.png)
+
+Vielleicht bist du inzwischen etwas verwirrt und fragst dich, was all die Dinge, die wir erstellt haben, eigentlich sind. Nehmen wir uns deshalb einen Moment Zeit, um die grundlegenden Bausteine jedes Defold-Projekts anzusehen:
+
+Spielobjekte
+: Spielobjekte sind Dinge, die im laufenden Spiel existieren. Jedes Spielobjekt hat eine Position im 3D-Raum, eine Drehung und eine Skalierung. Es muss nicht unbedingt sichtbar sein. Ein Spielobjekt enthält eine beliebige Anzahl von _Komponenten_, die ihm Fähigkeiten verleihen: Grafik (Sprites, Kachelkarten (tile maps), Modelle, Spine-Modelle und Partikeleffekte), Ton, Physik, Fabriken (factories, zum dynamischen Erzeugen) und mehr. Du kannst auch _Skriptkomponenten_ in Lua hinzufügen, um einem Spielobjekt Verhalten zu geben. Jedes Spielobjekt in deinen Spielen hat eine *id*, die du benötigst, um per Nachrichtenübermittlung mit ihm zu kommunizieren.
+
+Sammlungen
+: Sammlungen existieren im laufenden Spiel nicht als eigenständige Objekte. Sie ermöglichen eine feste Benennung von Spielobjekten und gleichzeitig mehrere Instanzen desselben Spielobjekts. In der Praxis dienen Sammlungen als Behälter für Spielobjekte und andere Sammlungen. Du kannst Sammlungen wie Prototypen (in anderen Engines auch „Prefabs“ oder „Baupläne“ genannt) für komplexe Hierarchien aus Spielobjekten und Sammlungen verwenden. Beim Start lädt die Engine eine Hauptsammlung und erweckt alles zum Leben, was du darin abgelegt hast. Standardmäßig ist das die Datei *main.collection* im Ordner *main* deines Projekts. Du kannst dies aber in den Projekteinstellungen ändern.
+
+Für den Moment reichen diese Beschreibungen wahrscheinlich aus. Eine wesentlich ausführlichere Erklärung findest du jedoch im [Handbuch zu Bausteinen](/manuals/building-blocks). Es ist sinnvoll, dieses Handbuch später zu lesen, um genauer zu verstehen, wie Defold funktioniert.
+
+## SCHRITT 3 - Den Boden bewegen {#step-3-making-the-ground-move}
+
+Jetzt, wo alle Bodenstücke an ihrem Platz sind, können wir sie recht einfach in Bewegung setzen. Die Idee: Wir bewegen die Stücke von rechts nach links. Sobald ein Stück links außerhalb des Bildschirms angekommen ist, verschieben wir es an die Position ganz rechts. Um all diese Spielobjekte zu bewegen, brauchen wir ein Lua-Skript. Erstellen wir also eines:
+
+1. Klicke im Bereich *Assets pane* mit der rechten Maustaste auf den Ordner *main* und wähle <kbd>New ▸ Script File</kbd>. Nenne die neue Datei *ground.script*.
+2. Doppelklicke auf die neue Datei, um den Lua-Skripteditor zu öffnen.
+3. Lösche den Standardinhalt der Datei und kopiere den folgenden Lua-Code hinein. Speichere anschließend die Datei.
+
+```lua
+-- ground.script
+local pieces = { "ground0", "ground1", "ground2", "ground3",
+                    "ground4", "ground5", "ground6" } -- <1>
+
+function init(self) -- <2>
+    self.speed = 360  -- Speed in pixels/s
+end
+
+function update(self, dt) -- <3>
+    for i, p in ipairs(pieces) do -- <4>
+        local pos = go.get_position(p)
+        if pos.x <= -228 then -- <5>
+            pos.x = 1368 + (pos.x + 228)
+        end
+        pos.x = pos.x - self.speed * dt -- <6>
+        go.set_position(pos, p) -- <7>
+    end
+end
+```
+1. Speichere die Bezeichner der Boden-Spielobjekte in einer Lua-Tabelle, damit wir sie durchlaufen können.
+2. Die Funktion `init()` wird aufgerufen, wenn das Spielobjekt im Spiel zum Leben erweckt wird. Wir initialisieren eine zum Objekt gehörende Variable, die die Geschwindigkeit des Bodens enthält.
+3. `update()` wird einmal pro Frame aufgerufen, normalerweise 60-mal pro Sekunde. `dt` enthält die Anzahl der Sekunden seit dem letzten Aufruf.
+4. Durchlaufe alle Boden-Spielobjekte.
+5. Speichere die aktuelle Position in einer lokalen Variablen. Wenn sich das aktuelle Objekt am linken Rand befindet, verschiebe es an den rechten Rand.
+6. Verringere die aktuelle X-Position entsprechend der eingestellten Geschwindigkeit. Multipliziere mit `dt`, um eine von der Bildrate unabhängige Geschwindigkeit in Pixel/s zu erhalten.
+7. Aktualisiere die Position des Objekts mit der neuen Geschwindigkeit.
+
+::: sidenote
+Defold ist ein schneller Engine-Kern, der deine Daten und Spielobjekte verwaltet. Alle Logik und jedes Verhalten, das du für dein Spiel brauchst, erstellst du in Lua. Lua ist eine schnelle und schlanke Programmiersprache, die sich hervorragend zum Schreiben von Spiellogik eignet. Es gibt gute Lernmaterialien, zum Beispiel das Buch [Programming in Lua](http://www.lua.org/pil/) und das offizielle [Lua-Referenzhandbuch](http://www.lua.org/manual/5.3/).
+
+Defold ergänzt Lua um mehrere APIs sowie ein System zur _Nachrichtenübermittlung_, mit dem du die Kommunikation zwischen Spielobjekten programmieren kannst. Wie das funktioniert, erfährst du im [Handbuch zur Nachrichtenübermittlung](/manuals/message-passing).
+:::
+
+::: sidenote
+Du kannst die Editorbereiche Assets Pane, Console und Outline mit den Tasten <kbd>F6</kbd>, <kbd>F7</kbd> beziehungsweise <kbd>F8</kbd> ein- und ausblenden.
+:::
+
+Jetzt, wo wir eine Skriptdatei haben, sollten wir eine Referenz darauf in einer Komponente eines Spielobjekts hinterlegen. So wird das Skript als Teil des Lebenszyklus des Spielobjekts ausgeführt. Dazu erstellen wir ein neues Spielobjekt in *ground.collection* und fügen ihm eine *Script*-Komponente hinzu, die auf die gerade erstellte Lua-Skriptdatei verweist:
+
+1. Klicke mit der rechten Maustaste auf den obersten Knoten der Sammlung und wähle <kbd>Add Game Object</kbd>. Setze den *id*-Wert des Objekts auf "controller".
+2. Klicke mit der rechten Maustaste auf das Objekt "controller" und wähle <kbd>Add Component from file</kbd>. Wähle anschließend die Datei *ground.script*.
+
+![Bodensteuerung](images/runner/1/ground_controller.png)
+
+Wenn du das Spiel jetzt startest, führt das Spielobjekt "controller" das Skript in seiner *Script*-Komponente aus. Dadurch scrollt der Boden gleichmäßig über den Bildschirm.
+
+## SCHRITT 4 - Eine Heldenfigur erstellen {#step-4-creating-a-hero-character}
+
+Die Heldenfigur wird ein Spielobjekt, das aus den folgenden Komponenten besteht:
+
+Ein *Spine Model*
+: Damit erhalten wir eine kleine Heldenfigur, die einer Papierpuppe ähnelt und deren Körperteile sich flüssig und mit geringem Rechenaufwand animieren lassen.
+
+Ein *Collision Object*
+: Dieses Kollisionsobjekt (collision object) erkennt Kollisionen zwischen der Heldenfigur und Dingen im Level, auf denen sie laufen kann, die gefährlich sind oder die sie einsammeln kann.
+
+Ein *Script*
+: Dieses Skript empfängt Benutzereingaben und reagiert darauf, lässt die Heldenfigur springen, animiert sie und verarbeitet Kollisionen.
+
+Importiere zunächst die Bilder der Körperteile und füge sie dann zu einem neuen Atlas hinzu, den wir *hero.atlas* nennen:
+
+1. Erstelle einen neuen Ordner, indem du im Bereich *Assets pane* mit der rechten Maustaste klickst und <kbd>New ▸ Folder</kbd> wählst. Achte darauf, vorher keinen Ordner auszuwählen, sonst wird der neue Ordner innerhalb des markierten Ordners erstellt. Nenne den Ordner "hero".
+2. Erstelle eine neue Atlasdatei, indem du mit der rechten Maustaste auf den Ordner *hero* klickst und <kbd>New ▸ Atlas File</kbd> wählst. Nenne die Datei *hero.atlas*.
+3. Erstelle im Ordner *hero* einen neuen Unterordner *images*. Klicke dazu mit der rechten Maustaste auf den Ordner *hero* und wähle <kbd>New ▸ Folder</kbd>.
+4. Ziehe die Bilder der Körperteile aus dem Ordner *hero-images* des Asset-Pakets in den gerade erstellten Ordner *images* im Bereich *Assets pane*.
+5. Öffne *hero.atlas*, klicke in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Images</kbd>. Markiere alle Bilder der Körperteile und klicke auf *OK*.
+6. Speichere die Atlasdatei.
+
+![Atlas der Heldenfigur](images/runner/2/hero_atlas.png)
+
+Außerdem müssen wir die Spine-Animationsdaten importieren und dafür eine *Spine Scene* einrichten:
+
+1. Ziehe die Datei *hero.spinejson* (sie ist im Asset-Paket enthalten) in den Ordner *hero* im Bereich *Assets pane*.
+2. Erstelle eine *Spine Scene*-Datei. Klicke mit der rechten Maustaste auf den Ordner *hero* und wähle <kbd>New ▸ Spine Scene File</kbd>. Nenne die Datei *hero.spinescene*.
+3. Doppelklicke auf die neue Datei, um die *Spine Scene* zu öffnen und zu bearbeiten.
+4. Setze die Eigenschaft *spine_json* auf die importierte JSON-Datei *hero.spinejson*. Klicke auf die Eigenschaft und dann auf die Schaltfläche *...* zur Dateiauswahl, um den Ressourcenbrowser zu öffnen.
+5. Setze die Eigenschaft *atlas* so, dass sie auf die Datei *hero.atlas* verweist.
+6. Speichere die Datei.
+
+![Spine-Szene der Heldenfigur](images/runner/2/hero_spinescene.png)
+
+::: sidenote
+Die Datei *hero.spinejson* wurde im Spine-JSON-Format exportiert. Um solche Dateien zu erstellen, benötigst du die Animationssoftware Spine. Wenn du eine andere Animationssoftware verwenden möchtest, kannst du deine Animationen als Sprite-Bögen (sprite sheets) exportieren und sie als Flipbook-Animationen aus *Tile Source*- oder *Atlas*-Ressourcen verwenden. Weitere Informationen findest du im Handbuch zu [Animationen](/manuals/animation).
+:::
+
+### Das Spielobjekt aufbauen {#building-the-game-object}
+
+Jetzt können wir mit dem Aufbau des Spielobjekts für die Heldenfigur beginnen:
+
+1. Erstelle eine neue Datei *hero.go*. Klicke dazu mit der rechten Maustaste auf den Ordner *hero* und wähle <kbd>New ▸ Game Object File</kbd>.
+2. Öffne die Spielobjektdatei.
+3. Füge ihr eine *Spine Model*-Komponente hinzu. (Klicke in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Component</kbd>, dann "Spine Model".)
+4. Setze die Eigenschaft *Spine Scene* der Komponente auf die gerade erstellte Datei *hero.spinescene* und wähle "run_right" als Standardanimation (um die Animation kümmern wir uns später genauer).
+5. Speichere die Datei.
+
+![Eigenschaften des Spine-Modells](images/runner/2/spinemodel_properties.png)
+
+Jetzt fügen wir Physik hinzu, damit Kollisionen funktionieren:
+
+1. Füge dem Spielobjekt der Heldenfigur eine *Collision Object*-Komponente hinzu. (Klicke in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Component</kbd>, dann "Collision Object".)
+2. Klicke mit der rechten Maustaste auf die neue Komponente und wähle <kbd>Add Shape</kbd>. Füge zwei Formen hinzu, die den Körper der Figur abdecken. Eine Kugel und ein Quader reichen aus.
+3. Klicke auf die Formen und verwende das *Move Tool* (<kbd>Scene ▸ Move Tool</kbd>), um die Formen passend zu positionieren.
+4. Markiere die *Collision Object*-Komponente und setze die Eigenschaft *Type* auf "Kinematic".
+
+::: sidenote
+Bei Kollisionen vom Typ "Kinematic" werden Kollisionen erkannt, aber die Physik-Engine löst sie nicht automatisch auf und simuliert die Objekte nicht. Die Physik-Engine unterstützt verschiedene Typen von Kollisionsobjekten. Mehr darüber erfährst du in der [Physikdokumentation](/manuals/physics).
+:::
+
+Wir müssen angeben, womit das Kollisionsobjekt interagieren soll:
+
+1. Setze die Eigenschaft *Group* auf eine neue Kollisionsgruppe namens "hero".
+2. Setze die Eigenschaft *Mask* auf eine andere Gruppe namens "geometry", mit der dieses Kollisionsobjekt Kollisionen erkennen soll. Beachte, dass die Gruppe "geometry" noch nicht existiert. Wir werden aber gleich Kollisionsobjekte hinzufügen, die ihr angehören.
+
+Erstelle abschließend eine neue Datei *hero.script* und füge sie dem Spielobjekt hinzu.
+
+1. Klicke im Bereich *Assets pane* mit der rechten Maustaste auf den Ordner *hero* und wähle <kbd>New ▸ Script File</kbd>. Nenne die neue Datei *hero.script*.
+2. Öffne die neue Datei, kopiere den folgenden Code in die Skriptdatei und speichere sie. (Der Code ist recht übersichtlich, abgesehen von der Kollisionsauflösung, die die Kollisionsform der Heldenfigur von dem trennt, womit sie kollidiert. Das übernimmt die Funktion `handle_geometry_contact()`.)
+
+![Spielobjekt der Heldenfigur](images/runner/2/hero_game_object.png)
+
+::: sidenote
+Wir behandeln die Kollisionen selbst, weil die Engine eine Newtonsche Simulation der beteiligten Körper ausführen würde, wenn wir den Typ des Kollisionsobjekts der Figur auf dynamisch setzen würden. Für ein Spiel wie dieses ist eine solche Simulation alles andere als optimal. Anstatt der Physik-Engine mit verschiedenen Kräften entgegenzuwirken, übernehmen wir die volle Kontrolle.
+
+Dafür und für eine korrekte Behandlung der Kollisionen brauchen wir ein wenig Vektorrechnung. Eine ausführliche Erklärung zur Auflösung kinematischer Kollisionen findest du in der [Physikdokumentation](/manuals/physics-resolving-collisions/).
+:::
+
+```lua
+-- gravity pulling the player down in pixel units/sˆ2
+local gravity = -20
+
+-- take-off speed when jumping in pixel units/s
+local jump_takeoff_speed = 900
+
+function init(self)
+    -- this tells the engine to send input to on_input() in this script
+    msg.post(".", "acquire_input_focus")
+
+    -- save the starting position
+    self.position = go.get_position()
+
+    -- keep track of movement vector and if there is ground contact
+    self.velocity = vmath.vector3(0, 0, 0)
+    self.ground_contact = false
+end
+
+function final(self)
+    -- Return input focus when the object is deleted
+    msg.post(".", "release_input_focus")
+end
+
+function update(self, dt)
+    local gravity = vmath.vector3(0, gravity, 0)
+
+    if not self.ground_contact then
+        -- Apply gravity if there's no ground contact
+        self.velocity = self.velocity + gravity
+    end
+
+    -- apply velocity to the player character
+    go.set_position(go.get_position() + self.velocity * dt)
+
+    -- reset volatile state
+    self.correction = vmath.vector3()
+    self.ground_contact = false
+end
+
+local function handle_geometry_contact(self, normal, distance)
+    -- project the correction vector onto the contact normal
+    -- (the correction vector is the 0-vector for the first contact point)
+    local proj = vmath.dot(self.correction, normal)
+    -- calculate the compensation we need to make for this contact point
+    local comp = (distance - proj) * normal
+    -- add it to the correction vector
+    self.correction = self.correction + comp
+    -- apply the compensation to the player character
+    go.set_position(go.get_position() + comp)
+    -- check if the normal points enough up to consider the player standing on the ground
+    -- (0.7 is roughly equal to 45 degrees deviation from pure vertical direction)
+    if normal.y > 0.7 then
+        self.ground_contact = true
+    end
+    -- project the velocity onto the normal
+    proj = vmath.dot(self.velocity, normal)
+    -- if the projection is negative, it means that some of the velocity points towards the contact point
+    if proj < 0 then
+        -- remove that component in that case
+        self.velocity = self.velocity - proj * normal
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("contact_point_response") then
+        -- check if we received a contact point message. One message for each contact point
+        if message.group == hash("geometry") then
+            handle_geometry_contact(self, message.normal, message.distance)
+        end
+    end
+end
+
+local function jump(self)
+    -- only allow jump from ground
+    if self.ground_contact then
+        -- set take-off speed
+        self.velocity.y = jump_takeoff_speed
+    end
+end
+
+local function abort_jump(self)
+    -- cut the jump short if we are still going up
+    if self.velocity.y > 0 then
+        -- scale down the upwards speed
+        self.velocity.y = self.velocity.y * 0.5
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("jump") or action_id == hash("touch") then
+        if action.pressed then
+            jump(self)
+        elseif action.released then
+            abort_jump(self)
+        end
+    end
+end
+```
+
+1. Füge das Skript dem Heldenobjekt als *Script*-Komponente hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten von *hero.go* und wähle <kbd>Add Component from File</kbd>, dann die Datei *hero.script*.
+
+Wenn du möchtest, kannst du die Heldenfigur jetzt vorübergehend zur Hauptsammlung hinzufügen und das Spiel starten, um zu sehen, wie sie durch die Welt fällt.
+
+Damit die Heldenfigur funktioniert, fehlen uns nur noch Eingaben. Das obige Skript enthält bereits eine Funktion `on_input()`, die auf die Aktionen "jump" und "touch" (für Touchscreens) reagiert. Fügen wir Eingabebindungen (input bindings) für diese Aktionen hinzu.
+
+1. Öffne "input/game.input_bindings".
+2. Füge einen Tastenauslöser für "KEY_SPACE" hinzu und nenne die Aktion "jump".
+3. Füge einen Berührungsauslöser für "TOUCH_MULTI" hinzu und nenne die Aktion "touch". (Die Aktionsnamen sind frei wählbar, sollten aber mit den Namen in deinem Skript übereinstimmen. Beachte, dass du denselben Aktionsnamen nicht für mehrere Auslöser verwenden kannst.)
+4. Speichere die Datei.
+
+![Eingabebindungen](images/runner/2/input_bindings.png)
+
+## SCHRITT 5 - Das Level umstrukturieren {#step-5-refactoring-the-level}
+
+Jetzt, wo unsere Heldenfigur samt Kollisionen eingerichtet ist, müssen wir auch dem Boden Kollisionen hinzufügen. So bekommt die Figur etwas, mit dem sie kollidieren beziehungsweise auf dem sie laufen kann. Das machen wir gleich. Zunächst sollten wir aber etwas aufräumen: Wir legen alle Levelinhalte in eine separate Sammlung und ordnen die Dateistruktur neu:
+
+1. Erstelle eine neue Datei *level.collection*. Klicke dazu im Bereich *Assets pane* mit der rechten Maustaste auf *main* und wähle <kbd>New ▸ Collection File</kbd>.
+2. Öffne die neue Datei, klicke in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Collection from File</kbd>, dann *ground.collection*.
+3. Klicke in *level.collection* in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Game Object File</kbd>, dann *hero.go*.
+4. Erstelle nun im Stammverzeichnis des Projekts einen neuen Ordner namens *level*. Klicke dazu mit der rechten Maustaste auf die freie Fläche unter *game.project* und wähle <kbd>New ▸ Folder</kbd>. Verschiebe anschließend die bisher erstellten Level-Assets in diesen Ordner: die Dateien *level.collection* und *level.atlas*, den Ordner "images" mit den Bildern für den Level-Atlas sowie die Dateien *ground.collection* und *ground.script*.
+5. Öffne *main.collection*, lösche *ground.collection* und füge stattdessen *level.collection* hinzu, die jetzt die *ground.collection* enthält (Rechtsklick und <kbd>Add Collection from File</kbd>). Achte darauf, die Sammlung an der Position 0, 0, 0 zu platzieren.
+
+::: sidenote
+Wie du vielleicht schon bemerkt hast, ist die Dateihierarchie im Bereich *Assets pane* von der Inhaltsstruktur getrennt, die du in deinen Sammlungen aufbaust. Einzelne Dateien werden aus Sammlungs- und Spielobjektdateien referenziert, ihr Speicherort ist aber völlig frei wählbar.
+
+Wenn du eine Datei an einen neuen Ort verschieben möchtest, hilft Defold dir, indem es die Referenzen auf diese Datei automatisch aktualisiert (Refactoring). Beim Entwickeln komplexer Software wie eines Spiels ist es äußerst hilfreich, die Projektstruktur mit dem wachsenden und sich verändernden Projekt anpassen zu können. Defold unterstützt das und sorgt für einen reibungslosen Ablauf. Du brauchst also keine Scheu davor zu haben, deine Dateien zu verschieben!
+:::
+
+Außerdem sollten wir der Levelsammlung ein Spielobjekt für die Steuerung mit einer Skriptkomponente hinzufügen:
+
+1. Erstelle eine neue Skriptdatei. Klicke im Bereich *Assets pane* mit der rechten Maustaste auf den Ordner *level* und wähle <kbd>New ▸ Script File</kbd>. Nenne die Datei *controller.script*.
+2. Öffne die Skriptdatei, kopiere den folgenden Code hinein und speichere sie:
+
+    ```lua
+    -- controller.script
+    go.property("speed", 360) -- <1>
+
+    function init(self)
+        msg.post("ground/controller#ground", "set_speed", { speed = self.speed })
+    end
+    ```
+    1. Dies ist eine Skripteigenschaft. Wir geben ihr einen Standardwert. Jede platzierte Instanz des Skripts kann diesen Wert jedoch direkt in der Eigenschaftsansicht des Editors überschreiben.
+
+3. Öffne die Datei *level.collection*.
+4. Klicke in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Game Object</kbd>.
+5. Setze *Id* auf "controller".
+6. Klicke in der Ansicht *Outline* mit der rechten Maustaste auf das Spielobjekt "controller" und wähle <kbd>Add Component from File</kbd>. Wähle die Datei *controller.script* im Ordner *level*.
+7. Speichere die Datei.
+
+![Skripteigenschaft](images/runner/2/script_property.png)
+
+::: sidenote
+Das Spielobjekt "controller" liegt nicht in einer eigenen Datei vor, sondern wird direkt in der Levelsammlung erstellt. Die Spielobjektinstanz wird somit aus den dort eingebetteten Daten erzeugt. Für Spielobjekte mit einer einzigen Aufgabe wie dieses ist das in Ordnung. Wenn du mehrere Instanzen eines Spielobjekts brauchst und die Möglichkeit haben möchtest, den Prototyp beziehungsweise die Vorlage anzupassen, aus der jede Instanz entsteht, erstelle einfach eine Spielobjektdatei und füge das Spielobjekt aus dieser Datei zur Sammlung hinzu. Dadurch entsteht ein Spielobjekt, das die Datei als Prototyp beziehungsweise Vorlage referenziert.
+
+Das Spielobjekt "controller" soll alles steuern, was mit dem laufenden Level zusammenhängt. Bald wird dieses Skript Plattformen und Münzen dynamisch erzeugen, mit denen die Heldenfigur interagieren kann. Vorerst legt es aber nur die Geschwindigkeit des Levels fest.
+:::
+
+In seiner Funktion `init()` sendet das Skript zur Levelsteuerung eine Nachricht an die Skriptkomponente des Bodensteuerungsobjekts. Es adressiert sie über ihren Bezeichner:
+
+```lua
+msg.post("ground/controller#controller", "set_speed", { speed = self.speed })
+```
+
+Der Bezeichner des Spielobjekts für die Steuerung lautet `"ground/controller"`, da es in der Sammlung "ground" liegt. Den Komponentenbezeichner `"controller"` hängen wir hinter dem Rautenzeichen `"#"` an, das den Objektbezeichner vom Komponentenbezeichner trennt. Beachte, dass das Bodenskript noch keinen Code enthält, der auf die Nachricht `set_speed` reagiert. Deshalb müssen wir eine Funktion `on_message()` zu *ground.script* hinzufügen und die entsprechende Logik ergänzen.
+
+1. Öffne *ground.script*.
+2. Füge den folgenden Code hinzu und speichere die Datei:
+
+```lua
+-- ground.script
+function on_message(self, message_id, message, sender)
+    if message_id == hash("set_speed") then -- <1>
+        self.speed = message.speed -- <2>
+    end
+end
+```
+1. Alle Nachrichten werden beim Senden intern gehasht und müssen mit dem Hashwert verglichen werden.
+2. Die Nachrichtendaten sind eine Lua-Tabelle mit den Daten, die mit der Nachricht gesendet werden.
+
+![Code für den Boden hinzufügen](images/runner/insert_ground_code.png)
+
+## SCHRITT 6 - Bodenphysik und Plattformen {#step-6-ground-physics-and-platforms}
+
+An dieser Stelle sollten wir physikalische Kollisionen für den Boden hinzufügen:
+
+1. Öffne die Datei *ground.collection*.
+2. Füge einem geeigneten Spielobjekt eine neue *Collision Object*-Komponente hinzu. Da das Bodenskript nicht auf Kollisionen reagiert (die gesamte Logik dafür liegt im Heldenskript), können wir sie in einem beliebigen _unbewegten_ Spielobjekt platzieren. Die Objekte der Bodenkacheln bewegen sich, verwende diese also nicht. Das Spielobjekt "controller" eignet sich gut. Du kannst dafür aber auch ein separates Objekt erstellen, wenn du möchtest. Klicke mit der rechten Maustaste auf das Spielobjekt und wähle <kbd>Add Component</kbd>, dann *Collision Object*.
+3. Füge eine Quaderform hinzu, indem du mit der rechten Maustaste auf die *Collision Object*-Komponente klickst und <kbd>Add Shape</kbd>, dann *Box* wählst.
+4. Verwende das *Move Tool* und das *Scale Tool* (<kbd>Scene ▸ Move Tool</kbd> und <kbd>Scene ▸ Scale Tool</kbd>), damit der Quader alle Bodenkacheln abdeckt.
+5. Setze die Eigenschaft *Type* des Kollisionsobjekts auf "Static", da sich die Physik des Bodens nicht bewegen wird.
+6. Setze die Eigenschaft *Group* des Kollisionsobjekts auf "geometry" und *Mask* auf "hero". Jetzt erkennen dieses Kollisionsobjekt und das der Heldenfigur Kollisionen miteinander.
+7. Speichere die Datei.
+
+![Bodenkollision](images/runner/2/ground_collision.png)
+
+Jetzt solltest du das Spiel probeweise starten können (<kbd>Project ▸ Build</kbd>). Die Heldenfigur sollte auf dem Boden laufen und mit der Taste <kbd>Space</kbd> springen können. Wenn du das Spiel auf einem Mobilgerät ausführst, kannst du durch Tippen auf den Bildschirm springen.
+
+Um das Leben in unserer Spielwelt etwas weniger eintönig zu machen, sollten wir Plattformen hinzufügen, auf die wir springen können.
+
+1. Ziehe die Bilddatei *rock_planks.png* aus dem Asset-Paket in den Unterordner *level/images*.
+2. Öffne *level.atlas* und füge das neue Bild zum Atlas hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Images</kbd>.
+3. Speichere die Datei.
+4. Erstelle im Ordner *level* eine neue *Game Object*-Datei namens *platform.go*. (Klicke im Bereich *Assets pane* mit der rechten Maustaste auf *level* und wähle <kbd>New ▸ Game Object File</kbd>.)
+5. Füge dem Spielobjekt eine *Sprite*-Komponente hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Component</kbd>, dann *Sprite*.
+6. Setze die Eigenschaft *Image* so, dass sie auf die Datei *level.atlas* verweist, und setze *Default Animation* auf "rock_planks". Bewahre die Levelobjekte der Übersicht halber in einem Unterordner "level/objects" auf.
+7. Füge dem Spielobjekt der Plattform eine *Collision Object*-Komponente hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Component</kbd>.
+8. Achte darauf, *Type* der Komponente auf "Kinematic", *Group* auf "geometry" und *Mask* auf "hero" zu setzen.
+9. Füge der *Collision Object*-Komponente eine *Box Shape* hinzu. (Klicke in der Ansicht *Outline* mit der rechten Maustaste auf die Komponente und wähle <kbd>Add Shape</kbd>, dann *Box*.)
+10. Verwende das *Move Tool* und das *Scale Tool* (<kbd>Scene ▸ Move Tool</kbd> und <kbd>Scene ▸ Scale Tool</kbd>), damit die Form in der *Collision Object*-Komponente die Plattform abdeckt.
+11. Erstelle eine *Script*-Datei namens *platform.script*. Klicke dazu im Bereich *Assets pane* mit der rechten Maustaste und wähle <kbd>New ▸ Script File</kbd>. Füge den folgenden Code in die Datei ein und speichere sie:
+
+    ```lua
+    -- platform.script
+    function init(self)
+        self.speed = 540      -- Default speed in pixels/s
+    end
+
+    function update(self, dt)
+        local pos = go.get_position()
+        if pos.x < -500 then
+            go.delete() -- <1>
+        end
+        pos.x = pos.x - self.speed * dt
+        go.set_position(pos)
+    end
+
+    function on_message(self, message_id, message, sender)
+        if message_id == hash("set_speed") then
+            self.speed = message.speed
+        end
+    end
+    ```
+    1. Lösche die Plattform einfach, sobald sie über den rechten Bildschirmrand hinausbewegt wurde.
+
+12. Öffne *platform.go* und füge das neue Skript als Komponente hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Component From File</kbd>, dann *platform.script*.
+13. Kopiere *platform.go* in eine neue Datei. Klicke dazu im Bereich *Assets pane* mit der rechten Maustaste auf die Datei und wähle <kbd>Copy</kbd>. Klicke dann erneut mit der rechten Maustaste und wähle <kbd>Paste</kbd>. Nenne die neue Datei *platform_long.go*.
+14. Öffne *platform_long.go* und füge eine zweite *Sprite*-Komponente hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Component</kbd>. Alternativ kannst du das vorhandene *Sprite* kopieren.
+15. Verwende das *Move Tool* (<kbd>Scene ▸ Move Tool</kbd>), um die *Sprite*-Komponenten nebeneinander zu platzieren.
+16. Verwende das *Move Tool* und das *Scale Tool*, damit die Form in der *Collision Object*-Komponente beide Plattformen abdeckt.
+
+![Plattform](images/runner/2/platform_long.png)
+
+::: sidenote
+Beachte, dass sowohl *platform.go* als auch *platform_long.go* eine *Script*-Komponente haben, die auf dieselbe Skriptdatei verweist. Das ist praktisch, denn jede Änderung an dieser Skriptdatei wirkt sich sowohl auf das Verhalten der normalen als auch der langen Plattformen aus.
+:::
+
+## Plattformen dynamisch erzeugen {#spawning-platforms}
+
+Das Spiel soll ein einfacher Endless Runner werden. Deshalb können wir die Spielobjekte der Plattformen nicht im Editor in einer Sammlung platzieren. Stattdessen müssen wir sie dynamisch erzeugen:
+
+1. Öffne *level.collection*.
+2. Füge dem Spielobjekt "controller" zwei *Factory*-Komponenten hinzu. Klicke dazu mit der rechten Maustaste darauf und wähle <kbd>Add Component</kbd>, dann *Factory*.
+3. Setze die Eigenschaften *Id* der Komponenten auf "platform_factory" und "platform_long_factory".
+4. Setze die Eigenschaft *Prototype* von "platform_factory" auf die Datei */level/objects/platform.go*.
+5. Setze die Eigenschaft *Prototype* von "platform_long_factory" auf die Datei */level/objects/platform_long.go*.
+6. Speichere die Datei.
+7. Öffne die Datei *controller.script*, die das Level verwaltet.
+8. Ändere das Skript so, dass es den folgenden Inhalt hat, und speichere die Datei:
+
+```lua
+-- controller.script
+go.property("speed", 360)
+
+local grid = 460
+local platform_heights = { 100, 200, 350 } -- <1>
+
+function init(self)
+    msg.post("ground/controller#controller", "set_speed", { speed = self.speed })
+    self.gridw = 0
+end
+
+function update(self, dt) -- <2>
+    self.gridw = self.gridw + self.speed * dt
+
+    if self.gridw >= grid then
+        self.gridw = 0
+
+        -- Maybe spawn a platform at random height
+        if math.random() > 0.2 then
+            local h = platform_heights[math.random(#platform_heights)]
+            local f = "#platform_factory"
+            if math.random() > 0.5 then
+                f = "#platform_long_factory"
+            end
+
+            local p = factory.create(f, vmath.vector3(1600, h, 0), nil, {}, vmath.vector3(0.6, 0.6, 1))
+            msg.post(p, "set_speed", { speed = self.speed })
+        end
+    end
+end
+```
+1. Vordefinierte Werte für die Y-Positionen, an denen Plattformen dynamisch erzeugt werden.
+2. Die Funktion `update()` wird einmal pro Frame aufgerufen. Wir nutzen sie, um in bestimmten Abständen (damit keine Überlappungen entstehen) und auf bestimmten Höhen zu entscheiden, ob eine normale oder eine lange Plattform dynamisch erzeugt werden soll. Du kannst leicht mit verschiedenen Algorithmen für die Erzeugung experimentieren, um unterschiedliches Gameplay zu gestalten.
+
+Starte jetzt das Spiel (<kbd>Project ▸ Build</kbd>).
+
+Wow, langsam wird daraus etwas (fast) Spielbares ...
+
+![Das Spiel ausführen](images/runner/2/run_game.png)
+
+## SCHRITT 7 - Animation und Tod {#step-7-animation-and-death}
+
+Als Erstes erwecken wir die Heldenfigur zum Leben. Im Moment steckt die arme Figur in einer endlosen Laufanimation fest und reagiert weder auf Sprünge noch auf andere Ereignisse passend. Die Spine-Datei, die wir aus dem Asset-Paket hinzugefügt haben, enthält bereits mehrere Animationen genau dafür.
+
+1. Öffne die Datei *hero.script* und füge die folgenden Funktionen _vor_ der vorhandenen Funktion `update()` ein:
+
+```lua
+    -- hero.script
+    local function play_animation(self, anim)
+        -- only play animations which are not already playing
+        if self.anim ~= anim then
+            -- tell the spine model to play the animation
+            local anim_props = { blend_duration = 0.15 }
+            spine.play_anim("#spinemodel", anim, go.PLAYBACK_LOOP_FORWARD, anim_props)
+            -- remember which animation is playing
+            self.anim = anim
+        end
+    end
+
+    local function update_animation(self)
+        -- make sure the right animation is playing
+        if self.ground_contact then
+            play_animation(self, hash("run"))
+        else
+            play_animation(self, hash("jump"))
+
+        end
+    end
+```
+
+2. Suche die Funktion `update()` und füge einen Aufruf von `update_animation` hinzu:
+
+```lua
+    ...
+    -- apply it to the player character
+    go.set_position(go.get_position() + self.velocity * dt)
+
+    update_animation(self)
+    ...
+  ```
+
+![Code für die Heldenfigur einfügen](images/runner/insert_hero_code.png)
+
+::: sidenote
+Lua verwendet für lokale Variablen einen „lexikalischen Gültigkeitsbereich“. Deshalb kommt es auf die Reihenfolge an, in der du Funktionen mit `local` anordnest. Die Funktion `update()` ruft die lokalen Funktionen `update_animation()` und `play_animation()` auf. Die Laufzeitumgebung muss diese lokalen Funktionen also bereits kennen, um sie aufrufen zu können. Daher müssen wir die Funktionen vor `update()` platzieren. Wenn du die Reihenfolge der Funktionen vertauschst, erhältst du einen Fehler. Beachte, dass dies nur für `local`-Variablen gilt. Mehr über die Gültigkeitsbereiche und lokalen Funktionen in Lua erfährst du unter http://www.lua.org/pil/6.2.html
+:::
+
+Mehr ist nicht nötig, um der Heldenfigur Sprung- und Fallanimationen hinzuzufügen. Wenn du das Spiel startest, wirst du merken, dass es sich viel besser spielt. Vielleicht fällt dir auch auf, dass die Plattformen die Heldenfigur leider vom Bildschirm schieben können. Das ist eine Nebenwirkung der Kollisionsbehandlung. Die Lösung ist aber einfach: Füge etwas Gewalt hinzu und mache die Kanten der Plattformen gefährlich!
+
+1. Ziehe *spikes.png* aus dem Asset-Paket in den Ordner "level/images" im Bereich *Assets pane*.
+2. Öffne *level.atlas* und füge das Bild hinzu (Rechtsklick und <kbd>Add Images</kbd>).
+3. Öffne *platform.go* und füge einige *Sprite*-Komponenten hinzu. Setze *Image* auf *level.atlas* und *Default Animation* auf "spikes".
+4. Verwende das *Move Tool* und das *Rotate Tool*, um die Stacheln entlang der Plattformkanten zu platzieren.
+5. Damit die Stacheln hinter der Plattform gerendert werden, setze die *Z*-Position der Stachel-Sprites auf -0.1.
+6. Füge den Plattformen eine neue *Collision Object*-Komponente hinzu. Klicke dazu in der Ansicht *Outline* mit der rechten Maustaste auf den obersten Knoten und wähle <kbd>Add Component</kbd>. Setze die Eigenschaft *Group* auf "danger" und *Mask* auf "hero".
+7. Füge dem *Collision Object* eine Quaderform hinzu (Rechtsklick und <kbd>Add Shape</kbd>). Platziere die Form mit dem *Move Tool* (<kbd>Scene ▸ Move Tool</kbd>) und dem *Scale Tool* so, dass die Heldenfigur mit dem Objekt "danger" kollidiert, wenn sie von der Seite oder von unten auf die Plattform trifft.
+8. Speichere die Datei.
+
+    ![Stacheln an der Plattform](images/runner/3/danger_edges.png)
+
+9. Öffne *hero.go*, markiere das *Collision Object* und füge den Namen "danger" zur Eigenschaft *Mask* hinzu. Speichere anschließend die Datei.
+
+    ![Kollision der Heldenfigur](images/runner/3/hero_collision.png)
+
+10. Öffne *hero.script* und ändere die Funktion `on_message()`, damit eine Reaktion erfolgt, wenn die Heldenfigur mit einer "danger"-Kante kollidiert:
+
+    ```lua
+    -- hero.script
+    function on_message(self, message_id, message, sender)
+        if message_id == hash("reset") then
+            self.velocity = vmath.vector3(0, 0, 0)
+            self.correction = vmath.vector3()
+            self.ground_contact = false
+            self.anim = nil
+            go.set(".", "euler.z", 0)
+            go.set_position(self.position)
+            msg.post("#collisionobject", "enable")
+
+        elseif message_id == hash("contact_point_response") then
+            -- check if we received a contact point message
+            if message.group == hash("danger") then
+                -- Die and restart
+                play_animation(self, hash("death"))
+                msg.post("#collisionobject", "disable")
+                -- <1>
+                go.animate(".", "euler.z", go.PLAYBACK_ONCE_FORWARD, 160, go.EASING_LINEAR, 0.7)
+                go.animate(".", "position.y", go.PLAYBACK_ONCE_FORWARD, go.get_position().y - 200, go.EASING_INSINE, 0.5, 0.2,
+                    function()
+                        msg.post("#", "reset")
+                    end)
+            elseif message.group == hash("geometry") then
+                handle_geometry_contact(self, message.normal, message.distance)
+            end
+        end
+    end
+    ```
+    1. Füge eine Drehung und eine Fallbewegung hinzu, wenn die Heldenfigur stirbt. Das lässt sich noch deutlich verbessern!
+
+11. Ändere die Funktion `init()` so, dass sie zum Initialisieren des Objekts eine Nachricht "reset" sendet. Speichere anschließend die Datei:
+
+    ```lua
+    -- hero.script
+    function init(self)
+        -- this lets us handle input in this script
+        msg.post(".", "acquire_input_focus")
+        -- save position
+        self.position = go.get_position()
+        msg.post("#", "reset")
+    end
+    ```
+
+## SCHRITT 8 - Das Level zurücksetzen {#step-8-resetting-the-level}
+
+Wenn du das Spiel jetzt ausprobierst, wird schnell klar, dass das Zurücksetzen nicht richtig funktioniert. Die Heldenfigur selbst wird zwar korrekt zurückgesetzt, aber sie kann dabei leicht in eine Situation geraten, in der sie sofort auf eine Plattformkante fällt und erneut stirbt. Wir möchten beim Tod das gesamte Level richtig zurücksetzen. Da das Level nur aus einer Folge dynamisch erzeugter Plattformen besteht, müssen wir lediglich alle erzeugten Plattformen erfassen und sie beim Zurücksetzen löschen:
+
+1. Öffne die Datei *controller.script* und passe den Code so an, dass er die Bezeichner aller dynamisch erzeugten Plattformen speichert:
+
+    ```lua
+    -- controller.script
+    go.property("speed", 360)
+
+    local grid = 460
+    local platform_heights = { 100, 200, 350 }
+
+    function init(self)
+        msg.post("ground/controller#controller", "set_speed", { speed = self.speed })
+        self.gridw = 0
+        self.spawns = {} -- <1>
+    end
+
+    function update(self, dt)
+        self.gridw = self.gridw + self.speed * dt
+
+        if self.gridw >= grid then
+            self.gridw = 0
+
+            -- Maybe spawn a platform at random height
+            if math.random() > 0.2 then
+                local h = platform_heights[math.random(#platform_heights)]
+                local f = "#platform_factory"
+                if math.random() > 0.5 then
+                    f = "#platform_long_factory"
+                end
+
+                local p = factory.create(f, vmath.vector3(1600, h, 0), nil, {}, vmath.vector3(0.6, 0.6, 1))
+                msg.post(p, "set_speed", { speed = self.speed })
+                table.insert(self.spawns, p) -- <1>
+            end
+        end
+    end
+
+    function on_message(self, message_id, message, sender)
+        if message_id == hash("reset") then -- <2>
+            -- Tell the hero to reset.
+            msg.post("hero#hero", "reset")
+            -- Delete all platforms
+            for i,p in ipairs(self.spawns) do
+                go.delete(p)
+            end
+            self.spawns = {}
+        elseif message_id == hash("delete_spawn") then -- <3>
+            for i,p in ipairs(self.spawns) do
+                if p == message.id then
+                    table.remove(self.spawns, i)
+                    go.delete(p)
+                end
+            end
+        end
+    end
+    ```
+    1. Wir verwenden eine Tabelle, um alle dynamisch erzeugten Plattformen zu speichern.
+    2. Die Nachricht "reset" löscht alle in der Tabelle gespeicherten Plattformen.
+    3. Die Nachricht "delete_spawn" löscht eine bestimmte Plattform und entfernt sie aus der Tabelle.
+
+2. Speichere die Datei.
+3. Öffne *platform.script* und ändere es so, dass es eine Plattform, die den linken Rand erreicht hat, nicht einfach löscht. Stattdessen soll es eine Nachricht an die Levelsteuerung senden und sie auffordern, die Plattform zu entfernen:
+
+    ```lua
+    -- platform.script
+    ...
+    if pos.x < -500 then
+        msg.post("/level/controller#controller", "delete_spawn", { id = go.get_id() })
+    end
+    ...
+    ```
+
+    ![Code für die Plattform einfügen](images/runner/insert_platform_code.png)
+
+4. Speichere die Datei.
+5. Öffne *hero.script*. Als Letztes müssen wir jetzt dem Level mitteilen, dass es sich zurücksetzen soll. Die Nachricht, die die Heldenfigur zum Zurücksetzen auffordert, haben wir in das Skript zur Levelsteuerung verschoben. Es ist sinnvoll, das Zurücksetzen auf diese Weise zentral zu steuern. So können wir beispielsweise leichter eine längere, zeitlich gesteuerte Todessequenz einbauen:
+
+```lua
+-- hero.script
+...
+go.animate(".", "position.y", go.PLAYBACK_ONCE_FORWARD, go.get_position().y - 200, go.EASING_INSINE, 0.5, 0.2,
+    function()
+        msg.post("controller#controller", "reset")
+    end)
+...
+```
+
+![Code für die Heldenfigur einfügen](images/runner/insert_hero_code_2.png)
+
+Damit steht jetzt der grundlegende Ablauf aus Neustart und Tod!
+
+Als Nächstes kommt etwas, für das es sich zu leben lohnt: Münzen!
+
+## SCHRITT 9 - Münzen zum Einsammeln {#step-9-coins-to-collect}
+
+Wir möchten Münzen im Level platzieren, die der Spieler einsammeln kann. Zuerst stellt sich die Frage, wie wir sie ins Level bekommen. Wir könnten beispielsweise ein Verfahren zur dynamischen Erzeugung entwickeln, das auf den Algorithmus zum Erzeugen der Plattformen abgestimmt ist. Letztlich haben wir uns aber für einen viel einfacheren Ansatz entschieden: Die Plattformen selbst erzeugen die Münzen:
+
+1. Ziehe das Bild *coin.png* aus dem Asset-Paket nach "level/images" im Bereich *Assets pane*.
+2. Öffne *level.atlas* und füge das Bild hinzu (Rechtsklick und <kbd>Add Images</kbd>).
+3. Erstelle im Ordner *level* eine *Game Object*-Datei namens *coin.go*. Klicke dazu im Bereich *Assets pane* mit der rechten Maustaste auf *level* und wähle <kbd>New ▸ Game Object File</kbd>.
+4. Öffne *coin.go* und füge eine *Sprite*-Komponente hinzu (Rechtsklick in der Ansicht *Outline* und <kbd>Add Component</kbd>). Setze *Image* auf *level.atlas* und *Default Animation* auf "coin".
+5. Füge ein *Collision Object* hinzu (Rechtsklick in der Ansicht *Outline* und <kbd>Add Component</kbd>)
+und füge eine *Sphere*-Form hinzu, die das Bild abdeckt (Rechtsklick auf die Komponente und <kbd>Add Shape</kbd>).
+6. Verwende das *Move Tool* (<kbd>Scene ▸ Move Tool</kbd>) und das *Scale Tool*, damit die Kugel das Münzbild abdeckt.
+7. Setze *Type* des Kollisionsobjekts auf "Kinematic", *Group* auf "pickup" und *Mask* auf "hero".
+8. Öffne *hero.go* und füge "pickup" zur Eigenschaft *Mask* der *Collision Object*-Komponente hinzu. Speichere anschließend die Datei.
+9. Erstelle eine neue Skriptdatei namens *coin.script*. Klicke dazu im Bereich *Assets pane* mit der rechten Maustaste auf *level* und wähle <kbd>New ▸ Script File</kbd>. Ersetze den Vorlagencode durch Folgendes:
+
+    ```lua
+    -- coin.script
+    function init(self)
+        self.collected = false
+    end
+
+    function on_message(self, message_id, message, sender)
+        if self.collected == false and message_id == hash("collision_response") then
+            self.collected = true
+            msg.post("#sprite", "disable")
+        elseif message_id == hash("start_animation") then
+            pos = go.get_position()
+            go.animate(go.get_id(), "position.y", go.PLAYBACK_LOOP_PINGPONG, pos.y + 24, go.EASING_INOUTSINE, 0.75, message.delay)
+        end
+    end
+    ```
+
+10. Füge dem Münzobjekt die Skriptdatei als *Script*-Komponente hinzu (Rechtsklick auf den obersten Knoten in *Outline* und <kbd>Add Component from File</kbd>).
+
+    ![Spielobjekt der Münze](images/runner/3/coin.png)
+
+Die Münzen sollen von den Plattformobjekten dynamisch erzeugt werden. Füge deshalb Fabriken für die Münzen in *platform.go* und *platform_long.go* ein.
+
+1. Öffne *platform.go* und füge eine *Factory*-Komponente hinzu (Rechtsklick in der Ansicht *Outline* und <kbd>Add Component</kbd>).
+2. Setze die *Id* der *Factory* auf "coin_factory" und ihren *Prototype* auf die Datei *coin.go*.
+3. Öffne nun *platform_long.go* und erstelle eine identische *Factory*-Komponente.
+4. Speichere beide Dateien.
+
+![Münzfabrik](images/runner/3/coin_factory.png)
+
+Jetzt müssen wir *platform.script* so ändern, dass es die Münzen dynamisch erzeugt und löscht:
+
+```lua
+-- platform.script
+function init(self)
+    self.speed = 540     -- Default speed in pixels/s
+    self.coins = {}
+end
+
+function final(self)
+    for i,p in ipairs(self.coins) do
+        go.delete(p)
+    end
+end
+
+function update(self, dt)
+    local pos = go.get_position()
+    if pos.x < -500 then
+        msg.post("/level/controller#controller", "delete_spawn", { id = go.get_id() })
+    end
+    pos.x = pos.x - self.speed * dt
+    go.set_position(pos)
+end
+
+function create_coins(self, params)
+    local spacing = 56
+    local pos = go.get_position()
+    local x = pos.x - params.coins * (spacing*0.5) - 24
+    for i = 1, params.coins do
+        local coin = factory.create("#coin_factory", vmath.vector3(x + i * spacing , pos.y + 64, 1))
+        msg.post(coin, "set_parent", { parent_id = go.get_id() }) -- <1>
+        msg.post(coin, "start_animation", { delay = i/10 }) -- <2>
+        table.insert(self.coins, coin)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("set_speed") then
+        self.speed = message.speed
+    elseif message_id == hash("create_coins") then
+        create_coins(self, message)
+    end
+end
+```
+1. Indem wir die Plattform als übergeordnetes Objekt der dynamisch erzeugten Münze festlegen, bewegt sich die Münze mit der Plattform.
+2. Die Animation lässt die Münzen auf und ab tanzen, relativ zur Plattform, die jetzt ihr übergeordnetes Objekt ist.
+
+::: sidenote
+Eltern-Kind-Beziehungen verändern ausschließlich den _Szenengraphen_. Ein untergeordnetes Objekt wird zusammen mit seinem übergeordneten Objekt transformiert, also verschoben, skaliert oder gedreht. Wenn du zusätzliche „Besitzbeziehungen“ zwischen Spielobjekten benötigst, musst du diese ausdrücklich im Code verwalten.
+:::
+
+Als letzten Schritt dieses Tutorials fügen wir einige Zeilen zu *controller.script* hinzu:
+
+```lua
+-- controller.script
+...
+local platform_heights = { 100, 200, 350 }
+local coins = 3 -- <1>
+...
+```
+1. Die Anzahl der Münzen, die auf einer normalen Plattform dynamisch erzeugt werden sollen.
+
+```lua
+-- controller.script
+...
+local coins = coins
+if math.random() > 0.5 then
+    f = "#platform_long_factory"
+    coins = coins * 2 -- Twice the number of coins on long platforms
+end
+...
+```
+
+```lua
+-- controller.script
+...
+msg.post(p, "set_speed", { speed = self.speed })
+msg.post(p, "create_coins", { coins = coins })
+table.insert(self.spawns, p)
+...
+```
+
+![Code für die Steuerung einfügen](images/runner/insert_controller_code.png)
+
+Jetzt haben wir ein einfaches, aber funktionsfähiges Spiel! Wenn du es bis hierher geschafft hast, möchtest du vielleicht selbstständig weitermachen und Folgendes hinzufügen:
+
+1. Ein Punktesystem und Lebenszähler
+2. Partikeleffekte für Sammelobjekte und den Tod
+3. Ansprechende Hintergrundbilder
+
+> Lade die fertige Version des Projekts [hier](images/runner/sample-runner.zip) herunter.
+
+Damit endet dieses einführende Tutorial. Leg jetzt los und erkunde Defold. Wir haben viele [Handbücher und Tutorials](//www.defold.com/learn) vorbereitet, die dich unterstützen. Wenn du nicht weiterkommst, bist du im [Forum](//forum.defold.com) willkommen.
+
+Viel Spaß mit Defold!

--- a/docs/de/tutorials/shadertoy.md
+++ b/docs/de/tutorials/shadertoy.md
@@ -1,0 +1,340 @@
+---
+brief: In diesem Tutorial passt du einen Shader von shadertoy.com für Defold an.
+layout: tutorial
+locale: de
+title: Tutorial zur Übertragung von Shadertoy nach Defold
+---
+
+# Shadertoy-Tutorial
+
+[Shadertoy.com](https://www.shadertoy.com/) ist eine Website, die von Nutzern beigesteuerte GL-Shader sammelt. Sie ist eine hervorragende Quelle für Shader-Code und Inspiration. In diesem Tutorial nehmen wir einen Shader von Shadertoy und bringen ihn in Defold zum Laufen. Grundkenntnisse über Shader werden vorausgesetzt. Falls du dich erst einlesen möchtest, ist [das Shader-Handbuch](/manuals/shader/) ein guter Einstieg.
+
+Wir verwenden den Shader [Star Nest](https://www.shadertoy.com/view/XlfGRj) von Pablo Andrioli (Benutzer „Kali“ auf Shadertoy). Er ist ein rein prozeduraler Fragment-Shader, der mit mathematischer schwarzer Magie einen wirklich coolen Sternenfeldeffekt rendert.
+
+![Star Nest](../images/shadertoy/starnest.png)
+
+Der Shader besteht aus nur 65 Zeilen ziemlich kompliziertem GLSL-Code, aber keine Sorge. Wir behandeln ihn als Blackbox, die ihre Arbeit auf Grundlage einiger einfacher Eingaben erledigt. Unsere Aufgabe ist es, den Shader so anzupassen, dass er mit Defold statt mit Shadertoy zusammenarbeitet.
+
+## Ein Objekt zum Texturieren {#something-to-texture}
+
+Der Star-Nest-Shader ist ein reiner Fragment-Shader. Wir brauchen daher nur etwas, das der Shader texturieren kann. Dafür gibt es mehrere Möglichkeiten: ein Sprite, eine Kachelkarte (tile map), eine GUI oder ein Modell. In diesem Tutorial verwenden wir ein einfaches 3D-Modell. So können wir das Rendering des Modells leicht in einen Vollbildeffekt verwandeln – das brauchen wir beispielsweise für eine visuelle Nachbearbeitung.
+
+Wir können mit einem leeren Projekt beginnen.
+
+1. Öffne Defold und wähle Create From *Templates*.
+2. Wähle *Empty Project*.
+3. Lege den *Title* fest und wähle unter *Location* einen Speicherort auf deinem Datenträger.
+4. Klicke auf <kbd>Create New Project</kbd>.
+
+![Start](../images/shadertoy/empty_project.png)
+
+Du kannst das integrierte Mesh `quad.gltf` aus `builtins/assets/meshes` verwenden.
+
+Optional kannst du auch in Blender oder einem anderen 3D-Modellierungsprogramm ein Mesh in Form einer quadratischen Ebene erstellen – der Einfachheit halber liegen die Koordinaten der 4 Vertices bei -1 und 1 auf der X-Achse sowie bei -1 und 1 auf der Y-Achse. In Blender zeigt die Z-Achse standardmäßig nach oben. Deshalb musst du das Mesh um 90° um die X-Achse drehen. Du solltest außerdem darauf achten, korrekte UV-Koordinaten für das Mesh zu erzeugen. Wechsle in Blender bei ausgewähltem Mesh in den *Edit Mode* und wähle dann <kbd>Mesh ▸ UV unwrap... ▸ Unwrap</kbd>.
+
+<div class='sidenote' markdown='1'>
+Blender ist eine kostenlose Open-Source-3D-Software, die du von [blender.org](https://www.blender.org) herunterladen kannst.
+</div>
+
+![Quad in Blender](../images/shadertoy/quad_blender.png)
+
+1. Öffne deine Datei „main.collection“ in Defold und erstelle ein neues Spielobjekt (game object) namens „star-nest“.
+2. Füge dem Spielobjekt „star-nest“ eine Komponente (component) vom Typ *Model* hinzu.
+3. Setze die Eigenschaft *Mesh* auf unser `quad.gltf`.
+4. Wir müssen das Material für das Modell festlegen. Wähle dafür zunächst das integrierte `model.material`.
+
+Das Modell sollte im Szeneneditor erscheinen, wird aber vollständig schwarz gerendert. Das liegt daran, dass noch keine Textur zugewiesen ist:
+
+![Quad in Defold](../images/shadertoy/quad_default_material.png)
+
+## Das Material erstellen {#creating-the-material}
+
+1. Erstelle eine neue Materialdatei *`star-nest.material`*, indem du im Bereich `Assets` mit der <kbd>rechten Maustaste</kbd> auf den Ordner `main` klickst, <kbd>New</kbd>-><kbd>Material</kbd> wählst und sie `star-nest` nennst.
+
+ ![Material](../images/shadertoy/new_material.png)
+
+2. Erstelle auf dieselbe Weise ein Vertex-Shader-Programm `star-nest.vp` und ein Fragment-Shader-Programm `star-nest.fp`:
+3. Öffne die Datei *star-nest.material*.
+4. Setze *Vertex Program* auf `star-nest.vp`.
+5. Setze *Fragment Program* auf `star-nest.fp`.
+6. Füge eine *Vertex Constant* hinzu, nenne sie „`view_proj`“ und gib ihr den Typ `Viewproj` (für „Ansichtsprojektion“).
+8. Füge unter *Tags* das Tag „tile“ hinzu. So wird das Quad in den Renderdurchlauf aufgenommen, in dem Sprites und Kacheln gezeichnet werden.
+
+ ![Material](../images/shadertoy/material.png)
+
+### Vertex-Programm {#vertex-program}
+
+1. Öffne die Datei `star-nest.vp` des Vertex-Shader-Programms. Sie sollte den folgenden Code enthalten:
+
+    ```glsl
+    #version 140
+
+    // positions are in world space
+    in vec4 position;
+    in vec2 texcoord0;
+
+    out vec2 var_texcoord0;
+
+    uniform vertex_inputs
+    {
+        mat4 view_proj;
+    };
+
+    void main()
+    {
+        gl_Position = view_proj * vec4(position.xyz, 1.0);
+        var_texcoord0 = texcoord0;
+    }
+    ```
+
+### Fragment-Programm {#fragment-program}
+
+1. Öffne die Datei `star-nest.fp` des Fragment-Shader-Programms und ändere den Code so, dass die Fragmentfarbe anhand der X- und Y-Werte der UV-Koordinaten (`var_texcoord0`) gesetzt wird. So stellen wir sicher, dass wir das Modell korrekt eingerichtet haben:
+
+    ```glsl
+    #version 140
+
+    in vec2 var_texcoord0;
+
+    out vec4 out_fragColor;
+
+    void main()
+    {
+        out_fragColor = vec4(var_texcoord0.xy, 0.0, 1.0);
+    }
+    ```
+
+2. Setze die Eigenschaft `Material` der Modellkomponente im Spielobjekt `star-nest` in der Sammlung (collection) `main.collection` auf unser neu erstelltes Material `star-nest`.
+
+Jetzt sollte der Editor das Modell mit dem neuen Shader rendern, und wir können deutlich erkennen, ob die UV-Koordinaten korrekt sind: Die linke untere Ecke sollte schwarz (0, 0, 0), die linke obere Ecke grün (0, 1, 0), die rechte obere Ecke gelb (1, 1, 0) und die rechte untere Ecke rot (1, 0, 0) sein:
+
+![Quad in Defold](../images/shadertoy/quad_material.png)
+
+## Kamera {#camera}
+
+Wir können unser Projekt jetzt ausführen (<kbd>Project</kbd>-><kbd>Build</kbd> oder die Tastenkombination <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>B</kbd>), sehen aber einen schwarzen Bildschirm (na ja, fast – abgesehen von vielleicht einem winzigen Pixel in der linken unteren Ecke). Das liegt daran, dass es keine Kamera gibt und das Standard-Render-Skript auf eine einfache Ersatzdarstellung zurückgreift. Diese zeigt einen riesigen 2D-Raum, während unser Modell an Position (0,0,0) steht und eine Breite von nur 1 hat.
+
+Fügen wir ein Spielobjekt mit einer Kamerakomponente hinzu, um festzulegen, was wir im Spiel sehen werden.
+
+1. Füge ein Spielobjekt namens `camera` an Position (0,0,1) hinzu. (Es ist wichtig, die Z-Koordinate auf 1 zu setzen, damit dieses Spielobjekt vor unserem Modell liegt, denn die Z-Achse zeigt in der standardmäßigen 2D-Konfiguration auf uns zu).
+2. Füge eine Komponente vom Typ `Camera` hinzu. Daraufhin siehst du eine Kameravorschau mit unserem Quad darin. In dieser Konfiguration haben wir das Glück, dass die Standardeigenschaften bereits passen und wir das korrekte Ergebnis sehen sollten. Eine einzige Sache können wir noch ändern: Wir brauchen kein so großes Sichtvolumen der Kamera und können daher `Far Z` auf `2` reduzieren.
+
+![Kamera](../images/shadertoy/camera.png)
+
+Optional können wir den Kameratyp ändern, indem wir `Orthographic Projection` auf `true` setzen und anschließend auch `Orthographic Zoom` auf einen Wert wie 600 einstellen. In diesem Fall wird das Seitenverhältnis jedoch nicht automatisch angepasst, sodass unser Modell den Bildschirm nicht ausfüllt.
+
+## Der Star-Nest-Shader {#the-star-nest-shader}
+
+Jetzt ist alles vorbereitet, und wir können mit dem eigentlichen Shader-Code beginnen. Sehen wir uns zunächst den Originalcode an. Er besteht aus mehreren Abschnitten:
+
+![Code des Star-Nest-Shaders](../images/shadertoy/starnest_code.png)
+
+Wir verwenden eine moderne Pipeline mit GLSL in Version 140. Dazu geben wir die Version am Anfang der Datei mit `#version 140` an.
+
+1. Die Zeilen 5--18 definieren eine Reihe von Konstanten. Wir können sie unverändert lassen. Es sind gewöhnliche GLSL-Konstanten, die weder speziell von Shadertoy noch von Defold abhängen.
+
+2. Die Zeilen 21 und 63 enthalten die X- und Y-Texturkoordinaten des Eingabefragments im Bildschirmkoordinatensystem (`in vec2 fragCoord`) und die Fragmentfarbe der Ausgabe (`out vec4 fragColor`).
+
+    Defold übergibt Texturkoordinaten vom Vertex-Shader an den Fragment-Shader über eine interpolierte Variable als UV-Koordinaten (im Bereich 0--1). In unserem Vertex-Shader wird diese mit einem `out`-Qualifizierer deklariert:
+
+    ```glsl
+    // in star-nest.vp
+    out vec2 var_texcoord0;
+    ```
+
+     Im Fragment-Shader wird derselbe Wert mit einem `in`-Qualifizierer empfangen:
+
+    ```glsl
+    // in star-nest.fp
+    in vec2 var_texcoord0;
+    ```
+
+    Anschließend deklarieren wir in GLSL 140 mit dem `out`-Qualifizierer eine explizite Fragmentausgabe:
+
+    ```glsl
+    // in star-nest.fp
+    out vec4 out_fragColor;
+    ```
+
+    Wo der ursprüngliche Shadertoy-Code in `fragColor` schreibt, schreibt unser Defold-Shader also in `out_fragColor`.
+
+3. Die Zeilen 23--27 legen die Abmessungen der Textur sowie die Bewegungsrichtung und die skalierte Zeit fest. In Shadertoy erhält der Shader die Pixelposition über `fragCoord`, und die Auflösung des Ansichtsbereichs (viewport) beziehungsweise der Textur wird als `uniform vec3 iResolution` an den Shader übergeben. Aus den Fragmentkoordinaten und der Auflösung berechnet der Shader Koordinaten im Stil von UV-Koordinaten mit dem richtigen Seitenverhältnis. Außerdem werden einige auflösungsbezogene Verschiebungen vorgenommen, um einen schöneren Bildausschnitt zu erhalten.
+
+    In Defold gehen wir nicht von Pixelkoordinaten aus. Stattdessen erhalten wir vom Vertex-Shader über `var_texcoord0` bereits normalisierte UV-Koordinaten. Diese Koordinaten liegen über das gerenderte Quad hinweg im Bereich von `0.0` bis `1.0`.
+
+    In der Defold-Version müssen diese Berechnungen angepasst werden, damit sie die UV-Koordinaten aus `var_texcoord0` verwenden.
+    Eine typische Umrechnung sieht so aus:
+
+    ```glsl
+    vec2 uv = var_texcoord0.xy;
+    uv = uv * 2.0 - 1.0;
+    uv.x *= aspect;
+    ```
+    Der genaue Wert von `aspect` hängt vom Aufbau des Beispiels ab. Wird der Effekt auf einem Quad gerendert, das bei bekannter Anzeigegröße den gesamten Bildschirm ausfüllt, kann das Seitenverhältnis für das Tutorial fest im Code vorgegeben werden. Soll der Effekt beliebige Fenstergrößen unterstützen, übergib die Auflösung als Fragmentkonstante und platziere sie in einem GLSL-140-Uniform-Block.
+
+    Hier wird auch die Zeit eingerichtet. Sie wird als `uniform float iGlobalTime` an den Shader übergeben. Defold stellt Shadern seit Version 1.12.3 die Zeit über eine spezielle `Time`-Konstante bereit, die wir verwenden werden.
+
+    In aktuellen Defold-Versionen werden nicht opake Uniforms innerhalb von Uniform-Blöcken deklariert.
+    Im Fragment-Shader deklarieren wir sie so:
+
+    ```glsl
+    uniform fragment_inputs
+    {
+        vec4 time;
+    };
+    ```
+
+    Anschließend fügen wir in `star-nest.material` eine Fragment Constant namens `time` hinzu und setzen ihren Typ auf `Time`.
+
+    Der Wert kann dann so verwendet werden:
+
+    ```glsl
+    float iGlobalTime = time.x;
+    float dt = time.y;
+    ```
+    Dabei ist `time.x` die Zeit seit dem Start der Engine und `time.y` die seit dem vorherigen Frame vergangene Zeit.
+
+4. Die Zeilen 29--39 richten die Drehung des volumetrischen Renderings ein, wobei die Mausposition die Drehung beeinflusst. Die Mauskoordinaten werden als `uniform vec4 iMouse` an den Shader übergeben.
+
+    In diesem Tutorial lassen wir die Mauseingabe weg.
+
+5. Die Zeilen 41--62 bilden den Kern des Shaders. Wir können diesen Code unverändert lassen.
+
+## Der angepasste Star-Nest-Shader {#the-modified-star-nest-shader}
+
+Wenn wir die obigen Abschnitte durchgehen und die erforderlichen Änderungen vornehmen, erhalten wir den folgenden Shader-Code. Er wurde für eine bessere Lesbarkeit etwas aufgeräumt. Die Unterschiede zwischen der Defold- und der Shadertoy-Version sind gekennzeichnet:
+
+```glsl
+#version 140 // <1>
+
+// Star Nest by Pablo Román Andrioli
+// This content is under the MIT License.
+
+#define iterations 17
+#define formuparam 0.53
+
+#define volsteps 20
+#define stepsize 0.1
+
+#define zoom   0.800
+#define tile   0.850
+#define speed  0.010
+
+#define brightness 0.0015
+#define darkmatter 0.300
+#define distfading 0.730
+#define saturation 0.850
+
+in vec2 var_texcoord0; // <2>
+
+out vec4 out_fragColor; // <3>
+
+uniform fragment_inputs // <4>
+{
+	vec4 time;
+};
+
+void main() // <5>
+{
+	// get coords and direction
+	vec2 res = vec2(1.0, 1.0); // <6>
+	vec2 uv = var_texcoord0.xy * res.xy - 0.5;
+	vec3 dir = vec3(uv * zoom, 1.0);
+
+	float iGlobalTime = time.x; // <7>
+	float shader_time = iGlobalTime * speed;
+
+	float a1 = 0.5; // <8>
+	float a2 = 0.8;
+	mat2 rot1 = mat2(cos(a1), sin(a1), -sin(a1), cos(a1));
+	mat2 rot2 = mat2(cos(a2), sin(a2), -sin(a2), cos(a2));
+
+	dir.xz *= rot1;
+	dir.xy *= rot2;
+
+	vec3 from = vec3(1.0, 0.5, 0.5);
+	from += vec3(shader_time * 2.0, shader_time, -2.0);
+	from.xz *= rot1;
+	from.xy *= rot2;
+
+	// volumetric rendering
+	float s = 0.1;
+	float fade = 1.0;
+	vec3 v = vec3(0.0);
+
+	for (int r = 0; r < volsteps; r++) {
+		vec3 p = from + s * dir * 0.5;
+
+		// tiling fold
+		p = abs(vec3(tile) - mod(p, vec3(tile * 2.0)));
+
+		float pa = 0.0;
+		float a = 0.0;
+
+		for (int i = 0; i < iterations; i++) {
+			// the magic formula
+			p = abs(p) / dot(p, p) - formuparam;
+
+			// absolute sum of average change
+			a += abs(length(p) - pa);
+			pa = length(p);
+		}
+
+		// dark matter
+		float dm = max(0.0, darkmatter - a * a * 0.001);
+
+		a *= a * a;
+
+		// dark matter, don't render near
+		if (r > 6) {
+			fade *= 1.0 - dm;
+		}
+
+		v += fade;
+
+		// coloring based on distance
+		v += vec3(s, s * s, s * s * s * s) * a * brightness * fade;
+
+		fade *= distfading;
+		s += stepsize;
+	}
+
+	// color adjust
+	v = mix(vec3(length(v)), v, saturation);
+
+	out_fragColor = vec4(v * 0.01, 1.0); // <9>
+}
+```
+
+1. Wir geben am Anfang der Datei #version 140 an, um Defolds moderne GLSL-Pipeline zu verwenden. Die Konstantendefinitionen lassen wir anschließend unverändert.
+2. Der Vertex-Shader übergibt UV-Koordinaten über var_texcoord0 an den Fragment-Shader. In GLSL 140 empfängt der Fragment-Shader diesen interpolierten Wert mit in als Qualifizierer.
+3. In GLSL 140 sollte der Fragment-Shader eine explizite Ausgabevariable deklarieren, statt in gl_FragColor zu schreiben. Hier verwenden wir out vec4 out_fragColor.
+4. Defolds Materialkonstante Time wird dem Shader über einen Uniform-Block zugänglich gemacht. Füge in star-nest.material eine Fragment Constant namens time hinzu und setze ihren Typ auf Time.
+5. Shadertoy verwendet mainImage(out vec4 fragColor, in vec2 fragCoord). In Defold verwenden wir den normalen Einstiegspunkt void main(), lesen die interpolierten UV-Koordinaten aus var_texcoord0 und schreiben die endgültige Farbe in out_fragColor.
+6. Für dieses Tutorial definieren wir einen festen Wert für Auflösung und Seitenverhältnis des Renderings. Das Modell ist derzeit quadratisch, daher können wir vec2 res = vec2(1.0, 1.0); verwenden. Bei einem rechteckigen Modell mit den Abmessungen 1280 × 720 könnten wir stattdessen vec2 res = vec2(1.78, 1.0); verwenden und die UV-Koordinaten damit multiplizieren, um das korrekte Seitenverhältnis beizubehalten.
+7. Der ursprüngliche Shadertoy-Shader verwendet iGlobalTime. In dieser Defold-Version enthält time.x die Zeit seit dem Start der Engine. Deshalb weisen wir sie einer lokalen Variablen iGlobalTime zu und verwenden sie, um die Kamerabewegung durch das Sternenfeld zu animieren.
+8. Wir halten dieses Tutorial einfach, indem wir die iMouse-Werte vollständig entfernen. Die Drehung selbst behalten wir bei, da sie die visuelle Symmetrie im volumetrischen Rendering verringert.
+9. Abschließend schreibt der Shader die resultierende Fragmentfarbe in out_fragColor.
+
+Speichere das Fragment-Shader-Programm. Das Modell sollte jetzt im Szeneneditor und zur Laufzeit mit einem schönen Sternenfeld texturiert sein:
+
+![Quad mit Star Nest](../images/shadertoy/quad_starnest.png)
+
+
+## Animation
+
+Das letzte Puzzleteil ist die Zeit, mit der wir die Sterne in Bewegung versetzen. Defold stellt sie seit Version 1.12.3 automatisch über eine Fragmentkonstante vom Typ `Time` bereit.
+
+1. Öffne *star-nest.material*.
+2. Füge eine *Fragment Constant* hinzu und nenne sie „time“.
+3. Setze ihren *Type* auf `Time`.
+
+![Zeitkonstante](../images/shadertoy/time_constant.png)
+
+Das ist alles! Den Wert `time` verarbeiten wir bereits im Fragment-Shader. Wir sind fertig!
+
+## Übungen {#exercises}
+
+Eine unterhaltsame weiterführende Übung ist es, dem Shader die ursprüngliche Eingabe durch Mausbewegungen hinzuzufügen. Dafür musst du eine neue Fragment Constant erstellen, diesmal vom Typ `User`. Aktualisiere sie in `on_input` in einem Skript, das Mausbewegungen erkennt, indem du mit der Funktion `go.set()` die Eingabekoordinaten der neuen Konstante zuweist.
+
+Viel Spaß mit Defold!

--- a/docs/de/tutorials/side-scroller.md
+++ b/docs/de/tutorials/side-scroller.md
@@ -1,0 +1,27 @@
+---
+title: Side-Scroller-Tutorial
+brief: Dieses Tutorial gibt dir einen ersten Einblick in die Spieleentwicklung mit Defold. Du erstellst ein neues Projekt auf Grundlage eines einfachen Side-Scrollers. Anschließend lernst du, wie du das Spiel anpassen kannst, damit es mehr Spaß macht. Zum Schluss fügst du ein neues Spielobjekt (game object) hinzu. Das Tutorial sollte nur etwa 10 Minuten dauern.
+github: https://github.com/defold/tutorial-side-scroller
+---
+
+# Side-Scroller-Tutorial
+
+
+Das Tutorial ist in den Defold-Editor integriert und leicht zugänglich:
+
+Starte Defold und:
+1. Wähle links `Create From` ▸ `TUTORIALS`.
+2. Wähle „Side Scroller Tutorial“.
+3. Benenne das Projekt um, wenn du möchtest.
+4. Wähle einen Speicherort für das Projekt auf deinem lokalen Laufwerk.
+5. Klicke auf `Create New Project`.
+
+![Neues Projekt](images/new-side-scroller.webp)
+
+Der Editor öffnet automatisch die Datei „README“ aus dem Stammverzeichnis des Projekts, die den vollständigen Tutorialtext enthält.
+
+![Symbol](images/icon-tutorial.svg){.icon} [Du kannst den vollständigen Tutorialtext auch auf GitHub lesen](https://github.com/defold/tutorial-side-scroller)
+
+Wenn du nicht weiterkommst, besuche das [Defold-Forum](//forum.defold.com). Dort helfen dir das Defold-Team und viele freundliche Nutzer.
+
+Viel Spaß mit Defold!

--- a/docs/de/tutorials/snake.md
+++ b/docs/de/tutorials/snake.md
@@ -1,0 +1,659 @@
+---
+brief: Wenn du Defold noch nicht kennst, hilft dir diese Anleitung beim Einstieg in die Skriptlogik und einige Bausteine von Defold, mit denen du einen Snake-Klon von Grund auf erstellst.
+layout: tutorial
+title: Ein Snake-Spiel in Defold erstellen
+difficulty: Beginner
+---
+
+# Snake
+
+Dieses Tutorial führt dich durch die Entwicklung eines der bekanntesten Spieleklassiker, die du nachbauen kannst. Es gibt viele Varianten dieses Spiels. In dieser Variante frisst eine Schlange „Futter“ und wächst nur beim Fressen. Außerdem bewegt sie sich über ein Spielfeld mit Hindernissen.
+
+![Vorschaubild](images/snake/thumbnail.png)
+
+### Was du lernen wirst {#what-youll-learn}
+
+In diesem Tutorial lernst du, wie du:
+- In Defold ein Spiel von Grund auf erstellst
+- Eingaben einrichtest und verarbeitest
+- Kachelkarten (tile maps) erstellst und sie zur Laufzeit änderst
+- Skripte in Lua schreibst
+
+### Ein Hinweis für Einsteiger {#a-note-for-beginners}
+
+Dieses Tutorial richtet sich an Einsteiger. Wenn du aber mit Defold und der Spieleentwicklung noch gar nicht vertraut bist, empfehlen wir dir, zuerst einige einführende Handbücher zu lesen, insbesondere über [Defolds Bausteine](/manuals/building-blocks/) und das [Glossar](/manuals/glossary/). Falls du Defold noch nicht heruntergeladen hast, sieh dir das [Installationshandbuch](/manuals/install/) an. Empfehlenswert ist auch die [Übersicht des Editors](/manuals/editor/), um dich schnell im Editor zurechtzufinden. Hier zeigen wir aber ebenfalls Bildschirmaufnahmen zu jedem Schritt.
+
+## Das Projekt erstellen {#creating-the-project}
+
+Starte Defold und:
+
+1. Wähle auf der linken Seite *Create From* ▸ *Templates*.
+2. Wähle *Empty Project*.
+3. Gib im Feld *Title* einen Projektnamen ein.
+4. Wähle unter *Location* einen Speicherort für das Projekt.
+5. Klicke auf *Create New Project*.
+
+![Projekt erstellen](images/snake/1.png)
+
+<input type="checkbox"/> Erledigt!
+
+## Projekteinstellungen {#project-settings}
+
+Zuerst legen wir die Auflösung des Spiels fest.
+
+1. Suche nach dem Öffnen des Editors auf der linken Seite im Bereich *Assets* nach der Datei `game.project`. Doppelklicke darauf, um sie zu öffnen.
+2. Gehe zum Abschnitt *Display* der Datei `game.project`.
+3. Setze die Abmessungen des Spiels (`Width` und `Height`) auf 768 × 768 oder ein anderes Vielfaches von 16.
+
+![Anzeigeeinstellungen](images/snake/2.png)
+
+Das ist sinnvoll, weil das Spiel auf einem Raster gezeichnet wird, in dem jedes Segment 16 × 16 Pixel groß ist. So schneidet der Spielbildschirm keine Segmente teilweise ab. Die Datei `game.project` enthält alle wichtigen Einstellungen des Projekts. Du kannst sie im [Handbuch zu den Projekteinstellungen](/manuals/project-settings/) nachlesen.
+
+<input type="checkbox"/> Erledigt!
+
+## Neue Ordner im Bereich Assets erstellen {#creating-new-folders-in-the-assets-pane}
+
+Für einen minimalistischen Snake-Klon brauchst du nur wenig Grafik: ein grünes Segment mit 16 × 16 Pixeln für die Schlange, einen weißen Block für die Hindernisse und einen kleineren roten Block, der das Futter darstellt.
+
+Erstelle zuerst im Defold-Editor ein Verzeichnis für die Assets:
+
+1. Klicke mit der <kbd>rechten Maustaste</kbd> auf den Ordner `main`
+2. Wähle `New Folder`.
+3. Ein Popup fragt nach einem Namen. Gib `assets` ein und klicke auf `Create Folder`.
+
+![Neuer Ordner](images/snake/3.png)
+
+<input type="checkbox"/> Erledigt!
+
+## Dem Spiel Grafiken hinzufügen {#adding-graphics-to-the-game}
+
+Das folgende Bild ist das einzige Asset, das du brauchst:
+
+![Snake-Sprites](images/snake/snake.png)
+
+1. Klicke mit der <kbd>rechten Maustaste</kbd> auf das Bild oben und speichere es auf deinem lokalen Datenträger. Ziehe das heruntergeladene Bild anschließend an den gerade erstellten Ort im Projektordner und lege es dort ab (oder kopiere es und füge es dort ein).
+
+![Neuer Ordner](images/snake/4.png)
+
+Weitere Einzelheiten zum [Importieren von Assets findest du hier](/manuals/importing-graphics/).
+
+<input type="checkbox"/> Erledigt!
+
+## Eine Kachelquelle hinzufügen {#adding-a-tile-source}
+
+Defold bietet eine integrierte Komponente (component) für [Kachelkarten](/manuals/tilemap/), mit der du das Spielfeld aus *Kacheln* erstellst, die in einem Raster angeordnet sind. Eine Kachelkarte ermöglicht es dir, einzelne Kacheln zu setzen und auszulesen, was perfekt zu diesem Spiel passt. Da Kachelkarten ihre Grafiken aus einer [Kachelquelle](/manuals/tilesource/) (tile source) beziehen, musst du eine erstellen:
+
+1. Klicke mit der <kbd>rechten Maustaste</kbd> auf den Ordner `assets`.
+2. Wähle `New` ▸ `Tile Source` im Abschnitt „Resources“.
+3. Nenne die neue Datei „snake“ (der Editor speichert die Datei als `snake.tilesource`).
+
+![Neue Kachelquelle](images/snake/5.png)
+
+Die Kachelquelle öffnet sich in einem eigenen Kachelquelleneditor für diesen Dateityp. Du wirst aufgefordert, ein Bild dafür anzugeben, damit sie funktioniert. Auf der rechten Seite findest du den Bereich `Properties`:
+
+4. Setze die Eigenschaft `Image` auf die gerade importierte Grafikdatei.
+![Kachelquelle](images/snake/6.png)
+
+5. Die Eigenschaften `Width` und `Height` sollten auf 16 (dem Standardwert) bleiben. Dadurch wird das 32 × 32 Pixel große Bild in 4 Kacheln mit den Nummern 1–4 aufgeteilt.
+
+![Eigenschaften der Kachelquelle](images/snake/7.png)
+
+Beachte, dass die Eigenschaft *Extrude Borders* auf 2 Pixel gesetzt ist. Das verhindert Bildfehler an den Rändern von Kacheln, deren Grafik bis ganz an den Rand reicht.
+
+Wenn du eine Datei änderst, erscheint neben ihrem Namen auf ihrer Registerkarte ein Sternchen `*`. Wähle `File` ▸ `Save All` oder verwende die Tastenkombination <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘Cmd</kbd> + <kbd>S</kbd> auf dem Mac), um alle Dateien zu speichern.
+
+<input type="checkbox"/> Erledigt!
+
+## Die Kachelkarte für das Spielfeld erstellen {#creating-the-playfield-tile-map}
+
+Deine Kachelquelle ist jetzt einsatzbereit. Es ist also Zeit, die Kachelkartenkomponente für das Spielfeld zu erstellen:
+
+1. Klicke mit der <kbd>rechten Maustaste</kbd> auf den Ordner `main` und wähle <kbd>New</kbd> ▸ <kbd>Tile Map</kbd> im Abschnitt „Components“. Nenne die neue Datei „grid“ (der Editor speichert die Datei als „grid.tilemap“).
+![Kachelkarte hinzufügen](images/snake/8.png)
+
+2. Sie öffnet sich in einem Kachelkarteneditor, der hervorhebt, dass eine **Tile Source** benötigt wird. Setze deshalb die Eigenschaft *Tile Source* auf die zuvor erstellte Datei „snake.tilesource“.
+![Kachelquelle festlegen](images/snake/9.png)
+
+<input type="checkbox"/> Erledigt!
+
+## Kacheln in die Kachelkarte zeichnen {#drawing-tiles-in-the-tile-map}
+
+Defold speichert nur den tatsächlich verwendeten Bereich der Kachelkarte. Du musst daher genügend Kacheln hinzufügen, um den Bildschirm bis zu seinen Grenzen auszufüllen.
+
+1. Wähle im Bereich `Outline` auf der rechten Seite die Ebene `layer1`.
+2. Wähle den Menüpunkt `Edit` ▸ `Select Tile...` oder die Taste <kbd>Space</kbd>, um die Kachelpalette anzuzeigen. Klicke dann auf die Kachel, die du zum Zeichnen verwenden möchtest.
+![Kachelkarte](images/snake/10.png)
+
+3. Zeichne einen Rand entlang des Bildschirmrands und einige Hindernisse.
+![Fertige Kachelkarte](images/snake/11.png)
+
+Du brauchst eine Kachelkarte mit 48 × 48 Kacheln, um unseren Spielbildschirm auszufüllen (denn unsere Anzeige ist 768 Pixel groß und unsere Kacheln sind 16 Pixel groß, also 768/16 = 48).
+
+Speichere die Kachelkarte, wenn du fertig bist.
+
+<input type="checkbox"/> Erledigt!
+
+## Die Kachelkarte zum Spiel hinzufügen {#adding-the-tile-map-to-the-game}
+
+Jetzt müssen wir unsere Kachelkarte zum Spiel hinzufügen. Wenn du mit Defolds Bausteinen vertraut bist, weißt du: Komponenten sind Teil von Spielobjekten (game objects), und Spielobjekte können in Sammlungen (collections) definiert werden.
+
+1. Öffne `main.collection`, indem du im Bereich `Assets` darauf doppelklickst. In der Vorlage Empty Project ist dies standardmäßig die Startsammlung (bootstrap collection), die beim Start der Engine geladen wird.
+
+2. Klicke mit der <kbd>rechten Maustaste</kbd> auf die Wurzel in `Outline` und wähle `Add Game Object`. Dadurch entsteht ein neues Spielobjekt in der Sammlung, die beim Spielstart geladen wird.
+![Spielobjekt hinzufügen](images/snake/12.png)
+
+3. Klicke mit der <kbd>rechten Maustaste</kbd> auf das neue Spielobjekt und wähle `Add Component File`. Wähle die gerade erstellte Datei „grid.tilemap“.
+![Komponente hinzufügen](images/snake/13.png)
+
+Jetzt haben wir eine Kachelkarte in unserer Spielsammlung. Sie sollte sichtbar sein, wenn du das Spiel aus dem Editor startest.
+
+1. Wähle `Project` ▸ `Build` oder verwende die Tastenkombination <kbd>Ctrl</kbd> + <kbd>B</kbd> (<kbd>⌘Cmd</kbd> + <kbd>B</kbd> auf dem Mac).
+
+![Spiel starten](images/snake/14.png)
+
+<input type="checkbox"/> Erledigt!
+
+## Dem Spiel ein Skript hinzufügen {#adding-a-script-to-the-game}
+
+1. Klicke mit der <kbd>rechten Maustaste</kbd> im Browser `Assets` auf den Ordner `main` und wähle `New` ▸ `Script` im Abschnitt Scripts. Nenne die neue Skriptdatei „snake“ (sie wird als „snake.script“ gespeichert). Diese Datei wird die gesamte Spiellogik enthalten.
+![Skript hinzufügen](images/snake/15.png)
+
+2. Kehre zu *main.collection* zurück und klicke mit der <kbd>rechten Maustaste</kbd> auf das Spielobjekt, das die Kachelkarte enthält. Wähle <kbd>Add&nbsp;Component&nbsp;File</kbd> und dann die Datei „snake.script“.
+
+![Hauptsammlung](images/snake/16.png)
+
+Jetzt sind die Kachelkartenkomponente und das Skript eingerichtet.
+
+<input type="checkbox"/> Erledigt!
+
+## Das Spielskript {#the-game-script}
+
+Das Skript, das du jetzt schreibst, wird das gesamte Spiel steuern. Wir fügen die Funktionen nach und nach hinzu.
+
+### Einfacher Bewegungsalgorithmus {#simple-movement-algorithm}
+
+Die Idee dafür ist folgende:
+
+1. Das Skript führt eine Liste der Kachelpositionen, die die Schlange aktuell belegt.
+2. Wenn der Spieler eine Richtungstaste drückt, speichert es die Richtung, in die sich die Schlange bewegen soll.
+3. In regelmäßigen Abständen bewegt es die Schlange einen Schritt in die aktuelle Bewegungsrichtung.
+
+### Initialisierung {#initialization}
+
+Öffne *snake.script* und suche die Funktion `init()`. Die Engine ruft diese Funktion auf, wenn das Skript beim Spielstart initialisiert wird. Ändere den Code wie folgt:
+
+```lua
+function init(self)
+    self.segments = { -- <1>
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0} -- <2>
+    self.speed = 7.0 -- <3>
+    self.time = 0 -- <4>
+end
+```
+
+In diesem Code führen wir Folgendes aus:
+
+1. Wir speichern die Segmente der Schlange in einer Lua-Tabelle namens `self.segments`. Sie enthält eine Liste von Tabellen, die jeweils die X- und Y-Position eines Segments speichern.
+2. Wir speichern die aktuelle Richtung in einer Tabelle namens `self.dir`, die eine X- und eine Y-Richtung enthält.
+3. Wir speichern die aktuelle Bewegungsgeschwindigkeit in `self.speed`, angegeben in Kacheln pro Sekunde.
+4. Wir speichern in `self.time` einen Zeitgeberwert, mit dem wir die Bewegungsgeschwindigkeit steuern werden.
+
+Der Skriptcode oben ist in der Sprache Lua geschrieben. Es gibt ein paar Dinge am Code zu beachten, aber wenn du etwas davon noch nicht verstehst, mach dir keine Sorgen. Mach einfach mit, experimentiere und lass dir Zeit --- irgendwann wirst du es verstehen. Für den Moment kannst du dir merken, dass wir in `init()` nur die Variablen initialisiert haben, die wir verwenden werden.
+
+- Defold reserviert eine Reihe integrierter Callback-*Funktionen*, die während der Lebensdauer einer Skriptkomponente aufgerufen werden. Das sind *keine* Methoden, sondern gewöhnliche Funktionen.
+- Die Laufzeitumgebung übergibt über den Parameter `self` eine Referenz auf die aktuelle Instanz der Skriptkomponente. Die Referenz `self` wird zum Speichern von Instanzdaten verwendet.
+- Du kannst die Referenz `self` wie eine Lua-Tabelle verwenden, in der du Daten speicherst. Verwende dafür einfach die Punktnotation wie bei jeder anderen Tabelle: `self.data = "value"`. Die Referenz ist während der gesamten Lebensdauer des Skripts gültig, in diesem Fall vom Spielstart bis zum Beenden des Spiels.
+- Lua-Tabellenliterale werden von geschweiften Klammern `{}` umschlossen.
+- Tabelleneinträge können Schlüssel-Wert-Paare (`{x = 10, y = 20}`), verschachtelte Lua-Tabellen (`{ {a = 1}, {b = 2} }`) oder andere Datentypen sein.
+
+<input type="checkbox"/> Erledigt!
+
+### Aktualisierung {#update}
+
+Die Funktion `init()` wird genau einmal aufgerufen, wenn die Skriptkomponente im laufenden Spiel instanziiert wird. Die Funktion `update()` hingegen wird einmal **pro Frame** aufgerufen. Damit eignet sie sich ideal für Spiellogik in Echtzeit.
+
+Die Idee für die Aktualisierung ist, in einem festgelegten Zeitabstand Folgendes zu tun:
+
+1. Ermittle die Position des Schlangenkopfs und erstelle dann einen neuen Kopf an der benachbarten Position, die um die aktuelle Bewegungsrichtung versetzt ist. Wenn sich die Schlange also mit X=1 und Y=0 bewegt und der aktuelle Kopf bei X=0 und Y=0 liegt, sollte der neue Kopf bei X=1 und Y=0 liegen.
+2. Speichere die neue Kopfposition in der Liste der Segmente, aus denen die Schlange besteht.
+3. Lies die Position des Schwanzendes aus der Segmenttabelle aus.
+4. Lösche die Kachel des Schwanzendes an dieser Position.
+5. Zeichne alle Schlangensegmente (Kacheln) an den Positionen aus der Tabelle.
+
+![Algorithmus](images/snake/17.png)
+
+:::sidenote
+Denk daran, dass der Kopf unserer Schlange am Ende der Tabelle steht und das Schwanzende am Anfang.
+:::
+
+1. Suche die Funktion `update()` in *snake.script* und ändere den Code wie folgt:
+
+```lua
+function update(self, dt)
+    self.time = self.time + dt -- <1>
+    if self.time >= 1.0 / self.speed then -- <2>
+        local head = self.segments[#self.segments] -- <3>
+
+        local newhead = {
+            x = head.x + self.dir.x,
+            y = head.y + self.dir.y
+        } -- <4>
+
+        table.insert(self.segments, newhead) -- <5>
+
+        local tail = table.remove(self.segments, 1) -- <6>
+
+        tilemap.set_tile("#grid", "layer1", tail.x, tail.y, 0) -- <7>
+
+        for i, s in ipairs(self.segments) do -- <8>
+            tilemap.set_tile("#grid", "layer1", s.x, s.y, 2) -- <9>
+        end
+
+        self.time = 0 -- <10>
+    end
+end
+```
+
+In diesem Code führen wir Folgendes aus:
+
+1. Wir erhöhen den Zeitgeber um die Zeitdifferenz (in Sekunden) seit dem letzten Aufruf von `update()` --- die sogenannte „delta time“, kurz `dt`.
+2. Wenn genügend Zeit vergangen ist:
+3. Wir lesen die aktuelle Kopfposition aus. `#` ist der Operator, mit dem du die Länge einer Tabelle ermittelst, sofern sie als Array verwendet wird. Das ist bei uns der Fall --- alle Segmente sind Tabellenwerte ohne angegebenen Schlüssel.
+4. Wir erstellen anhand der aktuellen Kopfposition und der Bewegungsrichtung (`self.dir`) ein neues Kopfsegment.
+5. Wir fügen den neuen Kopf am Ende der Segmenttabelle hinzu.
+6. Wir entfernen das Schwanzende vom Anfang der Segmenttabelle.
+7. Wir löschen die Kachel an der Position des entfernten Schwanzendes. Unsere Kachelkarte `#grid` hat nur 1 Ebene namens `layer1`.
+8. Wir durchlaufen die Elemente der Segmenttabelle. Bei jedem Durchlauf enthält `i` die Position in der Tabelle (beginnend bei 1) und `s` das aktuelle Segment.
+9. Wir setzen die Kachel an der Position des Segments auf den Wert 2 (die Kachel mit der grünen Farbe der Schlange).
+10. Zum Schluss setzen wir den Zeitgeber auf null zurück.
+
+Wenn du das Spiel jetzt startest, solltest du sehen, wie die 4 Segmente lange Schlange von links nach rechts über das Spielfeld kriecht.
+
+![Spiel starten](images/snake/snake_run_1.png)
+
+<input type="checkbox"/> Erledigt!
+
+## Spielereingaben {#player-input}
+
+Bevor du Code hinzufügst, der auf Spielereingaben reagiert, musst du die Eingabezuordnungen einrichten.
+
+### Eingabebindungen {#input-bindings}
+
+1. Suche im Ordner `input` die Datei `game.input_binding` und öffne sie mit einem <kbd>Doppelklick</kbd>.
+2. Füge Eingabebindungen (input bindings) vom Typ *Key Trigger* für Bewegungen nach oben, unten, links und rechts hinzu. Wähle in der Spalte *Input* die Tastaturtasten aus und gib in der Spalte *Action* die Aktionsnamen ein.
+
+![Eingabe](images/snake/18.png)
+
+Die Eingabebindungsdatei ordnet tatsächliche Benutzereingaben (Tasten, Mausbewegungen usw.) den *Namen* von Aktionen zu. Diese werden an Skripte weitergegeben, die Eingaben angefordert haben.
+
+<input type="checkbox"/> Erledigt!
+
+### Den Eingabefokus anfordern {#acquiring-input-focus}
+
+Wenn die Bindungen eingerichtet sind, öffne *snake.script* und füge am Anfang der Funktion `init()` die folgende Zeile hinzu:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus") -- <1>
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.speed = 7.0
+    self.time = 0
+end
+```
+
+Die hinzugefügte Zeile:
+1. Sendet eine Nachricht an das aktuelle Spielobjekt („.“ ist die Kurzform für das aktuelle Spielobjekt), die es auffordert, Eingaben von der Engine zu empfangen.
+
+Suche dann die Funktion `on_input` und gib den folgenden Code ein:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("up") and action.pressed then -- <1>
+        self.dir.x = 0 -- <2>
+        self.dir.y = 1
+    elseif action_id == hash("down") and action.pressed then
+        self.dir.x = 0
+        self.dir.y = -1
+    elseif action_id == hash("left") and action.pressed then
+        self.dir.x = -1
+        self.dir.y = 0
+    elseif action_id == hash("right") and action.pressed then
+        self.dir.x = 1
+        self.dir.y = 0
+    end
+end
+```
+
+Diese `if...elseif...`-Verzweigungen führen Folgendes aus:
+1. Wenn die Eingabeaktion „up“ empfangen wird, wie in den Eingabebindungen eingerichtet, und das Feld `pressed` in der Tabelle `action` auf `true` gesetzt ist (der Spieler hat die Taste gedrückt), dann:
+2. Setzen sie die Bewegungsrichtung.
+
+Starte das Spiel erneut und prüfe, ob du die Schlange steuern kannst.
+
+<input type="checkbox"/> Erledigt!
+
+### Die Eingabeverarbeitung verbessern {#improving-input-handling}
+
+Beachte nun, dass das gleichzeitige Drücken zweier Tasten zu zwei Aufrufen von `on_input()` führt, einem für jeden Tastendruck. Im oben gezeigten Code wirkt sich nur der letzte Aufruf auf die Richtung der Schlange aus, weil nachfolgende Aufrufe von `on_input()` die Werte in `self.dir` überschreiben.
+
+Beachte außerdem, dass die Schlange in sich selbst hineinsteuert, wenn sie sich nach links bewegt und du die Taste <kbd>right</kbd> drückst. Die *scheinbar* naheliegende Lösung ist, den `if`-Bedingungen in `on_input()` eine weitere Bedingung hinzuzufügen:
+
+```lua
+if action_id == hash("up") and self.dir.y ~= -1 and action.pressed then
+    ...
+elseif action_id == hash("down") and self.dir.y ~= 1 and action.pressed then
+    ...
+```
+
+Wenn sich die Schlange jedoch nach links bewegt und der Spieler vor dem nächsten Bewegungsschritt *schnell* zuerst <kbd>up</kbd> und dann <kbd>right</kbd> drückt, wirkt sich nur der Tastendruck auf <kbd>right</kbd> aus, und die Schlange bewegt sich in sich selbst hinein. Mit den oben ergänzten Bedingungen in den `if`-Abfragen wird die Eingabe ignoriert. *Nicht gut!*
+
+Eine geeignete Lösung ist, die Eingaben in einer Warteschlange zu speichern und bei jeder Bewegung der Schlange Einträge daraus zu entnehmen:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.speed = 7.0
+    self.time = 0
+
+    self.dirqueue = {} -- <1>
+end
+```
+
+Diesmal haben wir:
+1. Eine Variable `self.dirqueue` hinzugefügt, die als leere Tabelle initialisiert wird.
+
+Ergänze die Funktion `update()` wie folgt:
+
+```lua
+function update(self, dt)
+    self.time = self.time + dt
+    if self.time >= 1.0 / self.speed then
+        local newdir = table.remove(self.dirqueue, 1) -- <1>
+        if newdir then
+            local opposite = newdir.x == -self.dir.x or newdir.y == -self.dir.y -- <2>
+            if not opposite then
+                self.dir = newdir -- <3>
+            end
+        end
+
+        local head = self.segments[#self.segments]
+        local newhead = {x = head.x + self.dir.x, y = head.y + self.dir.y}
+
+        table.insert(self.segments, newhead)
+
+        local tail = table.remove(self.segments, 1)
+        tilemap.set_tile("#grid", "layer1", tail.x, tail.y, 0)
+
+        for i, s in ipairs(self.segments) do
+            tilemap.set_tile("#grid", "layer1", s.x, s.y, 2)
+        end
+
+        self.time = 0
+    end
+end
+```
+
+1. Entnimm den ersten Eintrag aus der Richtungswarteschlange.
+2. Wenn ein Eintrag vorhanden ist (`newdir` ist nicht null), prüfe, ob `newdir` in die entgegengesetzte Richtung zu `self.dir` zeigt.
+3. Setze die neue Richtung nur, wenn sie nicht in die entgegengesetzte Richtung zeigt.
+
+Ändere außerdem `on_input` so, dass es die aktuelle Eingabe stattdessen in der Warteschlange speichert:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("up") and action.pressed then
+        table.insert(self.dirqueue, {x = 0, y = 1}) -- <1>
+    elseif action_id == hash("down") and action.pressed then
+        table.insert(self.dirqueue, {x = 0, y = -1})
+    elseif action_id == hash("left") and action.pressed then
+        table.insert(self.dirqueue, {x = -1, y = 0})
+    elseif action_id == hash("right") and action.pressed then
+        table.insert(self.dirqueue, {x = 1, y = 0})
+    end
+end
+```
+
+1. Füge die Eingaberichtung zur Richtungswarteschlange hinzu, statt `self.dir` direkt zu setzen.
+
+Starte das Spiel und prüfe, ob es sich wie erwartet spielt.
+
+<input type="checkbox"/> Erledigt!
+
+## Futter und Kollisionen mit Hindernissen {#food-and-collision-with-obstacles}
+
+Die Schlange braucht Futter auf der Karte, damit sie lang und schnell werden kann. Fügen wir es hinzu!
+
+### Das Futter erzeugen {#spawning-the-food}
+
+Füge oberhalb der Funktion `init()` eine neue Funktion hinzu:
+
+```lua
+local function put_food(self) -- <1>
+    self.food = {x = math.random(2, 47), y = math.random(2, 47)} -- <2>
+    tilemap.set_tile("#grid", "layer1", self.food.x, self.food.y, 3) -- <3>
+end
+```
+
+In dieser Funktion führen wir Folgendes aus:
+1. Wir deklarieren eine neue Funktion namens `put_food()`, die ein Stück Futter auf der Karte platziert.
+2. Wir speichern eine zufällige X- und Y-Position in einer Variablen namens `self.food`.
+3. Wir setzen die Kachel an der Position X und Y auf den Wert 3. Das ist die Kachelgrafik für das Futter.
+
+Rufe sie dann am Ende der Funktion `init()` auf:
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.dirqueue = {}
+    self.speed = 7.0
+    self.time = 0
+
+    math.randomseed(socket.gettime()) -- <1>
+    put_food(self) -- <2>
+end
+```
+
+1. Setze den Startwert des Zufallszahlengenerators, bevor du mit `math.random()` Zufallswerte abrufst. Sonst wird dieselbe Folge von Zufallswerten erzeugt. Dieser Startwert sollte nur einmal gesetzt werden.
+2. Rufe die Funktion `put_food()` beim Spielstart auf, damit sich zu Beginn ein Stück Futter auf der Karte befindet.
+
+<input type="checkbox"/> Erledigt!
+
+### Das Futter fressen {#eating-the-food}
+
+Um jetzt zu erkennen, ob die Schlange mit etwas kollidiert, musst du nur nachsehen, was sich auf der Kachelkarte an der Position befindet, auf die die Schlange zusteuert, und darauf reagieren.
+
+Füge eine Variable hinzu, die festhält, ob die Schlange lebt oder nicht:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.dirqueue = {}
+    self.speed = 7.0
+    self.time = 0
+
+    self.alive = true -- <1>
+
+    math.randomseed(socket.gettime())
+    put_food(self)
+end
+```
+
+1. Ein Kennzeichen, das angibt, ob die Schlange lebt oder nicht.
+
+Füge dann Logik hinzu, die auf Kollisionen mit Wänden/Hindernissen und Futter prüft:
+
+```lua
+function update(self, dt)
+    self.time = self.time + dt
+    if self.time >= 1.0 / self.speed and self.alive then -- <1>
+        local newdir = table.remove(self.dirqueue, 1)
+
+        if newdir then
+            local opposite = newdir.x == -self.dir.x or newdir.y == -self.dir.y
+            if not opposite then
+                self.dir = newdir
+            end
+        end
+
+        local head = self.segments[#self.segments]
+        local newhead = {x = head.x + self.dir.x, y = head.y + self.dir.y}
+
+        table.insert(self.segments, newhead)
+
+        local tile = tilemap.get_tile("#grid", "layer1", newhead.x, newhead.y) -- <2>
+
+        if tile == 2 or tile == 4 then
+            self.alive = false -- <3>
+        elseif tile == 3 then
+            self.speed = self.speed + 1 -- <4>
+            put_food(self)
+        else
+            local tail = table.remove(self.segments, 1) -- <5>
+            tilemap.set_tile("#grid", "layer1", tail.x, tail.y, 1)
+        end
+
+        for i, s in ipairs(self.segments) do
+            tilemap.set_tile("#grid", "layer1", s.x, s.y, 2)            
+        end
+
+        self.time = 0
+    end
+end
+```
+
+1. Bewege die Schlange nur weiter, wenn sie lebt.
+2. Lies vor dem Zeichnen auf die Kachelkarte aus, was sich an der Position des neuen Schlangenkopfs befindet.
+3. Wenn die Kachel ein Hindernis oder ein anderer Teil der Schlange ist, ist das Spiel vorbei!
+4. Wenn die Kachel Futter ist, erhöhe die Geschwindigkeit und platziere dann ein neues Stück Futter.
+5. Beachte, dass das Schwanzende nur entfernt wird, wenn keine Kollision vorliegt. Wenn der Spieler Futter frisst, wächst die Schlange deshalb um ein Segment, weil bei diesem Zug kein Schwanzende entfernt wird.
+
+Probiere das Spiel jetzt aus und stelle sicher, dass es sich gut spielt!
+
+Damit ist das Tutorial abgeschlossen. Experimentiere aber gern weiter mit dem Spiel und bearbeite einige der folgenden Übungen!
+
+<input type="checkbox"/> Erledigt!
+
+## Das vollständige Skript {#the-complete-script}
+
+Hier ist der vollständige Skriptcode zum Nachschlagen:
+
+```lua
+local function put_food(self)
+    self.food = {x = math.random(2, 47), y = math.random(2, 47)}
+    tilemap.set_tile("#grid", "layer1", self.food.x, self.food.y, 3)        
+end
+
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.dirqueue = {}
+    self.speed = 7.0
+    self.time = 0
+
+    self.alive = true
+
+    math.randomseed(socket.gettime())
+    put_food(self)
+end
+
+function update(self, dt)
+    self.time = self.time + dt
+    if self.time >= 1.0 / self.speed and self.alive then
+        local newdir = table.remove(self.dirqueue, 1)
+
+        if newdir then
+            local opposite = newdir.x == -self.dir.x or newdir.y == -self.dir.y
+            if not opposite then
+                self.dir = newdir
+            end
+        end
+
+        local head = self.segments[#self.segments]
+        local newhead = {x = head.x + self.dir.x, y = head.y + self.dir.y}
+
+        table.insert(self.segments, newhead)
+
+        local tile = tilemap.get_tile("#grid", "layer1", newhead.x, newhead.y)
+
+        if tile == 2 or tile == 4 then
+            self.alive = false
+        elseif tile == 3 then
+            self.speed = self.speed + 1
+            put_food(self)
+        else
+            local tail = table.remove(self.segments, 1)
+            tilemap.set_tile("#grid", "layer1", tail.x, tail.y, 1)
+        end
+
+        for i, s in ipairs(self.segments) do
+            tilemap.set_tile("#grid", "layer1", s.x, s.y, 2)            
+        end
+
+        self.time = 0
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("up") and action.pressed then
+        table.insert(self.dirqueue, {x = 0, y = 1})
+    elseif action_id == hash("down") and action.pressed then
+        table.insert(self.dirqueue, {x = 0, y = -1})
+    elseif action_id == hash("left") and action.pressed then
+        table.insert(self.dirqueue, {x = -1, y = 0})
+    elseif action_id == hash("right") and action.pressed then
+        table.insert(self.dirqueue, {x = 1, y = 0})
+    end
+end
+```
+
+## Übungen {#exercises}
+
+Es ist eine gute Übung, diese Verbesserungen umzusetzen:
+
+1. Füge die Verarbeitung einer Tastatureingabe hinzu, um das Spiel nach dem Spielende neu zu starten.
+2. Füge eine Punktewertung und einen Punktezähler hinzu, entweder nur mit einer Beschriftungskomponente (einfacher) oder mit einer vollständigen GUI.
+3. Die Funktion put_food() berücksichtigt weder die Position der Schlange noch Hindernisse. Behebe das, sodass Futter nur an freien Stellen erzeugt wird.
+4. Zeige nach dem Spielende die Nachricht „Game Over“ an und ermögliche dem Spieler einen neuen Versuch.
+5. Zusatzaufgabe: Füge eine zweite, vom Spieler gesteuerte Schlange hinzu.

--- a/docs/de/tutorials/war-battles.md
+++ b/docs/de/tutorials/war-battles.md
@@ -1,0 +1,28 @@
+---
+title: Tutorial zu War battles
+brief: In diesem Tutorial erstellst du die Grundlage für ein kleines Shooter-Spiel. Es ist ein guter Einstieg, wenn du Defold noch nicht kennst.
+github: https://github.com/defold/tutorial-war-battles
+---
+
+# Tutorial zu War battles {#war-battles-tutorial}
+
+In diesem Tutorial lernst du, wie du ein kleines, spielbares Spiel mit Bewegungs- und Schussmechaniken erstellst.
+
+Das Tutorial ist in den Defold-Editor integriert und leicht zugänglich:
+
+1. Starte Defold.
+2. Wähle links *New Project*.
+3. Wähle die Registerkarte *From Tutorial*.
+4. Wähle „War battles tutorial“
+5. Wähle einen Speicherort für das Projekt auf deinem lokalen Laufwerk und klicke auf *Create New Project*.
+
+![Neues Projekt](images/new-war-battles.png)
+
+Der Editor öffnet automatisch die Datei „README“ aus dem Stammverzeichnis des Projekts, die den vollständigen Tutorialtext enthält.
+
+![Symbol](images/icon-tutorial.svg){.icon}
+[Du kannst den vollständigen Tutorialtext auch auf GitHub lesen](https://github.com/defold/tutorial-war-battles)
+
+Wenn du nicht weiterkommst, besuche das [Defold-Forum](//forum.defold.com). Dort helfen dir das Defold-Team und viele freundliche Nutzer.
+
+Viel Spaß mit Defold!

--- a/docs/languages.json
+++ b/docs/languages.json
@@ -12,6 +12,11 @@
             "translation": "Translation by cocosgames.com",
             "active": true
         },
+        "de":
+        {
+            "name": "Deutsch (German)",
+            "active": true
+        },
         "es":
         {
             "name": "Español (Spanish)",
@@ -62,6 +67,11 @@
         {
             "name": "Русский (Russian)",
             "translation": "Translation by Demetrij87G",
+            "active": true
+        },
+        "tr":
+        {
+            "name": "Türkçe (Turkish)",
             "active": true
         },
         "uk":

--- a/docs/tr/faq/faq.md
+++ b/docs/tr/faq/faq.md
@@ -1,0 +1,313 @@
+---
+title: Defold motoru ve düzenleyicisi hakkında sık sorulan sorular
+brief: Defold oyun motoru, düzenleyicisi ve platformu hakkında sık sorulan sorular.
+---
+
+# Sık sorulan sorular
+
+## Genel sorular
+
+#### Q: Defold gerçekten ücretsiz mi?
+
+A: Evet, Defold motoru ve düzenleyicisi tüm işlevleriyle tamamen ücretsizdir. Gizli maliyet, ücret veya telif ücreti yoktur. Tamamen ücretsizdir.
+
+
+#### Q: Defold Foundation Defold'u neden ücretsiz dağıtıyor?
+
+A: [Defold Foundation](/foundation) kuruluşunun amaçlarından biri, Defold yazılımının dünyanın her yerindeki geliştiricilere sunulmasını ve kaynak kodunun ücretsiz olarak erişilebilir olmasını sağlamaktır.
+
+
+#### Q: Defold'u ne kadar süre destekleyeceksiniz?
+
+A: Defold'a güçlü bir bağlılık duyuyoruz. [Defold Foundation](/foundation), Defold'un sorumlu sahibi olarak uzun yıllar varlığını sürdürmesi güvence altına alınacak şekilde kurulmuştur. Varlığını sürdürecektir.
+
+
+#### Q: Profesyonel geliştirme için Defold'a güvenebilir miyim?
+
+A: Kesinlikle. Defold'u kullanan profesyonel oyun geliştiricilerinin ve oyun stüdyolarının sayısı giderek artıyor. Defold ile oluşturulmuş oyun örnekleri için [oyun vitrinine](/showcase) göz atın.
+
+
+#### Q: Ne tür kullanıcı takibi yapıyorsunuz?
+
+A: Hizmetlerimizi ve ürünümüzü iyileştirmek için web sitelerimizden ve Defold düzenleyicisinden anonim kullanım verileri kaydediyoruz. Oluşturduğunuz oyunlarda kullanıcı takibi yoktur (kendiniz bir analiz hizmeti eklemediğiniz sürece). Bu konuda daha fazla bilgiyi [Gizlilik Politikamızda](/privacy-policy) bulabilirsiniz.
+
+
+#### Q: Defold'u kim yaptı?
+
+A: Defold, Ragnar Svensson ve Christian Murray tarafından oluşturuldu. Motor, düzenleyici ve sunucular üzerinde çalışmaya 2009'da başladılar. King ve Defold 2013'te bir ortaklık başlattı, King ise 2014'te Defold'u satın aldı. Hikâyenin tamamını [buradan](/about) okuyabilirsiniz.
+
+
+## Oyun geliştirme soruları
+
+#### Q: Defold'da 3B oyunlar yapabilir miyim?
+
+A: Kesinlikle! Motor, tam donanımlı bir 3B motordur. Ancak araç seti 2B için hazırlanmıştır, bu nedenle pek çok zahmetli işi kendiniz yapmanız gerekir. Daha iyi 3B desteği planlanmaktadır.
+
+
+## Programlama dili soruları
+
+#### Q: Defold'da hangi programlama diliyle çalışırım?
+
+A: Defold projenizdeki oyun mantığı öncelikle Lua diliyle yazılır (özellikle Lua 5.1/LuaJIT; ayrıntılar için [Lua kılavuzuna](/manuals/lua) bakın). Lua, hızlı ve çok güçlü, hafif bir dinamik dildir. Defold, Lua kodu üreten kaynak koddan kaynak koda derleyicileri (transpiler) destekler. Böyle bir derleyici eklentisi kurulduğunda, statik olarak denetlenen Lua yazmak için [Teal](https://github.com/defold/extension-teal) gibi alternatif diller kullanabilirsiniz. Ayrıca [Defold motorunu yeni işlevlerle genişletmek](/manuals/extensions/) için yerel kod (native code; platforma bağlı olarak C/C++, Objective-C, Java ve JavaScript) kullanabilirsiniz. [Özel materyaller (material)](/manuals/material/) oluştururken köşe ve parça gölgelendiricileri (vertex shader ve fragment shader) yazmak için OpenGL ES SL gölgelendirici dili kullanılır.
+
+
+#### Q: Oyun mantığını yazmak için C++ kullanabilir miyim?
+
+A: Defold'daki C++ desteği esas olarak üçüncü taraf yazılım geliştirme kitleriyle (SDK) veya platforma özgü API'lerle iletişim kuran yerel kod eklentileri (native extension) yazmak için vardır. [dmSDK](https://defold.com/ref/stable/dmGameObject/) (yerel kod eklentilerinde kullanılan Defold C++ API'si), isteyen bir geliştiricinin tüm oyun mantığını C++ ile yazabilmesini sağlayacak şekilde zamanla daha fazla işlevle genişletilecektir. Lua, oyun mantığı için kullanılan ana dil olmaya devam edecek, ancak genişletilen C++ API'siyle oyun mantığını C++ kullanarak yazmak da mümkün olacaktır. C++ API'sini genişletme çalışmaları esas olarak mevcut özel başlık dosyalarını herkese açık bölüme taşımayı ve API'leri genel kullanıma uygun hâle getirmeyi kapsar.
+
+
+#### Q: Defold ile TypeScript kullanabilir miyim?
+
+A: TypeScript resmî olarak desteklenmez. Topluluk, TypeScript yazmak ve doğrudan VSCode içinden Lua koduna dönüştürmek için [ts-defold](https://ts-defold.dev/) araç setini geliştirmeye devam ediyor.
+
+
+#### Q: Defold ile Haxe kullanabilir miyim?
+
+A: Haxe resmî olarak desteklenmez. Topluluk, Haxe yazmak ve Lua koduna dönüştürmek için [hxdefold](https://github.com/hxdefold/hxdefold) projesini geliştirmeye devam ediyor.
+
+
+#### Q: Defold ile C# kullanabilir miyim?
+
+A: Defold Foundation, C# desteğini ekledi ve bir kütüphane bağımlılığı olarak kullanıma sundu. C#, yaygın olarak benimsenmiş bir programlama dilidir ve C# diline büyük yatırım yapmış stüdyoların ve geliştiricilerin Defold'a geçişine yardımcı olacaktır.
+
+
+#### Q: C# desteği eklenmesinin Defold'u olumsuz etkileyeceğinden endişeleniyorum. Endişelenmeli miyim?
+
+Defold, ana betik dili olarak Lua'dan UZAKLAŞMIYOR. C# desteği, eklentiler için yeni bir dil olarak ekleniyor. Projenizde C# eklentilerini kullanmayı seçmediğiniz sürece motoru etkilemeyecektir.
+
+C# desteğinin bazı maliyetleri (yürütülebilir dosya boyutu, çalışma zamanı performansı vb.) olacaktır, ancak buna her geliştirici veya stüdyo kendisi karar verecektir.
+
+C# dilinin kendisine gelince, eklenti sistemi zaten birçok dili (C/C++/Java/Objective-C/Zig) desteklediğinden bu nispeten küçük bir değişikliktir. C# bağlamaları üretilerek SDK'lerin birbiriyle uyumu korunacaktır. Böylece bağlamalar en az çabayla güncel tutulacaktır.
+
+Defold Foundation daha önce Defold'a C# desteği eklenmesine karşıydı, ancak çeşitli nedenlerle görüşünü değiştirdi:
+
+* Stüdyolar ve geliştiriciler C# desteği istemeye devam ediyor.
+* C# desteğinin kapsamı yalnızca eklentilerle sınırlı tutuldu (yani az çaba gerektiriyor).
+* Çekirdek motor etkilenmeyecek.
+* C# API'leri üretilirse en az çabayla birbiriyle uyumlu tutulabilir.
+* C# desteği, NativeAOT ile DotNet 9 üzerine kurulacak; böylece mevcut derleme hattının bağlayabileceği statik kütüphaneler üretilecek (diğer tüm Defold eklentileri gibi).
+
+
+## Platform soruları
+
+#### Q: Defold hangi platformlarda çalışır?
+
+A: Düzenleyici/araçlar ve motorun çalışma zamanı ortamı için aşağıdaki platformlar desteklenir:
+
+  | Sistem             | Sürüm              | Mimariler          | Desteklenen        |
+  | ------------------ | ------------------ | ------------------ | ------------------ |
+  | macOS              | 11 Big Sur         | `x86-64`, `arm-64` | Düzenleyici ve motor |
+  | Windows            | Vista              | `x86-32`, `x86-64` | Düzenleyici ve motor |
+  | Ubuntu (1)         | 22.04 LTS          | `x86-64`           | Düzenleyici        |
+  | Linux (2)          | Herhangi biri      | `x86-64`, `arm-64` | Motor              |
+  | iOS                | 15.0               | `arm-64`  `x86_64` | Motor              |
+  | Android            | 5.0 (API düzeyi 21) | `arm-32`, `arm-64` | Motor              |
+  | HTML5              |                    | `wasm-web`, `wasm_pthread-web` | Motor        |
+
+  (1 Düzenleyici, 64 bit Ubuntu için derlenir ve test edilir. Diğer dağıtımlarda da çalışması beklenir, ancak bunu garanti etmiyoruz.)
+
+  (2 Grafik sürücüleri güncel olduğu sürece motorun çalışma zamanı ortamının çoğu 64 bit Linux dağıtımında çalışması beklenir; grafik API'leri hakkında daha fazla bilgi için aşağıya bakın)
+
+
+#### Q: Defold ile hangi hedef platformlar için oyun geliştirebilirim?
+
+A: Tek tıklamayla PS4™, PS5™, Nintendo Switch, iOS (64 bit), Android (32 bit ve 64 bit) ve HTML5 için; ayrıca macOS (x86-64 ve arm64), Windows (32 bit ve 64 bit) ve Linux (x86-64 ve arm64) için yayımlayabilirsiniz. Gerçekten de tek bir kod tabanı birden çok platformu destekler.
+
+
+#### Q: Defold hangi işleme API'sini kullanır?
+
+A: Geliştirici olarak, [tamamen betiklerle yönetilebilen bir işleme hattı](/manuals/render/) kullanan tek bir işleme (rendering) API'siyle ilgilenmeniz yeterlidir. Defold'un işleme betiği API'si, işleme işlemlerini aşağıdaki grafik API'lerine dönüştürür:
+
+:[Graphics API](../shared/graphics-api.md)
+
+#### Q: Hangi sürümü çalıştırdığımı öğrenmenin bir yolu var mı?
+
+A: Evet, Help menüsündeki "About" seçeneğini seçin. Açılır pencere, Defold beta sürümünü ve daha da önemlisi, ilgili sürümün SHA1 değerini açıkça gösterir. Çalışma sırasında sürümü sorgulamak için [`sys.get_engine_info()`](/ref/sys/#sys.get_engine_info) işlevini kullanın.
+
+[http://d.defold.com/beta](http://d.defold.com/beta) adresinden indirilebilen en son beta sürümünü, [http://d.defold.com/beta/info.json](http://d.defold.com/beta/info.json) adresini açarak kontrol edebilirsiniz (aynı dosya kararlı sürümler için de vardır: [http://d.defold.com/stable/info.json](http://d.defold.com/stable/info.json)).
+
+
+#### Q: Oyunun çalışma sırasında hangi platformda çalıştığını öğrenmenin bir yolu var mı?
+
+A: Evet, [`sys.get_sys_info()`](/ref/sys#sys.get_sys_info) işlevine göz atın.
+
+
+## Düzenleyici soruları
+:[Editor FAQ](../shared/editor-faq.md)
+
+
+## Linux soruları {#linux-questions}
+:[Linux FAQ](../shared/linux-faq.md)
+
+
+## Android soruları
+:[Android FAQ](../shared/android-faq.md)
+
+
+## HTML5 soruları
+:[HTML5 FAQ](../shared/html5-faq.md)
+
+
+## iOS soruları
+:[iOS FAQ](../shared/ios-faq.md)
+
+
+## Windows soruları
+:[Windows FAQ](../shared/windows-faq.md)
+
+
+## Konsol soruları
+:[Consoles FAQ](../shared/consoles-faq.md)
+
+
+## Oyun yayımlama
+
+#### Q: Oyunumu App Store'da yayımlamaya çalışıyorum. IDFA sorusunu nasıl yanıtlamalıyım?
+
+A: Uygulamayı gönderirken Apple, IDFA'nın üç geçerli kullanım durumu için üç onay kutusu sunar:
+
+  1. Serve ads within the app
+  2. Install attribution from ads
+  3. User action attribution from ads
+
+  1 numaralı seçeneği işaretlerseniz uygulamayı inceleyen kişi uygulamada reklam gösterilip gösterilmediğini kontrol eder. Oyununuz reklam göstermiyorsa reddedilebilir. Defold'un kendisi reklam tanımlayıcısını kullanmaz.
+
+
+#### Q: Oyunumdan nasıl gelir elde edebilirim?
+
+A: Defold, uygulama içi satın almaları ve çeşitli reklam çözümlerini destekler. Kullanılabilir gelir elde etme seçeneklerinin güncel listesi için [Asset Portal'daki Monetization kategorisine](https://defold.com/tags/stars/monetization/) bakın.
+
+
+## Defold kullanırken karşılaşılan hatalar
+
+#### Q: Oyunu başlatamıyorum ve derleme hatası da yok. Sorun ne?
+
+A: Proje derleme süreci, daha önce karşılaşıp düzelttiğiniz derleme hatalarının ardından, nadiren de olsa dosyaları yeniden derleyemeyebilir. Menüden *Project > Rebuild And Launch* seçeneğini seçerek tam bir yeniden derlemeyi zorlayın.
+
+
+
+## Oyun içeriği
+
+#### Q: Defold, yeniden kullanılabilir nesne tanımları olan prefabları destekliyor mu?
+
+A: Evet, destekliyor. Bunlara [koleksiyon (collection)](/manuals/building-blocks/#collections) denir. Koleksiyonlar, karmaşık oyun nesnesi (game object) hiyerarşileri oluşturmanızı ve bunları, düzenleyicide veya çalışma sırasında (koleksiyon içeriği oluşturarak) örneklerini oluşturabileceğiniz ayrı yapı taşları olarak saklamanızı sağlar. Grafik kullanıcı arayüzü (GUI) düğümleri için GUI şablonları desteklenir.
+
+
+#### Q: Bir oyun nesnesini başka bir oyun nesnesine alt nesne olarak ekleyemiyorum, neden?
+
+A: Büyük olasılıkla oyun nesnesi dosyasında bir alt nesne eklemeye çalışıyorsunuz ve bu mümkün değildir. Bu yalnızca koleksiyon dosyasında yapılabilir. Bunun nedenini anlamak için üst-alt nesne hiyerarşilerinin yalnızca bir _sahne grafı (scene graph)_ dönüşüm hiyerarşisi olduğunu hatırlamanız gerekir. Bir sahneye (koleksiyona) yerleştirilmemiş (veya çalışma sırasında oluşturulmamış) bir oyun nesnesi, sahne grafının parçası değildir ve bu nedenle sahne grafı hiyerarşisinin de parçası olamaz. Oyun nesnesinin üst nesnesinin tanımlayıcısını [`go.get_parent()`](https://defold.com/ref/stable/go-lua/#go.get_parent:id) işlevini kullanarak alabilirsiniz.
+
+
+#### Q: Neden bir oyun nesnesinin tüm alt nesnelerine topluca ileti gönderemiyorum?
+
+A: Üst-alt nesne ilişkileri yalnızca sahne grafındaki dönüşüm ilişkilerini ifade eder ve nesne yönelimli programlamadaki nesne gruplarıyla karıştırılmamalıdır. Oyun verilerinize ve oyununuzun durumu değiştikçe bu verileri en iyi nasıl dönüştürebileceğinize odaklanırsanız, birçok nesneye sürekli durum verisi içeren iletiler gönderme ihtiyacınız muhtemelen azalacaktır. Veri hiyerarşilerine ihtiyaç duyduğunuz durumlarda bunları Lua'da kolayca oluşturabilir ve yönetebilirsiniz.
+
+
+#### Q: Sprite bileşenlerimin kenarlarında neden görüntü kusurları oluşuyor?
+
+A: Bu, bir atlastaki komşu piksellerin kenar piksellerinin sprite bileşeninize atanan görüntüye taştığı, "kenar taşması (edge bleeding)" adı verilen bir görüntü kusurudur. Çözüm, atlas görüntülerinizin kenarlarını aynı piksellerden oluşan ek satır ve sütunlarla doldurmaktır. Neyse ki Defold'un atlas düzenleyicisi bunu otomatik olarak yapabilir. Atlasınızı açın ve *Extrude Borders* değerini 1 olarak ayarlayın.
+
+
+#### Q: Sprite bileşenlerime renk çarpanı uygulayabilir veya onları saydam yapabilir miyim, yoksa bunun için kendi gölgelendiricimi mi yazmam gerekir?
+
+A: Tüm sprite bileşenleri için varsayılan olarak kullanılan yerleşik sprite gölgelendiricisinde "tint" adlı bir sabit tanımlıdır:
+
+  ```lua
+  local red = 1
+  local green = 0.3
+  local blue = 0.55
+  local alpha = 1
+  go.set("#sprite", "tint", vmath.vector4(red, green, blue, alpha))
+  ```
+
+
+#### Q: Bir sprite bileşeninin z koordinatını 100 olarak ayarlarsam çizilmiyor. Neden?
+
+A: Bir oyun nesnesinin Z konumu işleme sırasını belirler. Düşük değerler yüksek değerlerden önce çizilir. Varsayılan işleme betiğinde derinliği -1 ile 1 arasında olan oyun nesneleri çizilir; bu aralığın altında veya üstünde kalanlar çizilmez. İşleme betiği hakkında daha fazla bilgiyi resmî [İşleme belgelerinde](/manuals/render) bulabilirsiniz. GUI düğümlerinde Z değeri yok sayılır ve işleme sırasını hiçbir şekilde etkilemez. Bunun yerine düğümler listelendikleri sırayla ve alt düğüm hiyerarşilerine (ve katmanlara) göre işlenir. GUI işlemesi ve katmanları kullanarak çizim çağrılarını optimize etme hakkında daha fazla bilgiyi resmî [GUI belgelerinde](/manuals/gui) bulabilirsiniz.
+
+
+#### Q: Görünüm izdüşümünün Z aralığını -100 ile 100 olarak değiştirmek performansı etkiler mi?
+
+A: Hayır. Tek etkisi hassasiyet üzerindedir. Z arabelleği logaritmiktir; 0'a yakın z değerleri için çok yüksek, 0'dan uzak değerler içinse daha düşük çözünürlük sunar. Örneğin, 24 bitlik bir arabellekle 10,0 ve 10,000005 değerleri ayırt edilebilirken 10000 ve 10005 ayırt edilemez.
+
+
+#### Q: Açıların gösteriminde neden tutarlılık yok?
+
+A: Aslında tutarlılık var. Düzenleyicide ve oyun API'lerinde açılar her yerde derece cinsinden ifade edilir. Matematik kütüphaneleri radyan kullanır. Şu anda radyan/s cinsinden ifade edilen `angular_velocity` fizik özelliği bu kuralın dışındadır. Bunun değişmesi beklenmektedir.
+
+
+#### Q: Yalnızca renk içeren (dokusu olmayan) bir GUI kutu düğümü oluşturduğumda nasıl işlenir?
+
+A: Bu, yalnızca köşeleri renklendirilmiş bir şekildir. Yine de piksel doldurma hızı açısından bir maliyeti olacağını unutmayın.
+
+
+#### Q: Varlıkları çalışma sırasında değiştirirsem motor bunları otomatik olarak bellekten kaldırır mı?
+
+A: Tüm kaynaklar (resource) için motor içinde başvuru sayımı yapılır. Başvuru sayısı sıfıra iner inmez kaynak serbest bırakılır.
+
+
+#### Q: Bir oyun nesnesine bağlı ses bileşeni kullanmadan ses oynatmak mümkün mü?
+
+A: Her şey bileşen (component) temellidir. Birden fazla ses içeren, görsel bileşeni olmayan bir oyun nesnesi oluşturabilir ve sesleri denetleyen bu nesneye iletiler göndererek ses oynatabilirsiniz.
+
+
+#### Q: Bir ses bileşeniyle ilişkili ses dosyasını çalışma sırasında değiştirmek mümkün mü?
+
+A: Genel olarak tüm kaynaklar statik olarak bildirilir; bunun avantajı, kaynak yönetiminin ek bir çaba gerektirmeden sağlanmasıdır. Bir bileşene atanan kaynağı değiştirmek için [kaynak özelliklerini](/manuals/script-properties/#resource-properties) kullanabilirsiniz.
+
+
+#### Q: Fizik çarpışma şeklinin özelliklerine erişmenin bir yolu var mı?
+
+A: Evet, fizik API'sine, özellikle de [`physics.get_shape()`](https://defold.com/ref/stable/physics-lua/#physics.get_shape:url-shape) ve [`physics.set_shape()`](https://defold.com/ref/stable/physics-lua/#physics.set_shape:url-shape-table) işlevlerine göz atın. 
+
+
+#### Q: Sahnemdeki çarpışma nesnelerini çizdirmenin hızlı bir yolu var mı? (Box2D'nin hata ayıklama çizimi gibi)
+
+A: Evet, *game.project* dosyasında *physics.debug* bayrağını ayarlayın. (Resmî [Proje ayarları belgelerine](/manuals/project-settings/#debug) bakın)
+
+
+#### Q: Çok sayıda temas/çarpışma olmasının performans maliyetleri nelerdir?
+
+A: Defold arka planda Box2D'nin değiştirilmiş bir sürümünü çalıştırır ve performans maliyetinin oldukça benzer olması beklenir. [Profil çıkarıcıyı](/manuals/debugging) açarak motorun fizik için ne kadar zaman harcadığını her zaman görebilirsiniz. Kullandığınız çarpışma nesnelerinin türünü de göz önünde bulundurmalısınız. Örneğin, statik nesnelerin performans maliyeti daha düşüktür. Daha fazla ayrıntı için resmî Defold [Fizik belgelerine](/manuals/physics) bakın.
+
+
+#### Q: Çok sayıda parçacık efekti bileşeni olmasının performansa etkisi nedir?
+
+A: Bu, efektlerin oynatılıp oynatılmadığına bağlıdır. Oynatılmayan bir ParticleFx'in performans maliyeti sıfırdır. Oynatılan bir ParticleFx'in performans etkisi yapılandırmasına bağlı olduğundan profil çıkarıcı kullanılarak değerlendirilmelidir. Çoğu başka şeyde olduğu gibi bellek, *game.project* dosyasında max_count olarak tanımlanan ParticleFx sayısı için önceden ayrılır.
+
+
+#### Q: Bir koleksiyon vekili aracılığıyla yüklenen koleksiyondaki bir oyun nesnesine nasıl girdi alırım?
+
+A: Koleksiyon vekili (collection proxy) aracılığıyla yüklenen her koleksiyonun kendi girdi yığını vardır. Girdi, ana koleksiyonun girdi yığınından vekil bileşeni aracılığıyla koleksiyondaki nesnelere yönlendirilir. Bu, yüklenen koleksiyondaki oyun nesnesinin girdi odağını almasının yeterli olmadığı; vekil bileşenini _barındıran_ oyun nesnesinin de girdi odağını alması gerektiği anlamına gelir. Ayrıntılar için [Girdi belgelerine](/manuals/input) bakın.
+
+
+#### Q: Dize türünde betik özellikleri kullanabilir miyim?
+
+A: Hayır. Defold, [hash](/ref/builtins#hash) türünde özellikleri destekler. Bunlar türleri, durum tanımlayıcılarını veya her türlü anahtarı belirtmek için kullanılabilir. Karma değerleri oyun nesnesi tanımlayıcılarını (yollarını) saklamak için de kullanılabilir; ancak düzenleyici ilgili URL'leri içeren bir açılır listeyi sizin için otomatik olarak doldurduğundan [url](/ref/msg#msg.url) özellikleri genellikle daha uygundur. Ayrıntılar için [Betik özellikleri belgelerine](/manuals/script-properties) bakın.
+
+
+#### Q: Bir matrisin ([`vmath.matrix4()`](/ref/vmath/#vmath.matrix4:m1) veya benzeri bir işlevle oluşturulan) tek tek hücrelerine nasıl erişirim?
+
+A: Hücrelere `mymatrix.m11`, `mymatrix.m12`, `mymatrix.m21` vb. kullanarak erişebilirsiniz
+
+
+#### Q: [gui.clone()](/ref/gui/#gui.clone:node) veya [gui.clone_tree()](/ref/gui/#gui.clone_tree:node) kullanırken `Not enough resources to clone the node` hatasını alıyorum
+
+A: GUI bileşeninin `Max Nodes` değerini artırın. Bu değeri, Outline görünümünde bileşenin kökünü seçtiğinizde Properties panelinde bulabilirsiniz.
+
+
+## Forum
+
+#### Q: Çalışmalarımı tanıttığım bir konu açabilir miyim?
+
+A: Elbette! Bunun için özel bir ["Work for hire" kategorimiz](https://forum.defold.com/c/work-for-hire) var. Topluluğa yarar sağlayan her şeyi her zaman destekleriz; hizmetlerinizi ücret karşılığında olsun ya da olmasın topluluğa sunmanız buna iyi bir örnektir.
+
+
+#### Q: Bir konu açıp çalışmalarımı ekledim; daha fazlasını ekleyebilir miyim?
+
+A: "Work for hire" konularının üst sıralara taşınmasını azaltmak için kendi konunuza 14 günde birden fazla gönderi yazamazsınız (konudaki bir yoruma doğrudan yanıt vermeniz dışında; bu durumda yanıt verebilirsiniz). 14 günlük süre içinde konunuza başka çalışmalar eklemek istiyorsanız mevcut gönderilerinizi düzenleyerek yeni içeriği eklemeniz gerekir.
+
+
+#### Q: İş ilanı yayımlamak için Work for Hire kategorisini kullanabilir miyim?
+
+A: Tabii, dilediğiniz gibi kullanın! Hem hizmet sunmak hem de hizmet talep etmek için kullanılabilir; örneğin, "2B piksel sanatçısı arayan programcı; zenginim ve iyi ücret ödeyeceğim".

--- a/docs/tr/glossary.txt
+++ b/docs/tr/glossary.txt
@@ -1,0 +1,754 @@
+---
+title: Defold belgeleri için Türkçe terim sözlüğü
+brief: Defold belgelerinde kullanılacak Türkçe terimler, anlam ayrımları ve resmî kaynaklara dayalı kullanım notları.
+---
+
+# Defold belgeleri için Türkçe terim sözlüğü
+
+Bu sözlük, yeni Türkçe çeviriler için hazırlanmıştır. Araştırma sırasında `docs/tr` altında çeviri dosyası yoktu. Depodaki `de`, `es`, `fr`, `gr`, `it`, `ja`, `ko`, `pl`, `pt` ve `uk` dizinlerinde bulunan on sözlük ve on çeviri kılavuzunun kapsamı, terimleri ve kuralları incelendi. İngilizce Defold belgeleri, Godot projesinin resmî Türkçe belge çeviri kataloğu ve farklı yazılım üreticilerinin Türkçe belgeleriyle karşılaştırıldı. Hazırlama ve kaynakları kontrol etme tarihi: 2026-09-12.
+
+Açıklayıcı metinde önerilen Türkçe biçimi kullanın. Önemli kavramları bir yazıda ilk kez açıklarken İngilizcelerini de verin: `oyun nesnesi (game object)`. Ekranda bulunacak, yazılacak veya kopyalanacak arayüz etiketlerini, API adlarını, komutları, dosya adlarını ve diğer teknik dizeleri aynen koruyun. Ayrıntılar için [çeviri kılavuzuna](translation-guidelines.txt) bakın.
+
+Kaynaklar Türkçe kullanım örnekleri sağlar; başka bir motorun yapısını Defold için geçerli kılmaz. Anlam ve davranış için `docs/en` esas alınır. Özellikle `koleksiyon`, `başlangıç koleksiyonu`, `fabrika`, `koleksiyon fabrikası` ve `koleksiyon vekili` bu Türkçe belge seti için seçilmiş açıklama terimleridir; doğrulanmış Türkçe Defold arayüz etiketleri değildir. Ayrı kaynak gösterilmeyen maddeler de bu belge setinin terim önerileridir.
+
+## Defold ve genel kavramlar
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| Defold | Defold; ürün adını koruyun |
+| Defold Foundation | Defold Foundation; kuruluşun adını koruyun |
+| Defold Editor | Defold düzenleyicisi; ürünün tam İngilizce adı aktarılıyorsa `Defold Editor` |
+| editor | düzenleyici; Godot kataloğundaki kullanımla uyumludur [G1] |
+| engine | motor |
+| game engine | oyun motoru |
+| engine instance | motor örneği |
+| game | oyun |
+| gameplay | oynanış |
+| game logic | oyun mantığı |
+| application / app | uygulama |
+| software | yazılım |
+| feature | özellik; ürünün sunduğu yetenek anlamında |
+| tool | araç |
+| system / subsystem | sistem / alt sistem |
+| platform / target platform | platform / hedef platform |
+| documentation | belgeler; bir bütün olarak belgelendirme |
+| manual | kılavuz |
+| API documentation | API belgeleri |
+| API reference | API başvuru belgeleri |
+| tutorial | öğretici; adım adım uygulama içeren belge |
+| example / sample | örnek; `instance` anlamındaki nesne örneğiyle bağlamda ayırın |
+| overview | genel bakış |
+| product overview | ürüne genel bakış |
+| FAQ | sık sorulan sorular; başlıkta kullanılabilir, kaynak metindeki `Q:` ve `A:` işaretleri korunur |
+| community | topluluk |
+| forum | forum |
+
+## Projeler, dosyalar ve kaynaklar
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| project | proje |
+| project settings | proje ayarları |
+| project file | proje dosyası |
+| project template | proje şablonu |
+| file | dosya |
+| folder | klasör |
+| directory / root directory | dizin / kök dizin |
+| file extension | dosya uzantısı; motor eklentisiyle karıştırmayın |
+| source file | kaynak dosya |
+| source code | kaynak kod |
+| codebase | kod tabanı |
+| resource | kaynak; Defold kaynak sisteminin yönettiği veriler |
+| resource file | kaynak dosyası |
+| resource path | kaynak yolu |
+| resource tree | kaynak ağacı |
+| resource graph | kaynak grafı; bağımlılık ilişkilerini gösterir |
+| resource management | kaynak yönetimi |
+| resource property | kaynak özelliği; bir kaynağa başvuran özellik |
+| custom resource | özel kaynak |
+| built-in resource | yerleşik kaynak |
+| bundle resource | dağıtım paketine eklenen kaynak; tam ayar adı korunur |
+| asset | varlık; oyunda kullanılan görsel, model veya ses gibi üretim içeriği. `resource` için otomatik karşılık olarak kullanmayın |
+| Asset Portal | Asset Portal; özel adı koruyun |
+| content | içerik |
+| library | kütüphane; bu belgelerde `kitaplık` ile dönüşümlü kullanmayın |
+| dependency | bağımlılık |
+| library dependency | kütüphane bağımlılığı |
+| repository | depo; Git bağlamında kod deposu |
+| branch | dal |
+| version control | sürüm kontrolü |
+| clone | klonlamak; Git deposunun kopyasını oluşturmak |
+| archive | arşiv |
+| cache | önbellek |
+| caching | önbelleğe alma |
+| resource cache / asset cache | kaynak önbelleği / varlık önbelleği; kaynak metindeki ayrımı koruyun |
+| local cache / remote cache | yerel önbellek / uzak önbellek |
+| reference | başvuru; başka bir dosya, kaynak veya nesneye gönderme |
+| file reference | dosya başvurusu |
+| reference count / reference counting | başvuru sayısı / başvuru sayımı |
+| broken reference | bozuk başvuru |
+| extension | eklenti; dosya adı bağlamında uzantı |
+| native extension | yerel kod eklentisi; C, C++ gibi dillerde yazılan motor eklentisi |
+| checksum | sağlama toplamı |
+| read-only | salt okunur |
+| default value | varsayılan değer |
+| configuration / configuration value | yapılandırma / yapılandırma değeri |
+
+## Oyun yapısı ve örnekler
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| building blocks | yapı taşları |
+| game object | oyun nesnesi; kimlik, konum, dönme ve ölçek bilgileriyle bileşenleri barındırır [D1] |
+| current game object | geçerli oyun nesnesi |
+| component | bileşen; oyun nesnesine davranış veya görünüm gibi işlevler ekler [D1] |
+| component type | bileşen türü |
+| component property | bileşen özelliği |
+| collection | koleksiyon; oyun nesnelerinin ve alt koleksiyonların düzenini tanımlayan dosya. Çalışma zamanında doğrudan adreslenen bir oyun nesnesi değildir [D1] |
+| collection file | koleksiyon dosyası |
+| sub-collection | alt koleksiyon |
+| collection hierarchy | koleksiyon hiyerarşisi; adresleme bağlamını belirleyen yapı |
+| bootstrap collection | başlangıç koleksiyonu; motor başlatıldığında yüklenen koleksiyon |
+| main collection | ana koleksiyon; `game.project` içindeki tam ayar adı korunur |
+| root collection | kök koleksiyon; hiyerarşinin kökü, her bağlamda başlangıç koleksiyonu anlamına gelmez |
+| collection instance | koleksiyon örneği; koleksiyon tanımına dayalı içerik örneği |
+| factory | fabrika; çalışma sırasında oyun nesneleri oluşturan bileşen [D4] |
+| factory component | fabrika bileşeni |
+| collection factory | koleksiyon fabrikası; koleksiyonun içeriğini geçerli oyun dünyasında oluşturur [D3] |
+| collection proxy | koleksiyon vekili; koleksiyon içeriğini ayrı bir oyun dünyasına yükler ve yönetir. Ağdaki ara sunucu anlamında değildir [D2] |
+| prototype | prototip; Defold bağlamında örneklerin dayandığı tanım, yalnızca deneme sürümü anlamında değildir |
+| prefab | prefab; başka motorlardaki yeniden kullanılabilir nesne tanımı anlatılırken İngilizce terimi açıklayın |
+| blueprint | taslak; genel benzetmede. Unreal Engine özelliği olan `Blueprint` adını koruyun |
+| template | şablon |
+| hierarchy | hiyerarşi; öğelerin üst-alt ilişkilerine göre düzenlenmesi |
+| instance | örnek; belirsizlik varsa `nesne örneği` veya ilgili türle birlikte kullanın |
+| instantiate / instantiation | örnek oluşturmak / örnek oluşturma; doku veya ses örneklemesiyle karıştırmayın |
+| spawn | çalışma sırasında oluşturmak; nesnenin yeniden doğması anlamını kendiliğinden eklemeyin |
+| in-place | yerinde; ayrı prototip dosyasına başvurmak yerine içinde bulunduğu dosyada tanımlanan öğe |
+| embedded game object / component | gömülü oyun nesnesi / gömülü bileşen |
+| by reference | başvuru yoluyla; bir dosyaya başvurarak ekleme |
+| parent | üst nesne; GUI bağlamında üst düğüm |
+| child | alt nesne; GUI bağlamında alt düğüm |
+| parent-child hierarchy | üst-alt nesne hiyerarşisi; dönüşümlerin aktarılmasını belirler |
+| childing / reparenting | alt nesne olarak bağlama / üst nesneyi değiştirme; adresi değiştirmekle aynı işlem değildir [D1] |
+| root | kök |
+| scene | sahne; Defold koleksiyonu için her yerde kullanılabilecek bir eş anlamlı değildir |
+| scene graph | sahne grafı; çizelge veya grafik görüntüsü anlamında değildir |
+| game world | oyun dünyası |
+| physics world | fizik dünyası |
+| lifetime / lifespan | yaşam süresi; parçacıklarda ömür de kullanılabilir |
+| lifecycle | yaşam döngüsü; geçen süre yerine aşamaları ve geçişleri anlatır |
+
+## Bileşenler ve kaynak türleri
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| sprite | sprite; görüntü gösteren Defold bileşeni. İlk kullanımda `sprite bileşeni` diye açıklayın |
+| sprite component | sprite bileşeni |
+| script | betik; Godot kataloğunda da kullanılan karşılık [G1] |
+| script component | betik bileşeni |
+| script file | betik dosyası |
+| game object script | oyun nesnesi betiği |
+| GUI component | GUI bileşeni |
+| GUI scene | GUI sahnesi |
+| GUI script | GUI betiği; `.gui_script` uzantısı korunur |
+| editor script | düzenleyici betiği |
+| render script | işleme betiği; görüntü oluşturma akışını yöneten Lua betiği |
+| model / model component | model / model bileşeni |
+| mesh | örgü; köşelerden ve bunları birleştiren geometriden oluşan yapı. Epic belgelerindeki kullanımla uyumludur [E2] |
+| mesh component | örgü bileşeni |
+| camera / camera component | kamera / kamera bileşeni |
+| collision object | çarpışma nesnesi; adına rağmen Defold içinde bir bileşen türüdür |
+| sound component | ses bileşeni |
+| particle effect / Particle FX | parçacık efekti; `ParticleFX` gibi tam tür ve arayüz adlarını koruyun |
+| tile map / tilemap | karo haritası |
+| tile source | karo kaynağı; `.tilesource` uzantısı korunur |
+| tile set / tileset | karo kümesi; Defold karo kaynağının adı yerine kendiliğinden kullanmayın |
+| tile | karo; kare boyutunda olması gerektiğini çeviriye eklemeyin |
+| atlas | atlas; ayrı görüntüleri doku sayfalarında birleştiren kaynak |
+| animation set | animasyon kümesi |
+| material | materyal; gölgelendiricileri ve ilgili özellikleri tanımlayan kaynak. Doku ile aynı şey değildir [E2] |
+| texture | doku [E2] |
+| cubemap | küp haritası; küpün yüzlerine karşılık gelen görüntülerden oluşan doku |
+| font | yazı tipi [E2] |
+| label | etiket; oyun nesnesi üzerinde metin gösteren bileşen. GUI metin düğümünden ayrıdır |
+| GUI template | GUI şablonu |
+| texture profile | doku profili |
+| display profile | ekran profili |
+
+## Adresleme ve iletiler
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| identifier / ID | tanımlayıcı; `id`, `Id` veya `ID` tam alan adıysa yazımını koruyun |
+| unique identifier | benzersiz tanımlayıcı |
+| addressing | adresleme |
+| address | adres |
+| relative address / addressing | göreli adres / göreli adresleme |
+| absolute address / addressing | mutlak adres / mutlak adresleme |
+| target address | hedef adres |
+| target | hedef; işlem, ileti veya derleme bağlamını belirtin |
+| naming context | adlandırma bağlamı |
+| namespace | ad alanı |
+| name collision | ad çakışması; fiziksel çarpışmadan farklıdır |
+| path | yol; tam URL alanı adı `path` olarak kalır |
+| relative path / absolute path | göreli yol / mutlak yol |
+| URL | URL; adresin kendisini değiştirmeyin |
+| URL object / URL string | URL nesnesi / URL dizesi |
+| socket | soket; Defold URL adresinde oyun dünyasını belirleyen bölüm. Ağ bağlantısı anlamındaki soketten ayırın |
+| fragment (URL) | URL parçası; Defold adresinde bileşeni belirleyen bölüm. Alan adı `fragment` korunur |
+| separator | ayırıcı |
+| hash | karma; işlev, değer veya veri türünden hangisinin kastedildiğini belirtin. API adı `hash()` korunur |
+| hash value / hashed value | karma değeri |
+| hashed identifier | karma değeri alınmış tanımlayıcı |
+| shorthand | kısa gösterim; `.`, `#` ve diğer tam gösterimler korunur |
+| message | ileti; tam ileti adları çevrilmez |
+| message passing | ileti aktarımı |
+| send / post a message | ileti göndermek |
+| receive a message | ileti almak |
+| sender | gönderen |
+| receiver / recipient | alıcı |
+| message ID | ileti tanımlayıcısı |
+| message data | ileti verisi |
+| message queue | ileti kuyruğu |
+| message chain | ileti zinciri |
+| dispatch messages | iletileri dağıtmak |
+| dispatch pass | ileti dağıtım turu |
+| message handler | ileti işleyicisi |
+| broadcast | tüm alıcılara gönderim; yalnızca kaynak metin bu davranışı tanımlıyorsa |
+| system message | sistem iletisi |
+| user message | kullanıcı tanımlı ileti; oyuncunun yazdığı sohbet iletisi anlamını eklemeyin |
+| current component | geçerli bileşen |
+
+## Lua, programlama ve yaşam döngüsü
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| Lua / LuaJIT | Lua / LuaJIT; `LUA` yazmayın |
+| Lua script / Lua module | Lua betiği / Lua modülü |
+| Lua context | Lua bağlamı |
+| programming language | programlama dili |
+| high-level language | yüksek düzeyli dil |
+| native code | yerel kod; bilgisayarda yerel olarak saklanan dosya anlamından ayırın |
+| code | kod |
+| data | veri |
+| module | modül |
+| function | işlev; API işlevinin adı değişmez |
+| method | yöntem; türün üyesi olan çağrılabilir yapı |
+| callback | geri çağırım; gerektiğinde geri çağırım işlevi |
+| event | olay; ileti ve geri çağırım ile eş anlamlı değildir |
+| event handler | olay işleyicisi |
+| variable | değişken |
+| argument | bağımsız değişken; çağrı sırasında verilen değer |
+| parameter | parametre; işlev tanımındaki parametreyle verilen değeri ayırın |
+| return value | dönüş değeri |
+| property | özellik |
+| script property | betik özelliği |
+| attribute | öznitelik; özellikle köşe verilerinde `property` ile birleştirmeyin |
+| field | alan |
+| constant | sabit |
+| enum / enumeration | numaralandırma türü; sabit adlarını koruyun |
+| type / data type | tür / veri türü |
+| number | sayı; Lua tür adı `number` değişmez |
+| string | dize; metin içeren veri türü. `string` gibi tam tür adları korunur |
+| boolean | mantıksal değer; `boolean`, `true` ve `false` korunur |
+| nil | `nil`; değer bulunmadığını ifade eden Lua değeri, sıfır veya boş dize değildir |
+| userdata | `userdata`; Lua veri türü adını koruyun |
+| table / Lua table | tablo / Lua tablosu |
+| key-value pair | anahtar-değer çifti |
+| array | dizi; dize ile karıştırmayın |
+| scope | kapsam |
+| local scope / global scope | yerel kapsam / genel kapsam |
+| state | durum |
+| stateful / stateless | durum tutan / durum tutmayan |
+| coroutine | eş yordam; ilk kullanımda İngilizcesini ekleyin |
+| closure | kapanış; dış kapsamın değişkenlerine erişebilen işlev bağlamında |
+| metatable | meta tablo; `metatable` API veya tür adıysa korunur |
+| garbage collection | çöp toplama |
+| allocation / deallocation | bellek ayırma / ayrılan belleği serbest bırakma |
+| application lifecycle | uygulama yaşam döngüsü |
+| preinitialization | ön başlatma |
+| initialization | başlangıç işlemleri; nesne ve bileşenlerin hazırlanması |
+| finalization | sonlandırma işlemleri; doğrudan silme veya bellekten kaldırma ile aynı işlem değildir |
+| cleanup | temizleme; kullanılan kaynakların bırakılması gibi işlemler |
+| update loop | güncelleme döngüsü |
+| update | güncelleme; yaşam döngüsü aşaması. Yazılım sürümü güncellemesiyle bağlamda ayırın |
+| fixed update | sabit zaman adımlı güncelleme |
+| late update | geç güncelleme; `late_update()` korunur |
+| post update | güncelleme sonrası aşama |
+| time step / timestep | zaman adımı |
+| fixed timestep | sabit zaman adımı |
+| delta time | geçen süre; bu bağlamda zaman adımına karşılık gelen süre. `dt` korunur |
+| runtime | çalışma zamanı; yazılım ortamı kastediliyorsa çalışma zamanı ortamı |
+| at runtime | çalışma sırasında |
+| execution time | yürütme süresi; bir işlemin ne kadar sürdüğü |
+| load / unload | yüklemek / bellekten kaldırmak; diskteki dosyayı silmek anlamına gelmez |
+| enable / disable | etkinleştirmek / devre dışı bırakmak |
+| delete | silmek |
+
+## Koordinatlar, kamera ve ekran
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| 2D / 3D | iki boyutlu (2B) / üç boyutlu (3B); ad, tür veya arayüz etiketi içindeki `2D` ve `3D` korunur |
+| transform / transformation | dönüşüm; konum, dönme ve ölçek bilgisini kapsayan kavram |
+| translation (spatial) | öteleme; uzamsal dönüşümde `çeviri` kullanmayın |
+| translation (language) | çeviri |
+| position | konum |
+| rotation | dönme; işlem için döndürme |
+| scale | ölçek |
+| scaling | ölçekleme |
+| movement | hareket |
+| coordinate system | koordinat sistemi |
+| local space | yerel uzay |
+| world space | dünya uzayı |
+| screen space | ekran uzayı |
+| origin | başlangıç noktası; koordinat sisteminin sıfır noktası |
+| axis | eksen |
+| vector | vektör |
+| vector component | vektör bileşeni; oyun nesnesine eklenen bileşenden farklı anlam |
+| matrix | matris |
+| quaternion | kuaterniyon; ilk kullanımda `quaternion` karşılığını ekleyin |
+| projection | izdüşüm |
+| orthographic projection | ortografik izdüşüm |
+| perspective projection | perspektif izdüşüm |
+| projection matrix | izdüşüm matrisi |
+| view matrix | görünüm matrisi |
+| view-projection matrix | görünüm-izdüşüm matrisi |
+| view frustum | görüş hacmi; kesik piramit biçimindeki hacim için |
+| field of view / FOV | görüş açısı (FOV) |
+| near plane / far plane | yakın düzlem / uzak düzlem |
+| viewport | görüntü alanı; pencerede görüntünün oluşturulduğu bölge |
+| zoom | yakınlaştırma; azaltma işlemi için uzaklaştırma |
+| screen size | ekran boyutu |
+| resolution | çözünürlük |
+| aspect ratio | en boy oranı |
+| orientation | yönelim |
+| portrait / landscape | dikey / yatay; ekran yönelimi |
+| fullscreen | tam ekran |
+| high DPI | yüksek DPI; gerektiğinde yüksek piksel yoğunluğu açıklaması |
+| pixel | piksel [K1] |
+| subpixel | alt piksel |
+| pixel-perfect | piksel düzeyinde tam hizalı; ilgili görüntüleme davranışını açıklayın |
+
+## Grafikler, işleme ve dokular
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| graphics | grafikler; alana göre grafik sistemi |
+| render / rendering | işlemek / işleme; grafiklerden görüntü oluşturma. İlk açıklamada `işleme (rendering)` yazın [G1] |
+| renderer | işleyici; belirsizlik varsa grafik işleyicisi. CPU anlamındaki işlemciden farklıdır [G1] |
+| graphics API / render API | grafik API'si / işleme API'si |
+| rendering pipeline / render pipeline | işleme hattı; görüntü oluşturmanın aşamaları |
+| render target | işleme hedefi |
+| render predicate | işleme yüklemi; materyal etiketlerine göre çizilecek bileşenleri seçen koşul |
+| material tag | materyal etiketi |
+| render pass | işleme geçişi |
+| draw call | çizim çağrısı |
+| draw order | çizim sırası |
+| batching / batch rendering | toplu çizim; uyumlu çizim işlerini gruplandırma |
+| vertex | köşe; çokgen geometrisindeki köşe noktası |
+| vertex attribute | köşe özniteliği |
+| fragment (graphics) | parça; rasterleştirmede üretilen işleme birimi, her zaman son görüntüdeki tek bir pikselle aynı şey değildir |
+| shader | gölgelendirici [G1] [E2] |
+| vertex shader | köşe gölgelendiricisi |
+| fragment shader | parça gölgelendiricisi; kaynak metindeki adı `pixel shader` olarak değiştirmeyin |
+| compute shader | hesaplama gölgelendiricisi |
+| shader program | gölgelendirici programı |
+| shader constant | gölgelendirici sabiti |
+| uniform | uniform; gölgelendiriciye sağlanan parametre türü. `uniform` dil anahtar sözcüğü korunur |
+| sampler | örnekleyici |
+| texture sampling | doku örnekleme; nesne örneği oluşturma işleminden farklıdır |
+| texel | teksel; doku elemanı |
+| UV coordinates / UV mapping | UV koordinatları / UV eşleme |
+| texture filtering | doku filtreleme |
+| nearest-neighbor filtering | en yakın komşu filtreleme |
+| linear filtering | doğrusal filtreleme |
+| minification / magnification filtering | küçültme / büyütme filtrelemesi |
+| mipmap | mipmap; dokunun küçültülmüş sürümlerinden oluşan yapı |
+| texture compression | doku sıkıştırma |
+| wrap mode | sarma modu; doku koordinatlarının sınırlar dışında nasıl yorumlandığı |
+| blend mode | harmanlama modu; Krita aynı kavram için `harmanlama kipi` kullanır [K1] |
+| alpha / alpha channel | alfa / alfa kanalı |
+| premultiplied alpha | önceden çarpılmış alfa |
+| tint | renk çarpanı; Defold bağlamında görüntü rengine uygulanan renk değeri. `tint` alanı korunur |
+| depth buffer / depth test | derinlik arabelleği / derinlik testi |
+| stencil buffer / stencil test | şablon arabelleği / şablon testi; proje şablonuyla ilgisi yoktur |
+| back buffer | arka arabellek |
+| buffer | arabellek; `cache` için kullanılan önbellekten ayırın |
+| culling / frustum culling | görünmeyenleri eleme / görüş hacmi dışında kalanları eleme |
+| clipping | kırpma; görünür bölgeyi sınırlama |
+| texture bleeding / edge bleeding | doku taşması / kenar taşması; komşu görüntünün renginin örneklemeye karışması |
+| extrude borders | kenarları genişletme; sınır piksellerini dışarı doğru çoğaltma. `Extrude Borders` etiketi korunur |
+| sprite sheet | sprite sayfası |
+
+## GUI, yerleşim ve metin
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| user interface / UI | kullanıcı arayüzü (UI) |
+| graphical user interface / GUI | grafik kullanıcı arayüzü (GUI); Defold bileşeni için GUI kısaltmasını koruyun |
+| HUD | HUD; ilk kullanımda oyun içi bilgi göstergesi olarak açıklayın |
+| node / GUI node | düğüm / GUI düğümü; oyun nesnesi yerine kullanılmaz |
+| node tree | düğüm ağacı |
+| box node | kutu düğümü |
+| text node | metin düğümü |
+| pie node | daire dilimi düğümü |
+| template node | şablon düğümü |
+| particle effect node | parçacık efekti düğümü |
+| layer | katman [K1] |
+| layout | yerleşim |
+| adaptive GUI | uyarlanabilir GUI |
+| pivot | dayanak noktası; yerleştirme, döndürme ve ölçekleme için kullanılan referans noktası |
+| anchor | sabitleme noktası; GUI yerleşimi bağlamında |
+| adjust mode | uyarlama modu |
+| slice-9 / 9-slice | dokuz parçalı ölçekleme; köşe ve kenarları ayrı ele alan yöntem |
+| bounding box | sınırlayıcı kutu |
+| visibility / visible | görünürlük / görünür |
+| opacity | opaklık; saydam olmama derecesi. Krita kaynağındaki `matlık` yerine bu belgelerde opaklık kullanılır [K1] |
+| transparency | saydamlık [K1] |
+| glyph | glif; yazı tipindeki görsel şekil, Unicode karakteriyle bire bir aynı olmak zorunda değildir |
+| bitmap font | bit eşlem yazı tipi |
+| distance field font | uzaklık alanı yazı tipi |
+| font collection | yazı tipi koleksiyonu; Defold oyun koleksiyonuyla bağlamda ayırın |
+| glyph cache | glif önbelleği |
+| alignment | hizalama |
+| line break | satır sonu; otomatik satır düzenleme bağlamında satır kaydırma |
+| leading / tracking | satır aralığı / harf aralığı |
+| text / image / color | metin / görüntü / renk |
+| width / height / size | genişlik / yükseklik / boyut |
+| outline (text) | dış çizgi; yazı tipi çevresindeki çizgi. Düzenleyicideki `Outline` görünümüyle karıştırmayın |
+
+## Animasyon, parçacıklar ve ses
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| animation / animate | animasyon / animasyon uygulamak; cümlede doğal olduğunda canlandırmak |
+| flipbook animation / flip-book animation | kare dizisi animasyonu; sıralı görüntülerin oynatılması |
+| property animation | özellik animasyonu |
+| model animation | model animasyonu |
+| skeletal animation / bone animation | iskelet animasyonu / kemik animasyonu |
+| animation clip | animasyon klibi |
+| frame | kare; görüntü veya animasyon bağlamında, `çerçeve` kullanmayın |
+| frame rate / FPS | kare hızı / saniyedeki kare sayısı (FPS) |
+| keyframe | anahtar kare |
+| interpolation | ara değerleme; ilk kullanımda `interpolation` eklenebilir |
+| easing | geçiş eğrisi; animasyonun zamana göre ilerleyişini belirleyen eğri |
+| tween | ara geçiş animasyonu |
+| playback / playback rate | oynatma / oynatma hızı |
+| loop / looping | döngü / döngüde oynatma |
+| ping-pong playback | ileri geri oynatma |
+| skeleton / bone | iskelet / kemik |
+| skinning | iskelete bağlama; örgü köşelerinin kemiklere bağlanması ve bunlarla deforme edilmesi |
+| rig | iskelet düzeneği; ilk kullanımda İngilizce terimi ekleyin |
+| particle | parçacık; gölgelendiricideki `fragment` için kullanmayın |
+| emitter | yayıcı |
+| modifier | değiştirici |
+| spawn rate | oluşturma hızı; parçacık bağlamında yayım hızı |
+| sound / audio | ses; dosya veya bileşen türünü bağlamda belirtin |
+| sound effect | ses efekti |
+| sound group | ses grubu |
+| gain | kazanç; sinyale uygulanan çarpan, duyulan ses yüksekliğiyle aynı büyüklük değildir |
+| pan | stereo konumu; sesin sol ve sağ kanallar arasındaki dağılımı |
+| streaming audio | akış yoluyla ses oynatma |
+
+## Girdi
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| input | girdi; oyuncudan veya donanımdan alınan veri [G1] |
+| input binding | girdi eşlemesi; donanım girdisini oyun eylemine bağlar |
+| input action | girdi eylemi |
+| input trigger | girdi tetikleyicisi |
+| input focus | girdi odağı |
+| input stack | girdi yığını |
+| consume input | girdiyi tüketmek; girdinin diğer alıcılara aktarılmasını durdurma anlamında |
+| pressed / released / repeated | basıldı / bırakıldı / yinelendi; `pressed`, `released`, `repeated` alanları korunur |
+| gamepad | oyun kumandası |
+| controller | denetleyici; fiziksel aygıt bir gamepad ise oyun kumandası. `controller` tanımlayıcısı korunur |
+| analog stick / dead zone | analog çubuk / ölü bölge |
+| mouse button / mouse wheel | fare düğmesi / fare tekerleği |
+| touch / multitouch | dokunma / çoklu dokunma |
+| text input | metin girdisi |
+| marked text | işaretli metin; girdi yöntemi düzenleyicisinde henüz kesinleşmemiş metin |
+| accelerometer input | ivmeölçer girdisi |
+| listener | dinleyici |
+
+## Fizik ve çarpışmalar
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| physics / physics engine | fizik / fizik motoru |
+| collision | çarpışma |
+| collision detection | çarpışma algılama |
+| collision response | çarpışmaya tepki; `collision_response` ileti adı korunur |
+| collision shape | çarpışma şekli |
+| collision group / collision mask | çarpışma grubu / çarpışma maskesi |
+| dynamic object | dinamik nesne; hareketini fizik motoru hesaplar |
+| kinematic object | kinematik nesne; hareketi ve çarpışmaya tepkisi oyun koduyla yönetilir |
+| static object | statik nesne |
+| rigid body | katı cisim |
+| trigger (physics) | tetikleyici; giriş ve çıkışları algılayan çarpışma nesnesi türü |
+| ray cast / raycast | ışın sorgusu; ışının nesnelerle kesişmesini sınama. Işın izleme ile karıştırmayın |
+| hit | isabet; ışın sorgusunda kesişme sonucu |
+| contact point | temas noktası |
+| normal | normal; bağlam gerektiğinde normal vektörü |
+| penetration depth / penetration distance | iç içe geçme derinliği / iç içe geçme mesafesi |
+| velocity | hız; yönü olan vektörel büyüklük |
+| speed | sürat; hızın büyüklüğü. Oynatma veya yürütme bağlamında hız kullanın |
+| angular velocity | açısal hız |
+| force / torque / impulse | kuvvet / tork / itme; birbirinin yerine kullanmayın |
+| mass / friction / restitution | kütle / sürtünme / geri sekme katsayısı |
+| damping | sönümleme |
+| joint / constraint | eklem / kısıt |
+| hinge joint / spring joint | menteşe eklemi / yay eklemi |
+| rope joint / slider joint | halat eklemi / kayar eklem |
+| convex hull | dışbükey zarf |
+| box / sphere / capsule | kutu / küre / kapsül |
+
+## Derleme, paketleme ve platformlar
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| build (process) | proje derleme; kaynakları işleyip çalıştırılabilir çıktıyı hazırlayan bütün süreç [M1] |
+| build (result) | derleme çıktısı; bağlam açıkken derleme |
+| compile / compilation | kodu derlemek / kod derleme; build sürecinin belirli bir aşaması [M1] |
+| compiler | derleyici |
+| rebuild / clean build | yeniden derleme / temiz derleme |
+| build and launch | derleyip başlatmak |
+| build target | derleme hedefi |
+| build variant | derleme çeşidi; `Debug`, `Release` gibi tam adlar korunur |
+| debug build / release build | hata ayıklama derlemesi / yayıma yönelik derleme |
+| build error / build report | derleme hatası / derleme raporu |
+| build cache / build server | derleme önbelleği / derleme sunucusu |
+| bundle | dağıtım paketi; Defold ile belirli bir platform için oluşturulan bağımsız paket |
+| bundling / to bundle | paketleme / dağıtım paketi oluşturmak; yalnızca kod derleme değildir |
+| bundle resources (operation) | kaynakları pakete eklemek |
+| package | paket; her yazılım paketi bir Defold dağıtım paketi değildir |
+| standalone | bağımsız; düzenleyiciden ayrı çalıştırılabilen |
+| headless | grafik arayüzü olmadan çalışan; `headless` seçenek ve dosya adlarında korunur |
+| operating system / OS | işletim sistemi |
+| device | cihaz |
+| development app | geliştirme uygulaması |
+| executable / binary | yürütülebilir dosya / ikili dosya; her ikili dosya yürütülebilir değildir |
+| deployment | dağıtıma alma; uygulamayı hedef ortama yerleştirme |
+| distribution / publishing | dağıtım / yayımlama |
+| stable version / beta version | kararlı sürüm / beta sürümü |
+| version / release (version) | sürüm / yayımlanan sürüm; tam derleme çeşidi adı `Release` korunur |
+| hot reload | çalışma sırasında yeniden yükleme; geliştirme özelliği. `hot reload` ilk kullanımda eklenir |
+| Live Update | Live Update; ürün özelliğinin adını koruyun, gerektiğinde çalışma sırasında içerik güncelleme olarak açıklayın |
+| app manifest / application manifest | uygulama bildirimi; dosya adını ve yapılandırma anahtarlarını koruyun |
+| Android App Bundle / AAB | Android App Bundle (AAB); belirli Android yayımlama biçimi. Genel Defold dağıtım paketiyle aynı kapsamda değildir [A1] |
+| APK | APK; Android uygulama paketinin adı |
+| app signing | uygulama imzalama |
+| certificate / signing key / keystore | sertifika / imzalama anahtarı / anahtar deposu |
+| bundle identifier | paket tanımlayıcısı; değeri değişmez |
+| provisioning profile | sağlama profili; Apple geliştirme bağlamı |
+| entitlement | yetki; Apple platformlarına özgü anahtarların adları korunur |
+| SDK | yazılım geliştirme kiti (SDK) |
+| environment variable | ortam değişkeni |
+| driver | sürücü |
+| download / install | indirmek / kurmak; dosya veya kaynak yükleme işlemiyle ayırın |
+| extract an archive | arşivi çıkarmak |
+
+## Düzenleyici işlemleri, hata ayıklama ve performans
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| UI label | arayüz etiketi; bu sözlükteki açıklamalar gerçek etiketin yerine geçmez |
+| panel / pane | panel / bölme |
+| view | görünüm |
+| inspector | özellik denetleyicisi; bir ürünün tam panel adıysa korunur |
+| menu / context menu | menü / bağlam menüsü |
+| dialog / popup | iletişim kutusu / açılır pencere |
+| tab / button / checkbox | sekme / düğme / onay kutusu |
+| dropdown | açılır liste |
+| select / create / add | seçmek / oluşturmak / eklemek; yönergelerde seçin / oluşturun / ekleyin |
+| click / right-click / double-click | tıklamak / sağ tıklamak / çift tıklamak |
+| drag / drop / drag and drop | sürüklemek / bırakmak / sürükleyip bırakmak |
+| press and hold | basılı tutmak |
+| copy and paste | kopyalayıp yapıştırmak |
+| save / undo / redo | kaydetmek / geri almak / yinelemek |
+| import / export | içe aktarmak / dışa aktarmak [E2] |
+| keyboard shortcut | klavye kısayolu; tuş adlarını ve birleşimlerini koruyun |
+| preferences | tercihler |
+| console / console output | konsol / konsol çıktısı |
+| log / logging | günlük / günlüğe kaydetme |
+| log file | günlük dosyası |
+| debugging / debugger | hata ayıklama / hata ayıklayıcı [M2] |
+| breakpoint / conditional breakpoint | kesme noktası / koşullu kesme noktası [M2] |
+| call stack | çağrı yığını [M2] |
+| step into / step over / step out | işlevin içine ilerlemek / çağrıyı tamamlayıp ilerlemek / geçerli işlevden çıkana kadar ilerlemek; menü komutları korunur |
+| profiling / profiler | profil çıkarma / profil çıkarıcı; performans ölçümü bağlamında |
+| performance / optimization | performans / optimizasyon |
+| memory usage / memory footprint | bellek kullanımı / bellekte kaplanan alan |
+| memory | bellek |
+| stack / heap | yığın / öbek; bellek bölgeleri olarak birbirinden ayırın |
+| bottleneck | darboğaz |
+| fill rate | piksel doldurma hızı |
+| crash / crash log | çökme / çökme günlüğü |
+| bug / workaround | yazılım hatası / geçici çözüm |
+| minimal reproduction project | hatayı yeniden oluşturmak için gereken en küçük proje |
+| deprecated | kullanımı artık önerilmeyen; hâlâ bulunabilir, mutlaka kaldırıldığı veya kaldırılacağı anlamına gelmez |
+| removed | kaldırılmış; artık sunulmayan |
+| outdated | güncelliğini yitirmiş; `deprecated` ile otomatik olarak eşitlemeyin |
+| code completion / code linting | kod tamamlama / statik kod denetimi |
+| refactoring | yeniden düzenleme; kodun davranışını koruyarak yapısını iyileştirme |
+
+## Otomasyon ve HTTP
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| automation | otomasyon |
+| deterministic automation | belirlenimci otomasyon; aynı koşullarda aynı sonucu verme |
+| automation loop | otomasyon döngüsü |
+| workflow | iş akışı |
+| inspect / modify / verify / evaluate | incelemek / değiştirmek / doğrulamak / değerlendirmek |
+| command-line tool / CLI | komut satırı aracı / komut satırı arayüzü (CLI) |
+| command line | komut satırı |
+| command / shell / terminal | komut / kabuk / terminal |
+| API | uygulama programlama arayüzü (API); kısaltmayı ve API adlarını koruyun |
+| server / client | sunucu / istemci |
+| editor server | düzenleyici sunucusu; açık projeye ait düzenleyici sürecinde çalışır |
+| engine service | motor hizmeti; çalışan motor sürecine aittir |
+| editor HTTP API | düzenleyici HTTP API'si |
+| runtime API | çalışma zamanı API'si |
+| source of truth | esas alınan kaynak; karar için hangi bilginin temel olduğunu belirtin |
+| service discovery / port discovery | hizmet keşfi / bağlantı noktası keşfi |
+| port / localhost | bağlantı noktası / yerel makine; `localhost` adres değeri korunur |
+| endpoint / route | uç nokta / rota |
+| request / response | istek / yanıt [M4] |
+| request body / response body | istek gövdesi / yanıt gövdesi [M4] |
+| header / status code | üstbilgi / durum kodu; `Content-Type` gibi tam adlar korunur |
+| schema / OpenAPI document | şema / OpenAPI belgesi |
+| authentication / authorization | kimlik doğrulama / yetkilendirme |
+| access token / bearer token | erişim belirteci / taşıyıcı belirteç; `Authorization: Bearer` aynen korunur |
+| asynchronous operation | eşzamansız işlem |
+| timeout / retry / polling | zaman aşımı / yeniden deneme / düzenli aralıklarla sorgulama |
+| structured result / structured error | yapılandırılmış sonuç / yapılandırılmış hata |
+| editor transaction | düzenleyici işlemi; bir değişiklik grubunu uygulayan transaction bağlamında |
+| lifecycle hook | yaşam döngüsü kancası; belirli aşamada çağrılan işlev |
+| stream | akış |
+| screenshot | ekran görüntüsü |
+| editor preview / scene preview | düzenleyici önizlemesi / sahne önizlemesi |
+| canvas | tuval [K1] |
+| injected input | program yoluyla sağlanan girdi |
+| capability / capability negotiation | yetenek / yetenek uzlaşması; desteklenen işlemler üzerinde anlaşma |
+| version compatibility | sürüm uyumluluğu |
+
+## Test ve doğrulama
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| automated testing | otomatik test |
+| unit test | birim testi [M3] |
+| integration test | tümleştirme testi [M3] |
+| end-to-end test / E2E test | uçtan uca test (E2E) |
+| regression test | gerileme testi; önceki davranışın bozulup bozulmadığını denetler |
+| visual regression test | görsel gerileme testi |
+| browser test / platform test | tarayıcı testi / platform testi |
+| test collection | test koleksiyonu; test için hazırlanan Defold koleksiyonu |
+| test framework / test runner | test çatısı / test çalıştırıcısı |
+| test suite / test case | test takımı / test durumu |
+| test fixture | test düzeneği |
+| setup / teardown | hazırlık / test sonrası temizleme |
+| assertion | doğrulama koşulu; testin denetlediği koşul. `assert()` gibi API adlarını koruyun |
+| mock / stub | mock / stub; testte bağımlılık yerine kullanılan yapılar. Kaynakta yapılan ayrımı koruyup gerektiğinde açıklayın |
+| expected result / test result | beklenen sonuç / test sonucu |
+| pass / failure | başarılı sonuç / başarısızlık; makine çıktılarındaki değerler korunur |
+| exit code / exit status | çıkış kodu / çıkış durumu |
+| code coverage | kod kapsamı |
+| acceptance criteria | kabul ölçütleri |
+| evidence | kanıt; sonucu destekleyen günlük, ölçüm veya görüntü |
+| artifact | çıktı dosyası; derleme veya testin ürettiği saklanabilir sonuç |
+| verification / validation | doğrulama / geçerleme; teknik doğruluk ve ihtiyaca uygunluk ayrımını kaynak metnin bağlamına göre koruyun |
+| baseline image / difference image | referans görüntü / fark görüntüsü |
+| image comparison / visual inspection | görüntü karşılaştırması / görsel inceleme |
+| deterministic / reproducible | belirlenimci / yeniden üretilebilir |
+| continuous integration / CI | sürekli tümleştirme (CI) |
+| completion event / run ID | tamamlanma olayı / çalıştırma tanımlayıcısı |
+
+## Yapay zekâ ve geliştirme araçları
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| artificial intelligence / AI | yapay zekâ; açıklayıcı metinde açık yazın, tam ürün adları ve alanlardaki `AI` korunur |
+| AI agent / coding agent | yapay zekâ ajanı / kodlama ajanı |
+| large language model / LLM | büyük dil modeli (LLM) |
+| multimodal model | çok modlu model |
+| model-neutral | belirli bir modele bağlı olmayan |
+| prompt | istem; modele verilen talimat veya girdi. Kabuk bağlamında komut istemi |
+| token (LLM) | token; modelin işlediği metin birimi. Kimlik doğrulama belirtecinden farklıdır |
+| skill | skill; bir aracın tanıdığı talimat paketi kastediliyorsa koruyup açıklayın. Genel yetenek için beceri |
+| Model Context Protocol / MCP | Model Context Protocol (MCP); protokol adını koruyun |
+| Automation Bridge | Automation Bridge; özel adı koruyun |
+| retrieval-augmented generation / RAG | bilgi getirmeyle desteklenen üretim (RAG) |
+| adapter / wrapper / integration layer | bağdaştırıcı / sarmalayıcı / tümleştirme katmanı |
+| permission / approval | izin / onay |
+| credential / secret | kimlik bilgisi / gizli bilgi |
+| sandbox / isolation | yalıtılmış çalışma ortamı / yalıtım |
+| untrusted input | güvenilmeyen girdi |
+| worktree / container | çalışma ağacı / konteyner; `git worktree` komutu korunur |
+
+## Yayımlama ve gelir elde etme
+
+| English term | Önerilen Türkçe karşılık / kullanım notu |
+|---|---|
+| monetization | gelir elde etme |
+| advertisement / ad | reklam |
+| ad network / ad provider | reklam ağı / reklam sağlayıcısı |
+| banner ad / interstitial ad | bant reklam / geçiş reklamı |
+| rewarded ad / incentivized ad | ödüllü reklam / teşvikli reklam |
+| ad revenue | reklam geliri |
+| in-app purchase | uygulama içi satın alma |
+| privacy policy | gizlilik politikası |
+| anonymous usage data | anonim kullanım verileri |
+| user tracking | kullanıcı takibi |
+| free / royalty-free | ücretsiz / telif ücreti gerektirmeyen; aynı lisans koşulunu ifade etmez |
+| open source / source available | açık kaynaklı / kaynak kodu erişime açık; lisans anlamlarını birleştirmeyin |
+| question / answer | soru / yanıt |
+
+## Aynen korunacak dizeler
+
+Bu tablo bir terim çevirisi değildir. Aşağıdaki örnekler, kullanıcıların ekranda, dosyada veya kodda aynı biçimde bulması gereken dizelerdir. Türkçe ekleri dizenin içine eklemeyin; `game.project` dosyasını, `msg.post()` işlevini, <kbd>Outline</kbd> görünümünü gibi yapılar kullanın.
+
+| Kategori | Örnekler |
+|---|---|
+| Ürünler, diller ve araçlar | `Defold`, `Defold Foundation`, `Lua`, `LuaJIT`, `C++`, `JavaScript`, `Bob`, `Spine`, `Rive`, `GitHub`, `OpenAPI`, `Automation Bridge` |
+| Platformlar, biçimler ve hizmetler | `Android`, `iOS`, `macOS`, `Windows`, `Linux`, `HTML5`, `WebGL`, `Vulkan`, `Metal`, `OpenGL`, `WebAssembly`, `Google Play`, `App Store`, `Android App Bundle` |
+| API ve geri çağırımlar | `msg.post()`, `go.animate()`, `gui.get_node()`, `factory.create()`, `collectionfactory.create()`, `init()`, `update()`, `fixed_update()`, `late_update()`, `final()`, `on_message()`, `on_input()` |
+| İletiler, sabitler ve alanlar | `enable`, `disable`, `set_parent`, `proxy_loaded`, `collision_response`, `acquire_input_focus`, `message_id`, `action_id`, `PLAYBACK_LOOP_PINGPONG` |
+| Dosyalar, yollar ve ayarlar | `game.project`, `main.collection`, `.collectionfactory`, `.gui_script`, `.render_script`, `.internal/editor.port`, `display.width`, `main_collection`, `max_count` |
+| Adresler ve örnek tanımlayıcıları | `main:/manager#controller`, `@render`, `@system`, `bean`, `buddy`, `shield`, `controller`, `team_1` |
+| Arayüz ve menü yolları | `Outline`, `Properties`, `Assets`, `Add Game Object`, `Add Collection File`, `Collection Proxy`, `Edit ▸ World Space`, `Help ▸ Open Editor Server`, `Project ▸ Rebuild And Launch` |
+| Komutlar, HTTP ve sonuç verileri | `build`, `clean-build`, `build-html5`, `--variant`, `GET /ping`, `POST /eval`, `/openapi.json`, `Authorization: Bearer`, `success`, `issues`, `duration_ms` |
+
+## İncelenen resmî kaynaklar
+
+Türkçe kullanım için aşağıdaki kaynaklar incelendi. Godot kaynağı, projenin kendi deposunda yayımlanan Türkçe belge çeviri kataloğudur; tamamlanmış bir Türkçe web kılavuzu olduğu varsayılmaz. `msgstr` metinleri İngilizce `msgid` metinleriyle karşılaştırıldı; boş ve `fuzzy` işaretli çeviriler dayanak olarak kullanılmadı. İncelenen Godot revizyonu `b8a5a2ee3186c8007ea3f88fc055fc6461ffb8a3` olarak sabitlendi. Genel kontrol tarihi: 2026-09-12.
+
+- [G1: Godot — Türkçe belge çeviri kataloğu][G1]. Düğüm ve sahne bölümü, özellik listesi, betikler, girdiler ve işleme terimleri. Kaynak metin yolları katalogdaki `#:` satırlarında bulunur. Godot belge çevirileri Juan Linietsky, Ariel Manzur ve Godot topluluğuna aittir; katalog CC BY 3.0 lisanslıdır. Buradaki açıklamalar Defold için yeniden yazılmıştır.
+- [E1: Unreal Engine — Unity'den Unreal Engine'a genel bakış][E1]. Bileşenler, dönüşümler, çalışma zamanı, derleme ve paketleme. Epic tarafından yayımlanan bir karşılaştırmadır; Unity'nin kendi Türkçe belgesi olarak gösterilmez.
+- [E2: Unreal Engine — Unity'den varlık taşıma][E2]. Örgü, doku, materyal, gölgelendirici, yazı tipi ve içe/dışa aktarma terimleri.
+- [K1: Krita — Temel konseptler][K1]. Piksel, katman, tuval, saydamlık ve harmanlama terimleri. Kaynağın tüm sözcük seçimleri Defold için zorunlu kabul edilmez.
+- [M1: Visual Studio — Derleme ve oluşturma][M1]. Proje derleme, derleyici, hedef platform, günlük ve iş akışı.
+- [M2: Visual Studio — Hata ayıklayıcıya genel bakış][M2]. Hata ayıklama, kesme noktası, çağrı yığını ve adımlama.
+- [M3: .NET — Test etme][M3]. Birim testi ve tümleştirme testi.
+- [M4: .NET — HttpClient ile HTTP istekleri][M4]. İstek, yanıt, yanıt gövdesi ve durum kodu.
+- [A1: Android Developers — Android App Bundle hakkında][A1]. Biçimin adı, uygulama paketi, imzalama ve yayımlama kavramları.
+
+Defold kavramlarının anlamı için ayrıca İngilizce [yapı taşları][D1], [koleksiyon vekili][D2], [koleksiyon fabrikası][D3] ve [fabrika][D4] kılavuzları kullanıldı. Dil kuralları ve kaynaklar arasındaki seçimlerin gerekçeleri [çeviri kılavuzunda](translation-guidelines.txt) açıklanır.
+
+[D1]: ../en/manuals/building-blocks.md
+[D2]: ../en/manuals/collection-proxy.md
+[D3]: ../en/manuals/collection-factory.md
+[D4]: ../en/manuals/factory.md
+[G1]: https://github.com/godotengine/godot-docs-l10n/blob/b8a5a2ee3186c8007ea3f88fc055fc6461ffb8a3/weblate/tr.po
+[E1]: https://dev.epicgames.com/documentation/unreal-engine/unity-to-unreal-engine-overview?lang=tr
+[E2]: https://dev.epicgames.com/documentation/unreal-engine/migrating-assets-from-unity-to-unreal-engine?lang=tr
+[K1]: https://docs.krita.org/tr/user_manual/getting_started/basic_concepts.html
+[M1]: https://learn.microsoft.com/tr-tr/visualstudio/ide/compiling-and-building-in-visual-studio?view=visualstudio
+[M2]: https://learn.microsoft.com/tr-tr/visualstudio/debugger/debugger-feature-tour?view=visualstudio
+[M3]: https://learn.microsoft.com/tr-tr/dotnet/core/testing/
+[M4]: https://learn.microsoft.com/tr-tr/dotnet/fundamentals/networking/http/httpclient
+[A1]: https://developer.android.com/guide/app-bundle?hl=tr

--- a/docs/tr/manuals/2dgraphics.md
+++ b/docs/tr/manuals/2dgraphics.md
@@ -1,0 +1,9 @@
+---
+title: Defold 2B grafikler kılavuzu
+brief: Bu kılavuz güncelliğini yitirmiştir
+---
+
+# 2B grafikler
+
+Bu kılavuzun yerini [Grafiklere genel bakış kılavuzu](/manuals/graphics) almıştır.
+

--- a/docs/tr/manuals/3dgraphics.md
+++ b/docs/tr/manuals/3dgraphics.md
@@ -1,0 +1,8 @@
+---
+title: Defold 3B grafik kılavuzu
+brief: Bu kılavuz güncelliğini yitirmiştir
+---
+
+# 3B grafikler
+
+Bu kılavuzun yerini [Grafiklere genel bakış kılavuzu](/manuals/graphics) almıştır.

--- a/docs/tr/manuals/adapting-graphics-to-screen-size.md
+++ b/docs/tr/manuals/adapting-graphics-to-screen-size.md
@@ -1,0 +1,126 @@
+---
+title: Grafikleri farklı ekran boyutlarına uyarlama
+brief: Bu kılavuz, oyununuzu ve grafiklerinizi farklı ekran boyutlarına nasıl uyarlayacağınızı açıklar.
+---
+
+# Giriş
+
+Oyununuzu ve grafiklerinizi farklı ekran boyutlarına uyarlarken dikkate almanız gereken birkaç nokta vardır:
+
+* Bu, düşük çözünürlüklü, piksel düzeyinde tam hizalı (pixel-perfect) grafiklere sahip retro bir oyun mu, yoksa HD kalitesinde grafiklere sahip modern bir oyun mu?
+* Oyun, farklı ekran boyutlarında tam ekran oynandığında nasıl davranmalı?
+  * Oyuncu, yüksek çözünürlüklü bir ekranda oyun içeriğinin daha büyük bir bölümünü mü görmeli, yoksa grafikler her zaman aynı içeriği gösterecek şekilde yakınlaştırmayı uyarlamalı mı?
+* Oyun, *game.project* dosyasında ayarladığınızdan farklı en boy oranlarını nasıl ele almalı?
+  * Oyuncu, oyun içeriğinin daha büyük bir bölümünü mü görmeli? Belki siyah şeritler mi olmalı? Ya da GUI öğeleri yeniden mi boyutlandırılmalı?
+* Ne tür menülere ve ekranda gösterilen GUI bileşenlerine (GUI component) ihtiyacınız var ve bunlar farklı ekran boyutlarına ve ekran yönelimlerine nasıl uyarlanmalı?
+  * Yönelim değiştiğinde menüler ve diğer GUI bileşenleri yerleşimlerini değiştirmeli mi, yoksa yönelimden bağımsız olarak aynı yerleşimi korumalı mı?
+
+Bu kılavuz, bu konuların bazılarını ele alır ve önerilen uygulamaları sunar.
+
+
+## İçeriğinizin işlenme biçimini değiştirme
+
+Defold işleme betiği (render script), grafiklerden görüntü oluşturmayı sağlayan işleme (rendering) hattının tamamı üzerinde tam denetim sağlar. İşleme betiği, çizim sırasının yanı sıra nelerin nasıl çizileceğine de karar verir. İşleme betiğinin varsayılan davranışı, pencere yeniden boyutlandırılsa veya gerçek ekran çözünürlüğü bu boyutlarla eşleşmese de her zaman *game.project* dosyasındaki genişlik ve yüksekliğin tanımladığı aynı piksel alanını çizmektir. Bunun sonucunda en boy oranı değişirse içerik esnetilir, pencere boyutu değişirse içerik yakınlaştırılır veya uzaklaştırılır. Bazı oyunlarda bu kabul edilebilir; ancak ekran çözünürlüğü veya en boy oranı farklı olduğunda büyük olasılıkla oyun içeriğinin daha fazla veya daha az bir bölümünü göstermek ya da en azından en boy oranını değiştirmeden içeriği yakınlaştırmak istersiniz. Varsayılan esnetme davranışı kolayca değiştirilebilir; bunun nasıl yapılacağı hakkında daha fazla bilgiyi [İşleme kılavuzunda](https://www.defold.com/manuals/render/#default-view-projection) bulabilirsiniz.
+
+
+## Retro/8 bit grafikler
+
+Retro/8 bit grafikler genellikle eski oyun konsollarının veya bilgisayarların düşük çözünürlüğünü ve sınırlı renk paletini içeren grafik tarzını taklit eden oyunları ifade eder. Örneğin Nintendo Entertainment System (NES) 256x240, Commodore 64 320x200 ve Gameboy 160x144 ekran çözünürlüğüne sahipti; bunların tümü modern ekranların boyutunun yalnızca küçük bir bölümüdür. Bu grafik tarzını ve ekran çözünürlüğünü taklit eden oyunların modern, yüksek çözünürlüklü bir ekranda oynanabilmesi için grafiklerin birkaç kat büyütülmesi veya yakınlaştırılması gerekir. Bunu yapmanın basit bir yolu, tüm grafiklerinizi taklit etmek istediğiniz düşük çözünürlükte ve tarzda çizmek ve işlenirken grafikleri yakınlaştırmaktır. Defold'da işleme betiğini kullanarak ve [Sabit izdüşümü](/manuals/render/#fixed-projection) uygun bir yakınlaştırma değerine ayarlayarak bunu kolayca yapabilirsiniz.
+
+Bu karo kümesini (tileset) ve oyuncu karakterini ([kaynak](https://ansimuz.itch.io/grotto-escape-game-art-pack)) alıp 320x200 çözünürlüklü, 8 bitlik retro bir oyun için kullanalım:
+
+![](images/screen_size/retro-player.png)
+
+![](images/screen_size/retro-tiles.png)
+
+*game.project* dosyasında 320x200 ayarlayıp oyunu başlattığınızda görünüm şöyle olur:
+
+![](images/screen_size/retro-original_320x200.png)
+
+Pencere, modern ve yüksek çözünürlüklü bir ekranda gerçekten çok küçüktür! Pencere boyutunu dört katına, 1280x800 değerine çıkarmak, onu modern bir ekran için daha uygun hale getirir:
+
+![](images/screen_size/retro-original_1280x800.png)
+
+Pencere boyutu artık daha makul olduğuna göre grafikler için de bir şey yapmamız gerekiyor. Grafikler o kadar küçük ki oyunda neler olduğunu görmek çok zor. Sabit ve yakınlaştırılmış bir izdüşüm ayarlamak için işleme betiğini kullanabiliriz:
+
+```Lua
+msg.post("@render:", "use_fixed_projection", { zoom = 4 })
+```
+
+::: sidenote
+Aynı sonuç, bir oyun nesnesine (game object) [kamera bileşeni](/manuals/camera/) ekleyip *Orthographic Projection* seçeneğini işaretleyerek ve *Orthographic Zoom* değerini 4.0 olarak ayarlayarak da elde edilebilir:
+
+![](images/screen_size/retro-camera_zoom.png)
+:::
+
+Bu, aşağıdaki sonucu verir:
+
+![](images/screen_size/retro-zoomed_1280x800.png)
+
+Bu daha iyi. Hem pencerenin hem de grafiklerin boyutu uygun, ancak daha yakından baktığımızda belirgin bir sorun var:
+
+![](images/screen_size/retro-zoomed_linear.png)
+
+Grafikler bulanık görünüyor! Bunun nedeni, yakınlaştırılmış grafiklerin GPU tarafından işlenirken dokudan örneklenme biçimidir. *game.project* dosyasının *Graphics* bölümündeki varsayılan ayar *linear* değeridir:
+
+![](images/screen_size/retro-settings_linear.png)
+
+Bunu *nearest* olarak değiştirmek, istediğimiz sonucu verir:
+
+![](images/screen_size/retro-settings_nearest.png)
+
+![](images/screen_size/retro-zoomed_nearest.png)
+
+Artık retro oyunumuz için keskin, *piksel düzeyinde tam hizalı* grafiklerimiz var. *game.project* dosyasında sprite bileşenleri için alt pikselleri devre dışı bırakmak gibi dikkate alınması gereken başka noktalar da vardır:
+
+![](images/screen_size/retro-subpixels.png)
+
+*Subpixels* seçeneği devre dışı bırakıldığında sprite bileşenleri hiçbir zaman yarım piksel konumlarında işlenmez ve her zaman en yakın tam piksele hizalanır.
+
+## Yüksek çözünürlüklü grafikler
+
+Yüksek çözünürlüklü grafiklerle çalışırken proje ve içerik kurulumuna retro/8 bit grafiklerden farklı yaklaşmamız gerekir. Bit eşlem grafiklerde içeriğinizi, yüksek çözünürlüklü bir ekranda 1:1 ölçekte gösterildiğinde iyi görünecek şekilde oluşturmanız gerekir.
+
+Retro/8 bit grafiklerde olduğu gibi işleme betiğini değiştirmeniz gerekir. Bu durumda grafiklerin, özgün en boy oranını korurken ekran boyutuyla birlikte ölçeklenmesini istersiniz:
+
+```Lua
+msg.post("@render:", "use_fixed_fit_projection")
+```
+
+Bu, ekranın her zaman *game.project* dosyasında belirtilen miktarda içeriği gösterecek şekilde yeniden boyutlandırılmasını sağlar; en boy oranının farklı olup olmamasına bağlı olarak üstte ve altta ya da yanlarda ek içerik de gösterilebilir.
+
+*game.project* dosyasındaki genişlik ve yüksekliği, oyun içeriğinizi ölçeklemeden göstermenize olanak tanıyan bir boyuta ayarlamanız önerilir.
+
+### Yüksek DPI ayarı ve retina ekranlar
+
+Yüksek çözünürlüklü retina ekranları da desteklemek isterseniz bunu *game.project* dosyasının Display bölümünde etkinleştirebilirsiniz:
+
+![](images/screen_size/highdpi-enabled.png)
+
+Bu, destekleyen ekranlarda yüksek DPI değerine sahip bir arka arabellek oluşturur. Oyun, Width ve Height ayarlarında belirtilen çözünürlüğün iki katında işlenir; bu ayarlar, betiklerde ve özelliklerde kullanılan mantıksal çözünürlüğü belirtmeye devam eder. Bu, tüm ölçülerin aynı kalacağı ve 1x ölçekte işlenen içeriğin aynı görüneceği anlamına gelir. Ancak yüksek çözünürlüklü görüntüleri içe aktarıp 0.5x ölçeğine küçültürseniz ekranda yüksek DPI değerinde görüntülenirler.
+
+
+## Uyarlanabilir bir GUI oluşturma
+
+GUI bileşenlerini oluşturma sistemi, temel yapı taşları olan [düğümler (node)](/manuals/gui/#node-types) üzerine kuruludur. Fazlasıyla basit görünse de düğmelerden karmaşık menülere ve açılır pencerelere kadar her şeyi oluşturmak için kullanılabilir. Oluşturduğunuz GUI'ler, ekran boyutu ve yönelim değişikliklerine otomatik olarak uyarlanacak şekilde yapılandırılabilir. Örneğin *düğümleri* ekranın üstüne, altına veya yanlarına sabitleyebilirsiniz; düğümler boyutlarını koruyabilir veya esneyebilir. *Düğümler* arasındaki ilişki, boyutları ve görünümleri de ekran boyutu veya yönelimi değiştiğinde değişecek şekilde yapılandırılabilir.
+
+### *Düğüm* özellikleri
+
+Bir GUI'deki her *düğümün* bir dayanak noktası (pivot), yatay ve dikey sabitleme noktaları (anchor) ve bir uyarlama modu (adjust mode) vardır.
+
+* Dayanak noktası, düğümün merkez noktasını tanımlar.
+* Sabitleme modu, sahnenin veya üst düğümün sınırları fiziksel ekran boyutuna sığacak şekilde esnetildiğinde düğümün dikey ve yatay konumunun nasıl değişeceğini denetler.
+* Uyarlama modu ayarı, sahnenin veya üst düğümün sınırları fiziksel ekran boyutuna sığacak şekilde uyarlandığında düğüme ne olacağını denetler.
+
+Bu özellikler hakkında daha fazla bilgiyi [GUI kılavuzunda](/manuals/gui/#node-properties) bulabilirsiniz.
+
+### Yerleşimler
+
+Defold, mobil cihazlarda ekran yönelimi değişikliklerine otomatik olarak uyarlanan GUI'leri destekler. Bu özelliği kullanarak farklı ekran boyutlarının yönelimine ve en boy oranına uyarlanabilen bir GUI tasarlayabilirsiniz. Belirli cihaz modelleriyle eşleşen yerleşimler oluşturmak da mümkündür. Bu sistem hakkında daha fazla bilgiyi [GUI yerleşimleri kılavuzunda](/manuals/gui-layouts/) bulabilirsiniz.
+
+
+## Farklı ekran boyutlarını test etme
+
+*Debug* menüsü, belirli bir cihaz modelinin çözünürlüğünü veya özel bir çözünürlüğü benzetmek için bir seçenek içerir. Uygulama çalışırken <kbd>Debug->Simulate Resolution</kbd> seçeneğini seçip listeden cihaz modellerinden birini seçebilirsiniz. Çalışan uygulamanın penceresi yeniden boyutlandırılır ve oyununuzun farklı bir çözünürlükte veya farklı bir en boy oranıyla nasıl göründüğünü görebilirsiniz.
+
+![](images/screen_size/simulate-resolution.png)

--- a/docs/tr/manuals/addressing.md
+++ b/docs/tr/manuals/addressing.md
@@ -1,0 +1,246 @@
+---
+title: Defold'da adresleme
+brief: Bu kılavuz, Defold'un adresleme sorununu nasıl çözdüğünü açıklar.
+---
+
+# Adresleme
+
+Çalışan bir oyunu denetleyen kod, oyuncunun gördüğü ve duyduğu öğeleri taşımak, ölçeklemek, canlandırmak, silmek ve değiştirmek için her nesneye ve bileşene (component) erişebilmelidir. Defold'un adresleme (addressing) mekanizması bunu mümkün kılar.
+
+## Tanımlayıcılar
+
+Defold, oyun nesnelerine (game object) ve bileşenlere başvurmak için adresler (veya URL'ler; şimdilik bunu bir kenara bırakalım) kullanır. Bu adresler tanımlayıcılardan (identifier) oluşur. Aşağıdakilerin tümü, Defold'un adresleri nasıl kullandığına ilişkin örneklerdir. Bu kılavuz boyunca bunların nasıl çalıştığını ayrıntılı olarak inceleyeceğiz:
+
+```lua
+local id = factory.create("#enemy_factory")
+go.set("my_gameobject#my_label", "text", "Hello World!")
+
+local pos = go.get_position("my_gameobject")
+go.set_position(pos, "/level/stuff/other_gameobject")
+
+msg.post("#", "hello_there")
+local id = go.get_id(".")
+```
+
+Çok basit bir örnekle başlayalım. Tek bir sprite bileşeni içeren bir oyun nesneniz olduğunu varsayalım. Oyun nesnesini denetlemek için bir betik bileşeniniz (script component) de var. Düzenleyicideki yapı şuna benzer:
+
+![Düzenleyicide bean](images/addressing/bean_editor.png)
+
+Şimdi, daha sonra görünür kılabilmek için oyun başladığında sprite bileşenini devre dışı bırakmak istiyorsunuz. Aşağıdaki kodu "controller.script" dosyasına ekleyerek bunu kolayca yapabilirsiniz:
+
+```lua
+function init(self)
+    msg.post("#body", "disable") -- <1>
+end
+```
+1. '#' karakteri kafanızı karıştırdıysa endişelenmeyin. Birazdan buna değineceğiz.
+
+Bu kod beklendiği gibi çalışır. Oyun başladığında betik bileşeni, sprite bileşenini "body" tanımlayıcısıyla *adresler* ve bu adresi kullanarak ona "disable" adlı bir *ileti* (message) gönderir. Bu özel motor iletisi, sprite bileşeninin sprite görselini gizlemesini sağlar. Yapı şematik olarak şöyle görünür:
+
+![bean](images/addressing/bean.png)
+
+Bu yapıdaki tanımlayıcılar geliştirici tarafından belirlenir ve kendi adlandırma bağlamları (naming context) içinde benzersiz olmalıdır. Burada oyun nesnesine "bean" tanımlayıcısını vermeyi seçtik; sprite bileşenine "body", karakteri denetleyen betik bileşenine ise "controller" adını verdik. Dize olarak yazılan URL adreslerinde kullanılan tanımlayıcılar `:` veya `#` içermemelidir; çünkü URL sözdiziminde `:` karakteri soket ayırıcısı, `#` karakteri ise oyun nesnesi/bileşen ayırıcısı olarak kullanılmak üzere ayrılmıştır. URL ayrıştırıcısı bunların dışında noktalama işaretlerini reddetmez.
+
+::: sidenote
+Bir ad seçmezseniz düzenleyici sizin yerinize seçer. Düzenleyicide yeni bir oyun nesnesi veya bileşen oluşturduğunuzda, benzersiz bir *Id* özelliği otomatik olarak ayarlanır.
+
+- Oyun nesnelerine otomatik olarak, bir sıra numarasıyla birlikte "go" adlı bir tanımlayıcı verilir ("go2", "go3" vb.).
+- Bileşenlere, bileşen türüne karşılık gelen bir tanımlayıcı verilir ("sprite", "sprite2" vb.).
+
+İsterseniz otomatik olarak atanan bu adları kullanmayı sürdürebilirsiniz, ancak tanımlayıcıları uygun ve açıklayıcı adlarla değiştirmenizi öneririz.
+:::
+
+Şimdi başka bir sprite bileşeni ekleyip bean nesnesine bir kalkan verelim:
+
+![bean](images/addressing/bean_shield_editor.png)
+
+Yeni bileşenin oyun nesnesi içinde benzersiz bir tanımlayıcısı olmalıdır. Ona "body" adını verseydiniz, betik kodunun "disable" iletisini hangi sprite bileşenine göndermesi gerektiği belirsiz olurdu. Bu nedenle benzersiz (ve açıklayıcı) "shield" tanımlayıcısını seçiyoruz. Artık "body" ve "shield" sprite bileşenlerini istediğimiz gibi etkinleştirebilir ve devre dışı bırakabiliriz.
+
+![bean](images/addressing/bean_shield.png)
+
+::: sidenote
+Bir tanımlayıcıyı birden fazla kez kullanmaya çalışırsanız düzenleyici hata bildirir; dolayısıyla bu durum uygulamada hiçbir zaman sorun olmaz:
+
+![bean](images/addressing/name_collision.png)
+:::
+
+Şimdi daha fazla oyun nesnesi eklerseniz neler olacağına bakalım. İki "bean" nesnesini eşleştirerek küçük bir takım oluşturmak istediğinizi varsayalım. Bu oyun nesnelerinden birine "bean", diğerine "buddy" adını vermeye karar veriyorsunuz. Ayrıca, "bean" bir süre boşta kaldığında "buddy" nesnesine dans etmeye başlamasını söylemelidir. Bunun için "bean" içindeki "controller" betik bileşeninden "buddy" içindeki "controller" betiğine "dance" adlı özel bir ileti gönderilir:
+
+![bean](images/addressing/bean_buddy.png)
+
+::: sidenote
+Her oyun nesnesinde bir tane olmak üzere "controller" adlı iki ayrı bileşen vardır, ancak her oyun nesnesi yeni bir adlandırma bağlamı oluşturduğundan bu tamamen geçerlidir.
+:::
+
+İletinin alıcısı, iletiyi gönderen oyun nesnesinin ("bean") dışında olduğundan, kodun iletiyi hangi "controller" bileşeninin alacağını belirtmesi gerekir. Hem hedef oyun nesnesinin tanımlayıcısı hem de bileşenin tanımlayıcısı belirtilmelidir. Bileşenin tam adresi `"buddy#controller"` olur ve bu adres iki ayrı bölümden oluşur.
+
+- Önce hedef oyun nesnesinin tanımlayıcısı ("buddy") gelir,
+- ardından oyun nesnesi/bileşen ayırıcı karakteri ("#") gelir,
+- son olarak hedef bileşenin tanımlayıcısını ("controller") yazarsınız.
+
+Tek bir oyun nesnesi içeren önceki örneğe dönersek, hedef adresin oyun nesnesi tanımlayıcısı bölümünü yazmadığımızda kodun *geçerli oyun nesnesindeki* bileşenleri adresleyebildiğini görürüz.
+
+Örneğin, `"#body"` geçerli oyun nesnesindeki "body" bileşeninin adresini belirtir. Bu çok kullanışlıdır; çünkü bu kod, "body" bileşeni bulunduğu sürece *herhangi bir* oyun nesnesinde çalışır.
+
+## Koleksiyonlar
+
+Koleksiyonlar (collection), oyun nesnesi grupları veya hiyerarşileri oluşturmanızı ve bunları kontrollü bir şekilde yeniden kullanmanızı sağlar. Oyununuza içerik eklerken düzenleyicide koleksiyon dosyalarını şablon (ya da "prototip" veya "prefab") olarak kullanırsınız.
+
+Çok sayıda bean/buddy takımı oluşturmak istediğinizi varsayalım. Bunun iyi bir yolu, yeni bir *koleksiyon dosyasında* bir şablon oluşturmaktır (dosyaya "team.collection" adını verin). Takımın oyun nesnelerini koleksiyon dosyasında oluşturup dosyayı kaydedin. Ardından bu koleksiyon dosyasının içeriğinin bir örneğini (instance) ana başlangıç koleksiyonunuza (bootstrap collection) yerleştirin ve örneğe bir tanımlayıcı verin ("team_1" adını verin):
+
+![bean](images/addressing/team_editor.png)
+
+Bu yapıda "bean" oyun nesnesi, `"buddy#controller"` adresiyle "buddy" içindeki "controller" bileşenine başvurmaya devam edebilir.
+
+![bean](images/addressing/collection_team.png)
+
+"team.collection" dosyasının ikinci bir örneğini eklerseniz ("team_2" adını verin), "team_2" içindeki betik bileşenlerinde çalışan kod da aynı şekilde çalışır. "team_2" koleksiyonundaki "bean" oyun nesnesi örneği, "buddy" içindeki "controller" bileşenini yine `"buddy#controller"` adresiyle adresleyebilir.
+
+![bean](images/addressing/teams_editor.png)
+
+## Göreli adresleme
+
+`"buddy#controller"` adresi, *göreli* (relative) bir adres olduğu için her iki koleksiyondaki oyun nesneleri için de çalışır. "team_1" ve "team_2" koleksiyonlarının her biri yeni bir adlandırma bağlamı, başka bir deyişle bir "ad alanı" (namespace) oluşturur. Defold, adresleme sırasında koleksiyonun oluşturduğu adlandırma bağlamını dikkate alarak ad çakışmalarını önler:
+
+![Göreli tanımlayıcı](images/addressing/relative_same.png)
+
+- "team_1" adlandırma bağlamı içinde "bean" ve "buddy" oyun nesneleri benzersiz olarak tanımlanır.
+- Benzer şekilde, "team_2" adlandırma bağlamı içinde de "bean" ve "buddy" oyun nesneleri benzersiz olarak tanımlanır.
+
+Göreli adresleme, bir hedef adres çözümlenirken başına geçerli adlandırma bağlamının otomatik olarak eklenmesiyle çalışır. Bu da son derece kullanışlı ve güçlüdür; çünkü kodlarıyla birlikte oyun nesnesi grupları oluşturabilir ve bunları oyunun tamamında verimli bir şekilde yeniden kullanabilirsiniz.
+
+### Kısa gösterimler
+
+Defold, tam bir URL belirtmeden ileti göndermek için kullanabileceğiniz iki kullanışlı kısa gösterim sunar:
+
+:[Shorthands](../shared/url-shorthands.md)
+
+## Oyun nesnesi yolları
+
+Adlandırma mekanizmasını doğru anlamak için projeyi derleyip çalıştırdığınızda neler olduğuna bakalım:
+
+1. Düzenleyici, başlangıç koleksiyonunu ("main.collection") ve içeriğinin tamamını (oyun nesneleri ve diğer koleksiyonlar) okur.
+2. Derleyici, her statik oyun nesnesi için bir tanımlayıcı oluşturur. Bunlar, başlangıç koleksiyonunun kökünden başlayıp koleksiyon hiyerarşisinde nesneye kadar inen "yollar" olarak oluşturulur. Her düzeyde bir '/' karakteri eklenir.
+
+Yukarıdaki örneğimizde oyun, aşağıdaki 4 oyun nesnesiyle çalışır:
+
+- /team_1/bean
+- /team_1/buddy
+- /team_2/bean
+- /team_2/buddy
+
+::: sidenote
+Tanımlayıcılar karma değerleri (hash) olarak saklanır. Çalışma zamanı ortamı, her koleksiyon tanımlayıcısının karma durumunu da saklar; bu durum, göreli dizenin karma hesaplamasını sürdürüp mutlak bir tanımlayıcı elde etmek için kullanılır.
+:::
+
+Çalışma sırasında koleksiyon gruplaması mevcut değildir. Belirli bir oyun nesnesinin derlemeden önce hangi koleksiyona ait olduğunu öğrenmenin bir yolu yoktur. Bir koleksiyondaki tüm nesneleri aynı anda değiştirmek de mümkün değildir. Bu tür işlemler yapmanız gerekiyorsa takibi kodda kendiniz kolayca yapabilirsiniz. Her nesnenin tanımlayıcısı statiktir ve nesnenin yaşam süresi boyunca sabit kalması garanti edilir. Bu, bir nesnenin tanımlayıcısını güvenle saklayıp daha sonra kullanabileceğiniz anlamına gelir.
+
+## Mutlak adresleme
+
+Adresleme sırasında yukarıda açıklanan tam tanımlayıcıları kullanmak mümkündür. Çoğu durumda içeriğin yeniden kullanılmasını sağladığı için göreli adresleme tercih edilir, ancak mutlak adreslemenin (absolute addressing) gerekli olduğu durumlar da vardır.
+
+Örneğin, her bean nesnesinin durumunu izleyen bir yapay zekâ yöneticisi istediğinizi varsayalım. Bean nesnelerinin geçerli durumlarını yöneticiye bildirmesini, yöneticinin de bu durumlara göre taktik kararlar alıp bean nesnelerine emir vermesini istiyorsunuz. Bu durumda, betik bileşeni içeren tek bir yönetici oyun nesnesi oluşturup bunu başlangıç koleksiyonunda takım koleksiyonlarının yanına yerleştirmek oldukça mantıklı olur.
+
+![Yönetici nesnesi](images/addressing/manager_editor.png)
+
+Bu durumda her bean nesnesi, yöneticiye durum iletileri göndermekten sorumludur: Bir düşman görürse "contact", vurulup hasar alırsa "ouch!". Bunun çalışması için bean nesnesinin denetleyici betiği, "manager" içindeki "controller" bileşenine ileti göndermek üzere mutlak adreslemeyi kullanır.
+
+'/' ile başlayan her adres, oyun dünyasının kökünden çözümlenir. Bu, oyun başlangıcında yüklenen *başlangıç koleksiyonunun* köküne karşılık gelir.
+
+Yönetici betiğinin mutlak adresi `"/manager#controller"` olur ve bu mutlak adres, nerede kullanılırsa kullanılsın doğru bileşene çözümlenir.
+
+![Takımlar ve yönetici](images/addressing/teams_manager.png)
+
+![Mutlak adresleme](images/addressing/absolute.png)
+
+## Karma değeri alınmış tanımlayıcılar
+
+Motor, tüm tanımlayıcıları karma değerleri olarak saklar. Bağımsız değişken olarak bileşen veya oyun nesnesi alan tüm işlevler bir dize, karma değeri veya URL nesnesi kabul eder. Yukarıda, adresleme için dizelerin nasıl kullanıldığını gördük.
+
+Bir oyun nesnesinin tanımlayıcısını aldığınızda motor her zaman karma değeri alınmış bir mutlak yol tanımlayıcısı döndürür:
+
+```lua
+local my_id = go.get_id()
+print(my_id) --> hash: [/path/to/the/object]
+
+local spawned_id = factory.create("#some_factory")
+print(spawned_id) --> hash: [/instance42]
+```
+
+Böyle bir tanımlayıcıyı dize tanımlayıcısının yerine kullanabilir veya kendiniz oluşturabilirsiniz. Ancak karma değeri alınmış bir tanımlayıcının nesnenin yoluna, yani mutlak bir adrese karşılık geldiğini unutmayın:
+
+::: sidenote
+Göreli adreslerin dize olarak verilmesi gerekir; çünkü motor, geçerli adlandırma bağlamının (koleksiyonun) karma durumunu temel alıp verilen dizeyi karma hesaplamasına ekleyerek yeni bir karma tanımlayıcısı hesaplar.
+:::
+
+```lua
+local spawned_id = factory.create("#some_factory")
+local pos = vmath.vector3(100, 100, 0)
+go.set_position(pos, spawned_id)
+
+local other_id = hash("/path/to/the/object")
+go.set_position(pos, other_id)
+
+-- This will not work! Relative addresses must be given as strings.
+local relative_id = hash("my_object")
+go.set_position(pos, relative_id)
+```
+
+## URL'ler {#urls}
+
+Konuyu tamamlamak için Defold adreslerinin tam biçimi olan URL'ye bakalım.
+
+URL, genellikle özel bir biçime sahip dize olarak yazılan bir nesnedir. Genel bir URL üç bölümden oluşur:
+
+`[socket:][path][#fragment]`
+
+socket
+: Hedefin oyun dünyasını tanımlar. [Koleksiyon vekilleriyle (collection proxy)](/manuals/collection-proxy) çalışırken bu önemlidir ve bu durumda _dinamik olarak yüklenen koleksiyonu_ tanımlamak için kullanılır.
+
+path
+: URL'nin bu bölümü, hedef oyun nesnesinin tam tanımlayıcısını içerir.
+
+fragment
+: Belirtilen oyun nesnesi içindeki hedef bileşenin tanımlayıcısıdır.
+
+Yukarıda gördüğümüz gibi, çoğu durumda bu bilgilerin bir kısmını veya çoğunu yazmayabilirsiniz. Soketi (socket) belirtmeniz neredeyse hiçbir zaman gerekmez; yolu belirtmeniz ise her zaman olmasa da çoğunlukla gerekir. Başka bir oyun dünyasındaki öğeleri adreslemeniz gerektiğinde URL'nin soket bölümünü belirtmeniz gerekir. Örneğin, yukarıdaki "manager" oyun nesnesindeki "controller" betiğinin tam URL dizesi şöyledir:
+
+`"main:/manager#controller"`
+
+team_2 içindeki buddy denetleyicisinin adresi ise şöyledir:
+
+`"main:/team_2/buddy#controller"`
+
+Bu adreslere ileti gönderebiliriz:
+
+```lua
+-- Send "hello" to the manager script and team buddy bean
+msg.post("main:/manager#controller", "hello_manager")
+msg.post("main:/team_2/buddy#controller", "hello_buddy")
+```
+
+## URL nesneleri oluşturma
+
+URL nesneleri Lua koduyla da oluşturulabilir:
+
+```lua
+-- Construct URL object from a string:
+local my_url = msg.url("main:/manager#controller")
+print(my_url) --> url: [main:/manager#controller]
+print(my_url.socket) --> 786443 (internal numeric value)
+print(my_url.path) --> hash: [/manager]
+print(my_url.fragment) --> hash: [controller]
+
+-- Construct URL from parameters:
+local my_url = msg.url("main", "/manager", "controller")
+print(my_url) --> url: [main:/manager#controller]
+
+-- Build from empty URL object:
+local my_url = msg.url()
+my_url.socket = "main" -- specify by valid name
+my_url.path = hash("/manager") -- specify as string or hash
+my_url.fragment = "controller" -- specify as string or hash
+
+-- Post to target specified by URL
+msg.post(my_url, "hello_manager!")
+```

--- a/docs/tr/manuals/ads.md
+++ b/docs/tr/manuals/ads.md
@@ -1,0 +1,62 @@
+---
+title: Defold'da reklam gösterme
+brief: Çeşitli reklam türleri göstermek, web ve mobil oyunlardan gelir elde etmenin yaygın bir yoludur. Bu kılavuz, reklamları kullanarak oyununuzdan gelir elde etmenin çeşitli yollarını gösterir.
+---
+
+# Reklamlar
+
+Reklamlar, web ve mobil oyunlardan gelir elde etmenin çok yaygın bir yolu haline gelmiş ve milyar dolarlık bir sektöre dönüşmüştür. Bir geliştirici olarak, oyununuzda gösterdiğiniz reklamları izleyen kişi sayısına göre ödeme alırsınız. Genellikle denklem basittir: daha fazla izleyici, daha fazla para demektir; ancak ne kadar ödeme alacağınızı başka etkenler de belirler:
+
+* Reklam kalitesi - oyuncularınızın kendilerine uygun reklamlarla etkileşime girme ve bu reklamlara dikkat etme olasılığı daha yüksektir.
+* Reklam biçimi - bant reklamlar genellikle daha az kazandırırken baştan sona izlenen tam ekran reklamlar daha fazla kazandırır.
+* Reklam ağı - aldığınız ödeme tutarı reklam ağından reklam ağına değişir.
+
+::: sidenote
+CPM = Bin gösterim başına maliyet (Cost per mille). Bir reklamverenin bin gösterim için ödediği tutardır. CPM, reklam ağlarına ve reklam biçimlerine göre değişir.
+:::
+
+## Biçimler
+
+Oyunlarda kullanılabilecek birçok farklı reklam biçimi vardır. Daha yaygın olanlardan bazıları bant reklamlar (banner ads), geçiş reklamları (interstitial ads) ve ödüllü reklamlardır (rewarded ads):
+
+### Bant reklamlar
+
+Bant reklamlar metin, görüntü veya video tabanlıdır ve genellikle ekranın üst veya alt kısmında, ekranın görece küçük bir bölümünü kaplar. Bant reklamların uygulamaya eklenmesi çok kolaydır ve ekranın bir bölümünü reklamlara ayırmanın kolay olduğu, tek ekranlı gündelik oyunlara çok iyi uyar. Bant reklamlar, kullanıcılar oyununuzu kesintisiz oynarken reklam görünürlüğünü en üst düzeye çıkarır.
+
+### Geçiş reklamları
+
+Geçiş reklamları, animasyonlar ve bazen etkileşimli *zengin medya (rich media)* içeriği barındıran, tüm ekranı kaplayan büyük reklam deneyimleridir. Geçiş reklamları genellikle bölümler veya oyun oturumları arasında gösterilir; çünkü bunlar oyun deneyimindeki doğal ara noktalardır. Geçiş reklamları genellikle bant reklamlardan daha az gösterim alır, ancak maliyetleri (CPM) bant reklamlara göre çok daha yüksektir ve bu da toplamda önemli bir reklam geliri sağlar.
+
+### Ödüllü reklamlar
+
+Ödüllü reklamlar (teşvikli reklamlar olarak da bilinir) isteğe bağlıdır ve bu nedenle diğer birçok reklam biçimine göre daha az rahatsız edicidir. Ödüllü reklamlar, geçiş reklamları gibi genellikle tam ekran deneyimleridir. Kullanıcı, reklamı izleme karşılığında bir ödül seçebilir; örneğin *ganimet*, oyun parası, can, süre ya da başka bir oyun içi para birimi veya avantaj. Ödüllü reklamlar genellikle en yüksek maliyete (CPM) sahiptir, ancak gösterim sayısı doğrudan kullanıcıların reklam izlemeyi kabul etme oranlarıyla ilişkilidir. Ödüllü reklamlar ancak ödüller yeterince değerliyse ve doğru zamanda sunuluyorsa yüksek performans sağlar.
+
+
+## Reklam ağları
+
+[Defold Asset Portal](/tags/stars/ads/), reklam sağlayıcılarıyla bütünleşen çeşitli varlıklar (assets) içerir:
+
+* [AdMob](https://defold.com/assets/admob-defold/) - Google AdMob ağını kullanarak reklam gösterin.
+* [AppLovin MAX](https://defold.com/extension-applovin/) - AppLovin MAX reklam uyumlulaştırmasını kullanarak reklam gösterin.
+* [Facebook Instant Games](https://defold.com/assets/facebookinstantgames/) - Facebook Instant Game oyununuzda reklam gösterin.
+* [LevelPlay](https://defold.com/extension-levelplay/) - Unity LevelPlay reklam uyumlulaştırmasını kullanarak reklam gösterin.
+* [Unity Ads](https://defold.com/assets/defvideoads/) - Unity Ads ağını kullanarak reklam gösterin.
+
+
+# Oyununuzda reklamları bütünleştirme
+
+Oyununuzda bütünleştireceğiniz reklam ağına karar verdiğinizde, ilgili *varlığın* kurulum ve kullanım yönergelerini izlemeniz gerekir. Genellikle ilk olarak eklentiyi bir [proje bağımlılığı](/manuals/libraries/#setting-up-library-dependencies) olarak eklersiniz. Varlığı projenize ekledikten sonra bütünleştirmeye devam edebilir ve reklamları yükleyip göstermek için varlığa özgü işlevleri çağırabilirsiniz.
+
+
+# Reklamlarla uygulama içi satın almaları birleştirme
+
+Mobil oyunlarda reklamları kalıcı olarak kaldırmak için [uygulama içi satın alma](/manuals/iap) sunmak oldukça yaygındır.
+
+
+## Daha fazla bilgi
+
+Reklam gelirini optimize etmeyi öğrenebileceğiniz birçok çevrimiçi kaynak vardır:
+
+* Google AdMob [Reklamlarla mobil oyunlardan gelir elde etme](https://admob.google.com/home/resources/monetize-mobile-game-with-ads/)
+* Game Analytics [Popüler reklam biçimleri ve bunların kullanımı](https://gameanalytics.com/blog/popular-mobile-game-ad-formats.html)
+* deltaDNA [Oyunlarda reklam sunumu: 10 uzman önerisi](https://deltadna.com/blog/ad-serving-in-games-10-tips/)

--- a/docs/tr/manuals/ai-agents.md
+++ b/docs/tr/manuals/ai-agents.md
@@ -1,0 +1,149 @@
+---
+title: Defold ile yapay zekâ kodlama ajanlarını kullanma
+brief: Bu kılavuz, doğrulama, izinler ve güvenlik konularını açıkça ele alarak belirli bir modele bağlı olmayan kodlama ajanlarının Defold otomasyon arayüzlerine nasıl bağlanacağını açıklar.
+---
+
+# Defold ile yapay zekâ kodlama ajanlarını kullanma
+
+Büyük dil modellerini (LLM) ve çok modlu modelleri kullanan kodlama ajanları (coding agents), geliştiricilerin, yerel betiklerin, IDE tümleştirmelerinin ve sürekli tümleştirmenin (CI) kullandığı, belirli bir modele bağlı olmayan arayüzleri çağırarak Defold projelerini inceleyebilir, değiştirebilir ve doğrulayabilir. İşin araştırma ve uyarlama gerektirdiği durumlarda bir ajan kullanabilirsiniz.
+
+Defold, belirli bir model sağlayıcısına veya ajan protokolüne bağlı değildir. Defold projeleri Claude Code, Codex, Cursor veya başka herhangi bir çözümle iyi çalışır. Bir ajan ortamı yalnızca görev için tanınan belirli yeteneklere ihtiyaç duyar; örneğin proje dosyalarını okuma, seçili komutları yürütme, yerel HTTP işlemlerini çağırma, JSON verilerini ayrıştırma veya görüntüleri inceleme. Bu, Defold'un düzenleyici ve çalışan bir oyun motoru örneği (engine instance) için sunduğu otomasyon arayüzleri ve Defold proje dosyalarının kolay ayrıştırılabilen metin tabanlı kaynak (resource) dosyaları olması sayesinde mümkündür.
+
+## Yapay zekâ ajanı ne zaman yararlıdır?
+
+Bir görev örneğin şunları gerektirdiğinde ajan yararlı olabilir:
+
+* ilgili kaynakları ve belgeleri bulmak;
+* olası uygulamalar arasından seçim yapmak;
+* birbiriyle ilişkili birden çok dosyayı değiştirmek;
+* derleme veya test başarısızlıklarını yorumlamak;
+* görsel bir sonucu anlamsal kabul ölçütleriyle karşılaştırmak;
+* toplanan kanıtlara dayanarak sınırları belirlenmiş bir düzeltme girişiminde bulunmak.
+
+Ajanlar, belirlenimci olmayan geliştirme, araştırma ve test süreçlerinde güçlü araçlardır. Farklı çözümler oluşturmaya yardımcı olabilirler ve Defold ile çok iyi çalışırlar.
+
+## Belirli bir modele bağlı olmayan Defold arayüzleri
+
+Defold, görevin mevcut herhangi bir model kullanılarak gerçekleştirilmesi için gereken, desteklenen çeşitli arayüzler sunar:
+
+* Proje dosyaları ve kabuk araçları doğrudan inceleme ve metin değişiklikleri yapma olanağı sağlar.
+* [Düzenleyici betikleri](/manuals/editor-scripts), projeye özgü kaynak işlemleri ve araçlar sağlayabilir.
+* [Düzenleyici HTTP API'si](/manuals/editor-http-api), düzenleyici komutları, derleme sonuçları, konsol çıktısı, başvuru araması, önizlemeler, tercihler ve düzenleyici betiği rotaları sağlar.
+* [Motor hizmeti ve çalışma zamanı otomasyon API'leri](/manuals/engine-service), hata ayıklama motorunun canlı durumunu, girdileri, ekran görüntülerini ve eklentilerin tanımladığı işlemleri sağlar.
+* [Bob](/manuals/bob), komut satırından proje derleme olanağı, raporlar, arşivler ve dağıtım paketleri sağlar.
+
+Yalnızca sohbet arayüzü üzerinden erişilebilen bir model kod değişiklikleri önerebilir, ancak yerel projeyi bağımsız olarak inceleyemez veya çalışan bir sonucu doğrulayamaz. Ajanın gerçekte neyi gözlemleyip yapabileceğini, onu çevreleyen ek tümleştirme belirler.
+
+## Tümleştirme katmanları
+
+Bir ajanı yerel Defold işlemlerine bağlamak için tümleştirme katmanı (integration layer) kurulabilir. Bu katman bir kabuk sarmalayıcısı, komut satırı programı, IDE eklentisi, OpenAPI istemcisi, test denetleyicisi veya protokol bağdaştırıcısı olabilir.
+
+Politikaları ve kimlik bilgilerini bu yerel katmanda tutun. Değişiklik yapan her işlemin yapılandırılmış sonuçlar döndürmesi veya belirlenimci bir doğrulama adımına yol açması önerilir.
+
+Düzenleyici işlemleri için ajana API'nin kalıcı olarak kod içine sabitlenmiş bir kopyasını vermek yerine, geçerli arayüzü `/openapi.json` üzerinden keşfedin. Çalışma zamanı eklentileri için bunların sağlık durumunu, API sürümünü ve yeteneklerini kontrol edin.
+
+Araçları yetki düzeyine göre ayırmak pratik olabilir:
+
+| Düzey        | Örnekler                                              |
+| ------------ | ----------------------------------------------------- |
+| Salt okunur  | Proje inceleme, OpenAPI, `/ref`, konsol, önizleme       |
+| Doğrulama    | Kod derleme, testler, HTML5 derlemeleri, görüntü karşılaştırmaları |
+| Değişiklik   | Dosya değişiklikleri, kaynak işlemleri                 |
+| Ayrıcalıklı  | `/eval`, harici komutlar, bağımlılık değişiklikleri     |
+
+Bağdaştırıcıyı motordan ve düzenleyiciden ayrı tutmak, desteklenen Defold arayüzlerinin model sağlayıcısından veya ajan protokolünden bağımsız kalmasını sağlar. Bir bağdaştırıcı yalnızca kendi ortamına uygun işlemleri sunabilir; izin ve onay politikaları ise ajanı barındıran uygulamada kalır.
+
+### Model Context Protocol
+
+[Model Context Protocol](https://modelcontextprotocol.io/) (MCP), ajan ile tümleştirme katmanı arasında kullanılabilecek isteğe bağlı bir bağdaştırıcıdır. Bir MCP sunucusu, Defold işlemlerini araç olarak ve seçili belgeleri kaynak olarak sunabilir. 
+
+::: important
+Her modele sınırsız kabuk ve `/eval` erişimi vermeyin.
+:::
+
+Defold şu anda bir MCP sunucusu gerektirmez; çünkü temel otomasyon yetenekleri zaten açık, genel amaçlı arayüzler üzerinden sunulmaktadır. Düzenleyici, OpenAPI belirtimi olan yerel bir HTTP API'si sağlar. Modern ajanlar bu arayüzleri doğrudan çağırabilir veya kendi bağdaştırıcılarını oluşturabilir. 
+
+Bu nedenle resmî bir MCP, büyük ölçüde mevcut API'nin sunduğu işlemleri tekrarlayacak ve Defold'un bakımını yapması gereken bir tümleştirme katmanı daha oluşturacaktır. Uzun vadede daha iyi bir strateji, temel HTTP ve çalışma zamanı otomasyon API'lerini kararlı, keşfedilebilir ve iyi belgelenmiş tutarken topluluğun veya araç sağlayıcılarının gerektiğinde hafif MCP sarmalayıcıları oluşturmasına olanak tanımaktır.
+
+Bunun yerine, çalışan bir oyunun motor tarafındaki bir hizmet üzerinden kontrol edilmesini sağlayan resmî bir [Automation Bridge eklentisi](https://github.com/defold/extension-automation-bridge) sunduk.
+
+### Topluluk MCP tümleştirmeleri
+
+Topluluğun oluşturduğu MCP tümleştirmeleri arasında şunlar bulunur:
+
+* [Fulviuus Defold MCP projesi](https://github.com/Fulviuus/defold-mcp);
+* [ChadAragorn Defold MCP projesi](https://github.com/ChadAragorn/defold-mcp).
+
+Bu projeler Defold Foundation tarafından geliştirilmez, denetlenmez, bakımı yapılmaz veya resmî olarak desteklenmez. Herhangi bir topluluk tümleştirmesini kurmadan önce güncel kaynak kodunu, bağımlılıklarını, izinlerini, ağ davranışını ve kullanılan Defold sürümüyle uyumluluğunu inceleyin.
+
+## Proje talimatları
+
+Ajan tabanlı iş akışlarında kullanılan mevcut büyük dil modelleri genellikle iyi talimatlarla daha iyi performans gösterir. Bu nedenle projelere sıklıkla ajanlardan beklenen davranışı açıklayan Markdown dosyaları veya skill adı verilen talimat paketleri eklenir. En iyi sonuçları elde etmek için her projeye özel talimatlar tasarlayıp yazmak yararlıdır; ancak bazı ortak bilgiler ve kurallar yeniden kullanılabilir.
+
+Birçok ajanın arayıp okuduğu ilk dosya, aşağıdakileri açıklayabilen `AGENTS.md` gibi standart bir dosyadır:
+
+* proje yapısı ve önemli giriş noktaları;
+* biçimlendirme ve adlandırma kuralları;
+* derleme, test ve geçerleme komutları;
+* gerekli tamamlanma olayları ve çıktı dosyalarının konumları;
+* değiştirilmemesi gereken dosyalar veya dizinler;
+* onay gerektiren işlemler;
+* platforma ilişkin varsayımlar ve bilinen sınırlamalar.
+
+Bazı çözümler belirli eylemler için ayrı Markdown dosyalarına veya "skill" adı verilen talimat paketlerine dayanabilir.
+
+Defold'a yönelik talimatların ve skill paketlerinin topluluk tarafından hazırlanmış bir örneğine [Defold forumundaki bu gönderiden](https://forum.defold.com/t/agent-config-collection-of-agents-md-and-skills/82387) ulaşabilirsiniz.
+
+AGENTS.md gibi dosyalardaki talimatlarınızı ve skill tanımlarınızı kısa, öz, incelemesi ve bakımı kolay tutmanızı ve güncel tutmanızı öneririz. Projeye özgü talimatlar sürüm kontrolünde saklanabilir; bu, değişiklikleri izlenebilir kılar ve iş akışı performansının zamanla iyileştirilmesine yardımcı olur.
+
+En yeni modellerin bu talimatlar olmadan nasıl performans gösterdiğini düzenli olarak test etmek de yararlıdır. Daha yeni modeller, önceden gerekli olan yönlendirmelere çoğu zaman artık ihtiyaç duymaz; güncelliğini yitirmiş skill paketleri veya aşırı kuralcı talimatlar bazen performansı düşürebilir.
+
+Uzun vadede önemli miktarda bakım gerektiren karmaşık teknik skill paketleri oluşturmaktan kaçının. Bunun yerine, kullanılan modeller ne kadar gelişirse gelişsin değerini koruyan araçlar ve iş akışları geliştirmeye odaklanın.
+
+## Belgeleri keşfetme
+
+Ajanlar, doğru ve güncel belgelerle en iyi performansı gösterir. Güncel bilgileri şu kaynaklardan toplayın:
+
+* `/openapi.json`, geçerli düzenleyici HTTP API'sini açıklar.
+* `/ref`, bu işlem kullanılabilir olduğunda, çalışan düzenleyiciyle birlikte gelen API belgelerinde arama yapar.
+* [LLM belge dizini](https://defold.com/llms.txt), resmî kılavuzlara, API ad alanlarına ve örneklere bağlantılar içerir.
+* [Tam LLM belgeleri](https://defold.com/llms-full.txt), çevrimdışı aramayı ve yerel dizinlemeyi destekler.
+
+Yalnızca görevle ilgili sayfaları alın. Birleştirilmiş belgenin tamamının yalnızca çevrimdışı dizinleme veya [bilgi getirmeyle desteklenen üretim (RAG)](https://en.wikipedia.org/wiki/Retrieval-augmented_generation) için kullanılması önerilir. Yine, token kullanımından tasarruf etmek ve bağlamı gereksiz bilgilerle doldurmamak için dosyanın tamamının normalde her model isteğine eklenmemesi önerilir.
+
+## Sınırları belirlenmiş değişiklik ve doğrulama döngüleri
+
+Ajanların diğer tüm otomasyonlarla aynı [incele, değiştir, doğrula, değerlendir döngüsünü](/manuals/automation/#the-automation-loop) izlemesi önerilir.
+
+Dosyaları değiştirmeden önce kabul ölçütlerini ve isteğe bağlı olarak aşağıdakileri de tanımlamak yararlıdır:
+* izin verilen dosyalar ve işlemler;
+* derleme ve test komutları;
+* gerekli günlükler, raporlar, durum veya görüntüler;
+* her eşzamansız adım için bir zaman aşımı;
+* en fazla kaç düzeltme girişiminde bulunulacağı.
+
+Bir ajan, belirlenimci bir CI başarısızlığını tanılayıp düzeltebilir; ancak CI aşamasının kendisinin ajan olmadan da yeniden üretilebilir kalması önerilir.
+
+Otomatik test ve doğrulamaya ilişkin iyi uygulamalar [bu kılavuzda](/manuals/automated-testing) açıklanır.
+
+## Çok modlu değerlendirme
+
+Görüntü girdisi alabilen bir ajan, [düzenleyici önizlemelerini](/manuals/editor-http-api/#rendering-scene-previews), çalışma sırasında alınan ekran görüntülerini, görsel farkları ve tarayıcı görüntülerini inceleyebilir.
+
+Kırpılmış etiketler, üst üste binen denetimler, belirsiz seçim durumları, kompozisyon veya güvenli alanın dışındaki içerik gibi anlamsal konular için çok modlu değerlendirme kullanın. Beklenen görüntü alanını ve ölçütleri önceden tanımlayın.
+
+Düzenleyici önizlemeleri, çalışma sırasında alınan ekran görüntüleri ve görsel inceleme hakkında daha fazla bilgi için [bu kılavuzu](/manuals/automated-testing) okuyun.
+
+## Güvenlik, yalıtım ve iyi uygulamalar
+
+* Düzenleyici sunucusunu ve motor hizmetini güvenilen yerel kontrol arayüzleri olarak değerlendirin.
+* Düzenleyici erişim belirteçlerini, imzalama anahtarlarını, dağıtıma alma belirteçlerini, mağaza kimlik bilgilerini ve üretim ortamındaki gizli bilgileri istemlerin ve raporların dışında tutun.
+* Yerel tümleştirme katmanı, `/eval` kullanmak için yetkilendirildiğinde `.internal/editor.token` dosyasını okuyabilir; ancak belirteci model istemlerine, günlüklere veya raporlara koyması önerilmez.
+* Silme, bağımlılık değişiklikleri, yerel kod eklentisi değişiklikleri, yayımlanacak sürümün yapılandırılması, imzalama, yayımlama veya harici hizmetlere erişim öncesinde onay alın.
+* Kapsamlı otonom çalışmaları ayrı bir dalda, çalışma ağacında, geçici kopyada, konteynerde, yalıtılmış çalışma ortamında veya kısıtlı hesapta yürütün.
+* Sorun kaydı metinlerini, içe aktarılan dosyaları, kaynak kod yorumlarını, oluşturulan belgeleri ve araç çıktılarını talimat olarak değil, güvenilmeyen girdi olarak değerlendirin.
+* İndirilen bağımlılıkları ve betikleri yürütmeden önce inceleyin.
+* Proje politikasının kaynak kodun, varlıkların, günlüklerin, ekran görüntülerinin ve diğer proje verilerinin barındırılan bir modele gönderilmesine izin verdiğini doğrulayın.
+* Değişiklikleri kabul etmeden önce incelenebilir bir değişiklik dökümünü ve belirlenimci test kanıtlarını saklayın.
+
+Yalıtım, bir hatanın etkisini sınırlar.

--- a/docs/tr/manuals/android.md
+++ b/docs/tr/manuals/android.md
@@ -1,0 +1,140 @@
+---
+title: Android platformu için Defold ile geliştirme
+brief: Bu kılavuz, Defold uygulamalarının Android cihazlar için nasıl derleneceğini ve cihazlarda nasıl çalıştırılacağını açıklar
+---
+
+# Android için geliştirme
+
+Android cihazlarda kendi uygulamalarınızı serbestçe çalıştırabilirsiniz. Oyununuzun bir sürümünü derleyip bir Android cihaza kopyalamak çok kolaydır. Bu kılavuz, oyununuzu Android için paketleme adımlarını açıklar. Geliştirme sırasında oyununuzu [geliştirme uygulaması](/manuals/dev-app) üzerinden çalıştırmak genellikle tercih edilir; çünkü bu uygulama, içerik ve kodu doğrudan cihazınızda çalışma sırasında yeniden yüklemenize (hot reload) olanak tanır.
+
+## Android ve Google Play imzalama süreci
+
+Android, tüm APK dosyalarının bir cihaza kurulmadan veya güncellenmeden önce bir sertifikayla dijital olarak imzalanmasını gerektirir. Android App Bundle (AAB) biçimini kullanıyorsanız Play Console'a yüklemeden önce yalnızca uygulama paketinizi imzalamanız gerekir; geri kalanını [Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play) halleder. Bununla birlikte, uygulamanızı Google Play'e veya diğer uygulama mağazalarına yüklemek ve herhangi bir mağazanın dışında dağıtmak için elle de imzalayabilirsiniz.
+
+Defold düzenleyicisinden veya [komut satırı aracından](/manuals/bob) bir Android uygulaması dağıtım paketi (bundle) oluştururken uygulamanızın imzalanmasında kullanılacak bir anahtar deposu (keystore; sertifikanızı ve anahtarınızı içerir) ve anahtar deposu parolası sağlayabilirsiniz. Bunları sağlamazsanız Defold bir hata ayıklama anahtar deposu oluşturur ve uygulamanın dağıtım paketini imzalarken bunu kullanır.
+
+::: important
+Uygulamanız bir hata ayıklama anahtar deposuyla imzalandıysa onu Google Play'e **asla** yüklememelisiniz. Her zaman kendinizin oluşturduğu, bu amaca ayrılmış bir anahtar deposu kullanın.
+:::
+
+## Anahtar deposu oluşturma {#creating-a-keystore}
+
+::: sidenote
+Defold, Android imzalama süreci için bir anahtar deposu kullanır. [Bu forum gönderisinde daha fazla bilgi bulabilirsiniz](https://forum.defold.com/t/upcoming-change-to-the-android-build-pipeline/66084).
+:::
+
+Bir anahtar deposunu [Android Studio kullanarak](https://developer.android.com/studio/publish/app-signing#generate-key) veya bir terminalden/komut isteminden oluşturabilirsiniz:
+
+```bash
+keytool -genkey -v -noprompt -dname "CN=John Smith, OU=Area 51, O=US Air Force, L=Unknown, ST=Nevada, C=US" -keystore mykeystore.keystore -storepass 5Up3r_53cR3t -alias myAlias -keyalg RSA -validity 9125
+```
+
+Bu işlem, bir anahtar ve sertifika içeren `mykeystore.keystore` adlı bir anahtar deposu dosyası oluşturur. Anahtara ve sertifikaya erişim `5Up3r_53cR3t` parolasıyla korunur. Anahtar ve sertifika 25 yıl (9125 gün) boyunca geçerli olur. Oluşturulan anahtar ve sertifika `myAlias` takma adıyla tanımlanır.
+
+::: important
+Anahtar deposunu ve ona ait parolayı güvenli bir yerde sakladığınızdan emin olun. Uygulamalarınızı kendiniz imzalayıp Google Play'e yüklüyorsanız ve anahtar deposu veya anahtar deposu parolası kaybolursa uygulamayı Google Play'de güncellemeniz mümkün olmaz. Google Play App Signing kullanıp uygulamalarınızı sizin için Google'ın imzalamasını sağlayarak bu durumdan kaçınabilirsiniz.
+:::
+
+
+## Android uygulaması dağıtım paketi oluşturma {#creating-an-android-application-bundle}
+
+Düzenleyici, oyununuz için kolayca bağımsız bir uygulama dağıtım paketi oluşturmanızı sağlar. Paketlemeden önce *game.project* [proje ayarları dosyasında](/manuals/project-settings/#android) uygulama için kullanılacak simgeleri belirtebilir, sürüm kodunu ayarlayabilir ve benzeri işlemleri yapabilirsiniz.
+
+Paketlemek için menüden <kbd>Project ▸ Bundle... ▸ Android Application...</kbd> seçeneğini seçin.
+
+Düzenleyicinin otomatik olarak rastgele hata ayıklama sertifikaları oluşturmasını istiyorsanız *Keystore* ve *Keystore password* alanlarını boş bırakın:
+
+![Android dağıtım paketini imzalama](images/android/sign_bundle.png)
+
+Dağıtım paketinizi belirli bir anahtar deposuyla imzalamak istiyorsanız *Keystore* ve *Keystore password* alanlarını belirtin. *Keystore* dosyasının `.keystore` uzantısına sahip olması, parolanın ise `.txt` uzantılı bir metin dosyasında saklanması beklenir. Anahtar deposundaki anahtar, anahtar deposunun kendisinden farklı bir parola kullanıyorsa *Key password* belirtmeniz de mümkündür:
+
+![Android dağıtım paketini imzalama](images/android/sign_bundle2.png)
+
+Defold hem APK hem de AAB dosyalarının oluşturulmasını destekler. *Bundle Format* açılır listesinden APK veya AAB seçin.
+
+Uygulama dağıtım paketi ayarlarını yapılandırdıktan sonra <kbd>Create Bundle</kbd> düğmesine basın. Ardından, dağıtım paketinin bilgisayarınızda nerede oluşturulacağını belirtmeniz istenir.
+
+![Android uygulama paketi dosyası](images/android/apk_file.png)
+
+:[Build Variants](../shared/build-variants.md)
+
+### Android uygulaması dağıtım paketini kurma
+
+#### APK kurma
+
+Bir *`.apk`* dosyası `adb` aracıyla cihazınıza veya [Google Play geliştirici konsolu](https://play.google.com/apps/publish/) üzerinden Google Play'e kopyalanabilir.
+
+:[Android ADB](../shared/android-adb.md)
+
+```
+$ adb install Defold\ examples.apk
+4826 KB/s (18774344 bytes in 3.798s)
+  pkg: /data/local/tmp/my_app.apk
+Success
+```
+
+#### Düzenleyiciyi kullanarak APK kurma
+
+Düzenleyicinin Bundle iletişim kutusundaki "Install on connected device" ve "Launch installed app" onay kutularını kullanarak bir *`.apk`* dosyasını kurup başlatabilirsiniz:
+
+![APK kurma ve başlatma](images/android/install_and_launch.png)
+
+Bu özelliğin çalışması için *ADB* kurulu olmalı ve bağlı cihazda *USB debugging* etkinleştirilmelidir. Düzenleyici ADB komut satırı aracının kurulum konumunu algılayamazsa bunu [Preferences](/manuals/editor-preferences/#tools) içinde belirtmeniz gerekir.
+
+#### AAB kurma
+
+Bir *.aab* dosyası [Google Play geliştirici konsolu](https://play.google.com/apps/publish/) üzerinden Google Play'e yüklenebilir. [Android bundletool](https://developer.android.com/studio/command-line/bundletool) kullanarak bir *.aab* dosyasından yerel olarak kurmak üzere bir *`.apk`* dosyası oluşturmak da mümkündür.
+
+## R8 ile Java kodunu küçültme {#shrinking-java-code-with-r8}
+
+R8, küçültme, optimizasyon ve karartma (obfuscation) yoluyla Java kodunun boyutunu azaltır.
+
+### R8'i etkinleştirme {#enabling-r8}
+
+*game.project* dosyasındaki **Android ▸ R8 Keep Rules** alanında `/builtins/manifests/android/dmengine.keep` dosyasını seçin. Bu, Defold'un varsayılan kurallarını doğrudan kullanır:
+
+```ini
+[android]
+r8_keep_rules = /builtins/manifests/android/dmengine.keep
+```
+
+Java kodu içeren her eklentinin, çalışma sırasında ihtiyaç duyduğu sınıflar için bir `.keep` dosyası sağladığından emin olun. Eklenti kuralları, proje derlenirken seçili proje kurallarıyla birleştirilir. R8'i etkinleştirdikten sonra yayıma yönelik bir derlemeyi cihazda test edin.
+
+**R8 Keep Rules** alanı boş bırakıldığında küçültme işlemi yapılmadan D8 kullanılır. R8 etkinleştirildiğinde, yerel kod eklentileri (native extension) olmayan bir projede bile yerel kod eklentisi derleme hizmeti kullanılır.
+
+### Bir eklentiye kurallar ekleme
+
+Bir eklentinin koruma kuralları, eklentinin `manifests/android` dizininde, `build.gradle` dosyasının yanında bulunur. Bir dosyanın nasıl ekleneceğini ve eklentinin Java sınıflarının nasıl korunacağını öğrenmek için [Android eklentileri için R8 koruma kuralları](/manuals/extensions/#r8-keep-rules-for-android) bölümüne bakın.
+
+### Karartma eşlemesini saklama
+
+Derleme bir `mapping.txt` dosyası oluşturduğunda R8'in bu dosyasını saklamak için Android dağıtım paketi iletişim kutusunda **Generate debug symbols** seçeneğini etkinleştirin veya Bob'a `--with-symbols` seçeneğini geçirin. Örneğin, proje dizininden:
+
+```sh
+java -jar bob.jar --platform arm64-android --variant release \
+  --archive --with-symbols --bundle-output build/android \
+  resolve build bundle
+```
+
+Eşleme, oluşturulan APK veya AAB dosyasının yanına `<binary-name>.apk.symbols/mapping.txt` olarak kaydedilir. Örneğin, proje başlığı `My Game` olduğunda yukarıdaki komut `build/android/MyGame/MyGame.apk.symbols/mapping.txt` dosyasını oluşturur.
+
+Eşleme dosyasını, oluşturulduğu sürümle birlikte saklayın. Bu dosya, yığın izlerini (stack trace) yorumlamak için karartılmış Java adlarını özgün adlarla eşler; farklı bir derlemeye ait eşleme yanlış sonuçlar verebilir.
+
+## İzinler
+
+Defold motoru, tüm motor özelliklerinin çalışabilmesi için çeşitli izinler gerektirir. İzinler, *game.project* [proje ayarları dosyasında](/manuals/project-settings/#android) belirtilen `AndroidManifest.xml` dosyasında tanımlanır. Android izinleri hakkında daha fazla bilgiyi [resmî belgelerden](https://developer.android.com/guide/topics/permissions/overview) edinebilirsiniz. Varsayılan bildirimde aşağıdaki izinler istenir:
+
+### android.permission.INTERNET ve android.permission.ACCESS_NETWORK_STATE (Koruma düzeyi: normal)
+Uygulamaların *ağ soketleri* açmasına ve ağlar hakkındaki bilgilere erişmesine izin verir. Bu izinler internet erişimi için gereklidir. ([Android resmî belgeleri](https://developer.android.com/reference/android/Manifest.permission#INTERNET)) ve ([Android resmî belgeleri](https://developer.android.com/reference/android/Manifest.permission#ACCESS_NETWORK_STATE)).
+
+### android.permission.WAKE_LOCK (Koruma düzeyi: normal)
+İşlemcinin uyumasını veya ekranın kararmasını önlemek için PowerManager WakeLocks kullanılmasına izin verir. Bu izin, bir anlık bildirim alınırken cihazın uyumasını geçici olarak önlemek için gereklidir. ([Android resmî belgeleri](https://developer.android.com/reference/android/Manifest.permission#WAKE_LOCK))
+
+
+## AndroidX kullanma
+AndroidX, artık bakımı yapılmayan özgün Android Support Library'ye kıyasla büyük bir iyileştirmedir. AndroidX paketleri, aynı özellikleri ve yeni kütüphaneleri sağlayarak Support Library'nin yerini tamamen alır. [Asset Portal](/assets) üzerindeki Android eklentilerinin çoğu AndroidX'i destekler. AndroidX kullanmak istemiyorsanız [uygulama bildiriminde](https://defold.com/manuals/app-manifest/) `Use Android Support Lib` seçeneğini işaretleyerek AndroidX'i açıkça devre dışı bırakıp eski Android Support Library'yi kullanabilirsiniz.
+
+![](images/android/enable_supportlibrary.png)
+
+## Sık sorulan sorular
+:[Android FAQ](../shared/android-faq.md)

--- a/docs/tr/manuals/animation.md
+++ b/docs/tr/manuals/animation.md
@@ -1,0 +1,17 @@
+---
+title: Defold'da animasyon kılavuzu
+brief: Bu kılavuz, Defold'un animasyon desteğini açıklar.
+---
+
+# Animasyon
+
+Defold, bileşenler (component) için grafik kaynağı olarak kullanabileceğiniz birçok animasyon türünü yerleşik olarak destekler:
+
+* [Kare dizisi animasyonu (flip-book animation)](/manuals/flipbook-animation) - Bir dizi durağan görüntüyü art arda oynatma
+* [Model animasyonu (model animation)](/manuals/model-animation) - İskelete bağlama (skinning) kullanılan 3B animasyonları oynatma
+* [Özellik animasyonu (property animation)](/manuals/property-animation) - Konum, ölçek, dönme ve daha birçok özelliğe animasyon uygulama
+
+Eklentiler aracılığıyla ek animasyon biçimleri eklenebilir:
+
+* [Rive animasyonu](/extension-rive) - Vektör tabanlı 2B iskelet animasyonlarını oynatma
+* [Spine animasyonu](/extension-spine) - Dokulu 2B iskelet animasyonlarını oynatma

--- a/docs/tr/manuals/app-manifest.md
+++ b/docs/tr/manuals/app-manifest.md
@@ -1,0 +1,166 @@
+---
+title: Uygulama bildirimi
+brief: Bu kılavuz, uygulama bildiriminin özellikleri motordan çıkarmak için nasıl kullanılabileceğini açıklar.
+---
+
+# Uygulama bildirimi
+
+Uygulama bildirimi (application manifest), hangi özelliklerin ve arka uçların (backend) motora bağlanacağını belirler. Kullanılmayan özelliklerin çıkarılması önerilir; bu, oyununuzun son ikili dosyasının boyutunu küçültür. Uygulama bildirimi ayrıca desteklenen en düşük HTML5 tarayıcı sürümleri ve WebAssembly bellek ayarları gibi derleme zamanı seçeneklerini de içerir.
+
+![](images/app_manifest/create-app-manifest.png)
+
+![](images/app_manifest/app-manifest.png)
+
+# Bildirimi uygulama
+
+`game.project` dosyasında bildirimi `Native Extensions` -> `App Manifest` alanına atayın.
+
+## Physics 2D
+
+Dahil edilecek Box2D uygulamasını seçin:
+
+* **Box2D Version 3** - Box2D 3'ü dahil edin. Bunun için bu seçeneği açıkça seçmeniz gerekir. Eski uygulamadan farklı simülasyon sonuçları üretebileceğinden, mevcut projelerin fizik ayarlarını yeniden düzenlemesi gerekebilir.
+* **Box2D (Legacy Defold version)** - Eski Defold Box2D uygulamasını dahil edin. Varsayılan budur.
+* **None** - 2B fiziği çıkarın.
+
+Box2D çözücü ayarları sürüme özgüdür. Ayrıntılar için [Box2D proje ayarlarına](/manuals/project-settings/#box2d) bakın.
+
+## Physics 3D
+
+Bullet 3B fizik uygulamasını dahil edin. Varsayılan olarak dahildir; 3B fiziği çıkarmak için bu ayarı devre dışı bırakın.
+
+## Rig + Model
+
+İskelet düzeneği (rig) ve model işlevlerini belirleyin veya model ve iskelet düzeneğini tamamen çıkarmak için None seçeneğini seçin. ([`Model`](https://defold.com/manuals/model/#model-component) belgelerine bakın).
+
+
+## Exclude Record
+
+Video kaydetme özelliğini motordan çıkarın ([`start_record`](https://defold.com/ref/stable/sys/#start_record) iletisinin belgelerine bakın).
+
+
+## Profiler
+
+Profil çıkarıcı (profiler) işlevlerinin motora ne zaman bağlanacağını belirleyin:
+
+* **Debug Only** - Profil çıkarıcıyı yalnızca hata ayıklama derlemelerine dahil edin. Varsayılan budur.
+* **None** - Profil çıkarıcı işlevlerini tüm derleme çeşitlerinden çıkarın.
+* **Always** - Profil çıkarıcıyı hem hata ayıklama derlemelerine hem de yayıma yönelik derlemelere dahil edin.
+
+Uygulama bildirimi ayarı, profil çıkarıcı kodunun derlemeye bağlanıp bağlanmayacağını belirler. *game.project* dosyasındaki `profiler` altındaki ayarlar, profil çıkarıcının çalışma sırasındaki davranışını belirler. Mevcut olanakların nasıl kullanılacağını [Profil çıkarma kılavuzunda](/manuals/profiling/) öğrenin.
+
+
+## Sound
+
+Ses ayarları, hangi ses sisteminin ve kod çözücülerin motora bağlanacağını belirler.
+
+### Exclude Sound
+
+Tüm ses oynatma özelliklerini motordan çıkarın.
+
+### Exclude Sound Decoder: WAV
+
+WAV ses kaynakları desteğini çıkarın.
+
+### Exclude Sound Decoder: OGG
+
+Ogg Vorbis ses kaynakları desteğini çıkarın.
+
+### Include Sound Decoder: Opus
+
+Ogg Opus ses kaynakları desteğini dahil edin. Opus kod çözücü varsayılan olarak dahil değildir; bu nedenle `.opus` kaynaklarının oynatılabilmesi için bu seçeneğin etkinleştirilmesi gerekir. Desteklenen biçimler için [Ses kılavuzuna](/manuals/sound/) bakın.
+
+
+## Exclude Input
+
+Tüm girdi işleme özelliklerini motordan çıkarın.
+
+
+## Exclude GUI
+
+GUI kaynaklarını, bileşenlerini (component) ve Lua desteğini motordan kaldırın. Bunu yalnızca proje GUI sahneleri veya GUI betikleri kullanmıyorsa etkinleştirin. Etiket (label) bileşenleri kullanılabilir durumda kalır. Bu seçenek varsayılan olarak devre dışıdır.
+
+
+## Exclude Particle FX
+
+Parçacık efekti (particle effect) kaynaklarını, bileşenlerini ve `particlefx` Lua modülünü kaldırın. Bu işlem GUI sahnelerindeki parçacık düğümlerinin desteğini de kaldırır; parçacık düğümü içermeyen GUI sahneleri desteklenmeye devam eder. Bu seçeneği etkinleştirmeden önce parçacık efektlerine yapılan başvuruları ve bunların API çağrılarını kaldırın. Varsayılan olarak devre dışıdır.
+
+
+## Exclude Tilemaps
+
+Karo haritası (tilemap) kaynaklarını, bileşenlerini ve `tilemap` Lua modülünü kaldırın. Bunu yalnızca proje karo haritası bileşenlerini veya bunların API'lerini kullanmıyorsa etkinleştirin. Diğer bileşenlerin kullandığı karo kaynakları kullanılabilir durumda kalır. Bu seçenek varsayılan olarak devre dışıdır.
+
+
+## Exclude Live Update
+
+[Live Update işlevlerini](/manuals/live-update) motordan çıkarın.
+
+
+## Exclude Image
+
+`image` betik modülünü ([belgeler](https://defold.com/ref/stable/image/)) motordan çıkarın.
+
+
+## Exclude Types
+
+`types` betik modülünü ([belgeler](https://defold.com/ref/stable/types/)) motordan çıkarın.
+
+
+## Exclude Basis Transcoder
+
+Basis Universal [doku sıkıştırma kütüphanesini](/manuals/texture-profiles) motordan çıkarın.
+
+
+## Use Android Support Lib
+
+Android X yerine kullanımı artık önerilmeyen Android Support Library'yi kullanın. [Daha fazla bilgi](https://defold.com/manuals/android/#using-androidx).
+
+
+## Graphics
+
+Her platform için hangi grafik arka uçlarının dahil edileceğini seçin. Birleşik seçim her iki arka ucu da dahil eder; böylece tercih edilen arka uç kullanılamadığında diğerine geçilebilir.
+
+| Alan | Platformlar | Seçenekler | Varsayılan |
+|---|---|---|---|
+| **Graphics** | Windows ve Linux | OpenGL, Vulkan, OpenGL & Vulkan | OpenGL |
+| **Graphics (macOS)** | macOS | OpenGL, Metal, Vulkan, OpenGL & Metal, OpenGL & Vulkan | Vulkan |
+| **Graphics (iOS)** | iOS | OpenGL, Metal, Vulkan, OpenGL & Metal, OpenGL & Vulkan | OpenGL |
+| **Graphics (Android)** | Android | OpenGL+Vulkan, OpenGL, Vulkan | OpenGL+Vulkan |
+| **Graphics (HTML5)** | HTML5 | WebGL, WebGPU, WebGL & WebGPU | WebGL |
+
+Linux ARM64 üzerinde **OpenGL** seçeneği, OpenGL ES arka ucunu kullanır. Android'in varsayılan birleşik seçeneği, kullanılabiliyorsa Vulkan'ı tercih eder; kullanılamıyorsa OpenGL ES'ye geçer.
+
+## Use full text layout system
+
+Etkinleştirildiğinde (`true`), sağdan sola yazılan diller dahil olmak üzere metinleri şekillendirmek için tam metin yerleşim sistemi dahil edilir. Bu seçeneği *game.project* dosyasındaki `font.runtime_generation` ile birlikte etkinleştirin; böylece TrueType (`.ttf`) veya OpenType (`.otf`) kaynaklarından çalışma sırasında SDF yazı tipleri oluşturabilirsiniz. `.otf` kaynaklarından çalışma sırasında oluşturma, Defold 1.13.2'den beri desteklenir. [Yazı tipi kılavuzunda](/manuals/font/#enabling-runtime-fonts) daha fazla bilgi edinin.
+
+
+## Use Rich Text
+
+Etiketler ve GUI metni için zengin metin ayrıştırmasını ve stil efektlerini dahil edin. Bu seçenek varsayılan olarak etkindir. Proje yalnızca düz metne ihtiyaç duyduğunda motor boyutunu küçültmek için bu seçeneği devre dışı bırakın. Etiketler ve GUI metni desteklenmeye devam eder, ancak işaretleme, biçimlendirme veya efekt uygulamak yerine düz metin olarak görüntülenir.
+
+
+## En düşük tarayıcı sürümleri
+
+**`minSafariVersion`**, **`minFirefoxVersion`** ve **`minChromeVersion`** YAML alanları, Emscripten'in hedeflediği en düşük tarayıcı sürümlerini belirtir. Geçerli varsayılan değerler ve desteklenen en düşük sürümler, iş parçacığı kullanmayan ve kullanan hedefler arasında farklılık gösterir:
+
+| Hedef | Safari | Firefox | Chrome |
+|---|---:|---:|---:|
+| `wasm-web` | `101000` | `40` | `45` |
+| `wasm_pthread-web` | `150000` | `79` | `75` |
+
+Varsayılanların yerine kullanılacak değerleri ilgili hedefin bağlamında belirtin. İş parçacığı kullanan hedefin ayrıca ek [barındırma gereksinimleri](/manuals/html5/#creating-html5-bundle) vardır. Emscripten ayar başvurusundaki [`MIN_SAFARI_VERSION`](https://emscripten.org/docs/tools_reference/settings_reference.html#min-safari-version), [`MIN_FIREFOX_VERSION`](https://emscripten.org/docs/tools_reference/settings_reference.html#min-firefox-version) ve [`MIN_CHROME_VERSION`](https://emscripten.org/docs/tools_reference/settings_reference.html#min-chrome-version) ayarlarına bakın.
+
+## Başlangıç belleği (HTML5)
+YAML alan adı: **`initialMemory`**
+Varsayılan değer: **33554432**
+
+Web uygulaması için başlangıçta ayrılan bellek miktarı, bayt cinsindendir. Değer, WebAssembly sayfa boyutunun (64 KiB) katı olmalıdır. Emscripten'in [`INITIAL_MEMORY`](https://emscripten.org/docs/tools_reference/settings_reference.html#initial-memory) ayarına bakın.
+
+Bu seçenek, kod derleme zamanındaki varsayılan değeri sağlar. *game.project* dosyasındaki [`html5.heap_size`](/manuals/html5/#heap-size) değeri, çalışma sırasında bunun yerine geçer.
+
+## Yığın boyutu (HTML5)
+YAML alan adı: **`stackSize`**
+Varsayılan değer: **5242880**
+
+Uygulama yığınının bayt cinsinden boyutu. Emscripten'in [`STACK_SIZE`](https://emscripten.org/docs/tools_reference/settings_reference.html#stack-size) ayarına bakın.

--- a/docs/tr/manuals/application-lifecycle.md
+++ b/docs/tr/manuals/application-lifecycle.md
@@ -1,0 +1,240 @@
+---
+title: Defold uygulama yaşam döngüsü kılavuzu
+brief: Bu kılavuz, Defold oyunlarının ve uygulamalarının yaşam döngüsünü ayrıntılarıyla açıklar.
+---
+
+# Uygulama yaşam döngüsü
+
+Bir Defold uygulamasının veya oyununun yaşam döngüsü (lifecycle), genel hatlarıyla basittir. Motor üç yürütme aşamasından geçer: başlangıç işlemleri (initialization), uygulamaların ve oyunların zamanlarının çoğunu geçirdiği güncelleme döngüsü (update loop) ve sonlandırma işlemleri (finalization).
+
+::: sidenote
+Bu kılavuz, Defold'un 1.12.0 ve sonraki sürümlerini kapsar. 1.12.0 sürümünde yaşam döngüsüyle ilgili değişiklikler yapılmış ve yeni `late_update()` işlevi eklenmiştir.
+:::
+
+![Yaşam döngüsüne genel bakış](images/application_lifecycle/application_lifecycle.png)
+
+Çoğu durumda Defold'un iç işleyişini temel düzeyde anlamak yeterlidir. Ancak Defold'un görevlerini tam olarak hangi sırayla yürüttüğünün kritik önem taşıdığı uç durumlarla karşılaşabilirsiniz. Bu belge, motorun bir uygulamayı baştan sona nasıl çalıştırdığını açıklar.
+
+Uygulama, motorun çalışması için gereken her şeyin başlangıç işlemlerini yaparak başlar. Ana koleksiyonu (main collection) yükler ve `init()` Lua işlevi bulunan, yüklenmiş tüm bileşenlerin (component) [`init()`](/ref/go#init) işlevini çağırır. Bunlar betik bileşenleri ve GUI betiği içeren GUI bileşenleridir. Böylece kendi başlangıç işlemlerinizi yapabilirsiniz.
+
+Uygulama daha sonra yaşam süresinin büyük bölümünü geçireceği güncelleme döngüsüne girer. Her karede oyun nesneleri (game object) ve içerdikleri bileşenler güncellenir. Betiklerde ve GUI betiklerinde bulunan [`update()`](/ref/go#update) işlevleri çağrılır. Güncelleme döngüsü sırasında iletiler alıcılarına dağıtılır, sesler çalınır ve tüm grafikler, görüntü oluşturmak üzere işlenir (rendering).
+
+Bir noktada uygulamanın yaşam döngüsü sona erer. Uygulama kapanmadan önce motor güncelleme döngüsünden çıkar ve sonlandırma aşamasına girer. Yüklenmiş tüm oyun nesnelerini silinmek üzere hazırlar. Nesnelerin tüm bileşenlerinin [`final()`](/ref/go#final) işlevleri çağrılır; böylece kendi temizleme işlemlerinizi yapabilirsiniz. Ardından nesneler silinir ve ana koleksiyon bellekten kaldırılır.
+
+["İletileri dağıtma"](#dispatching-messages) geçişindeki adımlar, daha anlaşılır olması için bu kılavuzun sonunda ayrı bir şemada gösterilir ve şemalarda küçük bir "oklu zarf" simgesi 📩 ile işaretlenir.
+
+## Başlangıç işlemleri
+
+Oyununuz burada başlar; bu, çalışan oyunun ilk adımıdır. 3 aşamaya ayrılabilir:
+
+![Başlangıç işlemleri](images/application_lifecycle/initialization.png)
+
+### Ön başlatma
+
+Ön başlatma (`Preinitialization`) aşamasında motor, ana koleksiyon (başlangıç koleksiyonu, bootstrap collection) yüklenmeden önce birçok adım gerçekleştirir. Bellek profil çıkarıcısı, soketler, grafikler, HID (girdi aygıtları), ses, fizik ve daha pek çok şey hazırlanır. Uygulama yapılandırması (*game.project*) da yüklenir ve hazırlanır.
+
+![Ön başlatma](images/application_lifecycle/pre_init.png)
+
+Kullanıcının denetleyebildiği ilk giriş noktası, motorun başlangıç işlemlerinin sonunda geçerli işleme betiğinin `init()` işlevinin çağrılmasıdır.
+
+Ardından ana koleksiyon yüklenir ve başlangıç işlemleri yapılır.
+
+### Koleksiyonun başlangıç işlemleri
+
+`Collection Init` aşamasında, koleksiyondaki tüm oyun nesneleri dönüşümlerini, yani öteleme (konum değişikliği), dönme ve ölçeklemeyi alt nesnelerine uygular. Ardından tüm bileşenlerin mevcut `init()` işlevleri çağrılır.
+
+![Koleksiyonun başlangıç işlemleri](images/application_lifecycle/collection_init.png)
+
+::: sidenote
+Oyun nesnesi bileşenlerinin `init()` işlevlerinin çağrılma sırası tanımlanmamıştır. Motorun aynı koleksiyona ait nesnelerin başlangıç işlemlerini belirli bir sırayla yaptığını varsaymayın.
+:::
+
+### Başlangıç işlemlerinde güncelleme sonrası aşama
+
+Motor daha sonra tam bir `Post Update` geçişi gerçekleştirir; bu, ilerleyen süreçte her `Update Loop` adımından sonra gerçekleştirilen geçişin aynısıdır. Bu geçiş başlangıç işlemlerinin sonunda gerçekleştirilir çünkü `init()` kodunuz yeni iletiler gönderebilir, fabrikalara (factory) yeni nesneler oluşturmalarını söyleyebilir, nesneleri silinmek üzere işaretleyebilir ve başka eylemler gerçekleştirebilir.
+
+![Güncelleme sonrası aşama](images/application_lifecycle/post_init.png)
+
+Bu geçiş, ileti teslimini, fabrikaların oyun nesnelerini fiilen oluşturmasını ve nesnelerin silinmesini gerçekleştirir. `Post Update` geçişinin, kuyruktaki iletileri teslim etmenin yanı sıra koleksiyon vekillerine (collection proxy) gönderilen iletileri de işleyen bir "iletileri dağıtma" adım dizisi içerdiğine dikkat edin. Bunun sonucunda gereken vekil güncellemeleri (etkinleştirme, devre dışı bırakma, başlangıç işlemleri, sonlandırma işlemleri, yükleme ve bellekten kaldırılmak üzere işaretleme) bu adımlar sırasında gerçekleştirilir.
+
+`init()` sırasında bir [koleksiyon vekili](/manuals/collection-proxy) yüklemek, içerdiği tüm nesnelerin başlangıç işlemlerinin yapıldığından emin olmak ve ardından koleksiyonu vekil aracılığıyla bellekten kaldırmak mümkündür. Bunların tümü ilk bileşenin `update()` işlevi çağrılmadan, yani motor başlangıç işlemleri aşamasından çıkıp güncelleme döngüsüne girmeden önce gerçekleşebilir:
+
+```lua
+function init(self)
+    print("init()")
+    msg.post("#collectionproxy", "load")
+end
+
+function update(self, dt)
+    -- The proxy collection is unloaded before this code is reached.
+    print("update()")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        print("proxy_loaded. Init, enable and then unload.")
+        msg.post("#collectionproxy", "init")
+        msg.post("#collectionproxy", "enable")
+        msg.post("#collectionproxy", "unload")
+        -- The proxy collection objects’ init() and final() functions
+        -- are called before we reach this object’s update()
+    end
+end
+```
+
+## Güncelleme döngüsü
+
+`Update Loop`, her karede bir kez belirli bir adım dizisini yürütür. Bu dizi 5 ana aşamayla tanımlanabilir:
+
+![Güncelleme döngüsü](images/application_lifecycle/update_loop.png)
+
+1. Girdi (işleme ve ele alma)
+2. Güncelleme (sabit zaman adımlı, normal, geç güncellemeler ve motor bileşenlerinin güncellemeleri dahil)
+3. İşleme güncellemesi
+4. Güncelleme sonrası aşama (koleksiyon vekillerini bellekten kaldırma, oyun nesnelerini oluşturma ve silme)
+5. Kare işleme (son grafik görüntüsü oluşturulur)
+
+### Girdi aşaması
+
+Girdi, kullanılabilir aygıtlardan okunur, [girdi eşlemelerine (input binding)](/manuals/input) göre eşlenir ve ardından dağıtılır. Girdi odağını edinmiş her oyun nesnesinin tüm bileşenlerinin `on_input()` işlevlerine girdi gönderilir. Bir betik bileşeni ve GUI betiği içeren bir GUI bileşeni bulunan oyun nesnesinde, her iki bileşenin de `on_input()` işlevlerine girdi iletilir; bunun için bu işlevlerin tanımlanmış olması ve bileşenlerin girdi odağını edinmiş olması gerekir.
+
+![Girdi aşaması](images/application_lifecycle/input_phase.png)
+
+Girdi odağını edinmiş ve koleksiyon vekili bileşenleri içeren her oyun nesnesi, girdiyi vekil koleksiyonunun içindeki bileşenlere dağıtır. Bu işlem, etkin koleksiyon vekillerinin içindeki etkin koleksiyon vekilleri boyunca özyinelemeli olarak devam eder.
+
+### Güncelleme aşaması
+
+`Update` aşaması, `Update Loop` döngüsünün bir parçasıdır. Kök koleksiyon için bir kez başlatılır, ardından etkin her koleksiyon vekili için özyinelemeli olarak çalışır.
+
+Defold, bir koleksiyon içinde geri çağırımları (callback) bileşen türüne göre işler: ilgili aşamayı uygulayan bir bileşen türünün tüm örneklerini dolaşır, her örnek için Lua geri çağırımını çağırır, bekleyen iletileri dağıtır ve ardından sıradaki bileşen türüne geçer.
+
+*Betik* bileşenlerinin Lua geri çağırım aşamalarının genel sırası şöyledir:
+
+1. `fixed_update()` - kare başına 0..N kez çağrılır (sabit zaman adımı kullanılıyorsa)
+2. `update()` - kare başına 1 kez çağrılır
+3. `late_update()` - kare başına 1 kez çağrılır
+
+![Güncelleme aşaması](images/application_lifecycle/update_phase.png)
+
+
+Ana koleksiyondaki her oyun nesnesi bileşeni dolaşılır. Bu bileşenlerden herhangi birinin betiğinde `fixed_update()`/`update()`/`late_update()` işlevi varsa bu işlev çağrılır. Bileşen bir koleksiyon vekiliyse vekil koleksiyonundaki her bileşen, `Update` aşamasındaki tüm adımlarla özyinelemeli olarak güncellenir.
+
+::: sidenote
+Oyun nesnesi bileşenlerinin `update()` işlevlerinin çağrılma sırası tanımlanmamıştır. Motorun aynı koleksiyona ait nesneleri belirli bir sırayla güncellediğini varsaymayın. Aynı durum `fixed_update()` ve `late_update()` için de geçerlidir (1.12.0 sürümünden itibaren).
+:::
+
+#### Fizik
+
+Çarpışma nesnesi bileşenleri için fizik iletileri (çarpışmalar, tetikleyiciler, ışın sorgusu yanıtları vb.), bu bileşenleri barındıran oyun nesnesinde `on_message()` işlevi olan bir betik içeren tüm bileşenlere dağıtılır.
+
+Fizik benzetimi için [sabit zaman adımı](/manuals/physics/#physics-updates) kullanılıyorsa tüm betik bileşenlerinin `fixed_update()` işlevi de çağrılabilir. Bu işlev, fizik tabanlı oyunlarda kararlı bir fizik benzetimi elde etmek için fizik nesnelerini düzenli aralıklarla değiştirmek istediğinizde yararlıdır.
+
+#### Dönüşümler
+
+**Her** bileşen türünün güncellemesinden önce, `Update Loop` sırasında birden çok kez, gerekirse dönüşümler güncellenir. Böylece oyun nesnelerinin tüm hareket, dönme ve ölçekleme değişiklikleri her oyun nesnesi bileşenine ve tüm alt oyun nesnelerinin bileşenlerine uygulanır.
+
+`Update Loop` sonunda, gerekirse ek bir son dönüşüm güncellemesi yapılır.
+
+#### Motorun güncelleme aşaması (sabit zaman adımlı güncellemeler olmadan)
+
+Aşağıdaki tablolar *motor düzeyindeki* güncelleme geçişlerini açıklar. Bileşenlerin motor içindeki kesin öncelik sırasına (motorun uygulama ayrıntılarından biridir) bilinçli olarak yer vermezler; ancak betik yazımı açısından önemli olan sıralama güvencelerini yansıtırlar:
+
+- `fixed_update()`, `update()` işlevinden önce çalışır
+- `late_update()`, `update()` işlevinden sonra çalışır
+- gönderilen iletiler, bileşen türlerinin güncellemeleri arasında ve betik geri çağırım aşamaları arasında dağıtılır
+
+`Use Fixed Timestep` değeri `false` olduğunda ve/veya Fixed Update Frequency değeri `0` olduğunda, aşamanın başında `dt` hazırlanır ve ardından akış aşağıdaki tabloda gösterildiği gibi ilerler:
+
+:::sidenote
+**Her** bileşen türünün güncellemesinden sonra tüm iletilerin dağıtıldığına dikkat edin; tabloyu sade tutmak için bu işlem aşağıdaki tabloda işaretlenmemiştir.
+:::
+
+| Adım | Motor aşaması | Lua geri çağırımı | Açıklama |
+|-|-|-|-|
+| 1 | **Güncelleme** | `update()` | Güncelleme aşamasını uygulayan her bileşen türü için motorun iç öncelik sırasıyla kare başına bir kez çağrılır. Ayrıca `go.animate()` ile başlatılan oyun nesnesi özelliği animasyonları burada ayrı bir bileşen türü olarak güncellenir. **Fizik** bileşenleri burada güncellenir. Etkin her koleksiyon vekili için tüm `Update` aşaması 1. adımdan başlayarak özyinelemeli olarak çağrılır. |
+| 2 | **Geç güncelleme** | `late_update()` | Geç güncelleme aşamasını uygulayan her bileşen türü için motorun iç öncelik sırasıyla kare başına bir kez çağrılır. |
+| 3 | **Dönüşümler** | | Sonda her bileşen için, gerekirse ek bir son dönüşüm güncellemesi gerçekleştirilir. |
+
+#### Sabit zaman adımıyla motorun güncelleme aşaması
+
+`Use Fixed Timestep` değeri `true` ve Fixed Update Frequency değeri sıfırdan farklı olduğunda, aşamanın başında `dt` (geçen süre), `fixed_dt` ve `num_fixed_steps` (`0..N`) hazırlanır. Sonuncusu, sabit sayıda güncelleme yapılmasını sağlamak için son güncellemeden bu yana geçen süreye göre belirlenen, sabit zaman adımlı güncellemenin kaç kez çağrılacağını gösterir.
+
+:::sidenote
+**Her** bileşen türünün güncellemesinden sonra tüm iletilerin dağıtıldığına dikkat edin; tabloyu sade tutmak için bu işlem aşağıdaki tabloda işaretlenmemiştir.
+:::
+
+Ardından döngü başlar:
+
+| Adım | Motor aşaması | Lua geri çağırımı | Açıklama |
+|-|-|-|-|
+| 1 | **Sabit zaman adımlı güncelleme** | `fixed_update()` | Sabit zaman adımlı güncelleme aşamasını uygulayan her bileşen türü için motorun iç öncelik sırasıyla, zamanlamaya bağlı olarak kare başına `0..N` kez çağrılır. *Fizik* bileşenlerinin sabit zaman adımlı güncelleme adımlarını da içerir. |
+| 2 | **Güncelleme** | `update()` | Güncelleme aşamasını uygulayan her bileşen türü için motorun iç öncelik sırasıyla kare başına bir kez çağrılır. Ayrıca `go.animate()` ile başlatılan oyun nesnesi özelliği animasyonları burada ayrı bir bileşen türü olarak güncellenir. Etkin her koleksiyon vekili için `Update` aşaması 1. adımdan başlayarak özyinelemeli olarak çağrılır. |
+| 3 | **Geç güncelleme** | `late_update()` | Geç güncelleme aşamasını uygulayan her bileşen türü için motorun iç öncelik sırasıyla kare başına bir kez çağrılır. |
+| 4 | **Dönüşümler** | | Sonda her bileşen için, gerekirse ek bir son dönüşüm güncellemesi gerçekleştirilir. |
+
+Defold'un güncelleme aşamasındaki iç işleyişi hakkında daha fazla ayrıntıya ihtiyaç duyarsanız doğrudan [`gameobject.cpp`](https://github.com/defold/defold/blob/dev/engine/gameobject/src/gameobject/gameobject.cpp) kodunu okumanız yararlı olur.
+
+### İşleme güncellemesi aşaması
+
+İşleme güncellemesi bloğu önce `@render` soketine gönderilen tüm iletileri (örneğin kamera bileşeninin `set_view_projection` iletilerini, `set_clear_color` iletilerini vb.) dağıtır. Ardından işleme betiğinin `update()` işlevi çağrılır.
+
+![İşleme güncellemesi aşaması](images/application_lifecycle/render_update_phase.png)
+
+### Güncelleme sonrası aşama
+
+Güncellemelerden sonra, güncelleme sonrası adım dizisi çalıştırılır. Bu dizi, bellekten kaldırılmak üzere işaretlenen koleksiyon vekillerini bellekten kaldırır (bu işlem "iletileri dağıtma" adım dizisi sırasında gerçekleşir). Silinmek üzere işaretlenen her oyun nesnesi, varsa bileşenlerinin tüm `final()` işlevlerini çağırır. `final()` işlevlerindeki kod genellikle kuyruğa yeni iletiler gönderdiğinden, ardından "iletileri dağıtma" geçişi çalıştırılır.
+
+![Güncelleme sonrası aşama](images/application_lifecycle/post_update_phase.png)
+
+Sonraki adımda, oyun nesnesi oluşturması istenen her fabrika bileşeni bu nesneyi oluşturur. Son olarak, silinmek üzere işaretlenen oyun nesneleri fiilen silinir.
+
+### İşleme aşaması
+
+Güncelleme döngüsünün son adımı, `@system` iletilerinin (`exit`, `reboot` iletileri, profil çıkarıcıyı açıp kapatma, video kaydını başlatma ve durdurma vb.) dağıtılmasını içerir.
+
+![İşleme aşaması](images/application_lifecycle/render_phase.png)
+
+Ardından grafikler ve görsel profil çıkarıcının görüntüsü işlenir ([Hata ayıklama belgelerine](/manuals/debugging) bakın). Grafikler işlendikten sonra video kaydı yapılır.
+
+#### Kare hızı ve koleksiyonun zaman adımı
+
+Saniyedeki kare güncellemesi sayısı (güncelleme döngüsünün saniyedeki çalıştırılma sayısına eşittir), proje ayarlarında veya `@system` soketine `set_update_frequency` iletisi gönderilerek program aracılığıyla ayarlanabilir. Ayrıca vekile bir `set_time_step` iletisi göndererek koleksiyon vekillerinin _zaman adımını_ ayrı ayrı ayarlamak mümkündür. Bir koleksiyonun zaman adımını değiştirmek kare hızını etkilemez. Fizik güncellemesinin zaman adımını ve `update().` işlevine iletilen `dt` değişkenini etkiler. Zaman adımını değiştirmenin, her karede `update()` işlevinin kaç kez çağrılacağını değiştirmediğine de dikkat edin --- her zaman tam olarak bir kez çağrılır.
+
+(Ayrıntılar için [Koleksiyon vekili kılavuzuna](/manuals/collection-proxy) ve [`set_time_step`](/ref/collectionproxy#set-time-step) başvurusuna bakın)
+
+#### Motorun çalışmasını kısıtlama
+
+Defold 1.12.0 ile, girdileri algılamaya devam ederken motor güncellemelerini ve işlemeyi tamamen atlayabilen bir motor kısıtlama (engine throttling) API'si sunulmuştur. Herhangi bir girdi motoru yeniden uyandırır ve motor bir bekleme süresinden sonra yeniden kısıtlı çalışmaya geçebilir.
+
+Ayrıntılar ve kullanım örnekleri için `sys.set_engine_throttle()` API'sine bakın.
+
+## Sonlandırma işlemleri
+
+Uygulama kapanırken önce son güncelleme döngüsünün adım dizisini tamamlar. Bu dizi, her vekil koleksiyonundaki tüm oyun nesnelerinin sonlandırma işlemlerini yapıp nesneleri silerek tüm koleksiyon vekillerini bellekten kaldırır.
+
+Bu tamamlandığında motor, ana koleksiyonu ve nesnelerini ele alan bir sonlandırma dizisine girer:
+
+![Sonlandırma işlemleri](images/application_lifecycle/finalization.png)
+
+Önce bileşenlerin `final()` işlevleri çağrılır. Ardından iletiler dağıtılır. Son olarak tüm oyun nesneleri silinir ve ana koleksiyon bellekten kaldırılır.
+
+Motor daha sonra arka planda alt sistemleri kapatmaya devam eder: proje yapılandırması silinir, bellek profil çıkarıcısı kapatılır ve benzeri işlemler gerçekleştirilir.
+
+Uygulama artık tamamen kapanmıştır.
+
+## İletileri dağıtma {#dispatching-messages}
+
+**İletileri dağıtma**, **her** bileşen türünün güncellemesinden sonra gerçekleştirilen özel bir geçiştir; örneğin sprite bileşenlerinin güncellenmesi, betiklerin güncellenmesi ve ileti gönderebilecek diğer eylemlerden sonra çalıştırılır. Bu geçiş sırasında bir kuyrukta biriken, gönderilmiş tüm iletiler dağıtılır. Bunlar şemalarda küçük "oklu zarf" simgeleri 📩 ile işaretlenir.
+
+![İletileri dağıtma](images/application_lifecycle/dispatch_messages.png)
+
+Her bileşen için `on_message()` çağrılarak tüm **kullanıcı tanımlı iletiler** dağıtıldıktan sonra, Defold'un özel iletileri her koleksiyon vekili için (şemada da gösterildiği gibi) aşağıdaki sırayla işlenir:
+
+1. `load` iletileri - yüklenmek üzere işaretlenen koleksiyon vekillerini yükler, yanıt olarak `proxy_loaded` iletisi gönderir.
+2. `unload` iletileri - bellekten kaldırılmak üzere işaretlenen koleksiyon vekillerini bellekten kaldırır, yanıt olarak `proxy_unloaded` iletisi gönderir.
+3. `init` iletileri - başlangıç işlemleri yapılacak tüm koleksiyon vekilleri için `Collection Init` aşamasını tetikler.
+4. `final` iletileri - sonlandırılmak üzere işaretlenen vekilin tüm bileşenlerinde `final()` işlevini tetikler.
+5. `enable` iletileri - koleksiyon vekilini etkinleştirir; böylece bir sonraki karede bu vekil için `Update Loop` çalıştırılır. Bu işlem, koleksiyonun her bileşeni için dolaylı olarak `init()` işlevini tetikler.
+6. `disable` iletileri - koleksiyon vekilini devre dışı bırakır; böylece bir sonraki karede bu vekil için `Update Loop` **çalıştırılmaz**. Bu vekil için `Update Loop` çalıştırılmasını tamamen durdurur.
+
+Alıcı bileşenlerin `on_message()` kodu ek iletiler gönderebildiğinden, ileti dağıtıcısı ileti kuyruğu boşalana kadar gönderilen iletileri özyinelemeli olarak dağıtmaya devam eder. Ancak ileti dağıtıcısının ileti kuyruğunu kaç kez dolaşacağına ilişkin bir sınır vardır. Ayrıntılar için [İleti zincirlerine](/manuals/message-passing) bakın.

--- a/docs/tr/manuals/application-security.md
+++ b/docs/tr/manuals/application-security.md
@@ -1,0 +1,108 @@
+---
+title: Uygulama güvenliği kılavuzu
+brief: Bu kılavuzda güvenli geliştirme uygulamalarıyla ilgili çeşitli alanlar ele alınır.
+---
+
+# Uygulama güvenliği
+
+Uygulama güvenliği, güvenli geliştirme uygulamalarından oyun yayımlandıktan sonra içeriğinin korunmasına kadar pek çok konuyu kapsayan geniş bir alandır. Bu kılavuzda çeşitli alanlar, Defold motoru, araçları ve hizmetleri kullanılırken uygulama güvenliği bağlamında ele alınır:
+
+* Fikrî mülkiyetin korunması
+* Hile önleme çözümleri
+* Güvenli ağ iletişimi
+* Üçüncü taraf yazılımların kullanımı
+* Bulut derleme sunucularının kullanımı
+* İndirilebilir içerik
+
+
+## Fikrî mülkiyetinizi hırsızlığa karşı koruma
+Çoğu geliştirici, ürettiklerini hırsızlığa karşı nasıl koruyacağını düşünür. Telif hakları, patentler ve ticari markalar, video oyunlarının fikrî mülkiyetinin farklı yönlerini hukuken korumak için kullanılabilir. Telif hakkı, sahibine yaratıcı eseri dağıtma konusunda münhasır hak tanır; patentler buluşları, ticari markalar ise adları, simgeleri ve logoları korur.
+
+Bir oyunu oluşturan yaratıcı çalışmayı korumak için teknik önlemler almak da istenebilir. Ancak oyun oyuncunun eline geçtiğinde varlıkları (asset) çıkarmanın yollarının bulunabileceğini akılda tutmak önemlidir. Bu, oyun uygulamasına ve dosyalarına tersine mühendislik uygulanarak yapılabileceği gibi, dokular ve modeller GPU birimine gönderilirken veya diğer varlıklar belleğe yüklenirken bunları çıkaran araçlar kullanılarak da yapılabilir.
+
+Bu nedenle genel görüşümüz, kullanıcılar bir oyunun varlıklarını çıkarmaya kararlıysa bunu yapabilecekleri yönündedir.
+
+Geliştiriciler kendi koruma önlemlerini ekleyerek varlıkların çıkarılmasını zorlaştırabilir, __ancak imkânsız hâle getiremezler__. Bu genellikle oyun varlıklarını korumak ve gizlemek için çeşitli şifreleme ve karartma (obfuscation) yöntemlerini içerir.
+
+### Kaynak kodunu karartma
+Kaynak kodunu karartma, programın çıktısını etkilemeden kaynak kodun insanlar tarafından anlaşılmasını kasıtlı olarak zorlaştıran otomatik bir işlemdir. Amaç genellikle hırsızlığa karşı koruma sağlamak, bunun yanında hile yapmayı da zorlaştırmaktır.
+
+Defold'da kaynak kodunu karartma işlemi, derleme öncesi bir adım olarak veya Defold proje derleme sürecinin bir parçası olarak uygulanabilir. Derleme öncesi karartmada, Defold proje derleme süreci başlatılmadan önce kaynak kod bir karartma aracı kullanılarak karartılır.
+
+Derleme sırasındaki karartma ise bir Lua derleme eklentisi (Lua builder plugin) kullanılarak derleme sürecine dahil edilir. Lua derleme eklentisi, ham kaynak kodu girdi olarak alır ve kaynak kodun karartılmış bir sürümünü çıktı olarak döndürür. Derleme sırasında karartmaya bir örnek, GitHub'da bulunan Prometheus Lua karartıcısını temel alan [Prometheus eklentisinde](https://github.com/defold/extension-prometheus) gösterilmiştir. Aşağıda, bir kod parçasını yoğun biçimde karartmak için Prometheus kullanımının bir örneği verilmiştir (bu tür yoğun karartmanın Lua kodunun çalışma zamanı performansını etkileyeceğini unutmayın):
+
+Örnek:
+
+```
+function init(self)
+ print("hello")
+ test.greet("Bob")
+end
+```
+
+Karartılmış çıktı:
+
+```
+local v={"+qdW","ZK0tEKf=";"XP/IX3+="}for o,J in ipairs({{1;3};{1,1},{2,3}})do while J[1]<J[2]do v[J[1]],v[J[2]],J[1],J[2]=v[J[2]],v[J[1]],J[1]+1,J[2]-1 end end local function J(o)return v[o+45816]end do local o={["/"]=9;["8"]=48;["9"]=1;q=38,o=62;V=33;y=43,d=61,B=50,L=54;v=2;["0"]=21,n=31;p=63;R=5;N=3;i=10;e=35;C=7;l=56;a=47,J=58;m=59;["2"]=36;z=11;M=12;Z=26;O=18;["5"]=20;s=8,["4"]=30,P=55;w=4;U=29;Q=28;r=24,h=41;G=45;c=19;W=34,k=57;T=14,t=44,S=0;f=60;F=42,E=27;u=40;X=25,j=17;["3"]=23,b=13;["1"]=53;Y=32,A=22,K=6,["+"]=16,["6"]=46;["7"]=51;I=37;D=52;H=15,x=49,g=39}local J=type local x=string.sub local d=v local l=string.len local W=string.char local L=table.insert local w=table.concat local h=math.floor for v=1,#d,1 do local X=d[v]if J(X)=="string"then local J=l(X)local H={}local S=1 local k=0 local K=0 while S<=J do local v=x(X,S,S)local d=o[v]if d then k=k+d*64^(3-K)K=K+1 if K==4 then K=0 local o=h(k/65536)local v=h((k%65536)/256)local J=k%256 L(H,W(o,v,J))k=0 end elseif v=="="then L(H,W(h(k/65536)))if S>=J or x(X,S+1,S+1)~="="then L(H,W(h((k%65536)/256)))end break end S=S+1 end d[v]=w(H)end end end local function o(o)test[J(-45815)](o)end function init(v)print(J(-45813))o(J(-45814))end
+```
+
+### Kaynakları şifreleme
+Defold proje derleme sürecinde oyun kaynakları (resource) işlenir ve Defold motorunun çalışma sırasında kullanımına uygun biçimlere dönüştürülür. Dokular Basis Universal biçimine derlenir; koleksiyonlar (collection), oyun nesneleri (game object) ve bileşenler (component), insanların okuyabildiği metin gösterimlerinden ikili karşılıklarına dönüştürülür; Lua kaynak kodu ise işlenip bayt koduna derlenir. Ses dosyaları gibi diğer varlıklar olduğu gibi kullanılır.
+
+Bu işlem tamamlandığında varlıklar oyun arşivine tek tek eklenir. Oyun arşivi büyük bir ikili dosyadır ve her kaynağın arşiv içindeki konumu bir arşiv dizini dosyasında saklanır. Biçim [burada](https://github.com/defold/defold/blob/dev/engine/docs/ARCHIVE_FORMAT.md) belgelenmiştir.
+
+Lua kaynak dosyaları, arşive eklenmeden önce isteğe bağlı olarak ayrıca şifrelenir. Defold'da sağlanan varsayılan şifreleme, oyun arşivi bir ikili dosya görüntüleme aracıyla incelendiğinde koddaki dizelerin hemen görünmesini önlemek için kullanılan basit bir blok şifrelemedir. Defold kaynak kodu, şifreleme anahtarı da kaynak kodda görülebilecek şekilde GitHub'da bulunduğundan bu şifreleme kriptografik açıdan güvenli kabul edilmemelidir.
+
+Bir kaynak şifreleme eklentisi (Resource encryption plugin) uygulayarak Lua kaynak dosyalarına özel şifreleme eklemek mümkündür. Kaynak şifreleme eklentisi, derleme sürecinin bir parçası olarak kaynakları şifreleyen bir derleme bölümü ile kaynaklar oyun arşivinden okunurken şifrelerini çözen bir çalışma zamanı bölümünden oluşur. Kendi şifreleme çözümünüz için başlangıç noktası olarak kullanabileceğiniz temel bir kaynak şifreleme eklentisi [GitHub'da mevcuttur](https://github.com/defold/extension-resource-encryption).
+
+
+### Proje yapılandırma değerlerini kodlama
+*game.project* dosyası, uygulamanızın dağıtım paketine olduğu gibi eklenir. Bazen hassas nitelikte olan ancak gizli olmayabilecek, herkese açık API erişim anahtarlarını veya benzer değerleri saklamak isteyebilirsiniz. Bu tür değerlerin güvenliğini artırmak için onları *game.project* dosyasında saklamak yerine uygulamanın ikili dosyasına ekleyebilir ve yine de `sys.get_config_string()` gibi Defold API işlevlerinden erişilebilir tutabilirsiniz. Bunun için *game.project* dosyanıza bir yerel kod eklentisi (native extension) ekleyebilir ve `DM_DECLARE_CONFIGFILE_EXTENSION` makrosunu kullanarak Defold API işlevleriyle yapılandırma değerleri alınırken varsayılan davranışı kendi kodunuzla geçersiz kılabilirsiniz. Başlangıç noktası olarak kullanabileceğiniz bir örnek proje [GitHub'da mevcuttur](https://github.com/defold/example-configfile-extension/tree/master).
+
+
+## Oyununuzu hilecilere karşı koruma
+Video oyunlarında hile, oyun sektörü kadar eskidir. Eskiden popüler video oyunu dergilerinde hile kodları paylaşılır, ilk ev bilgisayarları için özel hile kartuşları satılırdı. Sektör ve oyunlar geliştikçe hileciler ve yöntemleri de gelişti. Oyunlarda en yaygın hile yöntemlerinden bazıları şunlardır:
+
+* Özel mantık eklemek için oyun içeriğini yeniden paketleme
+* Oyunun normalden daha hızlı veya daha yavaş çalışmasını sağlayan hız hileleri
+* Otomatik nişan alma ve botlar için otomasyon ve görsel analiz
+* Puanları, canları, cephaneyi vb. değiştirmek için kod ve bellek enjeksiyonu
+
+Hilecilere karşı korunmak zordur, neredeyse imkânsızdır. Oyunların uzak sunucularda çalıştırılıp doğrudan kullanıcının cihazına akışla aktarıldığı bulut oyun hizmetleri bile hilecilerden tamamen arınmış değildir.
+
+Defold, motorda veya araçlarda herhangi bir hile önleme çözümü sağlamaz ve bu tür çalışmaları oyunlar için hile önleme çözümleri sunma konusunda uzmanlaşmış çok sayıdaki şirketten birine bırakır.
+
+
+## Ağ iletişiminizi güvenli hâle getirme
+Defold soket ve HTTP iletişimi, güvenli soket bağlantılarını destekler. Sunucunun kimliğini doğrulamak ve istemciden sunucuya ve ters yönde aktarılırken tüm verilerin gizliliğini ve bütünlüğünü korumak için her türlü sunucu iletişiminde güvenli bağlantılar kullanmanız önerilir. Defold, TLS ve SSL protokollerinin popüler ve yaygın olarak benimsenmiş açık kaynaklı [Mbed TLS](https://github.com/Mbed-TLS/mbedtls) uygulamasını kullanır. Mbed TLS, ARM ve teknoloji ortakları tarafından geliştirilmektedir.
+
+### SSL sertifikası doğrulama
+Ağ iletişiminize yönelik ortadaki adam (man in the middle) saldırılarını önlemek için bir sunucuyla bağlantı kurulurken SSL el sıkışması sırasında sertifika zincirini doğrulamak mümkündür. Bunun için Defold'daki ağ istemcisine açık anahtarların bir listesi sağlanabilir. Ağ iletişiminizi güvenli hâle getirme hakkında daha fazla bilgi için [ağ kılavuzundaki](https://defold.com/manuals/networking/#secure-connections) SSL doğrulama bölümünü okuyun.
+
+
+## Üçüncü taraf yazılımları güvenli kullanma
+Bir oyun oluşturmak için üçüncü taraf kütüphaneler veya yerel kod eklentileri kullanmak zorunlu olmasa da geliştirmeyi hızlandırmak için resmî [Asset Portal](https://defold.com/assets/) üzerinden varlık kullanmak geliştiriciler arasında çok yaygın bir uygulama hâline gelmiştir. Asset Portal, üçüncü taraf SDK tümleştirmelerinden ekran yöneticilerine, kullanıcı arayüzü kütüphanelerine, kameralara ve çok daha fazlasına kadar geniş bir varlık yelpazesi içerir.
+
+Asset Portal'daki varlıkların hiçbiri Defold Foundation tarafından incelenmemiştir ve Asset Portal üzerinden edinilen herhangi bir varlığın kullanımı sonucunda bilgisayar sisteminizde veya başka bir cihazınızda meydana gelebilecek hasardan ya da veri kaybından sorumlu değiliz. Ayrıntılı hükümleri [Hüküm ve Koşullarımızda](https://defold.com/terms-and-conditions/#3-no-warranties) okuyabilirsiniz.
+
+Her varlığı kullanmadan önce incelemenizi ve projenizde kullanıma uygun olduğuna karar verdikten sonra siz fark etmeden değişmemesini sağlamak için varlığı çatallamanızı (fork) veya bir kopyasını oluşturmanızı öneririz.
+
+
+## Bulut derleme sunucularını güvenli kullanma
+Defold bulut derleme sunucuları (extender sunucuları olarak da bilinir), geliştiricilerin motorun kendisini yeniden derlemesi gerekmeden Defold motoruna yeni işlevler eklemesine yardımcı olmak için oluşturulmuştur. Yerel kod içeren bir Defold projesi ilk kez derlendiğinde yerel kod ve ilişkili tüm kaynaklar bulut derleme sunucularına gönderilir; burada Defold motorunun özel bir sürümü oluşturulur ve geliştiriciye geri gönderilir. Kullanılmayan bileşenleri motordan çıkarmak için özel bir uygulama bildirimi (application manifest) kullanılarak proje derlendiğinde de aynı süreç uygulanır.
+
+Bulut derleme sunucuları AWS üzerinde barındırılır ve en iyi güvenlik uygulamalarına göre oluşturulmuştur. Ancak Defold Foundation, bulut derleme sunucularının gereksinimlerinizi karşılayacağını, kusur veya virüs içermeyeceğini, güvenli ya da hatasız olacağını veya sunucuları kullanımınızın kesintisiz ya da güvenli olacağını garanti etmez. Ayrıntılı hükümleri [Hüküm ve Koşullarımızda](https://defold.com/terms-and-conditions/#3-no-warranties) okuyabilirsiniz.
+
+Derleme sunucularının güvenliği ve kullanılabilirliği sizin için endişe kaynağıysa kendi özel derleme sunucularınızı kurmanızı öneririz. Kendi sunucunuzu nasıl kuracağınıza ilişkin yönergeler, GitHub'daki extender deposunun [ana readme dosyasında](https://github.com/defold/extender) bulunabilir.
+
+
+## İndirilebilir içeriğinizi güvenli hâle getirme
+Defold Live Update sistemi, geliştiricilerin içeriği daha sonra indirmek ve kullanmak üzere ana oyun dağıtım paketinin dışında bırakmasına olanak tanır. Tipik bir kullanım, oyuncu oyunda ilerledikçe ek bölümlerin, haritaların veya dünyaların indirilmesidir.
+
+Paket dışında bırakılan içerik indirilip oyunda kullanıma hazırlandığında, kullanılmadan önce motor tarafından doğrulanır. Doğrulama, çeşitli kontrollerden oluşur:
+
+* İkili biçim doğru mu?
+* İndirilen içerik, o anda çalışan motor sürümü tarafından destekleniyor mu?
+* İndirilen içerik tam mı ve tüm dosyalar mevcut mu?
+
+Bu süreç hakkında daha fazla bilgiyi [Live Update kılavuzunda](https://defold.com/manuals/live-update/#content-verification) bulabilirsiniz.

--- a/docs/tr/manuals/atlas.md
+++ b/docs/tr/manuals/atlas.md
@@ -1,0 +1,228 @@
+---
+title: Atlas kılavuzu
+brief: Bu kılavuz, Atlas kaynaklarının Defold'da nasıl çalıştığını açıklar.
+---
+
+# Atlas
+
+Sprite bileşenlerinde (sprite components) kaynak olarak çoğu zaman tek tek görüntüler kullanılsa da performans nedeniyle görüntülerin atlas adı verilen daha büyük görüntü kümelerinde birleştirilmesi gerekir. Küçük görüntü kümelerinin atlaslarda birleştirilmesi, özellikle bellek ve işlem gücünün masaüstü bilgisayarlara veya oyun konsollarına göre daha sınırlı olduğu mobil cihazlarda önemlidir.
+
+Defold'da atlas kaynağı (atlas resource), otomatik olarak daha büyük bir görüntüde birleştirilen ayrı görüntü dosyalarının listesidir.
+
+## Atlas oluşturma
+
+*Assets* tarayıcısındaki bağlam menüsünden <kbd>New... ▸ Atlas</kbd> seçeneğini seçin. Yeni atlas dosyasına bir ad verin. Düzenleyici dosyayı atlas düzenleyicisinde açar. Atlas özellikleri, düzenleyebilmeniz için
+*Properties* bölmesinde gösterilir (ayrıntılar için aşağıya bakın).
+
+Bir atlası, sprite ve ParticleFX gibi nesne bileşenleri için grafik kaynağı olarak kullanmadan önce atlasa görüntüler veya animasyonlar eklemeniz gerekir.
+
+Görüntülerinizi projeye eklediğinizden emin olun (görüntü dosyalarını *Assets* tarayıcısında uygun konuma sürükleyip bırakın)
+
+Tek tek görüntüler ekleme
+
+: Görüntüleri *Asset* bölmesinden düzenleyici görünümüne sürükleyip bırakın.
+  
+  Alternatif olarak, *Outline* bölmesindeki kök Atlas öğesine <kbd>sağ tıklayın</kbd>.
+
+  Tek tek görüntüler eklemek için açılan bağlam menüsünden <kbd>Add Images</kbd> seçeneğini seçin.
+
+  Atlasa eklemek istediğiniz görüntüleri bulup seçebileceğiniz bir iletişim kutusu açılır. Görüntü dosyalarını filtreleyebilir ve aynı anda birden fazla dosya seçebilirsiniz.
+
+  ![Atlas oluşturma, görüntü ekleme](images/atlas/add.png)
+
+  Eklenen görüntüler *Outline* görünümünde listelenir ve atlasın tamamı ortadaki düzenleyici görünümünde görülebilir. Seçimi görünüm alanına sığdırmak için <kbd>F</kbd> tuşuna basmanız (menüden <kbd>View ▸ Frame Selection</kbd>) gerekebilir.
+
+  ![Eklenen görüntüler](images/atlas/single_images.png)
+
+Kare dizisi animasyonları ekleme
+: *Outline* bölmesindeki kök Atlas öğesine <kbd>sağ tıklayın</kbd>.
+
+  Bir kare dizisi animasyonu (flipbook animation) grubu oluşturmak için açılan bağlam menüsünden <kbd>Add Animation Group</kbd> seçeneğini seçin.
+
+  Atlasa varsayılan ada (`New Animation`) sahip yeni, boş bir animasyon grubu eklenir.
+
+  Görüntüleri seçili gruba eklemek için *Asset* bölmesinden düzenleyici görünümüne sürükleyip bırakın.
+  
+  Alternatif olarak, yeni gruba <kbd>sağ tıklayın</kbd> ve bağlam menüsünden <kbd>Add Images</kbd> seçeneğini seçin.
+
+  Animasyon grubuna eklemek istediğiniz görüntüleri bulup seçebileceğiniz bir iletişim kutusu açılır.
+
+  ![Atlas oluşturma, görüntü ekleme](images/atlas/add_animation.png)
+
+  Animasyon grubu seçiliyken önizlemek için <kbd>Space</kbd> tuşuna, önizlemeyi kapatmak için <kbd>Ctrl/Cmd+T</kbd> tuşlarına basın. Animasyonun *Properties* bölmesindeki özelliklerini gerektiği gibi ayarlayın (aşağıya bakın).
+
+  ![Animasyon grubu](images/atlas/animation_group.png)
+
+Outline görünümündeki görüntüleri seçip <kbd>Alt + Up/down</kbd> tuşlarına basarak yeniden sıralayabilirsiniz. Outline görünümündeki görüntüleri kopyalayıp yapıştırarak kolayca çoğaltabilirsiniz (<kbd>Edit</kbd> menüsünü, sağ tıklama bağlam menüsünü veya klavye kısayollarını kullanarak).
+
+## Atlas özellikleri
+
+Her atlas kaynağının bir dizi özelliği vardır. *Outline* görünümündeki kök öğeyi seçtiğinizde bu özellikler *Properties* bölmesinde gösterilir.
+
+Size
+: Oluşturulan doku kaynağının (texture resource) hesaplanan toplam boyutunu gösterir. Genişlik ve yükseklik, ikinin en yakın kuvvetine ayarlanır. Doku sıkıştırmayı etkinleştirdiğinizde bazı biçimlerin kare dokular gerektirdiğini unutmayın. Bu durumda kare olmayan dokular, kare haline getirilmek için yeniden boyutlandırılır ve boş alanla doldurulur. Ayrıntılar için [Doku profilleri kılavuzuna](/manuals/texture-profiles/) bakın.
+
+Margin
+: Görüntülerin arasına eklenecek piksel sayısı.
+
+Inner Padding
+: Her görüntünün çevresine dolgu olarak eklenecek boş piksel sayısı.
+
+Extrude Borders
+: Her görüntünün çevresine tekrar tekrar dolgu olarak eklenecek kenar pikseli sayısı. Parça gölgelendiricisi (fragment shader), bir görüntünün kenarındaki pikselleri örneklerken aynı atlas dokusundaki komşu görüntünün pikselleri taşabilir. Kenarları genişletmek bu sorunu çözer.
+
+Max Page Size
+: Çok sayfalı bir atlasta bir sayfanın en büyük boyutu. Bu özellik, tek bir çizim çağrısı kullanmayı sürdürürken atlas boyutunu sınırlamak için atlası birden fazla sayfaya bölmek amacıyla kullanılabilir. Bu özelliğin, `/builtins/materials/*_paged_atlas.material` konumunda bulunan ve çok sayfalı atlas desteği etkin olan materyallerle (materials) birlikte kullanılması gerekir.
+
+![Çok sayfalı atlas](images/atlas/multipage_atlas.png)
+
+Rename Patterns
+: Her birinin `search=replace` biçiminde olduğu, virgülle (´,´) ayrılmış arama ve değiştirme desenleri listesi.
+Her görüntünün özgün adı (dosyanın uzantısız adı) bu desenler kullanılarak dönüştürülür. (Örneğin, `hat=cat,_normal=` deseni, `hat_normal` adlı bir görüntüyü `cat` olarak yeniden adlandırır). Bu, atlaslar arasında animasyonları eşleştirirken kullanışlıdır.
+
+Aşağıda, bir atlasa 64x64 boyutunda dört kare görüntü eklendiğinde farklı özellik ayarlarının sonuçlarını gösteren örnekler verilmiştir. Görüntüler 128x128 alana sığmadığı anda atlasın 256x256 boyutuna çıktığına ve bunun doku alanının büyük ölçüde boşa harcanmasına neden olduğuna dikkat edin.
+
+![Atlas özellikleri](images/atlas/atlas_properties.png)
+
+## Görüntü özellikleri
+
+Bir atlastaki her görüntünün bir dizi özelliği vardır:
+
+Id
+: Görüntünün kimliği (salt okunur).
+
+Size
+: Görüntünün genişliği ve yüksekliği (salt okunur).
+
+Pivot
+: Görüntünün dayanak noktası (pivot), birim cinsinden belirtilir. Sol üst köşe (0,0), sağ alt köşe (1,1) konumundadır. Varsayılan değer (0.5, 0.5) şeklindedir. Dayanak noktası 0-1 aralığının dışında olabilir. Dayanak noktası, görüntü örneğin bir sprite bileşeninde kullanıldığında merkezleneceği noktadır. Düzenleyici görünümündeki dayanak noktası tutamacını sürükleyerek bu noktayı değiştirebilirsiniz. Tutamaç yalnızca tek bir görüntü seçili olduğunda görünür. Sürüklerken <kbd>Shift</kbd> tuşunu basılı tutarak yapışmayı etkinleştirebilirsiniz.
+
+Sprite Trim Mode
+: Sprite bileşeninin nasıl işlendiğini (rendering) belirtir. Varsayılan olarak sprite dikdörtgen şeklinde işlenir (Sprite Trim Mode özelliği Off olarak ayarlanır). Sprite çok sayıda saydam piksel içeriyorsa 4 ile 8 arasında köşe kullanarak dikdörtgen olmayan bir şekil olarak işlemek daha verimli olabilir. Sprite kırpmanın, dokuz parçalı ölçekleme (slice-9) kullanan sprite bileşenleriyle birlikte çalışmadığını unutmayın.
+
+Image
+: Görüntünün kendisine giden yol.
+
+![Görüntü özellikleri](images/atlas/image_properties.png)
+
+## Animasyon özellikleri
+
+Bir animasyon grubundaki görüntülerin listesine ek olarak bir dizi özellik bulunur:
+
+Id
+: Animasyonun adı.
+
+Fps
+: Animasyonun saniyedeki kare sayısı (FPS) olarak ifade edilen oynatma hızı.
+
+Flip horizontal
+: Animasyonu yatay olarak çevirir.
+
+Flip vertical
+: Animasyonu dikey olarak çevirir.
+
+Playback
+: Animasyonun nasıl oynatılacağını belirtir:
+
+  - `None` animasyonu hiç oynatmaz, ilk görüntü gösterilir.
+  - `Once Forward` animasyonu ilk görüntüden son görüntüye kadar bir kez oynatır.
+  - `Once Backward` animasyonu son görüntüden ilk görüntüye kadar bir kez oynatır.
+  - `Once Ping Pong` animasyonu ilk görüntüden son görüntüye ve ardından ilk görüntüye geri dönerek bir kez oynatır.
+  - `Loop Forward` animasyonu ilk görüntüden son görüntüye kadar tekrar tekrar oynatır.
+  - `Loop Backward` animasyonu son görüntüden ilk görüntüye kadar tekrar tekrar oynatır.
+  - `Loop Ping Pong` animasyonu ilk görüntüden son görüntüye ve ardından ilk görüntüye geri dönerek tekrar tekrar oynatır.
+
+## Çalışma sırasında doku ve atlas oluşturma
+
+Çalışma sırasında bir doku ve bir atlas oluşturmak mümkündür.
+
+### Çalışma sırasında doku kaynağı oluşturma
+
+Yeni bir doku kaynağı oluşturmak için [`resource.create_texture(path, params)`](https://defold.com/ref/stable/resource/#resource.create_texture:path-table) işlevini kullanın:
+
+```lua
+  local params = {
+    width  = 128,
+    height = 128,
+    type   = graphics.TEXTURE_TYPE_2D,
+    format = graphics.TEXTURE_FORMAT_RGBA,
+  }
+  local my_texture_id = resource.create_texture("/my_custom_texture.texturec", params)
+```
+
+Doku oluşturulduktan sonra dokunun piksellerini ayarlamak için [`resource.set_texture(path, params, buffer)`](https://defold.com/ref/stable/resource/#resource.set_texture:path-table-buffer) işlevini kullanabilirsiniz:
+
+```lua
+  local width = 128
+  local height = 128
+  local buf = buffer.create(width * height, { { name=hash("rgba"), type=buffer.VALUE_TYPE_UINT8, count=4 } } )
+  local stream = buffer.get_stream(buf, hash("rgba"))
+
+  for y=1, height do
+      for x=1, width do
+          local index = (y-1) * width * 4 + (x-1) * 4 + 1
+          stream[index + 0] = 0xff
+          stream[index + 1] = 0x80
+          stream[index + 2] = 0x10
+          stream[index + 3] = 0xFF
+      end
+  end
+
+  local params = { width=width, height=height, x=0, y=0, type=graphics.TEXTURE_TYPE_2D, format=graphics.TEXTURE_FORMAT_RGBA, num_mip_maps=1 }
+  resource.set_texture(my_texture_id, params, buf)
+```
+
+::: sidenote
+`resource.set_texture()` işlevini, dokunun bir alt bölgesini güncellemek için de kullanabilirsiniz. Bunun için dokunun tam boyutundan daha küçük genişlik ve yüksekliğe sahip bir arabellek kullanın ve `resource.set_texture()` işlevine verilen x ve y parametrelerini değiştirin.
+:::
+
+Doku, `go.set()` kullanılarak doğrudan bir [model bileşeninde](/manuals/model/) kullanılabilir:
+
+```lua
+  go.set("#model", "texture0", my_texture_id)
+```
+
+### Çalışma sırasında atlas oluşturma
+
+Dokunun bir [sprite bileşeninde](/manuals/sprite/) kullanılması için önce bir atlas tarafından kullanılması gerekir. Bir atlas oluşturmak için [`resource.create_atlas(path, params)`](https://defold.com/ref/stable/resource/#resource.create_atlas:path-table) işlevini kullanın:
+
+```lua
+  local params = {
+    texture = texture_id,
+    animations = {
+      {
+        id          = "my_animation",
+        width       = width,
+        height      = height,
+        frames      = { 1 },
+      }
+    },
+    geometries = {
+      {
+        vertices  = {
+          0,     0,
+          0,     height,
+          width, height,
+          width, 0
+        },
+        uvs = {
+          0,     0,
+          0,     height,
+          width, height,
+          width, 0
+        },
+        indices = {0,1,2,0,2,3}
+      }
+    }
+  }
+  local my_atlas_id = resource.create_atlas("/my_atlas.texturesetc", params)
+
+  -- assign the atlas to the 'sprite' component on the same go
+  go.set("#sprite", "image", my_atlas_id)
+
+  -- play the "animation"
+  sprite.play_flipbook("#sprite", "my_animation")
+
+```
+
+`frames` öğeleri, `geometries` tablosuna başvuran ve 1'den başlayan indislerdir. Bir liste geometrileri yeniden kullanabilir, yeniden sıralayabilir veya atlayabilir; kullanımı artık önerilmeyen `frame_start` ve `frame_end` aralık alanlarıyla bunlar temsil edilemez. `resource.get_atlas()` işlevi `frames` döndürür; atlas verilerini `resource.set_atlas()` veya `resource.create_atlas()` işlevine aktarırken aynı gösterimi kullanın. Aralık alanları, uyumluluk için ayarlama ve oluşturma işlevleri tarafından hâlâ kabul edilir, ancak yeni kodda `frames` kullanılması önerilir.

--- a/docs/tr/manuals/automated-testing.md
+++ b/docs/tr/manuals/automated-testing.md
@@ -1,0 +1,197 @@
+---
+title: Otomatik test ve doğrulama
+brief: Bu kılavuz, belirlenimci Defold testlerinin yerel ortamda, çalışan bir oyunda, tarayıcılarda ve sürekli tümleştirme ortamında nasıl tasarlanacağını, çalıştırılacağını ve raporlanacağını açıklar.
+---
+
+# Otomatik test ve doğrulama
+
+Otomatik test (automated testing), Defold kodunu ve içeriğini açık, makine tarafından okunabilir kanıtlarla doğrular. Yerel betiklerle, sürekli tümleştirme (Continuous Integration, CI) çalıştırıcılarıyla ve kodlama ajanlarıyla kullanılabilen testler tasarlamak için bu kılavuzu kullanın. Kılavuz; modül testlerini, çalışan koleksiyonları, tarayıcı testlerini, çalışma zamanı otomasyonunu, görsel kontrolleri, grafik arayüzü olmadan çalışan (headless) derlemeleri ele alır ve yararlı uygulama önerileri sunar.
+
+## Doğrulama düzeyleri
+
+İyi bir otomatik test yapısı, testleri üç ana katmana ayıran test piramidi yaklaşımını izler: birim testleri (unit test), tümleştirme testleri (integration test) ve uçtan uca testler (end-to-end, E2E). Defold'da testleri başlangıçta yüklenebilen belirli koleksiyonlara (collection) ayırabilirsiniz. Genellikle sorunu saptayabilecek en dar kapsamlı ve en hızlı kontrolle başlayıp gerektiğinde çalışma zamanı veya platform testleri eklemek iyi bir yaklaşımdır.
+
+| Düzey | Uygun kanıt |
+| --- | --- |
+| Statik geçerleme | Ayrıştırıcı, biçimlendirici, kaynak geçerleyicisi veya oluşturulan dosyaların karşılaştırması |
+| Modül testi | Motor bağımlılıkları en az düzeyde olan, yeniden kullanılabilir Lua mantığı için doğrulama koşullarının sonuçları |
+| Çalışan koleksiyon | İletiler, bileşenler (component), girdi, fizik, yaşam döngüsü ve motor davranışı |
+| Çalışma zamanı otomasyonu | Canlı sahne durumu, program yoluyla sağlanan girdi, uygulama durumu ve çalışma sırasında alınan ekran görüntüleri |
+| HTML5 tarayıcı testi | Tuval girdisi, tarayıcı tümleştirmesi, görüntü alanının davranışı ve web çıktısı |
+| Platform testi | Asıl hedef platformdaki davranış ve işleme (rendering, görüntü oluşturma) |
+| Derleme ve paketleme | Bob çıkış durumu, derleme raporu, arşiv ve dağıtım paketi çıktı dosyaları |
+
+Başarılı bir kod derleme işlemi, projenin derlenebildiğini kanıtlar; ancak oynanış davranışının doğru olduğunu kanıtlamaz. Bir ekran görüntüsü karmaşık geçişleri, animasyonları, etkileşimleri veya oynanış akışını kanıtlamaz; ancak modern çok modlu çözümler, bir karenin nasıl göründüğünü ve gölgelendiriciler ile görsel yerleşimin doğru olup olmadığını incelemek için ekran görüntüsünü kullanabilir. Bununla birlikte, otomatik testlerde koşulun doğrudan ifade edilebildiği her durumda belirlenimci (deterministic) doğrulama koşullarını tercih edin.
+
+## Yeniden kullanılabilir ve test edilebilir Lua kodu
+
+Yeniden kullanılabilir mantığı, motor bağımlılıkları en az düzeyde olan Lua modüllerinde tutun. Böylece yan etkisiz veri dönüşümleri, kurallar, durum makineleri ve hesaplamalar, eksiksiz bir oyun dünyası oluşturmadan sınanabilir.
+
+Motorla etkileşen kodu, çağırdığı mantıktan ayırın. Bir betik, iletileri ve bileşen durumunu bir modüle yapılan çağrılara dönüştürebilir; testler ise modülü kontrollü girdilerle doğrudan çağırır.
+
+Daha fazla ayrıntı için [Kod yazma kılavuzuna](/manuals/writing-code) bakın.
+
+## Çalışan bir koleksiyonda testler {#tests-in-a-running-collection}
+
+Davranış oyun nesnelerine (game object), bileşenlere, iletilere, girdiye, fiziğe veya diğer motor sistemlerine bağlıysa özel bir test koleksiyonu kullanın.
+
+Her testin şu adımları izlemesi önerilir:
+
+1. bilinen bir durum oluşturmak;
+2. tek bir davranışı yürütmek;
+3. beklenen sonucu doğrulamak ve değerlendirmek;
+4. oluşturulan kaynakları temizlemek;
+5. yapılandırılmış bir sonuç açıklaması üretmek.
+
+Testler için yalıtılmış test koleksiyonlarını tercih edin. Bir proje, `game.project` dosyasındaki geçici bir proje ayarıyla test amaçlı bir başlangıç koleksiyonu (bootstrap collection) seçebilir:
+
+```ini
+[bootstrap]
+main_collection = /test/test.collectionc
+```
+
+Geçici test başlangıç koleksiyonunu projenin normal yapılandırmasında bırakmayın. CI ortamında, Bob'a iletilen özel bir ayar dosyasını tercih edin. CI deponun durumunu değiştiremez; yalnızca gerektiğinde geçici değişiklikler yapmalıdır.
+
+Karmaşık oyunlar için önceden tanımlanmış senaryolar ve basit kaba bölüm taslakları içeren küçük "geliştirme odası" koleksiyonları oluşturabilirsiniz. Bunlar mekaniklerin yeniden üretilebilmesini sağlar ve oyunun ilgisiz durumlarında ve bölümlerinde gezinmeden test yapmayı mümkün kılarak geliştirmeyi kolaylaştırır.
+
+### Test çatıları
+
+Projeler küçük bir test çalıştırıcısı uygulayabilir veya [topluluk tarafından sunulan bir test kütüphanesi](https://defold.com/assets/?tag=testing) kullanabilir.
+
+Örneğin [DefTest](https://defold.com/assets/deftest/), Telescope tabanlı bir birim testi kütüphanesidir. Test takımlarını, hazırlık ve test sonrası temizleme işlevlerini, doğrulama koşullarını, ada göre filtrelemeyi, seçili Defold API'leri için mock yapılarını ve isteğe bağlı LuaCov kod kapsamı ölçümünü destekler. Testler özel bir başlangıç koleksiyonundan çalıştırılabilir; buna Bob ile oluşturulmuş grafik arayüzü olmadan çalışan bir dağıtım paketinde çalıştırma da dahildir.
+
+## Yapılandırılmış test sonuçları {#structured-test-results}
+
+Bir test çatısının konsol/günlük özeti geliştiriciler için yararlı olabilir; ancak gözetimsiz çalışan bir otomatik denetleyicinin yine de açık bir tamamlanma sonucuna ihtiyacı vardır. Denetleyicinin test sonuçlarını kolayca işleyebilmesi için gerekirse çatının geri çağırımını veya özetini sarmalayan küçük bir bağdaştırıcı ekleyin.
+
+Basit bir sonuç açıklaması, her fiziksel konsol satırında benzersiz bir önekin ardından tek bir JSON nesnesi kullanabilir:
+
+```text
+TEST {"run":"8f13","event":"suite_start","tests":2}
+TEST {"run":"8f13","event":"case","name":"player_moves","status":"pass","duration_ms":3}
+TEST {"run":"8f13","event":"case","name":"player_stops","status":"pass","duration_ms":2}
+TEST {"run":"8f13","event":"suite_end","status":"pass","passed":2,"failed":0}
+```
+
+Bir toplayıcının her satırı bağımsız olarak işlemesi, `TEST` önekini bulması, ardından gelen JSON verisini ayrıştırması ve ilgisiz motor çıktısını yok sayması önerilir.
+
+Eski veya eşzamanlı bir sürecin çıktısının geçerli çalıştırmayı tamamlayamaması için benzersiz bir çalıştırma tanımlayıcısı ekleyin. Her test takımının, tek ve anlamı açık bir son olay üretmesi önerilir (`Pass`, `Failure`, `Crash`, `Timeout` vb.).
+
+### Konsol çıktısını toplama
+
+Bir oyun düzenleyiciden çalıştırıldığında hem mevcut konsol geçmişi hem de sürekli bir akış sunulur. Akışı, eşleşen bir test takımı tamamlanma olayından, sürecin sonlanmasından, bir hatadan veya yapılandırılan zaman aşımı ve satır sınırına ulaşılmasından sonra kapatın.
+
+[Düzenleyici HTTP API'si kılavuzunda](/manuals/editor-http-api/#reading-console-output) daha fazla bilgi bulabilirsiniz.
+
+### Kalıcı günlükler
+
+Defold, `Write Log File` seçeneğini `game.project` dosyasında etkinleştirerek oyun günlüğünü kalıcı olarak da kaydedebilir. [Oyun ve sistem günlüklerine](/manuals/debugging-game-and-system-logs/) bakın. Günlüğün dosyaya kaydedilmesi, paketlenmiş uygulamalar için ve düzenleyici konsolunun kullanılamadığı hedef cihazları test ederken yararlıdır.
+
+Proje, yerleşik `print()` ve `pprint()` işlevlerini veya örneğin Asset Portal'ımızdaki diğer [günlük kütüphanelerinden](https://defold.com/assets/?tag=logging) herhangi birini kullanabilir.
+
+## Çalışan bir oyunu çalışma zamanı API'si üzerinden test etme
+
+Bir çalışma zamanı otomasyonu API'si, çalışan bir hata ayıklama motorunu inceleyebilir ve kontrol edebilir. Testlerin çalışma zamanı nesnelerini bulması, program yoluyla girdi sağlaması, görünür bir durumu beklemesi veya işlenmiş görüntüyü alması gerektiğinde kullanılabilir.
+
+Daha fazla ayrıntı için [motor hizmeti kılavuzunu](/manuals/engine-service/#automation-bridge-extension) okuyun.
+
+Aşağıdaki örnek, [Automation Bridge](https://github.com/defold/extension-automation-bridge) Python yardımcı yapısını kullanır. Projenin hata ayıklama eklentisinin uyumlu bir sürümünü içermesi, belirtilen otomasyon tanımlayıcısına sahip bir öğeyi erişime açması ve `screen` uygulama durumunu yayımlaması gerekir:
+
+```python
+from automation_bridge import editor
+
+project = editor.open_project(".")
+game = project.build_and_run()
+
+try:
+    play = game.element(automation_id="play_button")
+    game.click(play)
+    game.wait_for_state("screen", "gameplay", timeout=5.0)
+    screenshot = game.screenshot()
+    print(screenshot.path)
+finally:
+    game.close_engine()
+```
+
+Uygulamanın tanımladığı durumlar ve otomasyon tanımlayıcıları, Automation Bridge'in isteğe bağlı, yalnızca hata ayıklamaya özel Lua API'sini kullanır; projenin bu API'yi etkinleştirmesi ve yayımlaması gerekir. Sabit süreli bir bekleme, makine hızından ve kare zamanlamasından etkilenir; tanımlanmış bir durumu sınırları belirlenmiş şekilde düzenli aralıklarla sorgulamak daha güvenilirdir.
+
+Automation Bridge bir eklentidir; çekirdek motorun parçası değildir. Kurulu sürüme ait seçiciler, beklemeler, durum, olaylar, ekran görüntüleri ve tanılama hakkında bilgi için [Python API başvuru belgelerine](https://github.com/defold/extension-automation-bridge/tree/master/automation_bridge/automation-bridge-python) bakın.
+
+## HTML5 için tarayıcı testleri {#browser-tests-for-html5}
+
+Düzenleyici, [düzenleyici HTTP API'si kılavuzunda](/manuals/editor-http-api/#building-html5) açıklandığı gibi, mevcut `build-html5` komutuyla bir HTML5 derlemesi oluşturup sunabilir. Bob da düzenleyici olmadan bir HTML5 dağıtım paketi oluşturabilir.
+
+Playwright, Puppeteer, Selenium, WebdriverIO veya Cypress gibi harici tarayıcı otomasyon araçları şunları yapabilir:
+
+* Defold tuvalinin ve uygulamanın hazır olmasını beklemek;
+* klavye, fare ve öykünülmüş dokunma girdisi göndermek;
+* görüntü alanını yeniden boyutlandırmak;
+* tarayıcı konsol çıktısını ve JavaScript hatalarını toplamak;
+* ekran görüntüleri almak ve çıktı dosyalarını karşılaştırmak.
+
+Tuvale yönlendirilen girdi, projenin normal girdi eşlemeleri (input binding) ve `on_input()` geri çağırımları aracılığıyla işlenir. Hem oyunun tepkisini hem de tarayıcıya özgü tümleştirme noktalarını test edin.
+
+En güvenilir yaklaşım, özel `index.html` dosyasında açık bir JavaScript test köprüsü sunmaktır. Defold tarafında HTML5 derlemeleri, `html5.run()` kullanarak JavaScript yürütebilir; bu da tarayıcı tarafındaki böyle bir köprüyle iletişimi mümkün kılar. JavaScript'ten Defold'a geri gönderilen komutlar için JavaScript'ten motora iletişim sağlayan özel bir köprü kullanın.
+
+Tarayıcı testlerinin sınırlarını belirleyin. Son raporda sayfanın yüklenememesini, tuvalin eksik olmasını, JavaScript hatasını, test zaman aşımını ve başarısız oyun doğrulama koşulunu birbirinden ayırın.
+
+## Görsel inceleme için düzenleyici önizlemeleri ve çalışma sırasında alınan ekran görüntüleri {#editor-previews-and-runtime-screenshots}
+
+Açık düzenleyicinin varsayılan sahne görünümünde kaynak dosyalarının veya çalışma sırasında oyunun ekran görüntüsünü alabilirsiniz.
+
+| Yöntem | Amaç |
+| --- | --- |
+| [Düzenleyici önizlemesi](/manuals/editor-http-api/#rendering-scene-previews) | Yüklenmiş kaynakların yerleşimi (ör. bölüm veya GUI), atlas düzeni, karo haritası incelemesi, statik sahne düzeni, düzenleyicide işleme ve gölgelendiricilerin doğruluğu veya belgeler için küçük resimler oluşturma |
+| [Çalışma sırasında alınan ekran görüntüsü](/manuals/engine-service) | Kontrollü bir senaryoda çalışan bir derlemenin işlenmiş durumu |
+
+Görüntü karşılaştırmasını örneğin gerileme testleri için kullanabilirsiniz. Bir kontrol başarısız olduğunda fark görüntüsünü ve karşılaştırma ölçümlerini saklayın.
+
+Çok modlu bir model; kırpılmış metin, üst üste binen denetimler, belirsiz seçim durumları veya güvenli alanın dışındaki içerik gibi başka türlü ifade edilmesi zor anlamsal koşulları görsel inceleme sırasında değerlendirebilir. Bu değerlendirmeyi, açık ölçütlere dayanan ek bir gösterge olarak ele almanız; belirlenimci mantık kontrollerinin veya görüntü karşılaştırmasının yerine kullanmamanız önerilir.
+
+## Grafik arayüzü olmadan çalışan testler ve CI
+
+Düzenleyiciden bağımsız CI için Bob derleme komut satırı aracını kullanın.
+
+Bu araçla bağımlılıkları çözümleyebilir, bir oyun, arşiv veya bağımsız dağıtım paketi oluşturabilir ve bir JSON raporu üretebilirsiniz:
+
+```sh
+mkdir -p build/reports
+
+java -jar bob.jar \
+  --root . \
+  --archive \
+  --build-report-json build/reports/build-report.json \
+  resolve build
+```
+
+Özel ayarlarla, grafik arayüzü olmadan çalışan bir test dağıtım paketi oluşturun:
+
+```sh
+java -jar bob.jar \
+  --root . \
+  --settings test/test.settings \
+  --platform x86_64-linux \
+  --variant headless \
+  --archive \
+  --bundle-output build/test-bundle \
+  resolve build bundle
+```
+
+Oluşan yürütülebilir dosyayı platforma uygun bir süreç denetleyicisiyle çalıştırın. Çıkış durumunu ve günlüklerini kaydedin, bir zaman aşımı uygulayın ve yapılandırılmış test takımı tamamlanma olayını zorunlu tutun.
+
+[Bob kılavuzu](/manuals/bob); platformları, ayar dosyalarını, dağıtım paketlerini, önbellekleri, yerel kod eklentilerini ve derleme raporlarını açıklar.
+
+## Başarısızlık raporları ve çıktı dosyaları
+
+İyi test sonuçlarının, bir başarısızlığı yeniden üretmek ve nedenini saptamak için yeterli kanıtı saklaması önerilir:
+
+* test adı, çalıştırma tanımlayıcısı ve doğrulama koşulunun ayrıntıları;
+* geçen süre ve sınıflandırılmış sonuç;
+* konsolun veya sürecin tam günlüğü;
+* Defold sürümü, hedef platform ve ilgili yapılandırma;
+* Bob derleme raporu ve süreç çıkış durumu;
+* varsa çalışma zamanı durumu veya sahnenin anlık görüntüsü;
+* ekran görüntüleri, referans görüntüye göre farklar, kayıtlar veya tarayıcı izleri;
+* oluşturulan tüm çıktı dosyalarına ait yollar veya bağlantılar.
+
+Aynı biçimin bir geliştirici, yerel betik, CI hizmeti veya [yapay zekâ kodlama ajanı](/manuals/ai-agents) tarafından kullanılabilir olması önerilir. Böylece tanılama veya onarım başka birine devredildiğinde bile doğrulama belirlenimci kalır.

--- a/docs/tr/manuals/automation.md
+++ b/docs/tr/manuals/automation.md
@@ -1,0 +1,63 @@
+---
+title: Defold'da otomasyon
+brief: Bu kılavuz Defold'un otomasyon arayüzlerini tanıtır ve düzenleyici, çalışma zamanı, komut satırı, test ve ajanların yönettiği iş akışları arasında nasıl seçim yapılacağını açıklar.
+---
+
+# Defold'da otomasyon
+
+Bu kılavuz, genel bir açıklama ve her konu için ayrı kılavuzlara bağlantılar sunar.
+
+Defold, çeşitli düzeylerde otomasyonu destekler. Göreve uygun bir arayüz seçmek, etkili otomasyonun en önemli yönlerinden biridir. Aşağıdaki tablo, belirli bir işlem için en basit arayüzü seçmenize yardımcı olabilir:
+
+| Katman | Amaç |
+| --- | --- |
+| [Düzenleyici betikleri (Editor Scripts)](/manuals/editor-scripts) | Test ve geliştirme süreçlerini hızlandıran özel komutlar ve düzenleyici iş akışları veya tümleştirmeleri; örneğin bölüm ve varlık (asset) oluşturma |
+| [Düzenleyici UI betikleri](/manuals/editor-scripts-ui/) | Düzenleyici betiklerinden yararlanan özel görsel araçlar, açılır pencereler, yapılandırma araçları veya kullanıcı arayüzleri (UI) |
+| [Düzenleyici HTTP API'si](/manuals/editor-http-api) | Özel işlemler, harici araçlar, IDE tümleştirmeleri ve test denetleyicileri için Defold düzenleyicisinde açık olan oyun projesini OpenAPI işlemleri, proje kaynakları (resource), derlemeler, düzenleyici komutları, önizlemeler, tercihler, konsol çıktısı veya düzenleyici betikleri aracılığıyla denetleme |
+| [Bob CLI](/manuals/bob) | Komut satırından proje derleme, veri arşivleri veya bağımsız dağıtım paketleri oluşturma, raporlar, CI |
+| [Yaşam döngüsü kancaları (lifecycle hooks)](/manuals/editor-http-api#lifecycle-hooks) | Düzenleyicide proje derleme veya paketleme işlemlerinden önce ve sonra geçerleme veya üretim |
+| [Motor HTTP hizmeti](/manuals/engine-service) | Çalışan Defold oyun motorunu (`dmengine`) inceleme, geliştirme hizmetleri, profil çıkarma, çalışma zamanı iletileri veya uzantıların tanımladığı çalışma zamanı otomasyon API'leri, harici araçlarla sorgulama, çalışan bir hata ayıklama derlemesine komut gönderme |
+| [Automation Bridge](https://github.com/defold/extension-automation-bridge) | motorun çalışma zamanı için ek otomasyon uç noktaları sağlayan resmî Defold uzantısı |
+| [Otomatik testler](/manuals/automated-testing) | Oyun mantığını, iletileri, bileşenleri (component), girdiyi, fiziği ve motor davranışını test etme, sahne inceleme, örneğin [düzenleyici önizlemesi](/manuals/editor-http-api/#rendering-scene-previews) aracılığıyla görsel geri bildirim, program yoluyla sağlanan girdi, canlı uygulama durumu, [test koleksiyonlarını (collection) çalıştırma](/manuals/automated-testing/#tests-in-a-running-collection) |
+| Kabuk betikleri veya görev çalıştırıcıları | Üretim, biçimlendirme, geçerleme ve tekrarlanabilir görevler, sıradan dosya işlemleri |
+| Platforma özgü harici araçlar ve web tarayıcısı otomasyon araçları | Masaüstü test araçları, HTML5 etkileşim testleri, ekran görüntüleri, web tümleştirmeleri |
+| Yapay zekâ kodlama ajanları ve çok modlu modeller | Belirlenimci (deterministic) bir yaklaşımı uygulamanın zor veya imkânsız olduğu görevler, sahnelerin, GUI yerleşimlerinin veya çalışma sırasında alınan ekran görüntülerinin anlamsal analizi |
+
+En önemli ayrım, Defold düzenleyicisi ile çalışan bir oyun arasındadır. Bunlar, ayrı HTTP sunucularına sahip ayrı süreçlerdir.
+
+## Belirlenimci otomasyon veya yapay zekâ ajanları
+
+İşlem sırası zaten biliniyorsa, örneğin bir bölüm geçerleme aracında, biçimlendiricide, derleme görevinde veya gerileme testinde, belirlenimci bir çözümü tercih edin. Bunların normalde girdilerinin, çıktılarının, zaman aşımı sürelerinin ve çıkış kodlarının tutarlı olması önerilir. Bu yaklaşım, CI üzerinde güvenilir biçimde çalıştırılabilen otomatik kancalar ve testler için uygundur. Projelerinizde kaynakları prosedürel olarak oluşturmak için de belirlenimci bir çözüm tercih edilir; örneğin gltf nesnelerini belirli bir materyale sahip modellere dönüştüren veya bir bölüme ağaçlar gibi nesneler yerleştiren bir araç. Bu işlemler, düzenleyici betikleri ve UI ile her proje için kolayca oluşturulabilir. Bunlar hakkında daha fazla bilgi için [kılavuzu](/manuals/editor-scripts-ui) okuyun.
+
+Bir görev araştırma veya çok modlu (örneğin görsel içeriği de kapsayan) analiz gerektiriyorsa ajan yararlı olabilir: ilgili kaynakları bulmak, bir uygulama biçimi seçmek, birkaç dosyayı değiştirmek, hataları yorumlamak ve tanımlanmış kabul ölçütlerine ulaşana kadar yinelemek gibi. Bununla birlikte ajanın yine de belirlenimci arayüzleri çağırması ve yerel bir betik veya CI çalıştırıcısıyla aynı kanıtları kullanması önerilir. [Defold ile yapay zekâ kodlama ajanlarını kullanma](/manuals/ai-agents) kılavuzuna bakın.
+
+## Otomasyon döngüsü {#the-automation-loop}
+
+Güvenilir bir otomasyon süreci kapalı bir döngü oluşturur:
+
+1. İnceleyin - proje dosyalarını, güncel arayüz açıklamasını ve ilgili belgeleri okuyun.
+2. Değiştirin - düzenleyici işlemlerini (editor transactions), düzenleyici betiklerini veya dosya ve kabuk araçlarını kullanın.
+3. Doğrulayın - projeyi derleyin, belirli bir konuya odaklanan testleri çalıştırın ve günlükleri, raporları, durum bilgilerini veya görüntüleri toplayın.
+4. Değerlendirin - kanıtları kabul ölçütleriyle karşılaştırın, ardından bitirin veya yeniden deneyin.
+
+![İnceleme, değiştirme, doğrulama ve değerlendirmeden oluşan otomasyon döngüsü](images/automation/automation_loop.png)
+
+Doğrulamanın gerçek ortamdan kanıt sağlaması önerilir. Uygun kanıtlar şunları içerir:
+
+* başarılı bir proje derleme sonucu;
+* tamamlandığı açıkça belirtilen bir test takımı;
+* çalışan oyundaki beklenen durum;
+* oluşturulmuş bir dağıtım paketi veya derleme raporu;
+* belirlenimci bir görüntü karşılaştırması;
+* tanımlanmış görsel ölçütleri karşılayan bir ekran görüntüsü.
+
+Değişiklik yapmadan önce beklenen sonucu tanımlayın. Ayrıca bir zaman aşımı süresi ve en fazla kaç düzeltme denemesi yapılacağını belirleyin. Gözetimsiz bir sürecin, kabul ölçütlerini karşılayamadığında süresiz olarak devam etmesi önerilmez.
+
+## Sonraki adımlar
+
+Otomasyon iş akışlarıyla ilgili belirli konular hakkında daha ayrıntılı bilgi için aşağıdaki kılavuzlara bakın:
+
+* [Defold düzenleyicisi görevlerini HTTP API ile otomatikleştirme](/manuals/editor-http-api)
+* [Motor hizmeti ve çalışma zamanı HTTP API'si](/manuals/engine-service)
+* [Otomatik test ve doğrulama](/manuals/automated-testing)
+* [Defold ile yapay zekâ kodlama ajanlarını kullanma](/manuals/ai-agents)

--- a/docs/tr/manuals/bob.md
+++ b/docs/tr/manuals/bob.md
@@ -1,0 +1,242 @@
+---
+title: Defold proje derleyicisi kılavuzu
+brief: Bob, Defold projelerini derlemek için kullanılan bir komut satırı aracıdır. Bu kılavuz aracın nasıl kullanılacağını açıklar.
+---
+
+# Derleyici Bob
+
+Bob, Defold projelerini normal düzenleyici iş akışının dışında derlemek (build) için kullanılan bir komut satırı aracıdır.
+
+Bob verileri derleyebilir (düzenleyicideki <kbd>Project ▸ Build</kbd> menü öğesini seçerek yapılan derleme adımına karşılık gelir), veri arşivleri oluşturabilir ve bağımsız uygulama dağıtım paketleri (bundle) hazırlayabilir (düzenleyicideki <kbd>Project ▸ Bundle ▸ ...</kbd> menü öğesinin seçeneklerine karşılık gelir)
+
+Bob, derleme için gereken her şeyi içeren bir Java _JAR_ arşivi olarak dağıtılır. En son *bob.jar* dağıtımını [GitHub Releases sayfasında](https://github.com/defold/defold/releases) bulabilirsiniz. Bir sürüm seçin, ardından *bob/bob.jar* dosyasını indirin. Çalıştırmak için OpenJDK 25 gerekir.
+
+Uyumlu OpenJDK 25 dağıtımlarının indirme adresleri:
+* [Microsoft tarafından sunulan OpenJDK 25](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-25)
+* [Adoptium Working Group tarafından sunulan OpenJDK 25](https://github.com/adoptium/temurin25-binaries/releases) / [Adoptium.net](https://adoptium.net/)
+
+Windows kullanıyorsanız OpenJDK için `.msi` kurulum dosyasını seçin.
+
+## Kullanım {#usage}
+
+Bob, bir kabuktan veya komut satırından `java` (Windows'ta `java.exe`) çağrılarak ve Bob Java arşivi bağımsız değişken olarak verilerek çalıştırılır:
+
+```text
+$ java -jar bob.jar --help
+usage: bob [options] [commands]
+ -a,--archive                            Build archive
+ -ar,--architectures <arg>               Comma separated list of
+                                         architectures to include for the
+                                         platform
+    --archive-resource-padding <arg>     The alignment of the resources in
+                                         the game archive. Default is 4
+ -bf,--bundle-format <arg>               Which formats to create the
+                                         application bundle in. Comma
+                                         separated list. (Android: 'apk'
+                                         and 'aab')
+    --binary-output <arg>                Location where built engine
+                                         binary will be placed. Default is
+                                         "<build-output>/<platform>/"
+ -bo,--bundle-output <arg>               Bundle output directory
+ -br,--build-report <arg>                DEPRECATED! Use
+                                         --build-report-json instead
+ -brhtml,--build-report-html <arg>       Filepath where to save a build
+                                         report as HTML
+ -brjson,--build-report-json <arg>       Filepath where to save a build
+                                         report as JSON
+    --build-artifacts <arg>              If left out, will default to
+                                         build the engine. Choices:
+                                         'engine', 'plugins', 'library'.
+                                         Comma separated list
+    --build-input <arg>                  Project resource path to build
+                                         instead of game.project. May be
+                                         specified more than once. More
+                                         than one occurrence is allowed
+    --build-input-file <arg>             File containing project resource
+                                         paths to build instead of
+                                         game.project. May be specified
+                                         more than once. More than one
+                                         occurrence is allowed
+    --build-server <arg>                 The build server (when using
+                                         native extensions)
+    --build-server-header <arg>          Additional build server header to
+                                         set. More than one occurrence is
+                                         allowed
+ -ce,--certificate <arg>                 DEPRECATED! Use --keystore
+                                         instead
+ -d,--debug                              DEPRECATED! Use --variant=debug
+                                         instead
+    --debug-ne-upload                    Outputs the files sent to build
+                                         server as upload.zip
+    --debug-output-glsl <arg>            Force build GLSL shaders
+    --debug-output-hlsl <arg>            Force build HLSL shaders
+    --debug-output-msl <arg>             Force build Metal shaders
+    --debug-output-spirv <arg>           Force build SPIR-V shaders
+    --debug-output-wgsl <arg>            Force build WGSL shaders
+    --defoldsdk <arg>                    What version of the defold sdk
+                                         (sha1) to use
+ -e,--email <arg>                        User email
+ -ea,--exclude-archive                   Exclude resource archives from
+                                         application bundle. Use this to
+                                         create an empty Defold
+                                         application for use as a build
+                                         target
+    --exclude-build-folder <arg>         DEPRECATED! Use '.defignore' file
+                                         instead
+    --experimental-path-minification     Minimizes resource path names in
+                                         order to save bundle size.
+ -h,--help                               This help message
+ -i,--input <arg>                        DEPRECATED! Use --root instead
+    --identity <arg>                     Sign identity (iOS)
+ -kp,--key-pass <arg>                    Password of the deployment key if
+                                         different from the keystore
+                                         password (Android)
+ -ks,--keystore <arg>                    Deployment keystore used to sign
+                                         APKs (Android)
+ -ksa,--keystore-alias <arg>             The alias of the signing key+cert
+                                         you want to use (Android)
+ -ksp,--keystore-pass <arg>              Password of the deployment
+                                         keystore (Android)
+ -l,--liveupdate <arg>                   Yes if liveupdate content should
+                                         be published
+    --max-cpu-threads <arg>              Max count of threads that bob.jar
+                                         can use
+ -mp,--mobileprovisioning <arg>          mobileprovisioning profile (iOS)
+    --ne-build-dir <arg>                 Specify a folder with includes or
+                                         source, to build a specific
+                                         library. More than one occurrence
+                                         is allowed
+    --ne-output-name <arg>               Specify a library target name
+ -o,--output <arg>                       Output directory. Default is
+                                         "build/default"
+ -p,--platform <arg>                     Platform (when building and
+                                         bundling)
+ -pk,--private-key <arg>                 DEPRECATED! Use --keystore
+                                         instead
+ -r,--root <arg>                         Build root directory. Default is
+                                         current directory
+    --resource-cache-local <arg>         Path to local resource cache
+    --resource-cache-remote <arg>        URL to remote resource cache
+    --resource-cache-remote-pass <arg>   Password/token to authenticate
+                                         access to the remote resource
+                                         cache
+    --resource-cache-remote-user <arg>   Username to authenticate access
+                                         to the remote resource cache
+    --settings <arg>                     Path to a game project settings
+                                         file. The settings files are
+                                         applied left to right. More than
+                                         one occurrence is allowed
+    --strip-executable                   Strip the dmengine of debug
+                                         symbols (when bundling iOS or
+                                         Android)
+ -tc,--texture-compression               Use texture compression as
+                                         specified in texture profiles
+ -tp,--texture-profiles <arg>            DEPRECATED! Use
+                                         --texture-compression instead
+ -u,--auth <arg>                         User auth token
+    --use-async-build-server             DEPRECATED! Asynchronous build is
+                                         now the default
+    --use-lua-bytecode-delta             Use byte code delta compression
+                                         when building for multiple
+                                         architectures
+    --use-uncompressed-lua-source        Use uncompressed and unencrypted
+                                         Lua source code instead of byte
+                                         code
+    --use-vanilla-lua                    DEPRECATED! Use
+                                         --use-uncompressed-lua-source
+                                         instead
+ -v,--verbose                            Verbose output
+    --variant <arg>                      Specify debug, release or
+                                         headless version of dmengine
+                                         (when bundling)
+    --version                            Prints the version number to the
+                                         output
+    --with-sha1                          Generate (and verify) sha1
+                                         signatures from build artifacts
+                                         (when bunding for web)
+    --with-symbols                       Generate the symbol file (if
+                                         applicable)
+```
+
+`--texture-compression`, değer almayan bir anahtardır. Doku profillerinde (texture profile) seçilen sıkıştırmayı etkinleştirmek için bu anahtarı ekleyin; doku sıkıştırmayı devre dışı bırakmak için kullanmayın. Eski `--texture-compression=true` biçimi hâlâ kabul edilir. Eski `--texture-compression=false` biçimi yok sayılır ve bir uyarı üretir; bunun yerine anahtarı hiç kullanmayın.
+
+Kullanılabilir komutlar:
+
+`clean`
+: Derleme dizinindeki derlenmiş dosyaları siler.
+
+`distclean`
+: Derleme dizinindeki tüm dosyaları siler.
+
+`build`
+: Seçilen derleme köklerinden (build root) erişilebilen bağımlılık grafını derler. Varsayılan kök `game.project` dosyasıdır; `--build-input` ve `--build-input-file` alternatif kökler belirtmek için kullanılabilir. Dosyalar, yalnızca projenin kök dizini altında bulundukları için derlenmez. `game.project` bir derleme kökü olduğunda, oyun verisi arşivini derleme dizininde oluşturmak için `--archive` seçeneğini ekleyin.
+
+`bundle`
+: Platforma özgü bir uygulama dağıtım paketi oluşturur. Paketleme için derlenmiş bir arşivin bulunması (`build` komutu `--archive` seçeneğiyle çalıştırılarak) ve bir hedef platformun belirtilmesi (`--platform` seçeneğiyle) gerekir. Bob, `--bundle-output` seçeneğiyle farklı bir dizin belirtilmedikçe dağıtım paketini çıktı dizininde oluşturur. Dağıtım paketi, *game.project* dosyasındaki proje adı ayarına göre adlandırılır. `--variant`, paketleme sırasında hangi tür yürütülebilir dosyanın derleneceğini belirtir ve `--strip-executable` seçeneğiyle birlikte `--debug` seçeneğinin yerini alır. `--variant` belirtilmezse motorun yayıma yönelik bir sürümünü elde edersiniz (Android ve iOS'ta sembolleri çıkarılmış olarak). `--variant` değerini debug olarak ayarlayıp `--strip-executable` seçeneğini kullanmamak, `--debug` seçeneğinin eskiden ürettiği türde bir yürütülebilir dosya verir.
+
+`resolve`
+: Tüm harici kütüphane bağımlılıklarını çözümler.
+
+Kullanılabilir platformlar ve mimariler:
+
+`x86_64-macos`
+: 64 bit macOS
+
+`arm64-macos`
+: Apple Silicon (ARM) üzerinde macOS
+
+`x86_64-win32`
+: 64 bit Windows
+
+`x86-win32`
+: 32 bit Windows
+
+`x86_64-linux`
+: 64 bit Linux
+
+`arm64-linux`
+: Raspberry Pi ve Linux tabanlı el tipi cihazlar için Linux ARM64.
+
+`arm64_sim-ios`
+: Apple Silicon Mac'lerde iOS Simulator. Simülatör dağıtım paketleri bir imzalama kimliği veya sağlama profili kullanmaz, bu nedenle `--identity` ve `--mobileprovisioning` yok sayılır.
+
+`arm64-ios`
+: 64 bit iOS. Varsayılan olarak `--architectures` bağımsız değişkeninin değeri `arm64-ios` olur.
+
+`armv7-android`
+: 32 bit `armv7-android`, 64 bit `arm64-android` ve 64 bit `x86_64-android` mimarilerinin kullanılabildiği Android. Varsayılan olarak `--architectures` bağımsız değişkeninin değeri `armv7-android,arm64-android` olur. `x86_64-android` mimarisi isteğe bağlıdır (esas olarak Android emülatörleri, ChromeOS ve Windows Subsystem for Android için kullanışlıdır) ve açıkça eklenmesi gerekir.
+
+`wasm-web`
+: `wasm-web` ve `wasm_pthread-web` mimarilerinin kullanılabildiği HTML5. Varsayılan olarak `--architectures` bağımsız değişkeninin değeri `wasm-web` olur.
+
+Bob varsayılan olarak geçerli dizinde bir proje arar ve `game.project` dosyasından erişilebilen kaynakları (resource) derleyerek *build/default* dizinine yerleştirir. Başvurusu olmayan kaynaklar derlenmez. Kod, çalışma sırasında ham dosyaları yollarını kullanarak yüklüyorsa bunları [Custom Resources proje ayarı](/manuals/project-settings/#custom-resources) aracılığıyla projeye dahil edin; diğer Defold kaynakları için bir derleme kökünden erişilebilen bir başvuru gerekir.
+
+```sh
+$ cd /Applications/Defold-beta/branches/14/4/main
+$ java -jar bob.jar
+100%
+$
+```
+
+Bir dizi görevi tek seferde gerçekleştirmek için komutları art arda yazabilirsiniz. Aşağıdaki örnek kütüphaneleri çözümler, derleme dizinini temizler, arşiv verilerini derler ve (*My Game.app* adlı) bir macOS uygulaması için dağıtım paketi oluşturur:
+
+```sh
+$ java -jar bob.jar --archive --platform x86_64-macos resolve distclean build bundle
+100%
+$ ls -al build/default/
+total 70784
+drwxr-xr-x   13 sicher  staff       442  1 Dec 10:15 .
+drwxr-xr-x    3 sicher  staff       102  1 Dec 10:15 ..
+drwxr-xr-x    3 sicher  staff       102  1 Dec 10:15 My Game.app
+drwxr-xr-x    8 sicher  staff       272  1 Dec 10:15 builtins
+-rw-r--r--    1 sicher  staff    140459  1 Dec 10:15 digest_cache
+drwxr-xr-x    4 sicher  staff       136  1 Dec 10:15 fonts
+-rw-r--r--    1 sicher  staff  35956340  1 Dec 10:15 game.darc
+-rw-r--r--    1 sicher  staff       735  1 Dec 10:15 game.projectc
+drwxr-xr-x  223 sicher  staff      7582  1 Dec 10:15 graphics
+drwxr-xr-x    3 sicher  staff       102  1 Dec 10:15 input
+drwxr-xr-x   20 sicher  staff       680  1 Dec 10:15 logic
+drwxr-xr-x   27 sicher  staff       918  1 Dec 10:15 sound
+-rw-r--r--    1 sicher  staff    131926  1 Dec 10:15 state
+$
+```

--- a/docs/tr/manuals/buffer.md
+++ b/docs/tr/manuals/buffer.md
@@ -1,0 +1,33 @@
+---
+title: Arabellek kılavuzu
+brief: Bu kılavuz, Defold'da arabellek kaynaklarının nasıl çalıştığını açıklar.
+---
+
+# Arabellek
+
+Arabellek (Buffer) kaynağı, konum veya renk gibi değerlerden oluşan bir ya da daha fazla akışı (stream) tanımlamak için kullanılır. Her akışın bir adı, veri türü, değer sayısı ve verisi vardır. Örnek:
+
+```
+[
+  {
+    "name": "position",
+    "type": "float32",
+    "count": 3,
+    "data": [
+      -1.0,
+      -1.0,
+      -1.0,
+      -1.0,
+      -1.0,
+      1.0,
+      ...
+    ]
+  }
+]
+```
+
+Yukarıdaki örnek, 32 bit kayan noktalı sayılarla temsil edilen üç boyutlu bir konum akışını tanımlar. Arabellek dosyasının biçimi JSON'dur ve dosya uzantısı `.buffer` şeklindedir.
+
+Arabellek kaynakları genellikle harici araçlar veya betikler kullanılarak, örneğin Blender gibi modelleme araçlarından dışa aktarma sırasında oluşturulur. 
+
+Bir arabellek kaynağı, bir [örgü bileşeninin (Mesh component)](/manuals/mesh) girdisi olarak kullanılabilir. Arabellek kaynakları `buffer.create()` ve [ilgili API işlevleri](/ref/stable/buffer/#buffer.create:element_count-declaration) kullanılarak çalışma sırasında da oluşturulabilir. 

--- a/docs/tr/manuals/building-blocks.md
+++ b/docs/tr/manuals/building-blocks.md
@@ -1,0 +1,116 @@
+---
+title: Defold'un yapı taşları
+brief: Bu kılavuz, oyun nesnelerinin, bileşenlerin ve koleksiyonların nasıl çalıştığını ayrıntılı olarak ele alır.
+---
+
+#  Yapı taşları
+
+Defold'un tasarımının temelinde, iyi kavranması çok önemli olan birkaç kavram bulunur. Bu kılavuz, Defold'un yapı taşlarının neler olduğunu açıklar. Bu kılavuzu okuduktan sonra [adresleme kılavuzuna](/manuals/addressing) ve [ileti aktarımı kılavuzuna](/manuals/message-passing) geçin. Hızla başlamanıza yardımcı olmak için düzenleyicinin içinden de erişebileceğiniz bir dizi [öğretici](/tutorials/getting-started) bulunur.
+
+![Yapı taşları](images/building_blocks/building_blocks.png)
+
+Bir Defold oyunu oluştururken kullandığınız üç temel yapı taşı türü vardır:
+
+Koleksiyon
+: Koleksiyon (collection), oyununuzu yapılandırmak için kullanılan bir dosyadır. Koleksiyonlarda oyun nesnelerinden ve diğer koleksiyonlardan oluşan hiyerarşiler oluşturursunuz. Bunlar genellikle oyun bölümlerini, düşman gruplarını veya birden fazla oyun nesnesinden oluşan karakterleri yapılandırmak için kullanılır.
+
+Oyun nesnesi
+: Oyun nesnesi (game object), bir tanımlayıcıya, konuma, dönme değerine ve ölçeğe sahip bir kapsayıcıdır. Bileşenleri barındırmak için kullanılır. Oyun nesneleri genellikle oyuncu karakterlerini, mermileri, oyunun kural sistemini veya bir bölüm yükleyicisini oluşturmak için kullanılır.
+
+Bileşen
+: Bileşenler (component), oyun nesnelerine oyunda görsel, işitsel ve/veya mantıksal bir karşılık kazandırmak için bu nesnelerin içine yerleştirilen öğelerdir. Bunlar genellikle karakter sprite bileşenleri ve betik dosyaları oluşturmak, ses efektleri veya parçacık efektleri eklemek için kullanılır.
+
+## Koleksiyonlar {#collections}
+
+Koleksiyonlar, oyun nesnelerini ve diğer koleksiyonları barındıran ağaç yapılarıdır. Bir koleksiyon her zaman bir dosyada saklanır.
+
+Defold motoru başladığında, *game.project* ayar dosyasında belirtilen tek bir _başlangıç koleksiyonunu_ (bootstrap collection) yükler. Başlangıç koleksiyonu genellikle "main.collection" olarak adlandırılır, ancak istediğiniz adı kullanabilirsiniz.
+
+Bir koleksiyon, istenen derinlikte iç içe yerleştirilmiş oyun nesneleri ve diğer koleksiyonları (alt koleksiyonun dosyasına başvurarak) içerebilir. Aşağıda "main.collection" adlı bir örnek dosya gösterilmektedir. Bu dosya bir oyun nesnesi (tanımlayıcısı "can") ve bir alt koleksiyon (tanımlayıcısı "bean") içerir. Alt koleksiyon ise iki oyun nesnesi içerir: "bean" ve "shield".
+
+![Koleksiyon](images/building_blocks/collection.png)
+
+"bean" tanımlayıcılı alt koleksiyonun "/main/bean.collection" adlı kendi dosyasında saklandığına ve "main.collection" dosyasında yalnızca bu dosyaya başvurulduğuna dikkat edin:
+
+![Bean koleksiyonu](images/building_blocks/bean_collection.png)
+
+"main" ve "bean" koleksiyonlarına karşılık gelen çalışma zamanı nesneleri olmadığından koleksiyonların kendilerini adresleyemezsiniz. Ancak bazen bir oyun nesnesine giden _yolun_ parçası olarak koleksiyonun kimliğini kullanmanız gerekir (ayrıntılar için [adresleme kılavuzuna](/manuals/addressing) bakın):
+
+```lua
+-- file: can.script
+-- get position of the "bean" game object in the "bean" collection
+local pos = go.get_position("bean/bean")
+```
+
+Bir koleksiyon, başka bir koleksiyona her zaman bir koleksiyon dosyasına başvuru olarak eklenir:
+
+*Outline* görünümündeki koleksiyona <kbd>sağ tıklayın</kbd> ve <kbd>Add Collection File</kbd> seçeneğini seçin.
+
+## Oyun nesneleri
+
+Oyun nesneleri, oyununuz çalışırken her biri ayrı bir yaşam süresine sahip olan basit nesnelerdir. Oyun nesnelerinin konum, dönme ve ölçek değerleri vardır; bunların her biri çalışma sırasında değiştirilebilir ve her birine animasyon uygulanabilir.
+
+```lua
+-- animate X position of "can" game object
+go.animate("can", "position.x", go.PLAYBACK_LOOP_PINGPONG, 100, go.EASING_LINEAR, 1.0)
+```
+
+Oyun nesneleri boş olarak kullanılabilir (örneğin konum işaretleyicileri olarak), ancak genellikle sprite, ses, betik, model, fabrika ve diğer çeşitli bileşenlerle donatılır. Oyun nesneleri düzenleyicide oluşturulup koleksiyon dosyalarına yerleştirilir veya çalışma sırasında _fabrika_ (factory) bileşenleri aracılığıyla dinamik olarak oluşturulur.
+
+Oyun nesneleri bir koleksiyona yerinde eklenir veya bir oyun nesnesi dosyasına başvuru olarak eklenir:
+
+*Outline* görünümündeki koleksiyona <kbd>sağ tıklayın</kbd> ve <kbd>Add Game Object</kbd> (yerinde eklemek için) veya <kbd>Add Game Object File</kbd> (dosya başvurusu olarak eklemek için) seçeneğini seçin.
+
+
+## Bileşenler
+
+:[components](../shared/components.md)
+
+Kullanılabilir tüm bileşen türlerinin listesi için [bileşenlere genel bakış](/manuals/components/) sayfasına bakın.
+
+## Yerinde veya başvuru yoluyla eklenen nesneler
+
+Bir koleksiyon, oyun nesnesi veya bileşen _dosyası_ oluşturduğunuzda, prototip (prototype) adını verdiğimiz bir tanım oluşturursunuz (diğer motorlarda "prefabs" veya "blueprints" olarak da bilinir). Bu işlem yalnızca projenin dosya yapısına bir dosya ekler; çalışan oyununuza hiçbir şey eklenmez. Bir prototip dosyasına dayalı koleksiyon, oyun nesnesi veya bileşen örneği (instance) eklemek için koleksiyon dosyalarınızdan birine onun bir örneğini eklersiniz.
+
+Bir nesne örneğinin hangi dosyaya dayandığını Outline görünümünde görebilirsiniz. "main.collection" dosyası, dosyalara dayalı üç örnek içerir:
+
+1. "bean" alt koleksiyonu.
+2. "bean" alt koleksiyonundaki "bean" oyun nesnesinde bulunan "bean" betik bileşeni.
+3. "can" oyun nesnesindeki "can" betik bileşeni.
+
+![Örnek](images/building_blocks/instance.png)
+
+Bir oyun nesnesinin veya koleksiyonun birden fazla örneğine sahip olduğunuzda ve hepsini değiştirmek istediğinizde prototip dosyaları oluşturmanın yararı ortaya çıkar:
+
+![Oyun nesnesi örnekleri](images/building_blocks/go_instance.png)
+
+Prototip dosyasını değiştirdiğinizde, o dosyayı kullanan tüm örnekler hemen güncellenir.
+
+![Oyun nesnesi prototipini değiştirme](images/building_blocks/go_change_blueprint.png)
+
+Burada prototip dosyasının sprite görüntüsü değiştirilir ve dosyayı kullanan tüm örnekler hemen güncellenir:
+
+![Güncellenen oyun nesnesi örnekleri](images/building_blocks/go_instance2.png)
+
+## Oyun nesnelerini alt nesne olarak bağlama
+
+Bir koleksiyon dosyasında, bir veya daha fazla oyun nesnesinin tek bir üst oyun nesnesine alt nesne olarak bağlı olduğu oyun nesnesi hiyerarşileri oluşturabilirsiniz. Bir oyun nesnesini <kbd>sürükleyip</kbd> diğerinin üzerine <kbd>bıraktığınızda</kbd>, sürüklenen oyun nesnesi hedefin alt nesnesi olur:
+
+![Oyun nesnelerini alt nesne olarak bağlama](images/building_blocks/childing.png)
+
+Üst-alt nesne hiyerarşileri, nesnelerin dönüşümlere nasıl tepki verdiğini etkileyen dinamik ilişkilerdir. Bir nesneye uygulanan her dönüşüm (hareket, döndürme veya ölçekleme), hem düzenleyicide hem de çalışma sırasında o nesnenin alt nesnelerine de uygulanır:
+
+![Alt nesnenin dönüşümü](images/building_blocks/child_transform.png)
+
+Buna karşılık, bir alt nesnenin ötelemeleri üst nesnenin yerel uzayında yapılır. Düzenleyicide <kbd>Edit ▸ World Space</kbd> (varsayılan) veya <kbd>Edit ▸ Local Space</kbd> seçeneğini seçerek bir alt oyun nesnesini yerel uzayda veya dünya uzayında düzenleyebilirsiniz.
+
+Bir nesneye `set_parent` iletisi göndererek çalışma sırasında üst nesnesini değiştirmek de mümkündür.
+
+```lua
+local parent = go.get_id("bean")
+msg.post("child_bean", "set_parent", { parent_id = parent })
+```
+
+::: important
+Yaygın bir yanlış anlama, bir oyun nesnesinin üst-alt nesne hiyerarşisinin parçası olduğunda koleksiyon hiyerarşisindeki yerinin değiştiğidir. Oysa bunlar birbirinden çok farklı iki kavramdır. Üst-alt nesne hiyerarşileri sahne grafını dinamik olarak değiştirerek nesnelerin görsel olarak birbirine bağlanmasını sağlar. Bir oyun nesnesinin adresini belirleyen tek şey, koleksiyon hiyerarşisindeki yeridir. Adres, nesnenin yaşam süresi boyunca sabit kalır.
+:::

--- a/docs/tr/manuals/bundling.md
+++ b/docs/tr/manuals/bundling.md
@@ -1,0 +1,91 @@
+---
+title: Bir uygulamayı paketleme
+brief: Bu kılavuz, bir uygulama dağıtım paketinin nasıl oluşturulacağını açıklar.
+---
+
+# Bir uygulamayı paketleme
+
+Uygulamanızı geliştirirken oyunu hedef platformlarda mümkün olduğunca sık test etmeyi alışkanlık haline getirmeniz önerilir. Böylece performans sorunlarını, çözmenin çok daha kolay olduğu geliştirme sürecinin erken aşamalarında tespit edebilirsiniz. Gölgelendiriciler (shader) gibi konulardaki farklılıkları bulmak için de tüm hedef platformlarda test yapmanız önerilir. Mobil cihazlar için geliştirme yaparken, tam bir paketleme (bundling) ve uygulamayı kaldırıp yeniden kurma döngüsü yerine [mobil geliştirme uygulamasını](/manuals/dev-app/) kullanarak içeriği uygulamaya gönderebilirsiniz.
+
+Defold'un desteklediği tüm platformlar için, harici araçlara gerek duymadan doğrudan Defold düzenleyicisinden bir uygulama dağıtım paketi (application bundle) oluşturabilirsiniz. Komut satırı araçlarımızı kullanarak komut satırından da paketleme yapabilirsiniz. Projeniz bir veya daha fazla [yerel kod eklentisi (native extension)](/manuals/extensions) içeriyorsa uygulamayı paketlemek için ağ bağlantısı gerekir.
+
+## Düzenleyiciden paketleme
+
+Project menüsündeki Bundle seçeneğiyle bir uygulama dağıtım paketi oluşturabilirsiniz:
+
+![](images/bundling/bundle_menu.png)
+
+Menü seçeneklerinden herhangi birini seçtiğinizde, ilgili platforma ait Bundle iletişim kutusu açılır.
+
+### Derleme raporları {#build-reports}
+
+Oyununuzu paketlerken bir derleme raporu (build report) oluşturma seçeneği bulunur. Bu, oyununuzun dağıtım paketindeki tüm varlıkların (asset) boyutlarını anlamak için çok yararlıdır. Oyunu paketlerken *Generate build report* onay kutusunu işaretlemeniz yeterlidir.
+
+![derleme raporu](images/profiling/build_report.png)
+
+Derleme raporları hakkında daha fazla bilgi edinmek için [Profil çıkarma kılavuzuna](/manuals/profiling/#build-reports) bakın.
+
+### Android
+
+Android uygulama dağıtım paketi (.apk dosyası) oluşturma işlemi [Android kılavuzunda](/manuals/android/#creating-an-android-application-bundle) açıklanır.
+
+### iOS
+
+iOS uygulama dağıtım paketi (.ipa dosyası) oluşturma işlemi [iOS kılavuzunda](/manuals/ios/#creating-an-ios-application-bundle) açıklanır.
+
+### macOS
+
+macOS uygulama dağıtım paketi (.app dosyası) oluşturma işlemi [macOS kılavuzunda](/manuals/macos) açıklanır.
+
+### Linux
+
+Linux uygulama dağıtım paketi oluşturmak, özel bir kurulum veya *game.project* [proje ayarları dosyasında](/manuals/project-settings/) platforma özgü isteğe bağlı bir yapılandırma gerektirmez.
+
+### Windows
+
+Windows uygulama dağıtım paketi (.exe dosyası) oluşturma işlemi [Windows kılavuzunda](/manuals/windows) açıklanır.
+
+### HTML5
+
+HTML5 uygulama dağıtım paketi oluşturma işlemi ve isteğe bağlı kurulum [HTML5 kılavuzunda](/manuals/html5/#creating-html5-bundle) açıklanır.
+
+#### Facebook Instant Games
+
+Bir HTML5 uygulama dağıtım paketinin, özellikle Facebook Instant Games için hazırlanmış özel bir sürümünü oluşturabilirsiniz. Bu işlem [Facebook Instant Games kılavuzunda](/manuals/instant-games/) açıklanır.
+
+## Komut satırından paketleme
+
+Düzenleyici, uygulamayı paketlemek için [Bob](/manuals/bob/) adlı komut satırı aracımızı kullanır.
+
+Uygulamanızın günlük geliştirme sürecinde derleme ve paketleme işlemlerini büyük olasılıkla Defold düzenleyicisinden yaparsınız. Başka durumlarda uygulama dağıtım paketlerini otomatik oluşturmak isteyebilirsiniz. Örneğin yeni bir sürüm yayımlarken tüm hedefler için toplu derleme yaparken veya oyunun en son sürümünün gece derlemelerini oluştururken bunu isteyebilirsiniz; bu işlemler bir sürekli tümleştirme (CI) ortamında da yapılabilir. Bir uygulamanın derlenmesi ve paketlenmesi, [Bob komut satırı aracı](/manuals/bob/) kullanılarak olağan düzenleyici iş akışının dışında gerçekleştirilebilir.
+
+## Dağıtım paketinin yapısı
+
+Dağıtım paketinin mantıksal yapısı şöyledir:
+
+![](images/bundling/bundle_schematic_01.png)
+
+Dağıtım paketi bir klasöre yazılır. Platforma bağlı olarak bu klasör, zip biçiminde arşivlenerek bir `.apk` veya `.ipa` dosyasına da dönüştürülebilir.
+Klasörün içeriği platforma bağlıdır.
+
+Paketleme sürecimiz, yürütülebilir dosyaların yanı sıra platform için gerekli varlıkları da toplar (örneğin Android için .xml kaynak dosyaları).
+
+[bundle_resources](https://defold.com/manuals/project-settings/#bundle-resources) ayarını kullanarak, dağıtım paketine olduğu gibi yerleştirilmesi gereken varlıkları yapılandırabilirsiniz.
+Bunu her platform için ayrı ayrı kontrol edebilirsiniz.
+
+Oyun varlıkları `game.arcd` dosyasında bulunur ve LZ4 sıkıştırması kullanılarak ayrı ayrı sıkıştırılır.
+[custom_resources](https://defold.com/manuals/project-settings/#custom-resources) ayarını kullanarak, `game.arcd` dosyasına (sıkıştırılarak) yerleştirilmesi gereken varlıkları yapılandırabilirsiniz.
+Bu varlıklara [`sys.load_resource()`](https://defold.com/ref/sys/#sys.load_resource) işlevi aracılığıyla erişilebilir.
+
+## Yayıma yönelik paketler ve hata ayıklama paketleri
+
+Bir uygulama dağıtım paketi oluştururken hata ayıklama paketi (debug) veya yayıma yönelik paket (release) oluşturmayı seçebilirsiniz. Bu iki paket arasındaki farklar küçüktür, ancak bunları akılda tutmak önemlidir:
+
+* Yayıma yönelik derlemeler varsayılan olarak [profil çıkarıcıyı (profiler)](/manuals/profiling) içermez. Hem hata ayıklama derlemelerine hem de yayıma yönelik derlemelere profil çıkarıcı desteği eklemek için [uygulama bildiriminde (App Manifest)](/manuals/app-manifest/#profiler) **Profiler** ayarını **Always** olarak ayarlayın.
+* Yayıma yönelik derlemeler [ekran kaydediciyi](/ref/stable/sys/#start_record) içermez
+* Yayıma yönelik derlemeler, `print()` çağrılarının veya herhangi bir yerel kod eklentisinin çıktısını göstermez
+* Yayıma yönelik derlemelerde `is_debug` değeri, `sys.get_engine_info()` içinde `false` olarak ayarlanır
+* Yayıma yönelik derlemeler, `hash` değerleri için `tostring()` çağrıldığında ters arama yapmaz. Pratikte bu, `tostring()` işlevinin `url` veya `hash` türündeki bir değer için özgün dize yerine sayısal gösterimi döndürmesi anlamına gelir (`'hash: [/camera_001]'` yerine `'hash: [11844936738040519888 (unknown)]'`)
+* Yayıma yönelik derlemeler, [çalışma sırasında yeniden yükleme (hot reload)](/manuals/hot-reload) ve benzer işlevler için düzenleyiciden hedef olarak seçilmeyi desteklemez
+
+

--- a/docs/tr/manuals/caching-assets.md
+++ b/docs/tr/manuals/caching-assets.md
@@ -1,0 +1,47 @@
+---
+title: Varlıkları önbelleğe alma
+brief: Bu kılavuz, proje derlemelerini hızlandırmak için varlık önbelleğinin nasıl kullanılacağını açıklar.
+---
+
+# Varlıkları önbelleğe alma
+
+Defold ile oluşturulan oyunlar genellikle saniyeler içinde derlenir, ancak proje büyüdükçe varlıkların (asset) sayısı da artar. Büyük bir projede yazı tiplerini derlemek ve dokuları sıkıştırmak önemli ölçüde zaman alabilir. Varlık önbelleği (asset cache), yalnızca değişen varlıkları yeniden derleyerek ve değişmeyen varlıklar için önbellekteki önceden derlenmiş varlıkları kullanarak proje derlemelerini hızlandırır.
+
+Defold üç katmanlı bir önbellek kullanır:
+
+1. Proje önbelleği
+2. Yerel önbellek
+3. Uzak önbellek
+
+
+## Proje önbelleği
+
+Defold varsayılan olarak derlenmiş varlıkları Defold projesinin `build/default` klasöründe önbelleğe alır. Proje önbelleği (project cache), yalnızca değiştirilen varlıkların yeniden derlenmesi gerektiği ve değişmeyen varlıklar proje önbelleğinden kullanıldığı için sonraki proje derlemelerini hızlandırır. Bu önbellek her zaman etkindir ve hem düzenleyici hem de komut satırı araçları tarafından kullanılır.
+
+Proje önbelleğini, `build/default` içindeki dosyaları silerek veya [komut satırı derleme aracı Bob](/manuals/bob) ile `clean` komutunu çalıştırarak elle silebilirsiniz.
+
+
+## Yerel önbellek
+
+Yerel önbellek (local cache), derlenmiş varlıkların aynı makinede veya bir ağ sürücüsünde, proje dışındaki bir dosya konumunda saklandığı isteğe bağlı ikinci bir önbellektir. Bu dış konum sayesinde proje önbelleği temizlendiğinde yerel önbelleğin içeriği korunur. Ayrıca aynı proje üzerinde çalışan birden fazla geliştirici tarafından paylaşılabilir. Bu önbellek şu anda yalnızca komut satırı araçlarıyla proje derlerken kullanılabilir. `resource-cache-local` seçeneğiyle etkinleştirilir:
+
+```sh
+java -jar bob.jar --resource-cache-local /Users/john.doe/defold_local_cache
+```
+
+Yerel önbellekteki derlenmiş varlıklara, Defold motorunun sürümünü, kaynak varlıkların adlarını ve içeriklerini, ayrıca proje derleme seçeneklerini dikkate alarak hesaplanan bir sağlama toplamına (checksum) göre erişilir. Bu, önbelleğe alınan varlıkların benzersiz olmasını ve önbelleğin birden fazla Defold sürümü arasında paylaşılabilmesini garanti eder.
+
+::: sidenote
+Yerel önbellekteki dosyalar süresiz olarak saklanır. Eski/kullanılmayan dosyaları elle kaldırmak geliştiricinin sorumluluğundadır.
+:::
+
+
+## Uzak önbellek
+
+Uzak önbellek (remote cache), derlenmiş varlıkların bir sunucuda saklandığı ve HTTP istekleriyle erişildiği isteğe bağlı üçüncü bir önbellektir. Bu önbellek şu anda yalnızca komut satırı araçlarıyla proje derlerken kullanılabilir. `resource-cache-remote` seçeneğiyle etkinleştirilir:
+
+```sh
+java -jar bob.jar --resource-cache-remote http://192.168.0.100/
+```
+
+Yerel önbellekte olduğu gibi, uzak önbellekteki tüm varlıklara hesaplanan bir sağlama toplamına göre erişilir. Önbelleğe alınan varlıklara GET, PUT ve HEAD HTTP istek yöntemleriyle erişilir. Defold uzak önbellek sunucusu sağlamaz. Bunu kurmak her geliştiricinin kendi sorumluluğundadır. [Basit bir Python sunucusu örneğini burada görebilirsiniz](https://github.com/britzl/httpserver-python).

--- a/docs/tr/manuals/camera.md
+++ b/docs/tr/manuals/camera.md
@@ -1,0 +1,335 @@
+---
+title: Kamera bileşeni kılavuzu
+brief: Bu kılavuz, Defold kamera bileşeninin işlevlerini açıklar.
+---
+
+# Kameralar
+
+Defold'da kamera, oyun dünyasının görüntü alanını (viewport) ve izdüşümünü (projection) değiştiren bir bileşendir (component). Kamera bileşeni, görüntü oluşturma sürecini yöneten işleme betiğine (render script) bir görünüm matrisi ve bir izdüşüm matrisi sağlayan temel bir perspektif veya ortografik kamera tanımlar.
+
+Perspektif kamera genellikle 3B oyunlarda kullanılır. Bu oyunlarda kameranın görünümü ile nesnelerin boyutu ve perspektifi; görüş hacmine (view frustum), kameradan oyun içindeki nesnelere olan uzaklığa ve bakış açısına göre belirlenir.
+
+2B oyunlarda sahnenin ortografik izdüşümle işlenmesi (rendering) sıklıkla tercih edilir. Bu durumda kameranın görünümünü artık bir görüş hacmi değil, bir kutu belirler. Ortografik izdüşüm, nesnelerin boyutunu uzaklıklarına göre değiştirmediği için gerçekçi değildir. 1000 birim uzaktaki bir nesne, kameranın hemen önündeki bir nesneyle aynı boyutta işlenir.
+
+![izdüşümler](images/camera/projections.png)
+
+
+## Kamera oluşturma
+
+Kamera oluşturmak için bir oyun nesnesine (game object) <kbd>sağ tıklayın</kbd> ve <kbd>Add Component ▸ Camera</kbd> seçeneğini seçin. Alternatif olarak, proje hiyerarşisinde bir bileşen dosyası oluşturup bu dosyayı oyun nesnesine ekleyebilirsiniz.
+
+![kamera bileşeni oluşturma](images/camera/create.png)
+
+Kamera bileşeni, kameranın *görüş hacmini* tanımlayan şu özelliklere sahiptir:
+
+![kamera ayarları](images/camera/settings.png)
+
+Id
+: Bileşenin tanımlayıcısı
+
+Aspect Ratio
+: (**Yalnızca perspektif kamera**) - Görüş hacminin genişliğinin yüksekliğine oranı. 1.0, kare bir görünüm varsaydığınız anlamına gelir. 1.33, 1024x768 gibi 4:3 oranlı bir görünüm için uygundur. 1.78 ise 16:9 oranlı bir görünüm için uygundur. *Auto Aspect Ratio* etkinse bu ayar yok sayılır.
+
+Fov
+: (**Yalnızca perspektif kamera**) - Kameranın *dikey* görüş açısının (FOV) _radyan_ cinsinden değeri. Görüş açısı ne kadar geniş olursa kamera o kadar çok şey görür.
+
+Near Z
+: Yakın kırpma düzleminin Z değeri.
+
+Far Z
+: Uzak kırpma düzleminin Z değeri.
+
+Auto Aspect Ratio
+: (**Yalnızca perspektif kamera**) - Kameranın en boy oranını otomatik olarak hesaplaması için bu ayarı etkinleştirin.
+
+Orthographic Projection
+: Kamerayı ortografik izdüşüme geçirmek için bu ayarı etkinleştirin (aşağıya bakın).
+
+Orthographic Zoom
+: (**Yalnızca ortografik kamera**) - Kullanıcının belirlediği yakınlaştırma çarpanı (> 1 = yakınlaştırma, < 1 = uzaklaştırma). `Fixed` modunda bu, uygulanan yakınlaştırma değeridir. `Auto Fit` ve `Auto Cover` modlarında otomatik hesaplanan yakınlaştırma değeriyle çarpılır; böylece otomatik boyutlandırmayı devre dışı bırakmadan ek yakınlaştırma uygulanabilir.
+
+Orthographic Mode
+: (**Yalnızca ortografik kamera**) - Ortografik kameranın pencere boyutuna ve tasarım çözünürlüğünüze (`game.project` → `display.width/height` değerleri) göre yakınlaştırmayı nasıl belirlediğini denetler.
+  - `Fixed` (sabit yakınlaştırma kullanır): Geçerli `Orthographic Zoom` değerini olduğu gibi kullanır.
+  - `Auto Fit` (sığdırma): Tasarım alanının tamamının pencereye sığmasını sağlayacak yakınlaştırma değerini otomatik olarak hesaplar, ardından bunu `Orthographic Zoom` ile çarpar. Yanlarda veya üstte/altta ek içerik gösterebilir.
+  - `Auto Cover` (kaplama): Tasarım alanının pencerenin tamamını kaplamasını sağlayacak yakınlaştırma değerini otomatik olarak hesaplar, ardından bunu `Orthographic Zoom` ile çarpar. Yanlardan veya üstten/alttan kırpabilir.
+  Yalnızca `Orthographic Projection` etkinken kullanılabilir.
+
+
+## Kamerayı kullanma
+
+Tüm kameralar bir kare sırasında otomatik olarak etkinleştirilir ve güncellenir; Lua'nın `camera` modülü tüm betik bağlamlarında kullanılabilir. Defold 1.8.1 sürümünden itibaren kamera bileşenine `acquire_camera_focus` iletisi göndererek kamerayı açıkça etkinleştirmek artık gerekli değildir. Odağı edinmek ve bırakmak için kullanılan eski iletiler hâlâ kullanılabilir; ancak etkinleştirmek veya devre dışı bırakmak istediğiniz diğer bileşenlerde olduğu gibi `enable` ve `disable` iletilerini kullanmanız önerilir:
+
+```lua
+msg.post("#camera", "disable")
+msg.post("#camera", "enable")
+```
+
+O anda kullanılabilir olan tüm kameraları listelemek için `camera.get_cameras()` kullanabilirsiniz:
+
+```lua
+-- Note: The render calls are only available in a render script.
+--       The camera.get_cameras() function can be used anywhere,
+--       but render.set_camera can only be used in a render script.
+
+for k,v in pairs(camera.get_cameras()) do
+    -- the camera table contains the URLs of all cameras
+    render.set_camera(v)
+    -- do rendering here - anything rendered here that uses materials with
+    -- view and projection matrices specified, will use matrices from the camera.
+end
+-- to disable a camera, pass in nil (or no arguments at all) to render.set_camera.
+-- after this call, all render calls will use the view and projection matrices
+-- that are specified on the render context (render.set_view and render.set_projection)
+render.set_camera()
+```
+
+Betiklerde kullanılan `camera` modülü, kamerayı değiştirmek için kullanılabilecek çeşitli işlevler sunar. Aşağıda bunlardan yalnızca birkaçı gösterilmiştir; kullanılabilir tüm işlevleri görmek için [API belgelerindeki](/ref/camera/) kılavuza bakın).
+
+```lua
+camera.get_aspect_ratio(camera) -- get aspect ratio
+camera.get_far_z(camera) -- get far z
+camera.get_fov(camera) -- get field of view
+camera.get_orthographic_mode(camera) -- get orthographic mode (one of camera.ORTHO_MODE_*)
+camera.get_orthographic_zoom(camera) -- get the user-controlled zoom multiplier
+camera.get_orthographic_auto_zoom(camera) -- get the automatically calculated zoom
+camera.set_aspect_ratio(camera, ratio) -- set aspect ratio
+camera.set_far_z(camera, far_z) -- set far z
+camera.set_near_z(camera, near_z) -- set near z
+camera.set_orthographic_mode(camera, camera.ORTHO_MODE_AUTO_FIT) -- set orthographic mode
+... And so forth
+```
+
+Kamera, bileşenin tam sahne yolu olan bir URL ile tanımlanır. Bu yol; koleksiyonu (collection), bileşenin ait olduğu oyun nesnesini ve bileşenin tanımlayıcısını içerir. Bu örnekte, kamera bileşenini aynı koleksiyon içinden tanımlamak için `/go#camera` URL adresini, farklı bir koleksiyondan veya işleme betiğinden kameraya erişirken ise `main:/go#camera` adresini kullanırsınız.
+
+![kamera bileşeni oluşturma](images/camera/create.png)
+
+```lua
+-- Accessing a camera from a script in the same collection:
+camera.get_fov("/go#camera")
+
+-- Accessing a camera from a script in a different collection:
+camera.get_fov("main:/go#camera")
+
+-- Accessing a camera from the render script:
+render.set_camera("main:/go#camera")
+```
+
+Her karede, o anda kamera odağına sahip olan kamera bileşeni `@render` soketine bir `set_view_projection` iletisi gönderir:
+
+```lua
+-- builtins/render/default.render_script
+--
+function on_message(self, message_id, message)
+    if message_id == hash("set_view_projection") then
+        self.view = message.view                    -- [1]
+        self.projection = message.projection
+    end
+end
+```
+1. Kamera bileşeninden gönderilen ileti bir görünüm matrisi ve bir izdüşüm matrisi içerir.
+
+Kamera bileşeni, kameranın *Orthographic Projection* özelliğine bağlı olarak işleme betiğine perspektif veya ortografik bir izdüşüm matrisi sağlar. İzdüşüm matrisi ayrıca tanımlanan yakın ve uzak kırpma düzlemlerini, kameranın görüş açısını ve en boy oranı ayarlarını da hesaba katar.
+
+Kameranın sağladığı görünüm matrisi, kameranın konumunu ve yönelimini tanımlar. *Orthographic Projection* kullanan bir kamera, görünümü bağlı olduğu oyun nesnesinin konumuna ortalar; *Perspective Projection* kullanan bir kamerada ise görünümün sol alt köşesi, bağlı olduğu oyun nesnesinin konumunda yer alır.
+
+
+### İşleme betiği
+
+Varsayılan işleme betiği kullanıldığında Defold, işleme için kullanılacak kamera olarak en son etkinleştirilen kamerayı otomatik olarak ayarlar. Bu değişiklikten önce, kamera bileşenlerinden gelen görünüm ve izdüşümün kullanılması gerektiğini işleyiciye bildirmek için projedeki bir betiğin açıkça `use_camera_projection` iletisini göndermesi gerekiyordu. Bu artık gerekli değildir, ancak geriye dönük uyumluluk için hâlâ yapılabilir.
+
+Alternatif olarak, bir işleme betiğinde işleme için kullanılacak belirli bir kamera ayarlayabilirsiniz. Bu, örneğin çok oyunculu bir oyunda, işleme için hangi kameranın kullanılacağını daha ayrıntılı denetlemeniz gereken durumlarda yararlı olabilir.
+
+```lua
+-- render.set_camera will automatically use the view and projection matrices
+-- for any rendering happening until render.set_camera() is called.
+render.set_camera("main:/my_go#camera")
+```
+
+Bir kameranın etkin olup olmadığını denetlemek için [Kamera API'sindeki](https://defold.com/ref/alpha/camera/#camera.get_enabled:camera) `get_enabled` işlevini kullanabilirsiniz:
+
+```lua
+if camera.get_enabled("main:/my_go#camera") then
+    -- camera is enabled, use it for rendering!
+    render.set_camera("main:/my_go#camera")
+end
+```
+
+::: sidenote
+`set_camera` işlevini görüş hacmi dışında kalanları eleme (frustum culling) ile birlikte kullanmak için bunu işleve bir seçenek olarak iletmeniz gerekir:
+`render.set_camera("main:/my_go#camera", {use_frustum = true})`
+:::
+
+### Kamerayı kaydırma
+
+Kamera bileşeninin bağlı olduğu oyun nesnesini hareket ettirerek kamerayı oyun dünyasında kaydırabilir/hareket ettirebilirsiniz. Kamera bileşeni, kameranın x ve y eksenlerindeki geçerli konumuna göre güncellenmiş bir görünüm matrisini otomatik olarak gönderir.
+
+### Kamerayla yakınlaştırma ve uzaklaştırma
+
+Perspektif kamera kullanırken, kameranın bağlı olduğu oyun nesnesini z ekseni boyunca hareket ettirerek yakınlaştırma ve uzaklaştırma yapabilirsiniz. Kamera bileşeni, kameranın geçerli z konumuna göre güncellenmiş bir görünüm matrisini otomatik olarak gönderir.
+
+Ortografik kamera kullanırken, kameranın *Orthographic Zoom* özelliğini düzenleyicide veya çalışma sırasında değiştirerek yakınlaştırma ve uzaklaştırma yapabilirsiniz:
+
+```lua
+-- In Fixed mode, this is the effective zoom.
+go.set("#camera", "orthographic_zoom", 2)
+```
+
+`Auto Fit` ve `Auto Cover` modlarında *Orthographic Zoom*, otomatik hesaplanan yakınlaştırma değerinin üzerine uygulanır; yok sayılmaz. Örneğin, tasarım alanını pencereye sığdırıp ardından ek %25 yakınlaştırma uygulamak için düzenleyicide *Orthographic Mode* değerini `Auto Fit`, *Orthographic Zoom* değerini ise `1.25` olarak ayarlayın. Çalışma sırasında aynı ayarları yapmak için:
+
+```lua
+camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_AUTO_FIT)
+go.set("#camera", "orthographic_zoom", 1.25)
+
+local auto_zoom = camera.get_orthographic_auto_zoom("#camera")
+local zoom_multiplier = camera.get_orthographic_zoom("#camera")
+local effective_zoom = auto_zoom * zoom_multiplier
+```
+
+`camera.get_orthographic_auto_zoom()`, `Auto Fit` ve `Auto Cover` modlarında geçerli pencere ve proje boyutlarından hesaplanan yakınlaştırma değerini döndürür. `Fixed` modunda `1.0` döndürür. Aynı değere, salt okunur `orthographic_auto_zoom` bileşen özelliği üzerinden de erişilebilir:
+
+```lua
+local auto_zoom = go.get("#camera", "orthographic_auto_zoom")
+```
+
+Ortografik kamera kullanırken yakınlaştırmanın nasıl belirleneceğini `Orthographic Mode` ayarıyla veya betik aracılığıyla da değiştirebilirsiniz:
+
+```lua
+-- get current mode (one of camera.ORTHO_MODE_FIXED, _AUTO_FIT, _AUTO_COVER)
+local mode = camera.get_orthographic_mode("#camera")
+
+-- switch to auto-fit (contain) to always keep the full design area visible
+camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_AUTO_FIT)
+
+-- switch to auto-cover to ensure the design area covers the window
+camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_AUTO_COVER)
+
+-- switch to fixed mode to use orthographic_zoom without automatic sizing
+camera.set_orthographic_mode("#camera", camera.ORTHO_MODE_FIXED)
+```
+
+### Uyarlanabilir yakınlaştırma
+
+Uyarlanabilir yakınlaştırmanın temelinde, ekran çözünürlüğü *game.project* dosyasında ayarlanan başlangıç çözünürlüğünden farklılaştığında kameranın yakınlaştırma değerini ayarlamak yatar.
+
+Uyarlanabilir yakınlaştırmada yaygın olarak kullanılan iki yaklaşım vardır:
+
+1. En yüksek yakınlaştırma - *game.project* dosyasındaki başlangıç çözünürlüğünün kapsadığı içeriğin ekranı doldurup ekran sınırlarının dışına taşmasını sağlayan bir yakınlaştırma değeri hesaplayın. Bu, yanlarda veya üstte ve altta bazı içerikleri gizleyebilir.
+2. En düşük yakınlaştırma - *game.project* dosyasındaki başlangıç çözünürlüğünün kapsadığı içeriğin tamamen ekran sınırları içinde kalmasını sağlayan bir yakınlaştırma değeri hesaplayın. Bu, yanlarda veya üstte ve altta ek içerik gösterebilir.
+
+Örnek:
+
+```lua
+local DISPLAY_WIDTH = sys.get_config_int("display.width")
+local DISPLAY_HEIGHT = sys.get_config_int("display.height")
+
+function init(self)
+    local initial_zoom = go.get("#camera", "orthographic_zoom")
+    local display_scale = window.get_display_scale()
+    window.set_listener(function(self, event, data)
+        if event == window.WINDOW_EVENT_RESIZED then
+            local window_width = data.width
+            local window_height = data.height
+            local design_width = DISPLAY_WIDTH / initial_zoom
+            local design_height = DISPLAY_HEIGHT / initial_zoom
+
+            -- max zoom: ensure that the initial design dimensions will fill and expand beyond the screen bounds
+            local zoom = math.max(window_width / design_width, window_height / design_height) / display_scale
+
+            -- min zoom: ensure that the initial design dimensions will shrink and be contained within the screen bounds
+            --local zoom = math.min(window_width / design_width, window_height / design_height) / display_scale
+            
+            go.set("#camera", "orthographic_zoom", zoom)
+        end
+    end)
+end
+```
+
+Uyarlanabilir yakınlaştırmanın eksiksiz bir örneğini [bu örnek projede](https://github.com/defold/sample-adaptive-zoom) görebilirsiniz.
+
+Not: Ortografik kamera kullanırken artık `Orthographic Mode` değerini `Auto Fit` (sığdırma) veya `Auto Cover` (kaplama) olarak ayarlayarak özel kod yazmadan sığdırma/kaplama davranışını elde edebilirsiniz. Bu modlarda, pencere boyutu ve tasarım çözünürlüğünden hesaplanan yakınlaştırma değeri `Orthographic Zoom` ile çarpılır.
+
+
+### Bir oyun nesnesini takip etme
+
+Kamera bileşeninin bağlı olduğu oyun nesnesini, takip edilecek oyun nesnesinin alt nesnesi olarak ayarlayarak kameranın bu oyun nesnesini takip etmesini sağlayabilirsiniz:
+
+![oyun nesnesini takip etme](images/camera/follow.png)
+
+Alternatif olarak, takip edilecek oyun nesnesi hareket ettikçe kamera bileşeninin bağlı olduğu oyun nesnesinin konumunu her karede güncelleyebilirsiniz.
+
+### Ekran ve dünya koordinatları arasında dönüştürme {#converting-mouse-to-world-coordinates}
+
+Kamera kaydırıldığında, yakınlaştırma veya uzaklaştırma yapıldığında ya da izdüşümü değiştirildiğinde, girdi koordinatları artık dünya koordinatlarıyla doğrudan eşleşmez. Kamera dönüştürme işlevlerini `action.screen_x` ve `action.screen_y` ile kullanın. İsteğe bağlı kamera URL adresi belirtilmezse en son etkinleştirilen kamera kullanılır.
+
+Ortografik bir kamerada [`camera.screen_xy_to_world()`](/ref/camera/#camera.screen_xy_to_world:x-y-[camera]), bir ekran pikseli için kameranın yakın düzlemindeki noktayı dünya uzayında döndürür:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local world_position = camera.screen_xy_to_world(
+            action.screen_x, action.screen_y, "#camera")
+        go.set_position(world_position, "/marker")
+    end
+end
+```
+
+Perspektif bir kamerada [`camera.screen_to_world()`](/ref/camera/#camera.screen_to_world:pos-[camera]), Z bileşeni kamera düzleminden dünya birimleriyle ölçülen görünüm derinliği olan bir `vector3` alır:
+
+```lua
+local depth = 10
+local world_position = camera.screen_to_world(
+    vmath.vector3(action.screen_x, action.screen_y, depth), "#camera")
+```
+
+[`camera.world_to_screen()`](/ref/camera/#camera.world_to_screen:world_pos-[camera]) ters dönüşümü gerçekleştirir. Ekran pikseli cinsinden X ve Y değerlerini, Z bileşeninde ise aynı kurala göre belirlenen görünüm derinliğini döndürür; böylece sonucu tekrar `camera.screen_to_world()` işlevine iletilebilir:
+
+```lua
+-- Update the cached world transform first if the object moved this frame.
+go.update_world_transform("/marker")
+local world_position = go.get_world_position("/marker")
+local screen_position = camera.world_to_screen(world_position, "#camera")
+```
+
+Koordinat dönüşümünü çalışırken görmek için [Örnekler sayfasını](https://defold.com/examples/render/screen_to_world/) ziyaret edin. Aynı API'leri gösteren bir [örnek proje](https://github.com/defold/sample-screen-to-world-coordinates/) de vardır.
+
+::: sidenote
+[Bu kılavuzda sözü edilen üçüncü taraf kamera çözümleri](/manuals/camera/#third-party-camera-solutions), ekran koordinatlarına ve ekran koordinatlarından dönüştürme işlevleri sağlar.
+:::
+
+## Çalışma sırasında değiştirme
+Çeşitli iletiler ve özellikler aracılığıyla kameraları çalışma sırasında değiştirebilirsiniz ([kullanım için API belgelerine](/ref/camera/) bakın).
+
+Kameranın, `go.get()` ve `go.set()` kullanılarak değiştirilebilen çeşitli özellikleri vardır:
+
+`fov`
+: Kameranın görüş açısı (`number`).
+
+`near_z`
+: Kameranın yakın Z değeri (`number`).
+
+`far_z`
+: Kameranın uzak Z değeri (`number`).
+
+`orthographic_zoom`
+: Kullanıcının belirlediği ortografik kamera yakınlaştırma çarpanı. `Auto Fit` ve `Auto Cover` modlarında `orthographic_auto_zoom` ile çarpılır. (`number`).
+
+`orthographic_auto_zoom`
+: `Auto Fit` ve `Auto Cover` modları için hesaplanan ortografik yakınlaştırma değeri; `Fixed` modunda ise `1.0`. SALT OKUNUR. (`number`).
+
+`aspect_ratio`
+: Görüş hacminin genişliğinin yüksekliğine oranı. Perspektif kameranın izdüşümü hesaplanırken kullanılır. (`number`).
+
+`view`
+: Kameranın hesaplanan görünüm matrisi. SALT OKUNUR. (`matrix4`).
+
+`projection`
+: Kameranın hesaplanan izdüşüm matrisi. SALT OKUNUR. (`matrix4`).
+
+
+## Üçüncü taraf kamera çözümleri {#third-party-camera-solutions}
+
+Topluluk tarafından geliştirilen kamera çözümleri; ekran sarsıntısı, oyun nesnelerini takip etme, ekran koordinatlarını dünya koordinatlarına dönüştürme gibi yaygın özellikler ve çok daha fazlasını sunar. Bunları Defold varlık portalından indirebilirsiniz:
+
+- Björn Ritzl tarafından geliştirilen [Orthographic camera](https://defold.com/assets/orthographic/) (yalnızca 2B).
+- Klayton Kowalski tarafından geliştirilen [Defold Rendy](https://defold.com/assets/defold-rendy/) (2B ve 3B).

--- a/docs/tr/manuals/collection-factory.md
+++ b/docs/tr/manuals/collection-factory.md
@@ -1,0 +1,169 @@
+---
+title: Koleksiyon fabrikası kılavuzu
+brief: Bu kılavuz, oyun nesnesi hiyerarşilerini çalışma sırasında oluşturmak için koleksiyon fabrikası bileşenlerinin nasıl kullanılacağını açıklar.
+---
+
+# Koleksiyon fabrikaları
+
+Koleksiyon fabrikası (collection factory) bileşeni (component), koleksiyon (collection) dosyalarında saklanan oyun nesnesi (game object) gruplarını ve hiyerarşilerini çalışan bir oyunda oluşturmak için kullanılır.
+
+Koleksiyonlar, Defold'da yeniden kullanılabilir şablonlar, diğer adıyla "prefab"lar oluşturmak için güçlü bir mekanizma sağlar. Koleksiyonlara genel bir bakış için [Yapı taşları belgelerine](/manuals/building-blocks#collections) bakın. Koleksiyonlar düzenleyicide yerleştirilebilir veya oyuna dinamik olarak eklenebilir.
+
+Bir koleksiyon fabrikası bileşeniyle, koleksiyon dosyasının içeriğini bir oyun dünyasında çalışma sırasında oluşturabilirsiniz. Bu, koleksiyondaki tüm oyun nesnelerini fabrika (factory) aracılığıyla oluşturup ardından nesneler arasında üst-alt nesne hiyerarşisini kurmaya benzer. Tipik bir kullanım örneği, birden çok oyun nesnesinden oluşan düşmanlar oluşturmaktır (örneğin düşman + silah).
+
+## Çalışma sırasında koleksiyon oluşturma {#spawning-a-collection}
+
+Bir karakter oyun nesnesi ve karaktere alt nesne olarak bağlı ayrı bir kalkan oyun nesnesi istediğimizi varsayalım. Oyun nesnesi hiyerarşisini bir koleksiyon dosyasında oluşturup `bean.collection` olarak kaydediyoruz.
+
+::: sidenote
+*Koleksiyon vekili* (collection proxy) bileşeni, bir koleksiyona dayanarak ayrı bir fizik dünyası da içeren yeni bir oyun dünyası oluşturmak için kullanılır. Yeni dünyaya yeni bir soket üzerinden erişilir. Yüklemeyi başlatması için vekile ileti gönderdiğinizde, koleksiyondaki tüm varlıklar vekil aracılığıyla yüklenir. Bu, koleksiyon vekillerini örneğin bir oyunda bölüm değiştirmek için çok kullanışlı kılar. Ancak yeni oyun dünyaları oldukça fazla ek yük getirir; bu nedenle onları küçük öğeleri dinamik olarak yüklemek için kullanmayın. Daha fazla bilgi için [Koleksiyon vekili belgelerine](/manuals/collection-proxy) bakın.
+:::
+
+![Çalışma sırasında oluşturulacak koleksiyon](images/collection_factory/collection.png)
+
+Ardından, oluşturma işlemini üstlenecek bir oyun nesnesine *Collection factory* ekliyor ve `bean.collection` dosyasını bileşenin *Prototype* değeri olarak ayarlıyoruz:
+
+![Koleksiyon fabrikası](images/collection_factory/factory.png)
+
+Artık bir `bean` ve kalkan oluşturmak için `collectionfactory.create()` işlevini çağırmak yeterlidir:
+
+```lua
+local bean_ids = collectionfactory.create("#bean_factory")
+```
+
+İşlev 5 parametre alır:
+
+`url`
+: Yeni oyun nesnesi kümesini oluşturacak koleksiyon fabrikası bileşeninin tanımlayıcısı.
+
+`[position]`
+: (isteğe bağlı) Oluşturulan oyun nesnelerinin dünya konumu. Bu değer bir `vector3` olmalıdır. Bir konum belirtmezseniz nesneler koleksiyon fabrikası bileşeninin konumunda oluşturulur.
+
+`[rotation]`
+: (isteğe bağlı) Yeni oyun nesnelerinin dünya uzayındaki dönmesi. Bu değer bir `quat` olmalıdır.
+
+`[properties]`
+: (isteğe bağlı) Oluşturulan oyun nesnelerinin başlangıç işlemlerinde kullanılan `id`-`table` çiftlerini içeren bir Lua tablosu. Bu tablonun nasıl oluşturulacağını aşağıda bulabilirsiniz.
+
+`[scale]`
+: (isteğe bağlı) Oluşturulan oyun nesnelerinin ölçeği. Ölçek, tüm eksenler boyunca aynı oranda ölçekleme belirten bir `number` (0'dan büyük) olarak ifade edilebilir. Her bileşeni ilgili eksendeki ölçeklemeyi belirten bir `vector3` de verebilirsiniz.
+
+`collectionfactory.create()`, oluşturulan oyun nesnelerinin tanımlayıcılarını bir tablo olarak döndürür. Tablo anahtarları, her nesnenin koleksiyon içindeki yerel tanımlayıcısının karma değerini, o nesnenin çalışma zamanı tanımlayıcısıyla eşler:
+
+::: sidenote
+`bean` ile `shield` arasındaki üst-alt nesne ilişkisi, döndürülen tabloya *yansıtılmaz*. Bu ilişki yalnızca çalışma zamanı sahne grafında, yani nesnelerin birlikte dönüştürülme biçiminde bulunur. Bir nesnenin üst nesnesini değiştirmek, tanımlayıcısını hiçbir zaman değiştirmez.
+:::
+
+```lua
+local bean_ids = collectionfactory.create("#bean_factory")
+go.set_scale_xy(0.5, bean_ids[hash("/bean")])
+pprint(bean_ids)
+-- DEBUG:SCRIPT:
+-- {
+--   hash: [/shield] = hash: [/collection0/shield], -- <1>
+--   hash: [/bean] = hash: [/collection0/bean],
+-- }
+```
+1. Her örneği benzersiz biçimde tanımlamak için tanımlayıcıya `/collection[N]/` öneki eklenir; burada `[N]` bir sayaçtır:
+
+## Özellikler
+
+Çalışma sırasında bir koleksiyon oluştururken, anahtarları nesne tanımlayıcıları ve değerleri ayarlanacak betik özelliklerini içeren tablolar olan bir tablo oluşturarak her oyun nesnesine özellik parametreleri geçirebilirsiniz.
+
+```lua
+local props = {}
+props[hash("/bean")] = { shield = false }
+local ids = collectionfactory.create("#bean_factory", nil, nil, props)
+```
+
+`bean` oyun nesnesinin `bean.collection` içinde `shield` özelliğini tanımladığını varsayalım. [Betik özelliği kılavuzu](/manuals/script-properties), betik özellikleri hakkında bilgi içerir.
+
+```lua
+-- bean/controller.script
+go.property("shield", true)
+
+function init(self)
+    if not self.shield then
+        go.delete("shield")
+    end     
+end
+```
+
+## Fabrika kaynaklarının dinamik olarak yüklenmesi {#dynamic-loading-of-factory-resources}
+
+Koleksiyon fabrikasının özelliklerindeki *Load Dynamically* onay kutusunu işaretlediğinizde motor, fabrikayla ilişkili kaynakların yüklenmesini erteler.
+
+![Dinamik olarak yükleme](images/collection_factory/load_dynamically.png)
+
+Kutu işaretli değilse motor, koleksiyon fabrikası bileşeni yüklendiğinde prototip kaynaklarını yükler; böylece kaynaklar nesne oluşturmak için hemen hazır olur.
+
+Kutu işaretliyse iki kullanım seçeneğiniz vardır:
+
+Eşzamanlı yükleme
+: Nesne oluşturmak istediğinizde [`collectionfactory.create()`](/ref/collectionfactory/#collectionfactory.create:url-[position]-[rotation]-[properties]-[scale]) işlevini çağırın. Bu işlem önce kaynakları eşzamanlı olarak yükler; bu, kısa bir takılmaya neden olabilir. Ardından yeni örnekler oluşturur.
+
+  ```lua
+  function init(self)
+      -- No factory resources are loaded when the collection factory’s
+      -- parent collection is loaded. Calling create without
+      -- having called load will create the resources synchronously.
+      self.go_ids = collectionfactory.create("#collectionfactory")
+  end
+
+  function final(self)  
+      -- Delete game objects. Will decref resources.
+      -- In this case resources are deleted since the collection
+      -- factory component holds no reference.
+      go.delete(self.go_ids)
+
+      -- Calling unload will do nothing since factory holds
+      -- no references
+      collectionfactory.unload("#factory")
+  end
+  ```
+
+Eşzamansız yükleme
+: Kaynakları açıkça eşzamansız olarak yüklemek için [`collectionfactory.load()`](/ref/collectionfactory/#collectionfactory.load:[url]-[complete_function]) işlevini çağırın. Kaynaklar nesne oluşturmak için hazır olduğunda bir geri çağırım alınır.
+
+  ```lua
+  function load_complete(self, url, result)
+      -- Loading is complete, resources are ready to spawn
+      self.go_ids = collectionfactory.create(url)
+  end
+
+  function init(self)
+      -- No factory resources are loaded when the collection factory’s
+      -- parent collection is loaded. Calling load will load the resources.
+      collectionfactory.load("#factory", load_complete)
+  end
+
+  function final(self)
+      -- Delete game object. Will decref resources.
+      -- In this case resources aren’t deleted since the collection factory
+      -- component still holds a reference.
+      go.delete(self.go_ids)
+
+      -- Calling unload will decref resources held by the factory component,
+      -- resulting in resources being destroyed.
+      collectionfactory.unload("#factory")
+  end
+  ```
+
+
+## Dinamik prototip
+
+Bir koleksiyon fabrikasının oluşturabileceği *Prototype* değerini, koleksiyon fabrikasının özelliklerindeki *Dynamic Prototype* onay kutusunu işaretleyerek değiştirebilirsiniz.
+
+![Dinamik prototip](images/collection_factory/dynamic_prototype.png)
+
+*Dynamic Prototype* seçeneği işaretliyken koleksiyon fabrikası bileşeni, `collectionfactory.set_prototype()` işlevini kullanarak prototipi değiştirebilir. Örnek:
+
+```lua
+collectionfactory.unload("#factory") -- unload the previous resources
+collectionfactory.set_prototype("#factory", "/main/levels/level1.collectionc")
+local ids = collectionfactory.create("#factory")
+```
+
+::: important
+*Dynamic Prototype* seçeneği etkinleştirildiğinde koleksiyonun bileşen sayısı optimize edilemez ve bileşenin bulunduğu koleksiyon, *game.project* dosyasındaki varsayılan bileşen sayılarını kullanır.
+:::

--- a/docs/tr/manuals/collection-proxy.md
+++ b/docs/tr/manuals/collection-proxy.md
@@ -1,0 +1,237 @@
+---
+title: Koleksiyon vekili kılavuzu
+brief: Bu kılavuz, yeni oyun dünyalarını dinamik olarak oluşturmayı ve aralarında geçiş yapmayı açıklar.
+---
+
+# Koleksiyon vekili
+
+Koleksiyon vekili (collection proxy) bileşeni (component), bir koleksiyon (collection) dosyasının içeriğine göre yeni oyun "dünyalarını" dinamik olarak yüklemek ve bellekten kaldırmak için kullanılır. Koleksiyon vekilleri; oyun seviyeleri ve GUI ekranları arasında geçiş yapmak, bir seviye boyunca hikâye "sahnelerini" yükleyip bellekten kaldırmak, mini oyunları yükleyip bellekten kaldırmak ve daha fazlası için kullanılabilir.
+
+Defold, tüm oyun nesnelerini (game object) koleksiyonlar halinde düzenler. Bir koleksiyon, oyun nesneleri ve başka koleksiyonlar (yani alt koleksiyonlar) içerebilir. Koleksiyon vekilleri, içeriğinizi ayrı koleksiyonlara bölmenizi ve ardından bu koleksiyonların yüklenmesini ve bellekten kaldırılmasını betikler aracılığıyla dinamik olarak yönetmenizi sağlar.
+
+Koleksiyon vekilleri, [koleksiyon fabrikası (collection factory) bileşenlerinden](/manuals/collection-factory/) farklıdır. Bir koleksiyon fabrikası, koleksiyon içeriğinin örneklerini geçerli oyun dünyasında oluşturur. Koleksiyon vekilleri ise çalışma sırasında yeni bir oyun dünyası oluşturur ve bu nedenle farklı kullanım alanlarına sahiptir.
+
+## Koleksiyon vekili bileşeni oluşturma
+
+1. Bir oyun nesnesine <kbd>sağ tıklayın</kbd> ve bağlam menüsünden <kbd>Add Component ▸ Collection Proxy</kbd> seçeneğini seçerek oyun nesnesine bir koleksiyon vekili bileşeni ekleyin.
+
+2. *Collection* özelliğini, daha sonra çalışma zamanı ortamına dinamik olarak yüklemek istediğiniz bir koleksiyona başvuracak şekilde ayarlayın. Bu, proje derleme sırasında belirlenen statik bir bağımlılıktır: başvurulan koleksiyon ve bağımlılıkları derlenir. *Exclude* işaretli olmadığı sürece ana dağıtım paketine dahil edilirler. *Exclude* işaretliyse yalnızca hariç tutulan vekiller üzerinden başvurulan kaynaklar Live Update için ana dağıtım paketinin dışında bırakılabilir ve yüklenmemiş vekil, aşağıda anlatıldığı gibi çalışma sırasında başka bir derlenmiş koleksiyona yönlendirilebilir.
+
+![Vekil bileşeni ekleme](images/collection-proxy/create_proxy.png)
+
+(İçeriği derleme çıktısından hariç tutup bunun yerine kodla indirmek için *Exclude* kutusunu işaretleyebilir ve [Live Update özelliğini](/manuals/live-update/) kullanabilirsiniz.)
+
+## Başlangıç
+
+Defold motoru başlatıldığında, bir *başlangıç koleksiyonundan (bootstrap collection)* tüm oyun nesnelerini çalışma zamanı ortamına yükler ve örneklerini oluşturur. Ardından oyun nesnelerinin ve bileşenlerinin başlangıç işlemlerini gerçekleştirip onları etkinleştirir. Motorun hangi başlangıç koleksiyonunu kullanacağı [proje ayarlarında](/manuals/project-settings/#main-collection) belirlenir. Bu koleksiyon dosyasına genellikle `main.collection` adı verilir.
+
+![Başlangıç](images/collection-proxy/bootstrap.png)
+
+Motor, oyun nesnelerini ve bileşenlerini barındırmak için başlangıç koleksiyonunun içeriğinden örneklerin oluşturulacağı "oyun dünyasının" tamamına gereken belleği ayırır. Çarpışma nesneleri ve fizik simülasyonu için ayrı bir fizik dünyası da oluşturulur.
+
+Betik bileşenlerinin, başlangıç dünyasının dışından bile oyundaki tüm nesneleri adresleyebilmesi gerektiğinden bu dünyaya benzersiz bir ad verilir. Bu ad, koleksiyon dosyasında ayarladığınız *Name* özelliğidir:
+
+![Başlangıç](images/collection-proxy/collection_id.png)
+
+Yüklenen koleksiyon koleksiyon vekili bileşenleri içeriyorsa bu bileşenlerin başvurduğu koleksiyonlar otomatik olarak *yüklenmez*. Bu kaynakların yüklenmesini betikler aracılığıyla yönetmeniz gerekir.
+
+## Koleksiyon yükleme
+
+Bir koleksiyonu vekil aracılığıyla dinamik olarak yüklemek için bir betikten vekil bileşenine `"load"` adlı ileti gönderilir:
+
+```lua
+-- Tell the proxy "myproxy" to start loading.
+msg.post("#myproxy", "load")
+```
+
+![Yükleme](images/collection-proxy/proxy_load.png)
+
+Vekil bileşeni, motora yeni bir dünya için yer ayırmasını söyler. Çalışma zamanı ortamında ayrı bir fizik dünyası da oluşturulur ve "`mylevel.collection`" koleksiyonundaki tüm oyun nesnelerinin örnekleri oluşturulur.
+
+Yeni dünya, adını koleksiyon dosyasındaki *Name* özelliğinden alır; bu örnekte özellik "`mylevel`" olarak ayarlanmıştır. Adın benzersiz olması gerekir. Koleksiyon dosyasında ayarlanan *Name* değeri yüklenmiş bir dünya için zaten kullanılıyorsa motor bir ad çakışması hatası bildirir:
+
+```txt
+ERROR:GAMEOBJECT: The collection 'default' could not be created since there is already a socket with the same name.
+WARNING:RESOURCE: Unable to create resource: build/default/mylevel.collectionc
+ERROR:GAMESYS: The collection /mylevel.collectionc could not be loaded.
+```
+
+Motor koleksiyonu yüklemeyi tamamladığında koleksiyon vekili bileşeni, `"load"` iletisini gönderen betiğe `"proxy_loaded"` adlı bir ileti gönderir. Betik daha sonra bu iletiye yanıt olarak koleksiyonun başlangıç işlemlerini gerçekleştirip koleksiyonu etkinleştirebilir:
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        -- New world is loaded. Init and enable it.
+        msg.post(sender, "init")
+        msg.post(sender, "enable")
+        ...
+    end
+end
+```
+
+`"load"`
+: Bu ileti, koleksiyon vekili bileşenine koleksiyonunu yeni bir dünyaya yüklemeye başlamasını söyler. Vekil, işini tamamladığında `"proxy_loaded"` adlı bir ileti gönderir.
+
+`"async_load"`
+: Bu ileti, koleksiyon vekili bileşenine koleksiyonunu arka planda yeni bir dünyaya yüklemeye başlamasını söyler. Vekil, işini tamamladığında `"proxy_loaded"` adlı bir ileti gönderir.
+
+`"init"`
+: Bu ileti, koleksiyon vekili bileşenine, örnekleri oluşturulan tüm oyun nesnelerinin ve bileşenlerin başlangıç işlemlerinin gerçekleştirilmesi gerektiğini söyler. Bu aşamada tüm betiklerin `init()` işlevleri çağrılır.
+
+`"enable"`
+: Bu ileti, koleksiyon vekili bileşenine tüm oyun nesnelerinin ve bileşenlerin etkinleştirilmesi gerektiğini söyler. Örneğin, tüm sprite bileşenleri etkinleştirildiklerinde çizilmeye başlar.
+
+## Hariç tutulan bir vekilin koleksiyonunu değiştirme {#changing-an-excluded-proxys-collection}
+
+[`collectionproxy.set_collection()`](/ref/collectionproxy/#collectionproxy.set_collection) işlevi, hariç tutulmuş ve yüklenmemiş bir vekili derlenmiş bir koleksiyona yönlendirebilir. Bu, bir Live Update paketi bağlandıktan sonra yararlıdır. Vekilin *Exclude* seçeneği işaretli olmalı ve vekil yüklenmiş veya yükleniyor durumda olmamalıdır. Yol, `.collectionc` ile bitmelidir. Vekil yüklendiğinde koleksiyon ve tüm bağımlılıkları kaynak sistemi tarafından erişilebilir durumda olmalıdır.
+
+Vekili yüklemeden önce dönüş değerini kontrol edin. Yeni dünyanın başlangıç işlemlerini yalnızca `proxy_loaded` iletisini aldıktan sonra gerçekleştirip dünyayı etkinleştirin:
+
+```lua
+local function load_mounted_level()
+    local ok, result = collectionproxy.set_collection(
+        "#level_proxy",
+        "/level_pack/level_3.collectionc"
+    )
+
+    if ok then
+        msg.post("#level_proxy", "load")
+    else
+        print("Unable to change proxy collection", result)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_loaded") then
+        msg.post(sender, "init")
+        msg.post(sender, "enable")
+    end
+end
+```
+
+Düzenleyicide atanan koleksiyona dönmek için vekil yüklenmiş veya yükleniyor durumda değilken `collectionproxy.set_collection("#level_proxy", nil)` işlevini çağırın. İçerik indirme ve bağlama işlemleri için [Live Update betik yazımı kılavuzuna](/manuals/live-update-scripting/), `collectionproxy.RESULT_*` hata kodları için API başvurusuna bakın.
+
+## Yeni dünyadaki nesneleri adresleme
+
+Koleksiyon dosyası özelliklerinde ayarlanan *Name* değeri, yüklenen dünyadaki oyun nesnelerini ve bileşenlerini adreslemek için kullanılır. Örneğin, başlangıç koleksiyonunda bir yükleyici nesnesi oluşturursanız yüklenmiş herhangi bir koleksiyondan bu nesneyle iletişim kurmanız gerekebilir:
+
+```lua
+-- tell the loader to load the next level:
+msg.post("main:/loader#script", "load_level", { level_id = 2 })
+```
+
+![Yükleme](images/collection-proxy/message_passing.png)
+
+Yükleyiciden, yüklenen koleksiyondaki bir oyun nesnesiyle iletişim kurmanız gerekirse [nesnenin tam URL adresini](/manuals/addressing/#urls) kullanarak bir ileti gönderebilirsiniz:
+
+```lua
+msg.post("mylevel:/myobject", "hello")
+```
+
+::: important
+Yüklenmiş bir koleksiyondaki oyun nesnelerine koleksiyonun dışından doğrudan erişmek mümkün değildir:
+
+```lua
+local position = go.get_position("mylevel:/myobject")
+-- loader.script:42: function called can only access instances within the same collection.
+```
+:::
+
+
+## Bir dünyayı bellekten kaldırma
+
+Yüklenmiş bir koleksiyonu bellekten kaldırmak için yükleme adımlarının tersine karşılık gelen iletileri gönderirsiniz:
+
+```lua
+-- unload the level
+msg.post("#myproxy", "disable")
+msg.post("#myproxy", "final")
+msg.post("#myproxy", "unload")
+```
+
+`"disable"`
+: Bu ileti, koleksiyon vekili bileşenine dünyadaki tüm oyun nesnelerini ve bileşenlerini devre dışı bırakmasını söyler. Bu aşamada sprite bileşenleri için görüntü oluşturma, yani işleme (rendering), durur.
+
+`"final"`
+: Bu ileti, koleksiyon vekili bileşenine dünyadaki tüm oyun nesnelerinin ve bileşenlerinin sonlandırma işlemlerini gerçekleştirmesini söyler. Bu aşamada tüm betiklerin `final()` işlevleri çağrılır.
+
+`"unload"`
+: Bu ileti, koleksiyon vekiline dünyayı bellekten tamamen kaldırmasını söyler.
+
+Daha ayrıntılı denetime ihtiyacınız yoksa koleksiyonu önce devre dışı bırakıp sonlandırma işlemlerini gerçekleştirmeden doğrudan `"unload"` iletisini gönderebilirsiniz. Bu durumda vekil, koleksiyonu bellekten kaldırmadan önce otomatik olarak devre dışı bırakır ve sonlandırma işlemlerini gerçekleştirir.
+
+Koleksiyon vekili, koleksiyonu bellekten kaldırmayı tamamladığında `"unload"` iletisini gönderen betiğe `"proxy_unloaded"` iletisini gönderir:
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("proxy_unloaded") then
+        -- Ok, the world is unloaded...
+        ...
+    end
+end
+```
+
+
+## Zaman adımı
+
+Koleksiyon vekilinin güncellemeleri, _zaman adımı (time step)_ değiştirilerek ölçeklenebilir. Bu, oyun sabit 60 FPS hızında çalışsa bile bir vekilin daha yüksek veya daha düşük bir hızda güncellenebileceği ve şu gibi unsurları etkileyebileceği anlamına gelir:
+
+* Fizik simülasyonu hızı
+* `update()` işlevine geçirilen `dt` değeri
+* [Oyun nesnesi ve GUI özellik animasyonları](https://defold.com/manuals/animation/#property-animation-1)
+* [Kare dizisi animasyonları](https://defold.com/manuals/animation/#flip-book-animation)
+* [Parçacık efekti simülasyonları](https://defold.com/manuals/particlefx/)
+* Zamanlayıcı hızı
+
+Güncelleme modunu da ayarlayabilirsiniz. Böylece ölçeklemenin kesikli olarak mı (yalnızca ölçek çarpanı 1,0'dan küçükse anlamlıdır) yoksa sürekli olarak mı yapılacağını denetleyebilirsiniz.
+
+Ölçek çarpanını ve ölçekleme modunu, vekile bir `set_time_step` iletisi göndererek denetlersiniz:
+
+```lua
+-- update loaded world at one-fifth-speed.
+msg.post("#myproxy", "set_time_step", {factor = 0.2, mode = 1}
+```
+
+Zaman adımını değiştirirken neler olduğunu görmek için betik bileşeninde aşağıdaki kodu içeren bir nesne oluşturup zaman adımını değiştirdiğimiz koleksiyona yerleştirebiliriz:
+
+```lua
+function update(self, dt)
+    print("update() with timestep (dt) " .. dt)
+end
+```
+
+Zaman adımı 0,2 olduğunda konsolda şu sonucu alırız:
+
+```txt
+INFO:ENGINE: Defold Engine 1.2.37 (6b3ae27)
+INFO:ENGINE: Loading data from: build/default
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0.016666667535901
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0
+DEBUG:SCRIPT: update() with timestep (dt) 0.016666667535901
+```
+
+`update()` hâlâ saniyede 60 kez çağrılır, ancak `dt` değeri değişir. `update()` çağrılarının yalnızca 1/5'inde (0,2) `dt` değerinin 1/60 (60 FPS'ye karşılık gelir) olduğunu görürüz---geri kalanında bu değer sıfırdır. Tüm fizik simülasyonları da bu `dt` değerine göre güncellenir ve karelerin yalnızca beşte birinde ilerler.
+
+::: sidenote
+Koleksiyonun zaman adımı işlevini, örneğin bir açılır pencere gösterilirken veya pencere odağını kaybettiğinde oyununuzu duraklatmak için kullanabilirsiniz. Duraklatmak için `msg.post("#myproxy", "set_time_step", {factor = 0, mode = 0})`, devam ettirmek için `msg.post("#myproxy", "set_time_step", {factor = 1, mode = 1})` kullanın.
+:::
+
+Daha fazla ayrıntı için [`set_time_step`](/ref/collectionproxy#set_time_step) başvurusuna bakın.
+
+## Dikkat edilmesi gerekenler ve yaygın sorunlar
+
+Fizik
+: Koleksiyon vekilleri aracılığıyla motora birden fazla en üst düzey koleksiyon, yani *oyun dünyası*, yüklemek mümkündür. Bunu yaparken her en üst düzey koleksiyonun ayrı bir fizik dünyası olduğunu bilmek önemlidir. Fizik etkileşimleri (çarpışmalar, tetikleyiciler, ışın sorguları) yalnızca aynı dünyaya ait nesneler arasında gerçekleşir. Bu nedenle iki dünyadaki çarpışma nesneleri görsel olarak tam üst üste gelseler bile aralarında herhangi bir fizik etkileşimi olamaz.
+
+Bellek
+: Yüklenen her koleksiyon, görece büyük miktarda bellek kullanan yeni bir oyun dünyası oluşturur. Vekiller aracılığıyla aynı anda onlarca koleksiyon yüklüyorsanız tasarımınızı yeniden değerlendirmek isteyebilirsiniz. Oyun nesnesi hiyerarşilerinin çok sayıda örneğini çalışma sırasında oluşturmak için [koleksiyon fabrikaları](/manuals/collection-factory) daha uygundur.
+
+Girdi
+: Yüklenen koleksiyonunuzda girdi eylemlerine ihtiyaç duyan nesneler varsa koleksiyon vekilini içeren oyun nesnesinin girdiyi aldığından emin olmanız gerekir. Oyun nesnesi girdi iletileri aldığında bunlar nesnenin bileşenlerine, yani koleksiyon vekillerine aktarılır. Girdi eylemleri vekil aracılığıyla yüklenen koleksiyona gönderilir.

--- a/docs/tr/manuals/components.md
+++ b/docs/tr/manuals/components.md
@@ -1,0 +1,108 @@
+---
+title: Oyun nesnesi bileşenleri
+brief: Bu kılavuz, bileşenlere ve bunların nasıl kullanılacağına genel bir bakış sunar.
+---
+
+#  Bileşenler
+
+:[components](../shared/components.md)
+
+## Bileşen türleri
+
+Defold aşağıdaki bileşen (component) türlerini destekler:
+
+* [Koleksiyon fabrikası (collection factory)](/manuals/collection-factory) - Koleksiyonları (collection) çalışma sırasında oluşturma
+* [Koleksiyon vekili (collection proxy)](/manuals/collection-proxy) - Koleksiyonları yükleme ve bellekten kaldırma
+* [Çarpışma nesnesi](/manuals/physics) - 2B ve 3B fizik
+* [Kamera](/manuals/camera) - Oyun dünyasının görüntü alanını ve izdüşümünü değiştirme
+* [Fabrika (factory)](/manuals/factory) - Oyun nesnelerini (game object) çalışma sırasında oluşturma
+* [GUI](/manuals/gui) - Grafik kullanıcı arayüzü işleme (rendering)
+* [Etiket](/manuals/label) - Bir metin parçasını işleme
+* [Işık](/manuals/light) - Gölgelendiriciler için ışık verisi ekleme
+* [Örgü](/manuals/mesh) 3B örgü gösterme (çalışma sırasında oluşturma ve değiştirme desteğiyle)
+* [Model](/manuals/model) 3B model gösterme (isteğe bağlı animasyonlarla)
+* [Parçacık efekti](/manuals/particlefx) -  Parçacıkları çalışma sırasında oluşturma
+* [Betik](/manuals/script) - Oyun mantığı ekleme
+* [Ses](/manuals/sound) - Ses veya müzik çalma
+* [Sprite bileşeni](/manuals/sprite) - 2B görüntü gösterme (isteğe bağlı kare dizisi animasyonuyla)
+* [Karo haritası](/manuals/tilemap) - Karolardan oluşan bir ızgara gösterme
+
+Eklentiler aracılığıyla başka bileşenler eklenebilir:
+
+* [Rive modeli](/extension-rive) - Rive animasyonu işleme
+* [Spine modeli](/extension-spine) - Spine animasyonu işleme
+
+
+## Bileşenleri etkinleştirme ve devre dışı bırakma
+
+Bir oyun nesnesinin bileşenleri, oyun nesnesi oluşturulduğunda etkinleştirilir. Bir bileşeni devre dışı bırakmak istiyorsanız bunu bileşene bir [`disable`](/ref/go/#disable) iletisi göndererek yapabilirsiniz:
+
+```lua
+-- disable the component with id 'weapon' on the same game object as this script
+msg.post("#weapon", "disable")
+
+-- disable the component with id 'shield' on the 'enemy' game object
+msg.post("enemy#shield", "disable")
+
+-- disable all components on the current game object
+msg.post(".", "disable")
+
+-- disable all components on the 'enemy' game object
+msg.post("enemy", "disable")
+```
+
+Bir bileşeni yeniden etkinleştirmek için bileşene bir [`enable`](/ref/go/#enable) iletisi gönderebilirsiniz:
+
+```lua
+-- enable the component with id 'weapon'
+msg.post("#weapon", "enable")
+```
+
+## Bileşen özellikleri
+
+Defold bileşen türlerinin her biri farklı özelliklere sahiptir. Düzenleyicideki [Properties paneli](/manuals/editor/#the-editor-views), [Outline panelinde](/manuals/editor/#the-editor-views) o anda seçili olan bileşenin özelliklerini gösterir. Kullanılabilir bileşen özellikleri hakkında daha fazla bilgi edinmek için ilgili bileşen türlerinin kılavuzlarına bakın.
+
+## Bileşen konumu, dönmesi ve ölçeği
+
+Görsel bileşenlerin genellikle konum ve dönme özellikleri, çoğu zaman da ölçek özelliği vardır. Bu özellikler düzenleyiciden değiştirilebilir ve hemen hemen hiçbir durumda çalışma sırasında değiştirilemez (tek istisna, çalışma sırasında değiştirilebilen sprite ve etiket bileşenlerinin ölçeğidir).
+
+Bir bileşenin konumunu, dönmesini veya ölçeğini çalışma sırasında değiştirmeniz gerekiyorsa bunun yerine bileşenin ait olduğu oyun nesnesinin konumunu, dönmesini veya ölçeğini değiştirin. Bunun bir yan etkisi olarak oyun nesnesindeki tüm bileşenler etkilenir. Bir oyun nesnesine bağlı birçok bileşenden yalnızca birini değiştirmek istiyorsanız söz konusu bileşeni ayrı bir oyun nesnesine taşımanız ve bu nesneyi, bileşenin başlangıçta ait olduğu oyun nesnesine alt nesne olarak eklemeniz önerilir.
+
+## Bileşen çizim sırası
+
+Görsel bileşenlerin çizim sırası iki şeye bağlıdır:
+
+### İşleme betiği yüklemleri
+Her bileşene bir [materyal (material)](/manuals/material/) atanır ve her materyalin bir veya daha fazla etiketi vardır. İşleme betiği (render script) ise her biri bir veya daha fazla materyal etiketiyle eşleşen bir dizi işleme yüklemi (render predicate) tanımlar. İşleme betiğinin *update()* işlevinde [yüklemler tek tek çizilir](/manuals/render/#render-predicates) ve her yüklemde tanımlanan etiketlerle eşleşen bileşenler çizilir. Varsayılan işleme betiği önce sprite bileşenlerini ve karo haritalarını bir geçişte, ardından parçacık efektlerini başka bir geçişte çizer; her iki geçiş de dünya uzayında gerçekleşir. İşleme betiği daha sonra GUI bileşenlerini ekran uzayında ayrı bir geçişte çizmeye devam eder.
+
+### Bileşen z değeri
+Tüm oyun nesneleri ve bileşenler, konumları `vector3` nesneleriyle ifade edilen 3B uzayda yer alır. Oyununuzun grafik içeriğini 2B olarak görüntülediğinizde X ve Y değerleri bir nesnenin "genişlik" ve "yükseklik" eksenlerindeki konumunu, Z konumu ise "derinlik" eksenindeki konumunu belirler. Z konumu, üst üste gelen nesnelerin görünürlüğünü kontrol etmenizi sağlar: Z değeri 1 olan bir sprite bileşeni, Z konumu 0 olan bir sprite bileşeninin önünde görünür. Defold varsayılan olarak -1 ile 1 arasındaki Z değerlerine izin veren bir koordinat sistemi kullanır:
+
+![model](images/graphics/z-order.png)
+
+Bir [işleme yüklemiyle](/manuals/render/#render-predicates) eşleşen bileşenler birlikte çizilir ve çizilme sıraları bileşenin son z değerine bağlıdır. Bir bileşenin son z değeri, bileşenin kendisinin, ait olduğu oyun nesnesinin ve varsa tüm üst oyun nesnelerinin z değerlerinin toplamıdır.
+
+::: sidenote
+Birden fazla GUI bileşeninin çizilme sırası, GUI bileşenlerinin z değeriyle **belirlenmez**. GUI bileşenlerinin çizim sırası [gui.set_render_order()](/ref/gui/#gui.set_render_order:order) işleviyle kontrol edilir.
+:::
+
+Örnek: A ve B adlı iki oyun nesnesi. B, A'nın alt nesnesidir. B'nin bir sprite bileşeni vardır.
+
+| Öğe      | Z değeri |
+|----------|---------|
+| A        | 2       |
+| B        | 1       |
+| B#sprite | 0.5     |
+
+![](images/graphics/component-hierarchy.png)
+
+Yukarıdaki hiyerarşide, B üzerindeki sprite bileşeninin son z değeri 2 + 1 + 0.5 = 3.5 olur.
+
+::: important
+İki bileşenin z değeri tam olarak aynıysa sıralama tanımsızdır; bileşenler sırayla birbirinin önüne geçerek titreyebilir veya bir platformda bir sırayla, başka bir platformda farklı bir sırayla işlenebilir.
+
+İşleme betiği, z değerleri için bir yakın düzlem ve bir uzak düzlem tanımlar. Z değeri bu aralığın dışında kalan bileşenler işlenmez. Varsayılan aralık -1 ile 1 arasındadır, ancak [kolayca değiştirilebilir](/manuals/render/#default-view-projection). Yakın ve uzak sınırları -1 ve 1 olduğunda Z değerlerinin sayısal hassasiyeti çok yüksektir. 3B varlıklarla çalışırken varsayılan izdüşümün yakın ve uzak sınırlarını özel bir işleme betiğinde değiştirmeniz gerekebilir. Daha fazla bilgi için [İşleme kılavuzuna](/manuals/render/) bakın.
+:::
+
+
+:[Component max count optimizations](../shared/component-max-count-optimizations.md)

--- a/docs/tr/manuals/compute.md
+++ b/docs/tr/manuals/compute.md
@@ -1,0 +1,248 @@
+---
+title: Defold hesaplama kılavuzu
+brief: Bu kılavuz, hesaplama programları, gölgelendirici sabitleri ve örnekleyicilerle nasıl çalışılacağını açıklar.
+---
+
+# Hesaplama programları
+
+::: sidenote
+Defold'da hesaplama gölgelendiricisi desteği şu anda *teknik önizleme* aşamasındadır.
+Bu, bazı özelliklerin eksik olduğu ve API'nin gelecekte değişebileceği anlamına gelir.
+:::
+
+Hesaplama gölgelendiricileri (compute shader), GPU üzerinde genel amaçlı hesaplamalar yapmak için güçlü bir araçtır. Fizik simülasyonları, görüntü işleme ve daha pek çok görev için GPU üzerindeki paralel işlem gücünden yararlanmanızı sağlar. Bir hesaplama gölgelendiricisi, arabelleklerde veya dokularda saklanan veriler üzerinde çalışır ve işlemleri birçok GPU iş parçacığında paralel olarak gerçekleştirir. Hesaplama gölgelendiricilerini yoğun hesaplamalar için bu kadar güçlü kılan, bu paralelliktir.
+
+* Görüntü oluşturmak için kullanılan işleme (rendering) hattı hakkında daha fazla bilgi için [İşleme belgelerine](/manuals/render) bakın.
+* Gölgelendirici programlarının ayrıntılı açıklaması için [Gölgelendirici belgelerine](/manuals/shader) bakın.
+
+## Hesaplama gölgelendiricileriyle neler yapabilirim?
+
+Hesaplama gölgelendiricileri genel amaçlı hesaplamalarda kullanılmak üzere tasarlandığından, bunlarla yapabileceklerinizin bir sınırı yoktur. Hesaplama gölgelendiricilerinin yaygın kullanım alanlarından bazıları şunlardır:
+
+Görüntü işleme
+  - Görüntü filtreleme: Bulanıklaştırma, kenar algılama, keskinleştirme filtresi ve benzeri işlemler uygulama.
+  - Renk derecelendirme: Bir görüntünün renk uzayını ayarlama.
+
+Fizik
+  - Parçacık sistemleri: Duman, ateş ve akışkan dinamiği gibi efektler için çok sayıda parçacığı simüle etme.
+  - Yumuşak cisim fiziği: Kumaş ve jöle gibi şekli değişebilen nesneleri simüle etme.
+  - Görünmeyenleri eleme: Örtülenleri eleme, görüş hacmi dışında kalanları eleme
+
+Prosedürel üretim
+  - Arazi üretimi: Gürültü işlevleri kullanarak ayrıntılı arazi oluşturma.
+  - Bitki örtüsü ve yapraklar: Bitkileri ve ağaçları prosedürel olarak oluşturma.
+
+İşleme efektleri
+  - Küresel aydınlatma: Işığın sahnede nasıl yansıdığını yaklaşık olarak hesaplayarak gerçekçi aydınlatmayı simüle etme.
+  - Vokselleştirme: Örgü verilerinden 3B bir voksel ızgarası oluşturma.
+
+## Hesaplama gölgelendiricileri nasıl çalışır?
+
+Genel olarak hesaplama gölgelendiricileri, bir görevi aynı anda yürütülebilecek çok sayıda küçük göreve bölerek çalışır. Bu, iş grupları (`work groups`) ve çağrılar (`invocations`) kavramlarıyla sağlanır:
+
+İş grupları
+: Hesaplama gölgelendiricisi, iş gruplarından (`work groups`) oluşan bir ızgara üzerinde çalışır. Her iş grubu sabit sayıda çağrı (veya iş parçacığı) içerir. İş gruplarının boyutu ve çağrı sayısı gölgelendirici kodunda tanımlanır.
+
+Çağrılar
+: Her çağrı (veya iş parçacığı) hesaplama gölgelendiricisi programını yürütür. Bir iş grubundaki çağrılar, paylaşılan bellek aracılığıyla veri paylaşabilir; bu da aralarında verimli iletişim ve eşzamanlama sağlar.
+
+GPU, birden çok iş grubunda çok sayıda çağrıyı paralel olarak başlatarak hesaplama gölgelendiricisini yürütür ve uygun görevler için önemli bir hesaplama gücü sağlar.
+
+## Hesaplama programı oluşturma
+
+Bir hesaplama programı oluşturmak için *Assets* tarayıcısında hedef klasöre <kbd>sağ tıklayın</kbd> ve <kbd>New... ▸ Compute</kbd> seçeneğini seçin. (Menüden <kbd>File ▸ New...</kbd> seçeneğini seçip ardından <kbd>Compute</kbd> seçeneğini de seçebilirsiniz). Yeni hesaplama dosyasına bir ad verin ve <kbd>Ok</kbd> düğmesine basın.
+
+![Hesaplama dosyası](images/compute/compute_file.png)
+
+Yeni hesaplama dosyası *Compute Editor* içinde açılır.
+
+![Hesaplama düzenleyicisi](images/compute/compute.png)
+
+Hesaplama dosyası aşağıdaki bilgileri içerir:
+
+Compute Program
+: Kullanılacak hesaplama gölgelendiricisi program dosyası (*`.cp`*). Gölgelendirici "soyut iş öğeleri" üzerinde çalışır; yani girdi ve çıktı veri türlerinin sabit bir tanımı yoktur. Hesaplama gölgelendiricisinin ne üretmesi gerektiğini tanımlamak programcıya bağlıdır.
+
+Constants
+: Hesaplama gölgelendiricisi programına aktarılacak uniform değerleri. Kullanılabilir sabitlerin listesi için aşağıya bakın.
+
+Samplers
+: İsteğe bağlı olarak materyal (material) dosyasında belirli örnekleyicileri (sampler) yapılandırabilirsiniz. Bir örnekleyici ekleyin, gölgelendirici programında kullanılan ada göre adlandırın ve sarma ile filtre ayarlarını istediğiniz gibi belirleyin.
+
+
+## Hesaplama programını Defold'da kullanma
+
+Materyallerden farklı olarak hesaplama programları hiçbir bileşene (component) atanmaz ve normal işleme akışının parçası değildir. Bir hesaplama programının herhangi bir iş yapabilmesi için bir işleme betiğinde (render script) yürütülmek üzere gönderilmesi (`dispatched`) gerekir. Ancak bunu yapmadan önce işleme betiğinde hesaplama programına bir başvuru olduğundan emin olmanız gerekir. Şu anda bir işleme betiğinin hesaplama programını tanımasını sağlamanın tek yolu, programı işleme betiğine başvuruyu içeren .render dosyasına eklemektir:
+
+![Hesaplama programı içeren işleme dosyası](images/compute/compute_render_file.png)
+
+Hesaplama programını kullanmak için önce onu işleme bağlamına bağlamanız gerekir. Bu, materyallerde olduğu gibi yapılır:
+
+```lua
+render.set_compute("my_compute")
+-- Do compute work here, call render.set_compute() to unbind
+render.set_compute()
+```
+
+Hesaplama sabitleri, program yürütülmek üzere gönderildiğinde otomatik olarak uygulansa da düzenleyiciden bir hesaplama programına herhangi bir girdi veya çıktı kaynağı (dokular, arabellekler vb.) bağlamak mümkün değildir. Bunun işleme betikleri aracılığıyla yapılması gerekir:
+
+```lua
+render.enable_texture("blur_render_target", "tex_blur")
+render.enable_texture(self.storage_texture, "tex_storage")
+```
+
+Programı belirlediğiniz çalışma uzayında çalıştırmak için programı yürütülmek üzere göndermeniz gerekir:
+
+```lua
+render.dispatch_compute(128, 128, 1)
+-- dispatch_compute also accepts an options table as the last argument
+-- you can use this argument table to pass in render constants to the dispatch call
+local constants = render.constant_buffer()
+constants.tint = vmath.vector4(1, 1, 1, 1)
+render.dispatch_compute(32, 32, 32, {constants = constants})
+```
+
+### Hesaplama programlarından veri yazma
+
+Şu anda bir hesaplama programından herhangi bir türde çıktı üretmek yalnızca depolama dokuları (`storage textures`) aracılığıyla mümkündür. Depolama dokusu, daha fazla işlev ve yapılandırma seçeneği sunması dışında "normal bir dokuya" benzer. Depolama dokuları, adından da anlaşılacağı gibi, bir hesaplama programından veri okuyup yazabileceğiniz genel amaçlı bir arabellek olarak kullanılabilir. Ardından aynı arabelleği okuma amacıyla farklı bir gölgelendirici programına bağlayabilirsiniz.
+
+Defold'da bir depolama dokusu oluşturmak için bu işlemi normal bir `.script` dosyasından yapmanız gerekir. İşleme betikleri bu işlevi sunmaz; çünkü dinamik dokuların `resource` API'si aracılığıyla oluşturulması gerekir ve bu API yalnızca normal `.script` dosyalarında kullanılabilir.
+
+```lua
+-- In a .script file:
+function init(self)
+    -- Create a texture resource like usual, but add the "storage" flag
+    -- so it can be used as the backing storage for compute programs
+    local t_backing = resource.create_texture("/my_backing_texture.texturec", {
+        type   = graphics.TEXTURE_TYPE_IMAGE_2D,
+        width  = 128,
+        height = 128,
+        format = graphics.TEXTURE_FORMAT_RGBA32F,
+        flags  = graphics.TEXTURE_USAGE_FLAG_STORAGE + graphics.TEXTURE_USAGE_FLAG_SAMPLE,
+    })
+
+    -- get the texture handle from the resource
+    local t_backing_handle = resource.get_texture_info(t_backing).handle
+
+    -- notify the renderer of the backing texture, so it can be bound with render.enable_texture
+    msg.post("@render:", "set_backing_texture", { handle = t_backing_handle })
+end
+```
+
+## Tüm parçaları birleştirme
+
+### Gölgelendirici programı
+
+```glsl
+// compute.cp
+#version 450
+
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+// specify the input resources
+uniform vec4 color;
+uniform sampler2D texture_in;
+
+// specify the output image
+layout(rgba32f) uniform image2D texture_out;
+
+void main()
+{
+    // This isn't a particularly interesting shader, but it demonstrates
+    // how to read from a texture and constant buffer and write to a storage texture
+
+    ivec2 tex_coord   = ivec2(gl_GlobalInvocationID.xy);
+    vec4 output_value = vec4(0.0, 0.0, 0.0, 1.0);
+    vec2 tex_coord_uv = vec2(float(tex_coord.x)/(gl_NumWorkGroups.x), float(tex_coord.y)/(gl_NumWorkGroups.y));
+    vec4 input_value = texture(texture_in, tex_coord_uv);
+    output_value.rgb = input_value.rgb * color.rgb;
+
+    // Write the output value to the storage texture
+    imageStore(texture_out, tex_coord, output_value);
+}
+```
+
+### Betik bileşeni
+```lua
+-- In a .script file
+
+-- Here we specify the input texture that we later will bind to the
+-- compute program. We can assign this texture to a model component,
+-- or enable it to the render context in the render script.
+go.property("texture_in", resource.texture())
+
+function init(self)
+    -- Create a texture resource like usual, but add the "storage" flag
+    -- so it can be used as the backing storage for compute programs
+    local t_backing = resource.create_texture("/my_backing_texture.texturec", {
+        type   = graphics.TEXTURE_TYPE_IMAGE_2D,
+        width  = 128,
+        height = 128,
+        format = graphics.TEXTURE_FORMAT_RGBA32F,
+        flags  = graphics.TEXTURE_USAGE_FLAG_STORAGE + graphics.TEXTURE_USAGE_FLAG_SAMPLE,
+    })
+
+    local textures = {
+        texture_in = resource.get_texture_info(self.texture_in).handle,
+        texture_out = resource.get_texture_info(t_backing).handle
+    }
+
+    -- notify the renderer of the input and output textures
+    msg.post("@render:", "set_backing_texture", textures)
+end
+```
+
+### İşleme betiği
+```lua
+-- respond to the message "set_backing_texture"
+-- to set the backing texture for the compute program
+function on_message(self, message_id, message)
+    if message_id == hash("set_backing_texture") then
+        self.texture_in = message.texture_in
+        self.texture_out = message.texture_out
+    end
+end
+
+function update(self)
+    render.set_compute("compute")
+    -- We can bind textures to specific named constants
+    render.enable_texture(self.texture_in, "texture_in")
+    render.enable_texture(self.texture_out, "texture_out")
+    render.set_constant("color", vmath.vector4(0.5, 0.5, 0.5, 1.0))
+    -- Dispatch the compute program as many times as we have pixels.
+    -- This constitutes our "working group". The shader will be invoked
+    -- 128 x 128 x 1 times, or once per pixel.
+    render.dispatch_compute(128, 128, 1)
+    -- when we are done with the compute program, we need to unbind it
+    render.set_compute()
+end
+```
+
+## Uyumluluk
+
+Defold şu anda aşağıdaki grafik bağdaştırıcılarında hesaplama gölgelendiricilerini destekler:
+
+- Vulkan
+- Metal (MoltenVK aracılığıyla)
+- OpenGL 4.3+
+- OpenGL ES 3.1+
+
+Etkin grafik bağdaştırıcısının hesaplama gölgelendiricilerini destekleyip desteklemediğini kontrol etmek için `graphics.get_adapter_info()` işlevini kullanın. `features` alanı, bağdaştırıcının desteklediği bağlam özelliği sabitlerini içeren bir dizidir:
+
+```lua
+local function has_context_feature(feature)
+    local adapter_info = graphics.get_adapter_info()
+    for _, supported_feature in ipairs(adapter_info.features) do
+        if supported_feature == feature then
+            return true
+        end
+    end
+    return false
+end
+
+local compute_shaders_supported = has_context_feature(
+    graphics.CONTEXT_FEATURE_COMPUTE_SHADER
+)
+```
+
+Diziye yalnızca desteklenen özellikler dahil edilir; bu yapı, anahtar olarak özellik sabitlerini kullanan bir tablo değildir. Oyun farklı grafik bağdaştırıcılarıyla veya sürücü desteği farklı cihazlarda çalışabiliyorsa, hesaplama gölgelendiricilerini kullanmadan önce her zaman bu kontrolü yapın. OpenGL ve OpenGL ES desteği API sürümüne ve sürücüye bağlıdır. Vulkan ve MoltenVK aracılığıyla Metal, 1.0 sürümünden itibaren hesaplama gölgelendiricilerini destekler. Vulkan'ın varsayılan grafik arka ucu olmadığı platformlarda Vulkan'ı seçmek için bir [uygulama bildirimi](/manuals/app-manifest) kullanın.

--- a/docs/tr/manuals/debugging-game-and-system-logs.md
+++ b/docs/tr/manuals/debugging-game-and-system-logs.md
@@ -1,0 +1,111 @@
+---
+title: Hata ayıklama - oyun ve sistem günlükleri
+brief: Bu kılavuz, oyun ve sistem günlüklerinin nasıl okunacağını açıklar.
+---
+
+# Oyun ve sistem günlüğü
+
+Oyun günlüğü (game log), motordan, yerel kod eklentilerinden (native extension) ve oyun mantığınızdan gelen tüm çıktıları gösterir. [print()](/ref/stable/base/#print:...) ve [pprint()](/ref/stable/builtins/?q=pprint#pprint:v) komutlarını betiklerinizden ve Lua modüllerinizden oyun günlüğünde bilgi göstermek için kullanabilirsiniz. Yerel kod eklentilerinden oyun günlüğüne yazmak için [`dmLog` ad alanındaki](/ref/stable/dmLog/) işlevleri kullanabilirsiniz. Oyun günlüğü düzenleyiciden, terminal penceresinden, platforma özgü araçlar kullanılarak veya bir günlük dosyasından okunabilir.
+
+Sistem günlükleri (system log) işletim sistemi tarafından oluşturulur ve bir sorunun kaynağını saptamanıza yardımcı olabilecek ek bilgiler sağlayabilir. Sistem günlükleri, çökmeler için yığın izleri (stack trace) ve bellek yetersizliği uyarıları içerebilir.
+
+::: important
+Konsola/ekrana günlük çıktısı yalnızca Debug derlemelerinde bilgi gösterir. Release derlemelerinde konsol günlüğü boştur, ancak "Write Log File" proje ayarını "Always" olarak ayarlayarak Release derlemelerinde dosyaya günlük kaydetmeyi etkinleştirebilirsiniz. Ayrıntılar için aşağıya bakın.
+:::
+
+## Oyun günlüğünü düzenleyiciden okuma
+
+Oyununuzu düzenleyiciden yerel olarak veya [mobil geliştirme uygulamasına](/manuals/dev-app) bağlı olarak çalıştırdığınızda tüm çıktılar düzenleyicinin konsol bölmesinde gösterilir:
+
+![Düzenleyici 2](images/editor/editor2_overview.png)
+
+## Oyun günlüğünü terminalden okuma
+
+Bir Defold oyununu terminalden çalıştırdığınızda günlük, terminal penceresinde gösterilir. Windows ve Linux'ta oyunu başlatmak için terminale yürütülebilir dosyanın adını yazın. macOS'te motoru .app dosyasının içinden başlatmanız gerekir:
+
+```
+$ > ./mygame.app/Contents/MacOS/mygame
+```
+
+## Oyun ve sistem günlüklerini platforma özgü araçlarla okuma
+
+### HTML5
+
+Günlükler, çoğu tarayıcının sunduğu geliştirici araçları kullanılarak okunabilir.
+
+* [Chrome](https://developers.google.com/web/tools/chrome-devtools/console) - Menu > More Tools > Developer Tools
+* [Firefox](https://developer.mozilla.org/en-US/docs/Tools/Browser_Console) - Tools > Web Developer > Web Console
+* [Edge](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide/console)
+* [Safari](https://support.apple.com/guide/safari-developer/log-messages-with-the-console-dev4e7dedc90/mac) - Develop > Show JavaScript Console
+
+### Android
+
+Oyun ve sistem günlüğünü görüntülemek için Android Debug Bridge (ADB) aracını kullanabilirsiniz.
+
+:[Android ADB](../shared/android-adb.md)
+
+Kurulum ve yapılandırma tamamlandıktan sonra cihazınızı USB üzerinden bağlayın, bir terminal açın ve şu komutları çalıştırın:
+
+```txt
+$ cd <path_to_android_sdk>/platform-tools/
+$ adb logcat
+```
+
+Cihaz, oyunun yazdırdığı bilgilerle birlikte tüm çıktıları geçerli terminale aktarır.
+
+Yalnızca Defold uygulamasının çıktılarını görmek istiyorsanız şu komutu kullanın:
+
+```txt
+$ cd <path_to_android_sdk>/platform-tools/
+$ adb logcat -s defold
+--------- beginning of /dev/log/system
+--------- beginning of /dev/log/main
+I/defold  ( 6210): INFO:ENGINE: Defold Engine 1.2.50 (8d1b912)
+I/defold  ( 6210): INFO:ENGINE: Loading data from:
+I/defold  ( 6210): INFO:ENGINE: Initialized sound device 'default'
+I/defold  ( 6210):
+D/defold  ( 6210): DEBUG:SCRIPT: Hello there, log!
+...
+```
+
+### iOS
+
+iOS'te oyun ve sistem günlüklerini okumak için birden fazla seçeneğiniz vardır:
+
+1. Oyun ve sistem günlüğünü okumak için [Console aracını](https://support.apple.com/guide/console/welcome/mac) kullanabilirsiniz.
+2. Cihazda çalışan bir oyuna bağlanmak için LLDB hata ayıklayıcısını kullanabilirsiniz. Bir oyunda hata ayıklamak için oyunun, hata ayıklamak istediğiniz cihazı içeren bir "Apple Developer Provisioning Profile" ile imzalanmış olması gerekir. Düzenleyiciden oyunun dağıtım paketini oluşturun ve paketleme iletişim kutusunda sağlama profilini (provisioning profile) belirtin (iOS için paketleme yalnızca macOS'te kullanılabilir).
+
+Oyunu başlatmak ve hata ayıklayıcıyı bağlamak için [ios-deploy](https://github.com/phonegap/ios-deploy) adlı bir araca ihtiyacınız vardır. Terminalde aşağıdaki komutu çalıştırarak oyununuzu kurun ve hata ayıklayın:
+
+```txt
+$ ios-deploy --debug --bundle <path_to_game.app> # NOTE: not the .ipa file
+```
+
+Bu işlem uygulamayı cihazınıza kurar, başlatır ve ona otomatik olarak bir LLDB hata ayıklayıcısı bağlar. LLDB'yi ilk kez kullanıyorsanız [LLDB'ye başlangıç](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/gdb_to_lldb_transition_guide/document/lldb-basics.html) yazısını okuyun.
+
+
+## Oyun günlüğünü günlük dosyasından okuma
+
+Dosyaya günlük kaydetmeyi denetlemek için *game.project* dosyasındaki "Write Log File" proje ayarını kullanın:
+
+- "Never": Günlük dosyası yazılmaz.
+- "Debug": Yalnızca Debug derlemeleri için günlük dosyası yazılır.
+- "Always": Hem Debug hem de Release derlemeleri için günlük dosyası yazılır.
+
+Etkinleştirildiğinde oyunun tüm çıktıları diskte "`log.txt`" adlı bir dosyaya yazılır. Oyunu cihazda çalıştırıyorsanız dosyayı şu şekilde çıkarabilirsiniz:
+
+iOS
+: Cihazınızı macOS ve Xcode kurulu bir bilgisayara bağlayın.
+
+  Xcode'u açın ve <kbd>Window ▸ Devices and Simulators</kbd> seçeneğine gidin.
+
+  Listeden cihazınızı, ardından *Installed Apps* listesinden ilgili uygulamayı seçin.
+
+  Listenin altındaki dişli simgesine tıklayın ve <kbd>Download Container...</kbd> seçeneğini seçin.
+
+  ![konteyneri indirme](images/debugging/download_container.png)
+
+  Konteyner çıkarıldıktan sonra *Finder* içinde gösterilir. Konteynere sağ tıklayın ve <kbd>Show Package Content</kbd> seçeneğini seçin. "`log.txt`" dosyasını bulun; bu dosyanın "`AppData/Documents/`" içinde bulunması beklenir.
+
+Android(
+: "`log.txt`" dosyasının çıkarılabilmesi, işletim sistemi sürümüne ve üreticiye bağlıdır. İşte kısa ve basit bir [adım adım kılavuz](https://stackoverflow.com/a/48077004/129360).

--- a/docs/tr/manuals/debugging-game-logic.md
+++ b/docs/tr/manuals/debugging-game-logic.md
@@ -1,0 +1,164 @@
+---
+title: Defold'da hata ayıklama
+brief: Bu kılavuz, Defold'da bulunan hata ayıklama olanaklarını açıklar.
+---
+
+# Oyun mantığında hata ayıklama
+
+Defold, inceleme olanağı sunan tümleşik bir Lua hata ayıklayıcısı (debugger) içerir. Yerleşik [profil çıkarma (profiling) araçlarıyla](/manuals/profiling) birlikte, oyun mantığınızdaki hataların nedenini bulmanıza veya performans sorunlarını analiz etmenize yardımcı olabilecek güçlü bir araçtır.
+
+## Yazdırarak ve görsel olarak hata ayıklama
+
+Defold'da oyununuzda hata ayıklamanın en basit yolu, [yazdırarak hata ayıklamayı](http://en.wikipedia.org/wiki/Debugging#Techniques) kullanmaktır. Değişkenleri izlemek veya yürütme akışını göstermek için `print()` ya da [`pprint()`](/ref/builtins#pprint) ifadelerini kullanın. Betiği (script) olmayan bir oyun nesnesi (game object) tuhaf davranıyorsa ona yalnızca hata ayıklama amacı taşıyan bir betik ekleyebilirsiniz. Yazdırma işlevlerinden herhangi birini kullanmak, düzenleyicideki *Console* görünümüne ve [oyun günlüğüne](/manuals/debugging-game-and-system-logs) çıktı yazar.
+
+Motor, yazdırmanın yanı sıra ekrana hata ayıklama metni ve düz çizgiler de çizebilir. Bunun için `@render` soketine (socket) iletiler (message) gönderilir:
+
+```lua
+-- Draw value of "my_val" with debug text on the screen
+msg.post("@render:", "draw_text", { text = "My value: " .. my_val, position = vmath.vector3(200, 200, 0) })
+
+-- Draw colored text on the screen
+local color_green = vmath.vector4(0, 1, 0, 1)
+msg.post("@render:", "draw_debug_text", { text = "Custom color", position = vmath.vector3(200, 180, 0), color = color_green })
+
+-- Draw debug line between player and enemy on the screen
+local start_p = go.get_position("player")
+local end_p = go.get_position("enemy")
+local color_red = vmath.vector4(1, 0, 0, 1)
+msg.post("@render:", "draw_line", { start_point = start_p, end_point = end_p, color = color_red })
+```
+
+Görsel hata ayıklama iletileri, görüntü oluşturan işleme (rendering) hattına veri ekler ve bu veriler normal işleme hattının bir parçası olarak çizilir.
+
+* `"draw_line"`, işleme betiğindeki `render.draw_debug3d()` işleviyle işlenen veriler ekler.
+* `"draw_text"`, `/builtins/fonts/debug/always_on_top_font.material` materyalini kullanan `/builtins/fonts/debug/always_on_top.font` yazı tipiyle işlenir.
+* `"draw_debug_text"`, `"draw_text"` ile aynıdır, ancak özel bir renkte işlenir.
+
+Bu verileri muhtemelen her karede güncellemek isteyeceğinizi unutmayın; bu nedenle iletileri `update()` işlevinde göndermek iyi bir fikirdir.
+
+## Hata ayıklayıcıyı çalıştırma
+
+Hata ayıklayıcıyı çalıştırmak için <kbd>Debug ▸ Start/Attach</kbd> seçeneğini seçin. Bu seçenek, oyunu hata ayıklayıcı bağlı olarak başlatır veya hata ayıklayıcıyı zaten çalışan bir oyuna bağlar.
+
+![genel bakış](images/debugging/overview.png)
+
+Hata ayıklayıcı bağlanır bağlanmaz konsoldaki hata ayıklayıcı kontrol düğmeleri veya <kbd>Debug</kbd> menüsü aracılığıyla oyunun yürütülmesini kontrol edebilirsiniz:
+
+Break
+: ![duraklatma](images/debugging/pause.svg){width=60px .left}
+  Oyunun yürütülmesini hemen kesin. Oyun, o anda bulunduğu noktada duraklar. Artık oyunun durumunu inceleyebilir, oyunu adım adım ilerletebilir veya bir sonraki kesme noktasına (breakpoint) kadar çalıştırmaya devam edebilirsiniz. Geçerli yürütme noktası kod düzenleyicisinde işaretlenir:
+
+  ![betik](images/debugging/script.png)
+
+Continue
+: ![oynatma](images/debugging/play.svg){width=60px .left}
+  Oyunu çalıştırmaya devam edin. Oyun kodu, duraklatma düğmesine basana veya yürütme ayarladığınız bir kesme noktasına ulaşana kadar çalışmaya devam eder. Yürütme, ayarlanmış bir kesme noktasında duraklarsa yürütme noktası kod düzenleyicisinde kesme noktası işaretinin üzerinde gösterilir:
+
+  ![kesme](images/debugging/break.png)
+
+Stop
+: ![durdurma](images/debugging/stop.svg){width=60px .left}
+  Hata ayıklayıcıyı durdurun. Bu düğmeye basmak, hata ayıklayıcıyı hemen durdurur, oyunla bağlantısını keser ve çalışan oyunu sonlandırır.
+
+Step Over
+: ![çağrıyı tamamlayıp ilerleme](images/debugging/step_over.svg){width=60px .left}
+  Programın yürütülmesini bir adım ilerletin. Yürütme başka bir Lua işlevinin çalıştırılmasını içeriyorsa yürütme _işlevin içine ilerlemez_; çalışmaya devam eder ve işlev çağrısının altındaki bir sonraki satırda durur. Bu örnekte kullanıcı "step over" düğmesine basarsa hata ayıklayıcı kodu yürütür ve `nextspawn()` işlevinin çağrıldığı satırın altındaki `end` ifadesinde durur:
+
+  ![adım](images/debugging/step.png)
+
+::: sidenote
+Bir Lua kodu satırı tek bir ifadeye karşılık gelmez. Hata ayıklayıcıda adımlama, her seferinde bir ifade ilerler; bu nedenle şu anda bir sonraki satıra geçmek için adım düğmesine birden fazla kez basmanız gerekebilir.
+:::
+
+Step Into
+: ![işlevin içine ilerleme](images/debugging/step_in.svg){width=60px .left}
+  Programın yürütülmesini bir adım ilerletin. Yürütme başka bir Lua işlevinin çalıştırılmasını içeriyorsa yürütme _işlevin içine ilerler_. İşlevin çağrılması, çağrı yığınına (call stack) bir kayıt ekler. Giriş noktasını ve o kapanıştaki (closure) tüm değişkenlerin içeriğini görmek için çağrı yığını listesindeki her kayda tıklayabilirsiniz. Burada kullanıcı `nextspawn()` işlevinin içine ilerlemiştir:
+
+  ![işlevin içine ilerleme](images/debugging/step_into.png)
+
+Step Out
+: ![geçerli işlevden çıkana kadar ilerleme](images/debugging/step_out.svg){width=60px .left}
+  Geçerli işlevden dönene kadar yürütmeye devam edin. Yürütmeyi bir işlevin içine ilerlettiyseniz "step out" düğmesine basmak, işlev dönene kadar yürütmeyi sürdürür.
+
+Kesme noktalarını ayarlama ve temizleme
+: Lua kodunuzda istediğiniz sayıda kesme noktası ayarlayabilirsiniz. Oyun, hata ayıklayıcı bağlı olarak çalışırken karşılaştığı bir sonraki kesme noktasında yürütmeyi duraklatır ve sizden yeni bir işlem bekler.
+
+  ![kesme noktası ekleme](images/debugging/add_breakpoint.png)
+
+  Bir kesme noktası ayarlamak veya temizlemek için kod düzenleyicisinde satır numaralarının hemen sağındaki sütuna tıklayın. Menüden <kbd>Edit ▸ Toggle Breakpoint</kbd> seçeneğini de seçebilirsiniz.
+
+Kesme noktalarını devre dışı bırakma ve etkinleştirme
+: Kesme noktaları, kaldırılmadan geçici olarak devre dışı bırakılabilir. Devre dışı bırakıldıklarında yürütme sırasında yok sayılırlar, ancak istendiği zaman yeniden etkinleştirilebilirler. Kod düzenleyicisinin kenar boşluğundaki kesme noktasına sağ tıklayın, ardından `Enabled` onay kutusunun durumunu değiştirin. Devre dışı bırakılan kesme noktaları, etkin olmadıklarını göstermek için içleri boş olarak görünür.
+
+  ![kesme noktasını devre dışı bırakma](images/debugging/disable_breakpoint.png)
+
+Koşullu kesme noktalarını ayarlama
+: Kesme noktanıza, tetiklenmesi için doğru olarak değerlendirilmesi gereken bir koşul ekleyebilirsiniz. Koşul, kod yürütülürken o satırda kullanılabilen yerel değişkenlere erişebilir.
+
+  ![kesme noktasını düzenleme](images/debugging/edit_breakpoint.png)
+
+  Kesme noktası koşulunu düzenlemek için kod düzenleyicisinde satır numaralarının hemen sağındaki sütuna sağ tıklayın veya menüden <kbd>Edit ▸ Edit Breakpoint</kbd> seçeneğini seçin.
+
+Lua ifadelerini değerlendirme
+: Hata ayıklayıcı bağlıyken ve oyun bir kesme noktasında duraklatılmışken geçerli bağlamı içeren bir Lua çalışma zamanı ortamı kullanılabilir. Değerlendirmek için konsolun alt kısmına Lua ifadeleri yazın ve <kbd>Enter</kbd> tuşuna basın:
+
+  ![konsol](images/debugging/console.png)
+
+  Şu anda değerlendirici aracılığıyla değişkenleri değiştirmek mümkün değildir.
+
+Hata ayıklayıcının bağlantısını kesme
+: Hata ayıklayıcının oyunla bağlantısını kesmek için <kbd>Debug ▸ Detach Debugger</kbd> seçeneğini seçin. Oyun hemen çalışmaya devam eder.
+
+## Breakpoints sekmesi
+
+  ![Breakpoints sekmesi](images/debugging/breakpoints_tab.png)
+
+  Farklı betiklerde birden çok kesme noktasıyla çalışırken Breakpoints sekmesi, tüm kesme noktalarınızı tek bir yerden yönetebileceğiniz merkezi bir görünüm sunar.
+
+##### Tek bir kesme noktasının kontrolleri
+
+  Tek bir kesme noktasıyla çalışmak için:
+  - Kesme noktasını kaldırmak için kırmızı çöp kutusu simgesine tıklayın
+  - Code View içinde ilgili satıra gitmek için satıra (koşul alanının dışına) çift tıklayın
+  - Koşullu kesme noktalarını düzenlemek için koşul hücresine çift tıklayın veya kalem simgesine tıklayın
+  - Koşulu temizlemek için imleci koşul hücresinin üzerine getirdiğinizde görünen X temizleme düğmesine tıklayın
+
+##### Toplu işlemler
+
+  Ctrl/Cmd+click veya Shift+click kullanarak birden çok kesme noktası seçin, ardından toplu işlemler yapmak için sağ tıklayın. Birden fazla kesme noktasının koşullarını aynı anda düzenleyebilir, etkinlik durumlarını değiştirebilir veya noktaları tamamen kaldırabilirsiniz.
+
+  Araç çubuğundaki düğmeler, tüm kesme noktalarını aynı anda etkinleştirmenizi, devre dışı bırakmanızı veya durumlarını tersine çevirmenizi sağlar. Bu, oyununuzu durmadan çalıştırmak istediğinizde ancak kesme noktalarının konumlarını kaybetmek istemediğinizde yararlıdır. Hata ayıklama oturumunuz bittiğinde tümünü kaldırabilirsiniz.
+
+## Lua hata ayıklama kütüphanesi
+
+Lua, bazı durumlarda, özellikle Lua ortamınızın iç yapısını incelemeniz gerektiğinde yararlı olan bir hata ayıklama kütüphanesiyle gelir. Bu konuda daha fazla bilgiyi [Lua kılavuzundaki hata ayıklama kütüphanesi bölümünde](http://www.lua.org/pil/contents.html#23) bulabilirsiniz.
+
+## Hata ayıklama kontrol listesi
+
+Bir hatayla karşılaşırsanız veya oyununuz beklendiği gibi davranmazsa aşağıdaki hata ayıklama kontrol listesini izleyin:
+
+1. Konsol çıktısını kontrol edin ve çalışma zamanı hatası olmadığını doğrulayın.
+
+2. Kodun gerçekten çalıştığını doğrulamak için kodunuza `print` ifadeleri ekleyin.
+
+3. Kod çalışmıyorsa çalışması için düzenleyicide gereken ayarları doğru yaptığınızı kontrol edin. Betik doğru oyun nesnesine eklenmiş mi? Betiğiniz girdi odağını (input focus) almış mı? Girdi tetikleyicileri (input trigger) doğru mu? Gölgelendirici kodu materyale eklenmiş mi? Ve benzeri.
+
+4. Kodunuz değişkenlerin değerlerine bağlıysa (örneğin bir if ifadesinde) bu değerleri kullanıldıkları veya kontrol edildikleri yerde `print` ile yazdırın ya da hata ayıklayıcıyla inceleyin.
+
+Bazen bir hatayı bulmak zor ve zaman alıcı bir süreç olabilir. Bu süreç, kodunuzu parça parça gözden geçirmenizi, her şeyi kontrol etmenizi, hatalı kodun kapsamını daraltmanızı ve hata kaynaklarını elemenizi gerektirir. Bunu en iyi şekilde yapmak için "böl ve yönet" adlı yöntem kullanılır:
+
+1. Kodun hangi yarısının (veya daha küçük bir bölümünün) hatayı içerdiğini belirleyin.
+2. Ardından bu yarının hangi yarısının hatayı içerdiğini belirleyin.
+3. Hatayı bulana kadar ona neden olan kodun kapsamını daraltmaya devam edin.
+
+İyi avlar!
+
+## Fizik sorunlarında hata ayıklama {#debugging-problems-with-physics}
+
+Fizikle ilgili sorunlar yaşıyorsanız ve çarpışmalar beklendiği gibi çalışmıyorsa fizik hata ayıklamasını etkinleştirmeniz önerilir. *game.project* dosyasının *Physics* bölümündeki *Debug* onay kutusunu işaretleyin:
+
+![fizik hata ayıklama ayarı](images/debugging/physics_debug_setting.png)
+
+Bu onay kutusu etkinleştirildiğinde Defold, tüm çarpışma şekillerini ve çarpışmaların temas noktalarını çizer:
+
+![fizik hata ayıklama görselleştirmesi](images/debugging/physics_debug_visualisation.png)

--- a/docs/tr/manuals/debugging-native-code-android.md
+++ b/docs/tr/manuals/debugging-native-code-android.md
@@ -1,0 +1,86 @@
+---
+title: Android'de hata ayıklama
+brief: Bu kılavuz, Android Studio kullanarak bir derleme çıktısında nasıl hata ayıklanacağını açıklar.
+---
+
+# Android'de hata ayıklama
+
+Burada, Google'ın Android işletim sistemi için resmî tümleşik geliştirme ortamı (IDE) olan [Android Studio](https://developer.android.com/studio/) ile bir derleme çıktısında nasıl hata ayıklanacağını açıklıyoruz.
+
+
+## Android Studio
+
+* *game.project* dosyasındaki `android.debuggable` seçeneğini ayarlayarak dağıtım paketini (bundle) hazırlayın
+
+	![android.debuggable](images/extensions/debugging/android/game_project_debuggable.png)
+
+* Uygulamayı hata ayıklama modunda, seçtiğiniz bir klasöre paketleyin.
+
+	![Android için paketleme](images/extensions/debugging/android/bundle_android.png)
+
+* [Android Studio](https://developer.android.com/studio/) uygulamasını başlatın
+
+* `Profile or debug APK` seçeneğini seçin
+
+	![APK hata ayıklama](images/extensions/debugging/android/android_profile_or_debug.png)
+
+* Az önce oluşturduğunuz APK dağıtım paketini seçin
+
+	![APK seçimi](images/extensions/debugging/android/android_select_apk.png)
+
+* Ana `.so` dosyasını seçin ve hata ayıklama sembolleri içerdiğinden emin olun
+
+	![.so dosyası seçimi](images/extensions/debugging/android/android_missing_symbols.png)
+
+* İçermiyorsa sembolleri ayıklanmamış bir `.so` dosyası yükleyin. (Boyutu yaklaşık 20mb'dir)
+
+* Yol eşlemeleri (path mappings), yürütülebilir dosyanın derlendiği yerdeki (buluttaki) yolları yerel diskinizdeki gerçek bir klasöre yeniden eşlemenizi sağlar.
+
+* .so dosyasını seçin, ardından yerel diskinize bir eşleme ekleyin
+
+	![Yol eşlemesi 1](images/extensions/debugging/android/path_mappings_android.png)
+
+	![Yol eşlemesi 2](images/extensions/debugging/android/path_mappings_android2.png)
+
+* Motorun kaynak koduna erişiminiz varsa ona da bir yol eşlemesi ekleyin.
+
+* Şu anda hata ayıkladığınız sürüme geçtiğinizden emin olun
+
+	defold$ git checkout 1.2.148
+
+* `Apply changes` düğmesine basın
+
+* Artık projenizde eşlenen kaynak kodu görmeniz gerekir
+
+	![Kaynak kod eşlemeleri](images/extensions/debugging/android/source_mappings_android.png)
+
+* Bir kesme noktası (breakpoint) ekleyin
+
+	![Kesme noktası](images/extensions/debugging/android/breakpoint_android.png)
+
+* `Run` -> `Debug "Appname"` seçeneğine basın ve yürütmeyi durdurmak istediğiniz kodu çağırın
+
+	![Kesme noktası](images/extensions/debugging/android/callstack_variables_android.png)
+
+* Artık çağrı yığınında (call stack) adım adım ilerleyebilir ve değişkenleri inceleyebilirsiniz
+
+
+## Notlar
+
+### Yerel kod eklentisinin iş klasörü
+
+Şu anda yerel kod eklentisi (native extension) geliştirme iş akışı biraz zahmetlidir. Bunun nedeni, iş klasörünün adının
+her derlemede rastgele belirlenmesi ve yol eşlemesinin her derlemede geçersiz hale gelmesidir.
+
+Ancak tek bir hata ayıklama oturumu için sorunsuz çalışır.
+
+Yol eşlemeleri, Android Studio projesindeki `.iml` proje dosyasında saklanır.
+
+İş klasörünü yürütülebilir dosyadan öğrenmek mümkündür
+
+```sh
+$ arm-linux-androideabi-readelf --string-dump=.debug_str build/armv7-android/libdmengine.so | grep /job
+```
+
+İş klasörü, her seferinde rastgele bir sayıyla `job1298751322870374150` biçiminde adlandırılır.
+

--- a/docs/tr/manuals/debugging-native-code-ios.md
+++ b/docs/tr/manuals/debugging-native-code-ios.md
@@ -1,0 +1,154 @@
+---
+title: iOS/macOS üzerinde hata ayıklama
+brief: Bu kılavuz, Xcode kullanarak bir derleme çıktısında nasıl hata ayıklanacağını açıklar.
+---
+
+# iOS/macOS üzerinde hata ayıklama
+
+Burada, Apple'ın macOS ve iOS için geliştirmede tercih ettiği bütünleşik geliştirme ortamı (IDE) olan [Xcode](https://developer.apple.com/xcode/) kullanılarak bir derleme çıktısında hata ayıklamanın (debugging) nasıl yapıldığını açıklıyoruz.
+
+## Xcode
+
+* bob kullanarak, `--with-symbols` seçeneğiyle uygulamanın dağıtım paketini oluşturun ([daha fazla bilgi](/manuals/debugging-native-code/#symbolicate-a-callstack)):
+
+```sh
+$ cd myproject
+$ wget http://d.defold.com/archive/<sha1>/bob/bob.jar
+$ java -jar bob.jar --platform armv7-darwin build --with-symbols --variant debug --archive bundle -bo build/ios -mp <app>.mobileprovision --identity "iPhone Developer: Your Name (ID)"
+```
+
+* Uygulamayı `Xcode`, `iTunes` veya [ios-deploy](https://github.com/ios-control/ios-deploy) ile kurun
+
+```sh
+$ ios-deploy -b <AppName>.ipa
+```
+
+* `.dSYM` klasörünü, yani hata ayıklama sembollerini (debug symbols) edinin
+
+	* Uygulama yerel kod eklentileri (Native Extensions) kullanmıyorsa `.dSYM` dosyasını [d.defold.com](http://d.defold.com) adresinden indirebilirsiniz
+
+	* Yerel kod eklentisi kullanıyorsanız `.dSYM` klasörü, [bob.jar](https://www.defold.com/manuals/bob/) ile projeyi derlediğinizde oluşturulur. Yalnızca projeyi derlemek gerekir (arşivleme veya paketleme gerekmez):
+
+```sh
+$ cd myproject
+$ unzip .internal/cache/arm64-ios/build.zip
+$ mv dmengine.dSYM <AppName>.dSYM
+$ mv <AppName>.dSYM/Contents/Resources/DWARF/dmengine <AppName>.dSYM/Contents/Resources/DWARF/<AppName>
+```
+
+### Proje oluşturma
+
+Düzgün hata ayıklayabilmek için bir projemiz olması ve kaynak kodun eşlenmesi gerekir.
+Bu projeyi yalnızca hata ayıklamak için kullanıyoruz; derleme yapmak için kullanmıyoruz.
+
+* Yeni bir Xcode projesi oluşturun, `Game` şablonunu seçin
+
+	![Proje şablonu](images/extensions/debugging/ios/project_template.png)
+
+* Bir ad (örneğin `debug`) ve varsayılan ayarları seçin
+
+* Projenin kaydedileceği klasörü seçin
+
+* Kodunuzu uygulamaya ekleyin
+
+	![Dosya ekleme](images/extensions/debugging/ios/add_files.png)
+
+* "Copy items if needed" seçeneğinin işaretli olmadığından emin olun.
+
+	![Kaynak kod ekleme](images/extensions/debugging/ios/add_source.png)
+
+* Sonuç şöyle görünür
+
+	![Eklenen kaynak kod](images/extensions/debugging/ios/added_source.png)
+
+
+* `Build` adımını devre dışı bırakın
+
+	![Şema düzenleme](images/extensions/debugging/ios/edit_scheme.png)
+
+	![Derleme adımını devre dışı bırakma](images/extensions/debugging/ios/disable_build.png)
+
+* `Deployment target` sürümünü, artık cihazınızın iOS sürümünden daha yüksek olacak şekilde ayarlayın
+
+	![Dağıtıma alma sürümü](images/extensions/debugging/ios/deployment_version.png)
+
+* Hedef cihazı seçin
+
+	![Cihaz seçme](images/extensions/debugging/ios/select_device.png)
+
+
+### Hata ayıklayıcıyı başlatma
+
+Bir uygulamada hata ayıklamak için birkaç seçeneğiniz vardır
+
+1. `Debug` -> `Attach to process...` yolunu seçip uygulamayı buradan seçebilirsiniz
+
+2. Ya da `Attach to process by PID or Process name` seçeneğini seçebilirsiniz
+
+	![Cihaz seçme](images/extensions/debugging/ios/attach_to_process_name.png)
+
+3. Uygulamayı cihazda başlatın
+
+4. `Edit Scheme` içinde <AppName>.app klasörünü yürütülebilir dosya olarak ekleyin
+
+### Hata ayıklama sembolleri
+
+**lldb kullanabilmek için yürütme duraklatılmış olmalıdır**
+
+* `.dSYM` yolunu lldb'ye ekleyin
+
+```
+(lldb) add-dsym <PathTo.dSYM>
+```
+
+	![dSYM ekleme](images/extensions/debugging/ios/add_dsym.png)
+
+* `lldb` tarafından sembollerin başarıyla okunduğunu doğrulayın
+
+```
+(lldb) image list <AppName>
+```
+
+### Yol eşlemeleri
+
+* Motorun kaynak kodunu ekleyin (gereksinimlerinize göre değiştirin)
+
+```
+(lldb) settings set target.source-map /Users/builder/ci/builds/engine-ios-64-master/build /Users/mathiaswesterdahl/work/defold
+(lldb) settings append target.source-map /private/var/folders/m5/bcw7ykhd6vq9lwjzq1mkp8j00000gn/T/job4836347589046353012/upload/videoplayer/src /Users/mathiaswesterdahl/work/projects/extension-videoplayer-native/videoplayer/src
+```
+
+* İş klasörünü yürütülebilir dosyadan öğrenebilirsiniz. İş klasörü `job1298751322870374150` biçiminde adlandırılır ve her seferinde rastgele bir sayı kullanılır.
+
+```sh
+$ dsymutil -dump-debug-map <executable> 2>&1 >/dev/null | grep /job
+
+```
+
+* Kaynak eşlemelerini doğrulayın
+
+```
+(lldb) settings show target.source-map
+```
+
+Bir sembolün hangi kaynak dosyadan geldiğini şu komutla kontrol edebilirsiniz
+
+```
+(lldb) image lookup -va <SymbolName>
+```
+
+### Kesme noktaları
+
+* Proje görünümünde bir dosya açın ve bir kesme noktası (breakpoint) belirleyin
+
+	![Kesme noktası](images/extensions/debugging/ios/breakpoint.png)
+
+## Notlar
+
+### İkili dosyanın UUID değerini kontrol etme
+
+Hata ayıklayıcının `.dSYM` klasörünü kabul etmesi için UUID değerinin, hata ayıklanan yürütülebilir dosyanın UUID değeriyle eşleşmesi gerekir. UUID değerini şu şekilde kontrol edebilirsiniz:
+
+```sh
+$ dwarfdump -u <PathToBinary>
+```

--- a/docs/tr/manuals/debugging-native-code.md
+++ b/docs/tr/manuals/debugging-native-code.md
@@ -1,0 +1,161 @@
+---
+title: Defold'da yerel kodda hata ayıklama
+brief: Bu kılavuz, Defold'da yerel kodda nasıl hata ayıklanacağını açıklar.
+---
+
+# Yerel kodda hata ayıklama
+
+Defold kapsamlı biçimde test edilmiştir ve normal koşullarda çok nadiren çökmesi beklenir. Ancak özellikle oyununuz yerel kod eklentileri (native extensions) kullanıyorsa, hiçbir zaman çökmeyeceğini garanti etmek mümkün değildir. Çökmelerle veya beklediğiniz gibi davranmayan yerel kodla (native code) ilgili sorunlarla karşılaşırsanız başvurabileceğiniz birkaç farklı yöntem vardır:
+
+* Kodda adım adım ilerlemek için bir hata ayıklayıcı kullanın
+* Çıktı yazdırarak hata ayıklayın
+* Bir çökme günlüğünü inceleyin
+* Bir çağrı yığınına sembol çözümlemesi uygulayın
+
+
+## Hata ayıklayıcı kullanma
+
+En yaygın yöntem, kodu bir hata ayıklayıcı (`debugger`) aracılığıyla çalıştırmaktır. Kodda adım adım ilerlemenizi ve kesme noktaları (`breakpoints`) belirlemenizi sağlar; bir çökme yaşanırsa yürütmeyi durdurur.
+
+Her platform için çeşitli hata ayıklayıcılar vardır.
+
+* Visual studio - Windows
+* VSCode - Windows, macOS, Linux
+* Android Studio - Windows, macOS, Linux
+* Xcode - macOS
+* WinDBG - Windows
+* lldb / gdb - macOS, Linux, (Windows)
+* ios-deploy - macOS
+
+Her araç belirli platformlarda hata ayıklayabilir:
+
+* Visual studio - Windows + gdbserver destekleyen platformlar (ör. Linux/Android)
+* VSCode - Windows, macOS (lldb), Linux (lldb/gdb) + gdbserver destekleyen platformlar
+* Xcode -  macOS, iOS ([daha fazla bilgi](/manuals/debugging-native-code-ios))
+* Android Studio - Android ([daha fazla bilgi](/manuals/debugging-native-code-android))
+* WinDBG - Windows
+* lldb/gdb - macOS, Linux, (iOS)
+* ios-deploy - iOS (lldb aracılığıyla)
+
+
+## Çıktı yazdırarak hata ayıklama
+
+Yerel kodunuzda hata ayıklamanın en basit yolu, [çıktı yazdırarak hata ayıklama (print debugging)](http://en.wikipedia.org/wiki/Debugging#Techniques) yöntemini kullanmaktır. Değişkenleri izlemek veya yürütme akışını belirtmek için [`dmLog` ad alanındaki](/ref/stable/dmLog/) işlevleri kullanın. Günlük işlevlerinden herhangi biri kullanıldığında, düzenleyicideki *Console* görünümüne ve [oyun günlüğüne](/manuals/debugging-game-and-system-logs) çıktı yazdırılır.
+
+
+## Çökme günlüğünü inceleme
+
+Defold motoru, kurtarılamayan bir çökme yaşarsa bir `_crash` dosyası kaydeder. Çökme dosyası, çökmeyle ilgili bilgilerin yanı sıra sistemle ilgili bilgileri de içerir. [Oyun günlüğü çıktısı](/manuals/debugging-game-and-system-logs), çökme dosyasının konumunu belirtir (bu konum işletim sistemine, cihaza ve uygulamaya göre değişir).
+
+Bu dosyayı bir sonraki oturumda okumak için [crash modülünü](https://www.defold.com/ref/crash/) kullanabilirsiniz. Dosyayı okumanız, bilgileri toplamanız, konsola yazdırmanız ve çökme günlüklerinin toplanmasını destekleyen bir [analiz hizmetine](/tags/stars/analytics/) göndermeniz önerilir.
+
+::: important
+Windows'ta ayrıca bir `_crash.dmp` dosyası oluşturulur. Bu dosya, bir çökmeye yol açan hatayı ayıklarken yararlıdır.
+:::
+
+### Bir cihazdan çökme günlüğünü alma
+
+Bir mobil cihazda çökme yaşanırsa, çökme dosyasını kendi bilgisayarınıza indirip yerel olarak ayrıştırmayı seçebilirsiniz.
+
+#### Android
+
+Uygulamada [hata ayıklama etkinse](/manuals/project-settings/#android), [Android Debug Bridge (ADB) aracını](https://developer.android.com/studio/command-line/adb.html) ve `adb shell` komutunu kullanarak çökme günlüğünü alabilirsiniz:
+
+```
+$ adb shell "run-as com.defold.example sh -c 'cat /data/data/com.defold.example/files/_crash'" > ./_crash
+```
+
+#### iOS
+
+iTunes'ta bir uygulamanın kapsayıcısını (container) görüntüleyebilir/indirebilirsiniz.
+
+`Xcode -> Devices` penceresinde çökme günlüklerini de seçebilirsiniz
+
+
+## Çağrı yığınına sembol çözümlemesi uygulama {#symbolicate-a-callstack}
+
+Bir `_crash` dosyasından veya bir [günlük dosyasından](/manuals/debugging-game-and-system-logs) çağrı yığını (callstack) elde ederseniz, buna sembol çözümlemesi (symbolication) uygulayabilirsiniz. Bu işlem, çağrı yığınındaki her adresi bir dosya adına ve satır numarasına dönüştürür; böylece sorunun asıl nedenini bulmanıza yardımcı olur.
+
+Çağrı yığınını doğru motorla eşleştirmeniz önemlidir; aksi takdirde büyük olasılıkla yanlış yerlerde hata ayıklamaya çalışırsınız! [`--with-symbols`](https://www.defold.com/manuals/bob/) seçeneğini [bob](https://www.defold.com/manuals/bob/) ile paketleme yaparken kullanın veya düzenleyicideki paketleme iletişim kutusunda "Generate debug symbols" onay kutusunu işaretleyin:
+
+* iOS - `dmengine.dSYM.zip` klasörü, `build/arm64-ios` içinde bulunur ve iOS derlemelerinin hata ayıklama sembollerini içerir.
+* macOS - `dmengine.dSYM.zip` klasörü, `build/x86_64-macos` içinde bulunur ve macOS derlemelerinin hata ayıklama sembollerini içerir.
+* Android - `projecttitle.apk.symbols/lib/` dağıtım paketi çıktı klasörü, hedef mimarilerin hata ayıklama sembollerini içerir.
+* Linux - yürütülebilir dosya, hata ayıklama sembollerini içerir.
+* Windows - `dmengine.pdb` dosyası, `build/x86_64-win32` içinde bulunur ve Windows derlemelerinin hata ayıklama sembollerini içerir.
+* HTML5 - HTML5 dağıtım paketinin yanındaki `<project_name>_symbols` dizini, `<project_name>_wasm.js.symbols` dosyasını ve `wasm_pthread-web` mimarisi seçildiğinde `<project_name>_pthread_wasm.js.symbols` dosyasını içerir.
+
+::: important
+Oyununuzun herkese açık olarak yayımladığınız her sürümü için hata ayıklama sembollerini bir yerde saklamanız ve bu sembollerin hangi sürüme ait olduğunu bilmeniz çok önemlidir. Hata ayıklama sembolleri olmadan yerel kodda meydana gelen hiçbir çökmenin hatasını ayıklayamazsınız! Ayrıca motorun sembolleri çıkarılmamış (`unstripped`) bir sürümünü saklamanız önerilir. Böylece çağrı yığınının sembol çözümlemesi en iyi biçimde yapılabilir.
+:::
+
+
+### Sembolleri Google Play'e yükleme
+Google Play'de kaydedilen çökmelerde sembolleri çözümlenmiş çağrı yığınlarının gösterilmesi için [hata ayıklama sembollerini Google Play'e yükleyebilirsiniz](https://developer.android.com/studio/build/shrink-code#android_gradle_plugin_version_40_or_earlier_and_other_build_systems). `projecttitle.apk.symbols/lib/` dağıtım paketi çıktı klasörünün içeriğini zip arşivi olarak sıkıştırın. Bu klasör, `arm64-v8a`, `armeabi-v7a` ve `x86_64` gibi mimari adlarını taşıyan bir veya daha fazla alt klasör içerir.
+
+
+### Android çağrı yığınına sembol çözümlemesi uygulama
+
+1. Motoru derleme klasörünüzden alın
+
+```sh
+	$ ls <project>/build/<platform>/[lib]dmengine[.exe|.so]
+```
+
+2. Zip arşivini bir klasöre çıkarın:
+
+```sh
+	$ unzip dmengine.apk -d dmengine_1_2_105
+```
+
+3. Çağrı yığınındaki adresi bulun
+
+	Örneğin, sembolleri çözümlenmemiş çağrı yığınında şöyle görünebilir
+
+	`#00 pc 00257224 libmy_game_name.so`
+
+	Burada adres *`00257224`* değeridir
+
+4. Adresi çözümleyin
+
+```sh
+    $ arm-linux-androideabi-addr2line -C -f -e dmengine_1_2_105/lib/armeabi-v7a/libdmengine.so _address_
+```
+
+Not: [Android günlüklerinden](/manuals/debugging-game-and-system-logs) bir yığın izi (stack trace) elde ederseniz, [ndk-stack](https://developer.android.com/ndk/guides/ndk-stack.html) kullanarak buna sembol çözümlemesi uygulamanız mümkün olabilir
+
+### iOS çağrı yığınına sembol çözümlemesi uygulama
+
+1. Yerel kod eklentileri kullanıyorsanız, sunucu sizin için sembolleri (.dSYM) sağlayabilir (bob.jar aracına `--with-symbols` seçeneğini geçirin)
+
+```sh
+	$ unzip <project>/build/arm64-darwin/build.zip
+	# it will produce a Contents/Resources/DWARF/dmengine
+```
+
+2. Yerel kod eklentileri kullanmıyorsanız, standart motorun sembollerini indirin:
+
+```sh
+	$ wget http://d.defold.com/archive/<sha1>/engine/arm64-darwin/dmengine.dSYM
+```
+
+3. Yükleme adresini kullanarak sembol çözümlemesi uygulayın
+
+	Bilinmeyen bir nedenle, yalnızca çağrı yığınındaki adresi girmek işe yaramaz (yani yükleme adresi 0x0 olduğunda)
+
+```sh
+		$ atos -arch arm64 -o Contents/Resources/DWARF/dmengine 0x1492c4
+```
+
+	# Yükleme adresini doğrudan belirtmek de işe yaramaz
+
+```sh
+		$ atos -arch arm64 -o MyApp.dSYM/Contents/Resources/DWARF/MyApp -l0x100000000 0x1492c4
+```
+
+	Adrese yükleme adresini eklemek işe yarar:
+
+```sh
+		$ atos -arch arm64 -o MyApp.dSYM/Contents/Resources/DWARF/MyApp 0x1001492c4
+		dmCrash::OnCrash(int) (in MyApp) (backtrace_execinfo.cpp:27)
+```

--- a/docs/tr/manuals/debugging.md
+++ b/docs/tr/manuals/debugging.md
@@ -1,0 +1,11 @@
+---
+title: Defold'da hata ayıklama
+brief: Bu kılavuz, Defold'da bulunan hata ayıklama olanaklarını açıklar.
+---
+
+# Hata ayıklama
+
+Defold, inceleme özelliğine sahip bütünleşik bir Lua hata ayıklayıcısı (debugger) içerir. Yerleşik [profil çıkarma (profiling) araçlarıyla](/manuals/profiling) birlikte, oyun mantığınızdaki yazılım hatalarının nedenini bulmanıza veya performans sorunlarını analiz etmenize yardımcı olabilecek güçlü bir araçtır. Defold, motorun kendisinin çöktüğü nadir durumlar için de çökme günlükleri sağlar.
+
+* [Oyun mantığınızda hata ayıklama](/manuals/debugging-game-logic) hakkında daha fazla bilgi edinin.
+* [Yerel kodda (native code) hata ayıklama](/manuals/debugging-native-code) hakkında daha fazla bilgi edinin.

--- a/docs/tr/manuals/design.md
+++ b/docs/tr/manuals/design.md
@@ -1,0 +1,24 @@
+---
+title: Defold'un tasarımı
+brief: Defold'un tasarımının ardındaki felsefe
+---
+
+# Defold'un tasarımı
+
+Defold şu hedeflerle oluşturuldu:
+
+- Oyun ekipleri için eksiksiz, profesyonel ve kullanıma hazır bir üretim platformu olmak.
+- Oyun geliştirmede sık karşılaşılan mimari ve iş akışı sorunlarına açık çözümler sunarak sade ve anlaşılır olmak.
+- Yinelemeli oyun geliştirme için ideal, son derece hızlı bir geliştirme platformu olmak.
+- Çalışma sırasında yüksek performans sunmak.
+- Gerçek anlamda birden çok platformu desteklemek.
+
+Düzenleyici ve motorun tasarımı bu hedeflere ulaşmak için özenle hazırlanmıştır. Tasarım kararlarımızdan bazıları, başka platformlarda deneyiminiz varsa alışık olabileceğiniz yaklaşımlardan farklıdır. Örneğin:
+
+- Kaynak ağacının (resource tree) ve tüm adlandırmaların statik olarak bildirilmesini zorunlu tutuyoruz. Bu, başlangıçta biraz çaba göstermenizi gerektirir, ancak uzun vadede geliştirme sürecine büyük katkı sağlar.
+- Basit ve kapsüllenmiş birimler arasında ileti aktarımını (message passing) teşvik ediyoruz.
+- Nesne yönelimli kalıtım yoktur.
+- API'lerimiz eşzamansızdır.
+- Görüntü oluşturmayı sağlayan işleme hattı (rendering pipeline) kodla yönetilir ve tamamen özelleştirilebilir.
+- Tüm kaynak dosyalarımız basit düz metin biçimlerindedir; hem Git birleştirmeleri hem de harici araçlarla içe aktarma ve işleme için en uygun şekilde yapılandırılmıştır.
+- Kaynaklar değiştirilebilir ve oyun çalışırken yeniden yüklenebilir (hot reload); bu da son derece hızlı yineleme ve denemeler yapmayı sağlar.

--- a/docs/tr/manuals/dev-app.md
+++ b/docs/tr/manuals/dev-app.md
@@ -1,0 +1,67 @@
+---
+title: Geliştirme uygulamasını cihazda çalıştırma
+brief: Bu kılavuz, cihazda yinelemeli geliştirme yapmak için geliştirme uygulamasının cihazınıza nasıl kurulacağını açıklar.
+---
+
+# Mobil geliştirme uygulaması
+
+Geliştirme uygulamasına (development app) Wi-Fi üzerinden içerik gönderebilirsiniz. Değişikliklerinizi test etmek istediğiniz her seferde paketleme ve kurulum yapmanız gerekmediği için bu, geliştirme döngülerinin süresini büyük ölçüde kısaltır. Geliştirme uygulamasını cihazlarınıza kurun, uygulamayı başlatın ve ardından düzenleyicide cihazı derleme hedefi olarak seçin.
+
+## Geliştirme uygulamasını kurma
+
+Debug modunda paketlenen herhangi bir iOS veya Android uygulaması, geliştirme uygulaması olarak kullanılabilir. Aslında önerilen çözüm budur; çünkü geliştirme uygulaması doğru proje ayarlarına sahip olur ve üzerinde çalıştığınız projeyle aynı [yerel kod eklentilerini (native extensions)](/manuals/extensions/) kullanır. 
+
+Projenizin Debug çeşidini hiçbir içerik olmadan paketleyebilirsiniz. Uygulamanızın yerel kod eklentileri içeren ve bu kılavuzda anlatılan yinelemeli geliştirmeye uygun bir sürümünü oluşturmak için bu seçeneği kullanın.
+
+![İçeriksiz dağıtım paketi](images/dev-app/contentless-bundle.png)
+
+### iOS üzerinde kurma
+
+iOS için dağıtım paketi oluşturmak üzere [iOS kılavuzundaki yönergeleri](/manuals/ios/#creating-an-ios-application-bundle) izleyin. Derleme çeşidi olarak Debug seçtiğinizden emin olun!
+
+### Android üzerinde kurma
+
+Android için dağıtım paketi oluşturmak üzere [Android kılavuzundaki yönergeleri](https://defold.com/manuals/android/#creating-an-android-application-bundle) izleyin.
+
+## Oyununuzu başlatma
+
+Oyununuzu cihazınızda başlatmak için geliştirme uygulaması ile düzenleyicinin aynı Wi-Fi ağı üzerinden veya USB kullanarak birbirine bağlanabilmesi gerekir (aşağıya bakın).
+
+1. Düzenleyicinin açık ve çalışır durumda olduğundan emin olun.
+2. Cihazda geliştirme uygulamasını başlatın.
+3. Düzenleyicide <kbd>Project ▸ Targets</kbd> altında cihazınızı seçin.
+4. Oyunu çalıştırmak için <kbd>Project ▸ Build</kbd> seçeneğini seçin. Oyun içeriği ağ üzerinden cihaza aktarıldığı için oyunun başlaması biraz zaman alabilir.
+5. Oyun çalışırken her zamanki gibi [çalışma sırasında yeniden yükleme (hot reload)](/manuals/hot-reload/) özelliğini kullanabilirsiniz.
+
+### Windows'ta USB kullanarak bir iOS cihazına bağlanma
+
+Windows'ta, bir iOS cihazında çalışan geliştirme uygulamasına USB üzerinden bağlanırken önce [iTunes'u kurmanız](https://www.apple.com/lae/itunes/download/) gerekir. iTunes kurulduktan sonra iOS cihazınızda Settings menüsünden [Personal Hotspot seçeneğini etkinleştirmeniz](https://support.apple.com/en-us/HT204023) de gerekir. "Trust This Computer?" yazan bir uyarı görürseniz Trust seçeneğine dokunun. Geliştirme uygulaması çalışırken cihazın artık <kbd>Project ▸ Targets</kbd> altında görünmesi gerekir.
+
+### Linux'ta USB kullanarak bir iOS cihazına bağlanma
+
+Linux'ta USB kullanarak bağlandığınızda cihazınızdaki Settings menüsünden Personal Hotspot seçeneğini etkinleştirmeniz gerekir. "Trust This Computer?" yazan bir uyarı görürseniz Trust seçeneğine dokunun. Geliştirme uygulaması çalışırken cihazın artık <kbd>Project ▸ Targets</kbd> altında görünmesi gerekir.
+
+### macOS'ta USB kullanarak bir iOS cihazına bağlanma
+
+Yeni iOS sürümlerinde, macOS'ta USB kullanarak bağlandığınızda cihaz, kendisiyle bilgisayar arasında otomatik olarak yeni bir Ethernet arayüzü açar. Geliştirme uygulaması çalışırken cihazın <kbd>Project ▸ Targets</kbd> altında görünmesi gerekir.
+
+Eski iOS sürümlerinde, macOS'ta USB kullanarak bağlandığınızda cihazınızdaki Settings menüsünden Personal Hotspot seçeneğini etkinleştirmeniz gerekir. "Trust This Computer?" yazan bir uyarı görürseniz Trust seçeneğine dokunun. Geliştirme uygulaması çalışırken cihazın artık <kbd>Project ▸ Targets</kbd> altında görünmesi gerekir.
+
+### macOS'ta USB kullanarak bir Android cihazına bağlanma
+
+macOS'ta, cihaz USB Tethering Mode durumundayken Android cihazında çalışan geliştirme uygulamasına USB üzerinden bağlanabilirsiniz. macOS'ta [HoRNDIS](https://joshuawise.com/horndis#available_versions) gibi üçüncü taraf bir sürücü kurmanız gerekir. HoRNDIS kurulduktan sonra Security & Privacy ayarları üzerinden çalışmasına izin vermeniz de gerekir. USB Tethering etkinleştirildiğinde, geliştirme uygulaması çalışırken cihaz <kbd>Project ▸ Targets</kbd> altında görünür.
+
+### Windows veya Linux'ta USB kullanarak bir Android cihazına bağlanma
+
+Windows ve Linux'ta, cihaz USB Tethering Mode durumundayken Android cihazında çalışan geliştirme uygulamasına USB üzerinden bağlanabilirsiniz. USB Tethering etkinleştirildiğinde, geliştirme uygulaması çalışırken cihaz <kbd>Project ▸ Targets</kbd> altında görünür.
+
+## Sorun giderme
+
+Uygulama indirilemiyor
+: Cihazınızın UDID değerinin, uygulamayı imzalamak için kullanılan mobil sağlama profilinde bulunduğundan emin olun.
+
+Cihazınız Targets menüsünde görünmüyor
+: Cihazınızın bilgisayarınızla aynı Wi-Fi ağına bağlı olduğundan emin olun. Geliştirme uygulamasının Debug modunda derlendiğinden emin olun.
+
+Oyun başlamıyor ve sürümlerin uyuşmadığını belirten bir ileti gösteriliyor
+: Bu durum, düzenleyiciyi en son sürüme yükselttiğinizde ortaya çıkar. Yeni bir sürüm derleyip kurmanız gerekir.

--- a/docs/tr/manuals/editor-http-api.md
+++ b/docs/tr/manuals/editor-http-api.md
@@ -1,0 +1,508 @@
+---
+title: Defold düzenleyicisini HTTP ile otomatikleştirme
+brief: Bu kılavuz, harici araçların Defold düzenleyicisinde açık olan bir projenin yerel HTTP API'sini nasıl keşfedip kullanabileceğini açıklar.
+---
+
+# Defold düzenleyicisini otomatikleştirme
+
+Defold düzenleyicisi otomatik işlemler için özel bir sunucu açar. HTTP API'si açık projeyi denetler. Bunu düzenleyici komutları, proje derleme işlemleri, proje kaynakları (resource), önizlemeler, tercihler, konsol çıktısı, belge arama veya düzenleyici betiği (editor script) tümleştirmeleri için kullanın. Çalışan oyunu incelemek veya denetlemek için ise [motor hizmetini ya da bir çalışma zamanı otomasyon API'sini](/manuals/engine-service) kullanın.
+
+::: important
+Düzenleyici HTTP API'si deneyseldir ve Defold sürümleri arasında değişebilir. Kullanılabilir işlemler ve şemalar için çalışan düzenleyicinin ürettiği `/openapi.json` belgesi esas alınır.
+:::
+
+## Düzenleyiciyi harici bir araçtan başlatma
+
+Harici bir araç, düzenleyicinin yürütülebilir dosyasına ve projenin `game.project` dosyasının mutlak yoluna ihtiyaç duyar.
+
+Kurulu Defold sürümlerinin konumları, [Düzenleyici kılavuzunda](/manuals/editor/#editor-installation-metadata) açıklandığı gibi `installations.json` aracılığıyla bulunabilir. Bu dosyanın `launcherPath` alanı, başlatılacak yürütülebilir dosyayı içerir. Projeyi doğrudan açmak için `game.project` yolunu ilk konumsal bağımsız değişken olarak geçirin.
+
+İsteğe bağlı `--port` veya `-p` bağımsız değişkeni, düzenleyici sunucusunun bağlantı noktasını seçer. Bu bağımsız değişkeni belirtmezseniz Defold kullanılabilir bir bağlantı noktası seçer; birden fazla projenin açık olabileceği durumlarda genellikle bu tercih edilir.
+
+```sh
+# Linux
+/path/to/Defold/Defold --port 8181 /absolute/path/to/project/game.project
+```
+
+```sh
+# macOS
+/path/to/Defold.app/Contents/MacOS/Defold --port 8181 /absolute/path/to/project/game.project
+```
+
+```powershell
+# Windows
+C:\path\to\Defold\Defold.exe --port 8181 C:\absolute\path\to\project\game.project
+```
+
+Düzenleyici, grafik arayüzü olan bir masaüstü uygulamasıdır. Ekrana erişimi olan etkileşimli bir kullanıcı oturumunda başlatın. Grafik arayüzü olmadan çalışan sürekli tümleştirme (CI) ortamlarında olduğu gibi grafik oturumun kullanılamadığı durumlarda veya bağımsız dağıtım paketleri (bundle) oluşturmak için [Bob](/manuals/bob) kullanın. Açık bir düzenleyici, `/command/compile` aracılığıyla yalnızca kod derleyen otomasyonu da destekler.
+
+Düzenleyiciyi başlattıktan sonra projenin açılmasını ve `.internal/editor.port` dosyasının oluşmasını bekleyin. Ardından geçerli bir belge dönene kadar `/openapi.json` yolunu düzenli aralıklarla sorgulayın. Sürecin oluşturulmasının projenin hazır olduğu anlamına geldiğini varsaymayın.
+
+## Düzenleyici sunucusunu bulma
+
+Düzenleyici, bir proje açıkken yerel bir HTTP sunucusu başlatır. Ana sayfasını varsayılan tarayıcıda açmak için <kbd>Help ▸ Open Editor Server</kbd> seçeneğini seçin:
+
+![Yerel düzenleyici sunucusunun ana sayfası](images/automation/editor_server.png)
+
+Seçilen bağlantı noktası, proje içinde şu dosyaya yazılır:
+
+```text
+.internal/editor.port
+```
+
+Bu kılavuzdaki örnekler ve komutlar bundan sonra şu kabuk değişkenlerine başvuracaktır:
+
+```sh
+PORT="$(cat .internal/editor.port)"
+BASE_URL="http://127.0.0.1:$PORT"
+```
+
+Bağlantı noktası dosyası geçerli düzenleyici oturumuna aittir. Düzenleyiciyi yeniden başlattıktan sonra dosyayı yeniden okuyun.
+
+::: important
+Düzenleyici sunucusu, güvenilir bir yerel denetim arayüzüdür. Herkese açık bir adres, bağlantı noktası yönlendirmesi veya güvenilmeyen bir tünel üzerinden erişime açmayın.
+:::
+
+## OpenAPI aracılığıyla işlemleri keşfetme
+
+Harici bir aracın ihtiyaç duyması gereken Defold'a özgü başlangıç bilgileri yalnızca düzenleyicinin bağlantı noktası ve OpenAPI belgesidir:
+
+```sh
+curl -sS "http://127.0.0.1:$(cat .internal/editor.port)/openapi.json"
+```
+
+Dönen OpenAPI 3.0.3 belgesi, çalışan düzenleyici sürümünün desteklediği işlemleri; yollar, yöntemler, parametreler, komut adları, istek biçimleri, yanıtlar, durum kodları ve kimlik doğrulama gereksinimleri dahil olmak üzere açıklar.
+
+Belgelenmiş yolları listeleyin:
+
+```sh
+curl -sS "$BASE_URL/openapi.json" |
+  jq -r '.paths | keys[]'
+```
+
+Belgelenmiş düzenleyici komut yollarını listeleyin:
+
+```sh
+curl -sS "$BASE_URL/openapi.json" |
+  jq -r '.paths | keys[] | select(startswith("/command/"))'
+```
+
+Defold 1.13.2 ve sonraki sürümlerde, her komutun OpenAPI belgesinde kendine ait bir yolu vardır. Önceki sürümler komutları `/command/{command}` yolu ve komut adlarını içeren bir numaralandırma türü (enum) aracılığıyla tanımlar.
+
+Sürümü dikkate alan bir tümleştirmenin, gerekli her işlemi doğrulaması ve istekleri dönen şemaya göre yapılandırması önerilir. Uç nokta veya komut adlarının eksiksiz olduğu varsayılan bir kopyasını tutmanızı önermiyoruz; bu kopya güncelliğini yitirebilir.
+
+Projede tanımlanan rotalar, düzenleyici betikleri bir OpenAPI işlem açıklaması sağladığında `/openapi.json` belgesinde de görünür.
+
+## Düzenleyici komutlarını yürütme
+
+Düzenleyici komutlarını, komutun belgelenmiş yoluna bir `POST` isteği göndererek çağırın; örneğin:
+
+```text
+POST /command/compile
+POST /command/run
+```
+
+Projeyi çalıştırmadan kodunu derlemek için:
+
+```sh
+curl -sS \
+  -X POST \
+  "$BASE_URL/command/compile" |
+  jq
+```
+
+Projenin kodunu derlemek ve projeyi çalıştırmak için:
+
+```sh
+curl -sS \
+  -X POST \
+  "$BASE_URL/command/run" |
+  jq
+```
+
+Bu komut zincirleri yanıt gövdesini görüntüler. Otomasyon betiklerinde, [HTML5 için derleme](#building-html5) bölümündeki örüntüyü kullanarak HTTP durumunu ve `success` değerini de kontrol edin.
+
+::: sidenote
+Defold 1.13.2 sürümünden itibaren `/command/build`, `/command/run` için kullanımı artık önerilmeyen bir uyumluluk takma adıdır ve OpenAPI içinde listelenmez. Yeni tümleştirmelerde `/command/run` kullanın.
+:::
+
+Başarılı bir kod derleme işlemi, yapılandırılmış bir sonuçla birlikte `200` HTTP durumunu döndürür:
+
+```json
+{
+  "success": true,
+  "issues": []
+}
+```
+
+Başarısız bir proje derleme işlemi, aşağıdaki gibi sorunlarla birlikte `422` HTTP durumunu döndürür:
+
+```json
+{
+  "success": false,
+  "issues": [
+    {
+      "message": "Example compiler message",
+      "severity": "error",
+      "resource": "/main/player.script",
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 4
+        },
+        "end": {
+          "line": 12,
+          "character": 17
+        }
+      }
+    }
+  ]
+}
+```
+
+Kullanılabilir alanlar hataya bağlıdır. Varsa kaynak yolunu ve kaynak kod aralığını kullanın; ancak yalnızca bir ileti içeren sorunları da işleyin.
+
+Çalışan düzenleyici tarafından listelendiklerinde genellikle yararlı olan komutlar şunlardır:
+
+`compile`
+: Projeyi çalıştırmadan kodunu derleyin.
+
+`run`
+: Projenin kodunu derleyin ve projeyi çalıştırın.
+
+`clean-build`
+: Derleme önbelleğini temizleyin, ardından kodu derleyip projeyi çalıştırın. Bunu yalnızca normal bir derleme tutarsız davrandığında veya değişiklikleri atlıyor gibi göründüğünde kullanın.
+
+`build-html5`
+: Projeyi HTML5 için derleyin ve çıktıyı düzenleyici sunucusu üzerinden kullanılabilir hâle getirin.
+
+`fetch-libraries`
+: Proje bağımlılıklarını indirin ve yeniden yükleyin.
+
+`hot-reload`
+: Değiştirilen kaynakları çalışan bir oyuna yeniden yükleyin.
+
+`reload-extensions`
+: Düzenleyici betiklerini yeniden yükleyin.
+
+`debugger-start`, `debugger-stop` ve hata ayıklayıcının adım komutları
+: Bir hata ayıklama oturumunu ve çalışan projeyi denetleyin.
+
+Tam adlar ve kullanılabilirlik, düzenleyici sürümüne ve düzenleyicinin geçerli durumuna bağlıdır; bunları `/openapi.json` üzerinden keşfedin.
+
+Proje kaynakları üzerinde çalışan komutlar, yürütülmeden önce harici dosya değişikliklerini eşitler.
+
+### Komut yanıtları ve eşzamansız işlemler
+
+Yanıtlar komuta bağlıdır. Defold 1.13.2 ve sonraki sürümlerde `compile`, `run`, `clean-build`, `build-html5`, `debugger-start` ve `hot-reload`, komutun tamamlanmasını bekler ve yukarıda gösterildiği gibi `success` ve `issues` içeren yapılandırılmış bir sonuç döndürür. Başarılı bir sonuç HTTP `200` döndürür; derleme veya doğrulama başarısızlığı `422` döndürür.
+
+Diğer komutlar, örneğin `debugger-break`, hâlâ `202` döndürebilir. Geçerli OpenAPI şemasındaki işlemi inceleyin ve dönen gerçek HTTP yanıt durumunu işleyin:
+
+| Durum | Anlamı |
+| --- | --- |
+| `200` | Komut tamamlandı ve bir sonuç döndürdü |
+| `202` | Komut kabul edildi ve eşzamansız olarak devam ediyor |
+| `403` | Komut, düzenleyicinin geçerli durumunda etkin değil |
+| `404` | Komut kullanılamıyor |
+| `422` | Derleme veya doğrulama başarısız oldu |
+| `500` | Düzenleyicinin içinde bir hata oluştu |
+
+Bir HTTP `202` yanıtı, istenen sonucun mevcut olduğunu kanıtlamaz. İlgili çıktıyı, kaynağı, konsol işaretini veya sunulan URL adresini bekleyin ve bir zaman aşımı uygulayın.
+
+### HTML5 için derleme {#building-html5}
+
+Geçerli OpenAPI belgesinde `/command/build-html5` listeleniyorsa komutu bu yol üzerinden çağırın. Bir kabuk betiğinde HTTP durumunu yanıt gövdesinden ayrı olarak alın ve istek veya derleme başarısız olduğunda durun:
+
+```sh
+build_response_file="$(mktemp)" || exit 1
+if ! build_http_status="$(curl -sS \
+  -X POST \
+  -o "$build_response_file" \
+  -w '%{http_code}' \
+  "$BASE_URL/command/build-html5")"; then
+  cat "$build_response_file"
+  rm -f "$build_response_file"
+  exit 1
+fi
+
+cat "$build_response_file"
+if [ "$build_http_status" != "200" ] ||
+   ! jq -e '.success == true' "$build_response_file" > /dev/null; then
+  rm -f "$build_response_file"
+  exit 1
+fi
+rm -f "$build_response_file"
+```
+
+Defold 1.13.2 ve sonraki sürümlerde bu istek, derlemenin bitmesini bekler ve yapılandırılmış bir sonuç döndürür. Örnek, derleme sorunları dahil yanıt gövdesini yazdırır ve yalnızca HTTP `200` ile `success: true` döndüğünde devam eder. Başarılı bir derlemeden sonra düzenleyici oyunu bir tarayıcıda açar ve şu adreste sunar:
+
+```text
+http://127.0.0.1:<editor-port>/html5/
+```
+
+Derlemenin tamamlanması, oyunun tarayıcıya yüklenmesinin bittiği anlamına gelmez. Girdi göndermeden veya oynanışı kontrol etmeden önce tuvalin ve uygulamanın hazır olmasını bekleyin. Daha fazla bilgi için [HTML5 için tarayıcı testleri](/manuals/automated-testing/#browser-tests-for-html5) bölümüne bakın.
+
+## API belgelerinde arama
+
+`/openapi.json` belgesinde yer aldığında `/ref` işlemi, çalışan düzenleyici sürümüyle birlikte gelen API belgelerinde arama yapar. Bu sürümle eşleşen adları ve imzaları sağlar.
+
+Örneğin bir işlevi aramak için şunu kullanın:
+
+```sh
+curl -sS \
+  --get \
+  --data-urlencode "q=go.animate" \
+  "$BASE_URL/ref" |
+  jq
+```
+
+Ortama ve dile göre filtreleyin:
+
+```sh
+curl -sS \
+  --get \
+  --data-urlencode "environment=runtime" \
+  --data-urlencode "language=Lua" \
+  --data-urlencode "q=collision message|raycast" \
+  "$BASE_URL/ref" |
+  jq
+```
+
+Arama parametreleri şunlardır:
+
+`environment`
+: `editor`, `runtime` veya virgülle ayrılmış değerler.
+
+`language`
+: `Lua`, `C`, `C++` veya virgülle ayrılmış değerler.
+
+`q`
+: Büyük/küçük harfe duyarlı olmayan bir ifade. Boşluk karakterleri VE anlamına gelirken `|`, VEYA anlamına gelir.
+
+Yoğunlaştırılmış belge kaynakları da vardır: [LLM belge dizini](https://defold.com/llms.txt), resmî kılavuzlara, API ad alanlarına ve örneklere bağlantılar verir; [tam LLM belgeleri](https://defold.com/llms-full.txt) ise çevrimdışı aramayı ve yerel dizinlemeyi desteklemek için belgelerin tamamını listeler.
+
+Yapay zekâ ajanlarının, yalnızca bir API veya ileti gerektiğinde tüm bir başvuru kaynağını getirmek yerine hedefi belirli aramaları tercih etmesi önerilir; böylece token kullanımını azaltabilir ve görev için daha iyi hazırlanmış, temiz bir bağlam elde edebilirler.
+
+## Konsol çıktısını okuma {#reading-console-output}
+
+Düzenleyici konsolunu JSON olarak okuyun:
+
+```sh
+curl -sS "$BASE_URL/console" | jq
+```
+
+Yanıt, `lines` içinde konsol metnini ve `regions` içinde hatalar, değerlendirme sonuçları ve kaynak başvuruları dahil anlamsal bölgeleri içerir.
+
+Konsol çıktısını sürekli izlemek için şunu kullanın:
+
+```sh
+curl -N "$BASE_URL/console/stream"
+```
+
+Akış, mevcut konsol satırlarını içerir ve ardından yeni çıktılar için açık kalır. Bir tamamlanma işareti veya hata aldıktan, sürecin sonlandığını algıladıktan ya da bir zaman aşımına veya satır sınırına ulaştıktan sonra kapatın.
+
+Test sonuçlarını diğer çıktılardan ayırma ve başarısızlıkları sınıflandırma hakkında bilgi için [Otomatik test ve doğrulama](/manuals/automated-testing/#structured-test-results) bölümüne bakın.
+
+## Sahne önizlemelerini işleme {#rendering-scene-previews}
+
+Defold düzenleyicisi (1.13.1 sürümünden itibaren), `/preview/{path}` komutuyla işleme (rendering) yaparak desteklenen bir sahne kaynağının "ekran görüntüsünü" PNG biçiminde oluşturabilir:
+
+```sh
+mkdir -p build/automation
+
+curl -sS \
+  "$BASE_URL/preview/main/main.collection?width=1280&height=720" \
+  --output build/automation/main-preview.png
+```
+
+Bu işlem, açık Basic 3D şablon projesindeki ana koleksiyonu (collection) varsayılan başlangıç görünümünde işler:
+
+![Ana koleksiyonun düzenleyicide işlenmiş önizlemesi](images/automation/main-preview.png)
+
+Görsel sahne düzenleyicisini kullanan kaynakların önizlemelerini almak için işlemeden yararlanabilirsiniz. Örneğin bir model bileşenini (component) aynı şekilde işleyerek görünümünü veya gölgelendiricinin doğruluğunu kontrol edebilirsiniz:
+
+```sh
+curl -sS \
+  "$BASE_URL/preview/assets/models/cube.model?width=1280&height=720" \
+  --output build/automation/cube-preview.png
+```
+
+![Küp modelinin düzenleyicide işlenmiş önizlemesi](images/automation/cube-preview.png)
+
+`/preview/` sonrasındaki yol, başında eğik çizgi içermez. İsteğe bağlı boyutlar varsayılan olarak projenin ekran boyutudur ve `1` ile `4096` arasında olmalıdır.
+
+| Durum | Anlamı |
+| --- | --- |
+| `200` | Önizleme işlendi |
+| `400` | Boyutlar geçersiz |
+| `404` | Kaynak bulunamadı |
+| `422` | Kaynak yüklenmemiş veya sahne önizlemelerini desteklemiyor |
+
+Önizlemeler; bölüm yerleşimlerini, GUI yerleşimlerini, gölgelendirici ve aydınlatma kurulumunu ya da görsel gerilemeleri kontrol etmek gibi projenin görsel analizi için veya belgeler için küçük resimler oluşturmakta çok yararlı olabilir.
+
+::: important
+Düzenleyici önizlemesi, çalışan oyunun ekran görüntüsü değildir. Dinamik olarak oluşturulan nesneleri, çalışma sırasındaki son işlemeyi veya platforma özgü işlemeyi doğrulamaz. Bu öğeler gerektiğinde [çalışan oyundan alınan bir ekran görüntüsünü](/manuals/automated-testing/#editor-previews-and-runtime-screenshots) kullanın.
+:::
+
+## Düzenleyicide Lua yürütme
+
+Kimlik doğrulaması gerektiren `POST /eval` işlemi, Lua kodunu düzenleyici eklenti ortamında yürütür. Her oturuma ait taşıyıcı belirteç (bearer token) şu dosyada saklanır:
+
+```text
+.internal/editor.token
+```
+
+Belirteci okuyun ve kodu yürütün:
+
+```sh
+TOKEN="$(cat .internal/editor.token)"
+
+curl -sS \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: text/plain" \
+  --data-binary 'print(editor.version) return editor.platform' \
+  "$BASE_URL/eval"
+```
+
+Yazdırılan çıktı ve dönüş değerleri metin olarak döndürülür. Tipik yanıtlar şunlardır:
+
+| Durum | Anlamı |
+| --- | --- |
+| `200` | Kod yürütüldü |
+| `401` | Taşıyıcı belirteç eksik veya geçersiz |
+| `422` | Lua kodu ayrıştırılamadı veya yürütülemedi |
+| `503` | Düzenleyici eklenti ortamı hazır değil |
+
+Bir istemci `503` yanıtından sonra yeniden deneyebilir, ancak deneme sayısını sınırlaması önerilir. `422` döndüren bir isteği yinelemeden önce kodu düzeltin.
+
+Değerlendirilen kod, [Düzenleyici API'sini](https://defold.com/ref/editor-lua/) ve düzenleyici betik ortamını kullanabilir. Çalışan bir oyunu değiştirmek için `go.*` gibi oyun çalışma zamanı API'lerini kullanamaz. Oynanış için bir çalışma zamanı testi, hata ayıklayıcı, tarayıcı testi veya [çalışma zamanı otomasyon API'si](/manuals/engine-service/#automation-bridge-extension) kullanın.
+
+### Kaynakları ve dosyaları değiştirme
+
+Birçok Defold kaynak dosyası metin biçimlerini kullanır ve herhangi bir metin düzenleme aracıyla düzenlenebilir. Defold projesinin yapılandırılmış kaynaklarını değiştirmek için düzenleyici işlemlerini (editor transaction) tercih edin.
+
+| Değişiklik | Tercih edilen yöntem |
+| --- | --- |
+| Lua, gölgelendirici, JSON veya bilinen başka bir metin biçimi | Dosyayı doğrudan değiştirme |
+| Açık bir düzenleyici sekmesindeki kaydedilmemiş metin | `editor.get()` ve `editor.transact()` |
+| Koleksiyon, oyun nesnesi (game object), GUI, atlas veya başka bir yapılandırılmış kaynak | Düzenleyici işlemi |
+| Tekrar tekrar üretilen içerik | Bağımsız üretici |
+| Tekrarlanabilir proje işlemi | Düzenleyici komutu veya özel HTTP uç noktası |
+| Yalnızca CI ortamında yapılan dönüşüm | Bob'dan önce çalıştırılan bağımsız betik |
+
+Bir kaynağı değiştirmeden önce inceleyin:
+
+```sh
+curl -sS \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: text/plain" \
+  --data-binary '
+    local path = "/game.project"
+    pprint(editor.properties(path))
+    return editor.get(path, "path")
+  ' \
+  "$BASE_URL/eval"
+```
+
+Bir işlem gerçekleştirmeden önce `editor.can_get()`, `editor.can_set()` ve diğer `editor.can_*()` işlevlerini kontrol edin.
+
+Bir biçimlendirici, doğrulayıcı veya üretici çalıştırmak için düzenleyici Lua ortamında `editor.execute()` kullanın:
+
+```lua
+local output = editor.execute(
+  "python3",
+  "scripts/generate_levels.py",
+  {
+    out = "capture"
+  }
+)
+
+print(output)
+```
+
+Komut proje kaynaklarını değiştirmiyorsa gereksiz bir yeniden yüklemeden kaçınmak için `reload_resources = false` ayarını kullanın.
+
+::: important
+`.internal/` içindeki dosyaları veya `build/` içindeki üretilmiş içeriği değiştirmeyin.
+:::
+
+## Tercihler
+
+Düzenleyici tercihleri, OpenAPI içinde belgelenen ve şu anda `/prefs/{path}` olan yol üzerinden okunabilir ve yazılabilir.
+
+Örneğin ayarlanmış kod yazı tipi boyutunu okuyabilirsiniz:
+
+```sh
+curl -sS "$BASE_URL/prefs/code/font/size" | jq
+```
+
+Veya örneğin 16 olarak ayarlayabilirsiniz:
+
+```sh
+curl -sS \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --data '16' \
+  "$BASE_URL/prefs/code/font/size"
+```
+
+Düzenleyici, değeri tercih şemasına göre doğrular. Geçersiz bir yol veya değer HTTP `400` döndürür.
+
+Tercihler, `game.project` dosyasında saklanan proje yapılandırması değil, kalıcı kullanıcı ayarları veya projeye özgü kullanıcı ayarlarıdır. Otomasyonun bir tercihi geçici olarak değiştirmesi gerekiyorsa önceki değeri kaydedin ve sonrasında geri yükleyin.
+
+## Projede tanımlanan rotalar
+
+Düzenleyici betikleri, [`get_http_server_routes()`](/manuals/editor-scripts/#http-server) ile ek rotalar tanımlayabilir. İsteğe bağlı bir OpenAPI işlem tablosu, bir rotayı yerleşik işlemlerle aynı `/openapi.json` belgesi üzerinden sunar.
+
+Projede tanımlanan rotalar; içerik üretimi, doğrulama, raporlar, yerelleştirme kontrolleri, kaynak analizi, projeye özgü testler veya bir IDE ya da harici denetleyici için daha küçük bir arayüz sağlayabilir.
+
+İyi bir rotanın, adı açıkça belirtilmiş tek bir işlem gerçekleştirmesi, girdisini doğrulaması, yapılandırılmış bir sonuç döndürmesi, mümkün olduğunda tekrarlandığında ek etki oluşturmaması (idempotent olması) ve yüksek maliyetli işlemleri sınırlaması önerilir.
+
+Projede tanımlanan rotalar `/eval` belirteciyle otomatik olarak korunmaz. Bir rota hassas işlemler gerçekleştiriyorsa projeye özgü kimlik doğrulama ve güvenlik kontrolleri ekleyin.
+
+## Yaşam döngüsü kancaları {#lifecycle-hooks}
+
+Yaşam döngüsü kancaları (lifecycle hook), derlemelerden ve dağıtım paketi oluşturmadan önce ve sonra, ayrıca bir oyun süreci başlatıldığında veya sonlandığında çalıştırılabilen işlevlerdir. Bir projenin kök dizininde bir adet `hooks.editor_script` dosyası bulunabilir. Bu olayları yalnızca kök dizindeki kanca dosyası alır; böylece proje, olayların sırasını tek bir yerde tanımlayabilir.
+
+```lua
+local M = {}
+
+local function validate_project()
+  print(editor.execute(
+    "python3",
+    "scripts/validate_project.py",
+    {
+      out = "capture",
+      reload_resources = false
+    }
+  ))
+end
+
+function M.on_build_started(opts)
+  validate_project()
+end
+
+function M.on_build_finished(opts)
+  print("Build successful:", opts.success)
+end
+
+return M
+```
+
+`on_build_started()` işlevinin ürettiği bir hata, düzenleyici derlemesini durdurur. Yaşam döngüsü kancaları yalnızca düzenleyicide çalışır; ortak doğrulama ve üretim mantığını, CI ortamından da çağrılabilen bağımsız betiklere yerleştirin.
+
+## Güvenlik ve uyumluluk
+
+Düzenleyici sunucusunun tamamını güvenilir bir yerel arayüz olarak ele alın:
+
+* Bağlantı noktasını herkese açık erişime açmayın.
+* `.internal/editor.token` dosyasını koruyun; bu dosya geçerli oturum için `/eval` yetkisi verir.
+* Dışarıya sınırsız `/eval` erişimi vermeyin.
+* Belirteci istemlerde, raporlarda veya günlüklerde değil, yerel tümleştirme katmanında tutun.
+* Projede tanımlanan rotaların `/eval` kimlik doğrulamasını devralmadığını unutmayın.
+* Güncel `/openapi.json` belgesini kullanın.
+* Eşzamansız otomatik komutlar ve düzenleyicinin başlatılması için sınırlı bekleme süreleri kullanın.
+
+## Motor sunucusu
+
+Düzenleyici sunucusu, düzenleyici sürecine aittir. Çalışan bir oyunun, [motor hizmeti ve çalışma zamanı HTTP API kılavuzunda](/manuals/engine-service) açıklanan farklı bir bağlantı noktası ve farklı sorumlulukları vardır.

--- a/docs/tr/manuals/editor-preferences.md
+++ b/docs/tr/manuals/editor-preferences.md
@@ -1,0 +1,127 @@
+---
+title: Düzenleyici tercihleri
+brief: Düzenleyicinin ayarlarını Preferences penceresinden değiştirebilirsiniz.
+---
+
+# Düzenleyici tercihleri
+
+Düzenleyicinin ayarlarını Preferences penceresinden değiştirebilirsiniz. Tercihler penceresi <kbd>File -> Preferences</kbd> menüsünden açılır.
+
+## General
+
+![](images/editor/preferences_general.png)
+
+Load External Changes on App Focus
+: Düzenleyici odaklandığında dışarıda yapılan değişikliklerin taranmasını etkinleştirir.
+
+Open Bundle Target Folder
+: Paketleme işlemi tamamlandıktan sonra dağıtım paketinin hedef klasörünün açılmasını etkinleştirir.
+
+Enable Texture Compression
+: Düzenleyicide yapılan tüm derlemeler için [doku sıkıştırmayı](/manuals/texture-profiles) etkinleştirir.
+
+Escape Quits Game
+: Oyununuzun çalışan bir derlemesini <kbd>Esc</kbd> tuşuyla kapatın.
+
+Track Active Tab in Asset Browser
+: *Editor* bölmesinde seçili sekmede düzenlenen dosya, Asset Browser görünümünde (*Asset* bölmesi olarak da bilinir) seçilir.
+
+Lint Code on Build
+: Proje derlenirken [statik kod denetimini](/manuals/writing-code/#linting-configuration) etkinleştirir. Bu seçenek varsayılan olarak etkindir, ancak büyük bir projede statik kod denetimi çok uzun sürüyorsa devre dışı bırakılabilir.
+
+Engine Arguments
+: Düzenleyici derleyip çalıştırdığında dmengine yürütülebilir dosyasına iletilecek bağımsız değişkenler.
+ Her satırda bir bağımsız değişken kullanın. Örneğin:
+ ```
+--config=bootstrap.main_collection=/my dir/1.collectionc
+--verbose
+--graphics-adapter=vulkan
+```
+
+
+## Code
+
+![](images/editor/preferences_code.png)
+
+Custom Editor
+: Harici bir düzenleyicinin mutlak yolu. macOS'ta .app içindeki yürütülebilir dosyanın yolu olmalıdır (ör. `/Applications/Atom.app/Contents/MacOS/Atom`).
+
+Open File
+: Özel düzenleyicinin hangi dosyanın açılacağını belirtmek için kullandığı kalıp. `{file}` kalıbı, açılacak dosyanın adıyla değiştirilir.
+
+Open File at Line
+: Özel düzenleyicinin hangi dosyanın ve hangi satır numarasında açılacağını belirtmek için kullandığı kalıp. `{file}` kalıbı, açılacak dosyanın adıyla; `{line}` ise satır numarasıyla değiştirilir.
+
+Code editor font
+: Kod düzenleyicisinde kullanılacak, sistemde yüklü bir yazı tipinin adı.
+
+Zoom on Scroll
+: Cmd/Ctrl tuşu basılı tutulurken kod düzenleyicisinde kaydırma yapıldığında yazı tipi boyutunun değiştirilip değiştirilmeyeceğini belirler.
+
+Auto-insert closing parens
+: Kod düzenlenirken eşleşen kapanış karakterlerini otomatik olarak ekler. Bu seçenek varsayılan olarak etkindir.
+
+Format on save
+: Kaydederken dil sunucusunun biçimlendiricisini değiştirilmiş açık kod dosyalarında çalıştırır. Varsayılan olarak devre dışıdır. Dil sunucusu biçimlendirmeyi desteklemelidir; bir belgeyi veya seçimi elle biçimlendirmek için [kod biçimlendirme](/manuals/writing-code/#formatting-code) bölümüne bakın.
+
+
+### Betik dosyalarını Visual Studio Code'da açma
+
+![](images/editor/preferences_vscode.png)
+
+Betik dosyalarını Defold düzenleyicisinden doğrudan Visual Studio Code'da açmak için yürütülebilir dosyanın yolunu belirterek aşağıdaki ayarları yapmanız gerekir:
+
+- macOS: `/Applications/Visual Studio Code.app/Contents/MacOS/Electron`
+- Linux: `/usr/bin/code`
+- Windows: `C:\Program Files\Microsoft VS Code\Code.exe`
+
+ Belirli dosyaları ve satırları açmak için şu parametreleri ayarlayın:
+
+- Open File: `. {file}`
+- Open File at Line: `. -g {file}:{line}`
+
+Buradaki `.` karakteri, tek bir dosya yerine çalışma alanının tamamını açmak için gereklidir.
+
+
+## Extensions
+
+![](images/editor/preferences_extensions.png)
+
+Build Server
+: [Yerel kod eklentileri (native extensions)](/manuals/extensions) içeren bir proje derlenirken kullanılan derleme sunucusunun URL adresi. Derleme sunucusuna kimliği doğrulanmış erişim için URL adresine bir kullanıcı adı ve erişim belirteci eklenebilir. Kullanıcı adını ve erişim belirtecini belirtmek için şu gösterimi kullanın: `username:token@build.defold.com`. Nintendo Switch derlemelerinde ve kimlik doğrulamanın etkinleştirildiği kendi derleme sunucusu örneğinizi çalıştırırken kimliği doğrulanmış erişim gerekir (daha fazla bilgi için [derleme sunucusu belgelerine bakın](https://github.com/defold/extender/blob/dev/README_SECURITY.md)). Kullanıcı adı ve parola, `DM_EXTENDER_USERNAME` ve `DM_EXTENDER_PASSWORD` sistem ortam değişkenleri olarak da ayarlanabilir.
+
+Build Server Username
+: Kimlik doğrulama için kullanıcı adı.
+
+Build Server Password
+: Kimlik doğrulama için parola; tercihler dosyasında şifrelenmiş olarak saklanır.
+
+Build Server Headers
+: Yerel kod eklentileri derlenirken derleme sunucusuna gönderilen ek üstbilgiler. CloudFlare hizmetini veya benzer hizmetleri extender ile kullanmak için önemlidir.
+
+## Tools
+
+![](images/editor/preferences_tools.png)
+
+ADB path
+: Bu sistemde kurulu [ADB](https://developer.android.com/tools/adb) komut satırı aracının yolu. Sisteminizde ADB kuruluysa Defold düzenleyicisi, paketlenmiş Android APK dosyalarını bağlı bir Android cihazına kurmak ve çalıştırmak için bu aracı kullanır. Düzenleyici varsayılan olarak ADB'nin yaygın konumlarda kurulu olup olmadığını denetler; bu nedenle yolu yalnızca ADB'yi özel bir konuma kurduysanız belirtmeniz gerekir.
+
+ios-deploy path
+: Bu sistemde kurulu [ios-deploy](https://github.com/ios-control/ios-deploy) komut satırı araçlarının yolu (yalnızca macOS için geçerlidir). ADB yolunda olduğu gibi Defold düzenleyicisi, paketlenmiş iOS uygulamalarını bağlı bir iPhone'a kurmak ve çalıştırmak için bu aracı kullanır. Düzenleyici varsayılan olarak ios-deploy aracının yaygın konumlarda kurulu olup olmadığını denetler; bu nedenle yolu yalnızca ios-deploy için özel bir kurulum kullanıyorsanız belirtmeniz gerekir.
+
+## Keymap
+
+![](images/editor/preferences_keymap.png)
+
+Düzenleyicinin klavye kısayollarını ve fare kontrollerini Keymap sekmesinde yapılandırabilirsiniz. Bir komutu değiştirmek için komuta çift tıklayın, <kbd>Enter</kbd> veya <kbd>Space</kbd> tuşuna basın ya da satırın bağlam menüsünü kullanın.
+
+Klavye kısayolları *Shortcuts* sütununda tuş birleşimleri olarak görünür. Fare kontrolleri aynı listede bir rozetle görünür:
+
+- <kbd>MB</kbd>, isteğe bağlı olarak <kbd>Shift</kbd>, <kbd>Ctrl</kbd>/<kbd>Control</kbd> veya <kbd>Alt</kbd> ile birleştirilen bir fare düğmesi eşlemesini belirtir.
+- <kbd>MM</kbd>, bir fare eyleminin kullandığı değiştirici tuşu belirtir.
+
+Bazı fare kontrolleri, varsayılan Scene 2D Camera eşlemelerini yeniden kullanır; bu nedenle bir satır, siz özelleştirmeden önce de bir eşleme gösterebilir. Bunlar genellikle daha koyu bir renkle gösterilir. Bu satır için özel bir eşleme ayarlarsanız Defold sizin eşlemenizi kullanır. Değişikliğinizi kaldırıp yerleşik veya devralınan davranışa dönmek için *Reset to Defaults* seçeneğini kullanın.
+
+Uyarılar turuncu renkte gösterilir. Ayrıntıları görmek için işaretçiyi uyarının üzerine getirin. Uyarılar genellikle şunları belirtir:
+- Kısayol metin girebilir ve metin alanlarını etkileyebilir.
+- Aynı kısayol veya fare eşlemesi başka bir komut tarafından zaten kullanılıyordur.

--- a/docs/tr/manuals/editor-scripts-ui.md
+++ b/docs/tr/manuals/editor-scripts-ui.md
@@ -1,0 +1,415 @@
+---
+title: "Düzenleyici betikleri: kullanıcı arayüzü"
+brief: Bu kılavuz, Lua kullanarak düzenleyicide kullanıcı arayüzü öğeleri oluşturmayı açıklar
+---
+
+# Düzenleyici betikleri ve kullanıcı arayüzü
+
+Bu kılavuz, Lua ile yazılan düzenleyici betiklerini (editor scripts) kullanarak düzenleyicide etkileşimli iletişim kutuları oluşturmayı ve kaynakları (resource) açmayı açıklar. Düzenleyici betiklerine başlamak için [Düzenleyici betikleri kılavuzuna](/manuals/editor-scripts) bakın. Düzenleyicinin tüm API başvuru belgelerini [burada](/ref/stable/editor-lua/) bulabilirsiniz.
+
+## Merhaba dünya
+
+Kullanıcı arayüzüyle (UI) ilgili tüm işlevler `editor.ui` modülünde bulunur. Başlangıç için özel bir arayüze sahip düzenleyici betiğinin en basit örneği şöyledir:
+```lua
+local M = {}
+
+function M.get_commands()
+    return {
+        {
+            label = "Do with confirmation",
+            locations = {"View"},
+            run = function()
+                local result = editor.ui.show_dialog(editor.ui.dialog({
+                    title = "Perform action?",
+                    buttons = {
+                        editor.ui.dialog_button({
+                            text = "Cancel",
+                            cancel = true,
+                            result = false
+                        }),
+                        editor.ui.dialog_button({
+                            text = "Perform",
+                            default = true,
+                            result = true
+                        })
+                    }
+                }))
+                print('Perform action:', result)
+            end
+        }
+    }
+end
+
+return M
+
+```
+
+Bu kod parçası, **View → Do with confirmation** komutunu tanımlar. Komutu yürüttüğünüzde aşağıdaki iletişim kutusunu görürsünüz:
+
+![Merhaba dünya iletişim kutusu](images/editor_scripts/perform_action_dialog.png)
+
+Son olarak, <kbd>Enter</kbd> tuşuna bastıktan (veya `Perform` düğmesine tıkladıktan) sonra düzenleyici konsolunda aşağıdaki satırı görürsünüz:
+```
+Perform action:	true
+```
+
+## Kaynakları açma
+
+Bir proje kaynağını açmak için bir komutun `run` işlevinden `editor.ui.open_resource()` işlevini çağırın. Yol `/` ile başlar. Görünümü belirtmezseniz kaynağın birincil görünümü seçilir:
+
+```lua
+editor.ui.open_resource("/main/main.script")
+```
+
+`code` ve `text` görünümleri, üçüncü bağımsız değişken olarak bir imleç konumu veya seçim kabul eder. Satır ve sütun numaraları `1` ile başlar; belirtilmeyen sütunun varsayılan değeri `1` olur. Bu bağımsız değişkenleri geçirirken görünümü belirtin:
+
+```lua
+editor.ui.open_resource("/main/main.script", "code", { line = 10 })
+editor.ui.open_resource("/main/main.script", "code", { line = 10, column = 5 })
+```
+
+Bir aralık seçmek için bunun yerine `from` ve `to` imleç konumlarını belirtin:
+
+```lua
+editor.ui.open_resource("/main/main.script", "code", {
+    from = { line = 10, column = 1 },
+    to = { line = 12, column = 1 }
+})
+```
+
+Yapılandırılmış kaynak görünümü düzenleyicide veya haricî bir uygulamada açılabilir. Yerleşik Code ve Text görünümleri, imleç ve seçim bağımsız değişkenlerini destekler. Desteklenen görünüm adları için [`editor.ui.open_resource()`](/ref/beta/editor/#editor.ui.open_resource:resource_path-view-args) başvurusuna bakın.
+
+## Temel kavramlar
+
+### Bileşenler
+
+Düzenleyici, istenen arayüzü oluşturmak için bir araya getirilebilen çeşitli arayüz **bileşenleri** (component) sunar. Geleneksel olarak tüm bileşenler, **özellikler** (props) adı verilen tek bir tablo kullanılarak yapılandırılır. Bileşenlerin kendileri tablo değildir; düzenleyicinin arayüzü oluşturmak için kullandığı **değiştirilemez userdata** değerleridir.
+
+### Özellikler
+
+**Özellikler**, bileşenlere verilen girdileri tanımlayan tablolardır. Özellikler değiştirilemez kabul edilmelidir: özellik tablosunu yerinde değiştirmek bileşenin yeniden işlenmesini (re-render) tetiklemez, ancak farklı bir tablo kullanmak tetikler. Bileşen örneği (instance), önceki tabloya sığ eşitlik (shallow equality) ölçütüne göre eşit olmayan bir özellik tablosu aldığında arayüz güncellenir.
+
+### Hizalama
+
+Arayüzde bir bileşene bir alan ayrıldığında bileşen alanın tamamını kullanır; ancak bu, bileşenin görünür kısmının esneyeceği anlamına gelmez. Görünür kısım, ihtiyaç duyduğu kadar yer kaplar ve ardından ayrılan alanın sınırları içinde hizalanır. Bu nedenle, yerleşik bileşenlerin çoğu bir `alignment` özelliği tanımlar.
+
+Örneğin, şu etiket bileşenini ele alalım:
+```lua
+editor.ui.label({
+    text = "Hello",
+    alignment = editor.ui.ALIGNMENT.RIGHT
+})
+```
+Görünür kısım `Hello` metnidir ve bileşene ayrılan alanın sınırları içinde hizalanır:
+
+![Hizalama](images/editor_scripts/alignment.png)
+
+## Yerleşik bileşenler
+
+Düzenleyici, arayüzü oluşturmak için birlikte kullanılabilen çeşitli yerleşik bileşenler tanımlar. Bileşenler kabaca 3 kategoride gruplandırılabilir: yerleşim, veri sunumu ve girdi.
+
+### Yerleşim bileşenleri
+
+Yerleşim bileşenleri, diğer bileşenleri yan yana yerleştirmek için kullanılır. Başlıca yerleşim bileşenleri **`horizontal`**, **`vertical`** ve **`grid`** bileşenleridir. Bu bileşenler ayrıca **padding** ve **spacing** gibi özellikler tanımlar. Burada padding, ayrılan alanın kenarından içeriğe kadar olan boşluğu; spacing ise alt bileşenler arasındaki boşluğu ifade eder:
+
+![İç boşluk ve aralık](images/editor_scripts/padding_and_spacing.png)
+
+Düzenleyici, iç boşluk ve aralık için `small`, `medium` ve `large` sabitlerini tanımlar. Aralık söz konusu olduğunda `small`, tek bir arayüz öğesinin farklı alt öğeleri arasındaki boşluk; `medium`, ayrı arayüz öğeleri arasındaki boşluk; `large` ise öğe grupları arasındaki boşluk içindir. Varsayılan aralık `medium` değeridir. İç boşluk değeri olarak `large`, pencerenin kenarlarından içeriğe kadar olan boşluğu; `medium`, belirgin bir arayüz öğesinin kenarlarından itibaren bırakılan boşluğu; `small` ise bağlam menüleri ve araç ipuçları (henüz uygulanmadı) gibi küçük arayüz öğelerinin kenarlarından itibaren bırakılan boşluğu ifade eder.
+
+**`horizontal`** kapsayıcısı, alt bileşenlerini yatay olarak art arda yerleştirir ve her alt bileşenin yüksekliğini her zaman kullanılabilir alanı dolduracak şekilde ayarlar. Varsayılan olarak her alt bileşenin genişliği en az düzeyde tutulur; ancak alt bileşenin `grow` özelliğini `true` olarak ayarlayarak mümkün olduğunca fazla yer kaplamasını sağlayabilirsiniz.
+
+**`vertical`** kapsayıcısı, eksenlerin yer değiştirmesi dışında yatay kapsayıcıya benzer.
+
+Son olarak, **`grid`**, alt bileşenlerini tablo gibi 2B bir ızgaraya yerleştiren bir kapsayıcı bileşenidir. Izgaradaki `grow` ayarı satır veya sütunlara uygulanır; bu nedenle alt bileşen üzerinde değil, sütun yapılandırma tablosunda ayarlanır. Ayrıca, ızgaradaki alt bileşenler `row_span` ve `column_span` özellikleriyle birden fazla satırı veya sütunu kaplayacak şekilde yapılandırılabilir. Izgaralar, birden çok girdi içeren formlar oluşturmak için kullanışlıdır:
+```lua
+editor.ui.grid({
+    padding = editor.ui.PADDING.LARGE, -- add padding around dialog edges
+    columns = {{}, {grow = true}}, -- make 2nd column grow
+    children = {
+        {
+            editor.ui.label({ 
+                text = "Level Name",
+                alignment = editor.ui.ALIGNMENT.RIGHT
+            }),
+            editor.ui.string_field({})
+        },
+        {
+            editor.ui.label({ 
+                text = "Author",
+                alignment = editor.ui.ALIGNMENT.RIGHT
+            }),
+            editor.ui.string_field({})
+        }
+    }
+})
+```
+Yukarıdaki kod, aşağıdaki iletişim kutusu formunu oluşturur:
+
+![Yeni bölüm iletişim kutusu](images/editor_scripts/new_level_dialog.png)
+
+### Veri sunumu bileşenleri
+
+Düzenleyici, aşağıdaki veri sunumu bileşenlerini tanımlar:
+
+- **`label`** — form girdileriyle birlikte kullanılması amaçlanan metin etiketi.
+- **`icon`** — bir simge; şu anda yalnızca önceden tanımlanmış küçük bir simge kümesini göstermek için kullanılabilir, ancak gelecekte daha fazla simgeye izin vermeyi amaçlıyoruz.
+- **`image`** — `/` ile başlayan bir proje kaynak yolundan veya haricî bir URL adresinden yüklenen görüntü. İsteğe bağlı `width` ve `height` özellikleri, görüntüyü en boy oranını koruyarak belirtilen boyutların içine sığdırır.
+- **`heading`** — örneğin bir formda veya iletişim kutusunda bir başlık satırı göstermek için tasarlanmış metin öğesi. `editor.ui.HEADING_STYLE` numaralandırma türü, HTML'nin `H1`-`H6` başlıklarının yanı sıra düzenleyiciye özgü `DIALOG` ve `FORM` stillerini içeren çeşitli başlık stilleri tanımlar.
+- **`paragraph`** — bir metin paragrafı göstermek için tasarlanmış metin öğesi. `label` ile temel farkı, paragrafın sözcük kaydırmayı desteklemesidir: ayrılan alan yatay olarak çok küçükse metin bir alt satıra kaydırılır ve görünüme sığmıyorsa `"..."` ile kısaltılabilir.
+
+Örneğin, bir arayüz hem projedeki bir görüntüyü hem de web üzerinden alınan bir görüntüyü gösterebilir:
+
+```lua
+editor.ui.vertical({
+    children = {
+        editor.ui.image({
+            image = "/builtins/assets/images/logo/logo_256.png",
+            width = 64,
+            height = 64
+        }),
+        editor.ui.image({
+            image = "https://defold.com/images/assets/monarch-hero.jpg"
+        })
+    }
+})
+```
+
+### Girdi bileşenleri
+
+Girdi bileşenleri, kullanıcının arayüzle etkileşime girmesi için tasarlanmıştır. Tüm girdi bileşenleri, etkileşimin etkin olup olmadığını denetlemek için `enabled` özelliğini destekler ve etkileşim olduğunda düzenleyici betiğine bildirim gönderen çeşitli geri çağırım (callback) özellikleri tanımlar.
+
+Statik bir arayüz oluşturuyorsanız yalnızca yerel değişkenleri değiştiren geri çağırımlar tanımlamanız yeterlidir. Dinamik arayüzler ve daha gelişmiş etkileşimler için [tepkisellik](#reactivity) bölümüne bakın.
+
+Örneğin, basit bir statik New File iletişim kutusunu şu şekilde oluşturabilirsiniz:
+```lua
+-- initial file name, will be replaced by the dialog
+local file_name = ""
+local create_file = editor.ui.show_dialog(editor.ui.dialog({
+    title = "Create New File",
+    content = editor.ui.horizontal({
+        padding = editor.ui.PADDING.LARGE,
+        spacing = editor.ui.SPACING.MEDIUM,
+        children = {
+            editor.ui.label({
+                text = "New File Name",
+                alignment = editor.ui.ALIGNMENT.CENTER
+            }),
+            editor.ui.string_field({
+                grow = true,
+                text = file_name,
+                -- Typing callback:
+                on_value_changed = function(new_text)
+                    file_name = new_text
+                end
+            })
+        }
+    }),
+    buttons = {
+        editor.ui.dialog_button({ text = "Cancel", cancel = true, result = false }),
+        editor.ui.dialog_button({ text = "Create File", default = true, result = true })
+    }
+}))
+if create_file then
+    print("create", file_name)
+end
+```
+Yerleşik girdi bileşenlerinin listesi şöyledir:
+- **`string_field`**, **`integer_field`** ve **`number_field`**, dizeleri, tam sayıları ve sayıları düzenlemeye izin veren tek satırlı metin alanının çeşitleridir.
+- **`select_box`**, bir açılır liste denetimiyle önceden tanımlanmış seçenek dizisinden bir seçenek seçmek için kullanılır.
+- **`check_box`**, `on_value_changed` geri çağırımına sahip bir mantıksal değer girdi alanıdır
+- **`button`**, düğmeye basıldığında çağrılan `on_press` geri çağırımına sahiptir.
+- **`external_file_field`**, bilgisayarda bir dosya yolu seçmek için tasarlanmış bir bileşendir. Bir metin alanından ve dosya seçimi iletişim kutusu açan bir düğmeden oluşur.
+- **`resource_field`**, projede bir kaynak seçmek için tasarlanmış bir bileşendir.
+
+Düğmeler dışındaki tüm bileşenler, bileşenle ilgili sorunu gösteren bir `issue` özelliğinin ayarlanmasına izin verir (bu sorun `editor.ui.ISSUE_SEVERITY.ERROR` veya `editor.ui.ISSUE_SEVERITY.WARNING` olabilir). Örneğin:
+```lua
+issue = {severity = editor.ui.ISSUE_SEVERITY.WARNING, message = "This value is deprecated"}
+```
+Bir sorun belirtildiğinde girdi bileşeninin görünümü değişir ve sorun iletisini içeren bir araç ipucu eklenir.
+
+Tüm girdilerin sorun durumlarıyla birlikte bir gösterimi şöyledir:
+
+![Girdiler](images/editor_scripts/inputs_demo.png)
+
+### İletişim kutusuyla ilgili bileşenler
+
+Bir iletişim kutusu göstermek için `editor.ui.show_dialog` işlevini kullanmanız gerekir. Bu işlev, Defold iletişim kutularının ana yapısını tanımlayan bir **`dialog`** bileşeni bekler: `title`, `header`, `content` ve `buttons`. İletişim kutusu bileşeni biraz özeldir: bir arayüz öğesini değil, bir pencereyi temsil ettiği için başka bir bileşenin alt bileşeni olarak kullanılamaz. Ancak `header` ve `content`, olağan bileşenlerdir.
+
+İletişim kutusu düğmeleri de özeldir: **`dialog_button`** bileşeni kullanılarak oluşturulurlar. Olağan düğmelerin aksine, iletişim kutusu düğmelerinin `on_pressed` geri çağırımı yoktur. Bunun yerine, iletişim kutusu kapatıldığında `editor.ui.show_dialog` işlevinin döndüreceği değeri içeren bir `result` özelliği tanımlarlar. İletişim kutusu düğmeleri ayrıca mantıksal değer alan `cancel` ve `default` özelliklerini tanımlar: `cancel` özelliğine sahip düğme, kullanıcı <kbd>Escape</kbd> tuşuna bastığında veya iletişim kutusunu işletim sisteminin kapatma düğmesiyle kapattığında tetiklenir; `default` düğmesi ise kullanıcı <kbd>Enter</kbd> tuşuna bastığında tetiklenir. Bir iletişim kutusu düğmesinin hem `cancel` hem de `default` özelliği aynı anda `true` olarak ayarlanabilir.
+
+### Yardımcı bileşenler
+
+Düzenleyici ayrıca bazı yardımcı bileşenler tanımlar: 
+- **`separator`**, içerik bloklarını ayırmak için kullanılan ince bir çizgidir
+- **`scroll`**, sardığı bileşen ayrılan alana sığmadığında kaydırma çubukları gösteren bir sarmalayıcı bileşendir
+
+## Tepkisellik {#reactivity}
+
+Bileşenler **değiştirilemez userdata** değerleri olduğu için oluşturulduktan sonra değiştirilemezler. Peki, arayüzün zaman içinde değişmesi nasıl sağlanır? Yanıt: **tepkisel bileşenler** (reactive components). 
+
+::: sidenote
+Düzenleyici betiklerinin arayüz sistemi, [React](https://react.dev/) kütüphanesinden esinlenir; bu nedenle tepkisel arayüzleri ve React kancalarını (hooks) bilmek yardımcı olur. 
+:::
+
+En basit anlatımla tepkisel bileşen, veri (özellikler) alan ve görünüm (başka bir bileşen) döndüren bir Lua işlevine sahip bileşendir. Tepkisel bileşen işlevi **kancalar** kullanabilir: bunlar, `editor.ui` modülünde bulunan ve bileşenlerinize tepkisel özellikler ekleyen özel işlevlerdir. Geleneksel olarak tüm kancaların adı `use_` ile başlar.
+
+Tepkisel bir bileşen oluşturmak için `editor.ui.component()` işlevini kullanın. 
+
+Şu örneğe bakalım: yalnızca girilen dosya adı boş olmadığında dosya oluşturmaya izin veren bir New File iletişim kutusu:
+
+```lua
+-- 1. dialog is a reactive component
+local dialog = editor.ui.component(function(props)
+    -- 2. the component defines a local state (file name) that defaults to empty string
+    local name, set_name = editor.ui.use_state("")
+
+    return editor.ui.dialog({ 
+        title = props.title,
+        content = editor.ui.vertical({
+            padding = editor.ui.PADDING.LARGE,
+            children = { 
+                editor.ui.string_field({ 
+                    value = name,
+                    -- 3. typing + Enter updates the local state
+                    on_value_changed = set_name 
+                }) 
+            }
+        }),
+        buttons = {
+            editor.ui.dialog_button({ 
+                text = "Cancel", 
+                cancel = true 
+            }),
+            editor.ui.dialog_button({ 
+                text = "Create File",
+                -- 4. creation is enabled when the name exists
+                enabled = name ~= "",
+                default = true,
+                -- 5. result is the name
+                result = name
+            })
+        }
+    })
+end)
+
+-- 6. show_dialog will either return non-empty file name or nil on cancel
+local file_name = editor.ui.show_dialog(dialog({ title = "New File Name" }))
+if file_name then 
+    print("create " .. file_name)
+else
+    print("cancelled")
+end
+```
+
+Bu kodu çalıştıran bir menü komutunu yürüttüğünüzde düzenleyici bir iletişim kutusu gösterir. `"Create File"` iletişim kutusu başlangıçta devre dışıdır, ancak bir ad yazıp <kbd>Enter</kbd> tuşuna bastığınızda etkinleşir:
+
+![Yeni dosya iletişim kutusu](images/editor_scripts/reactive_new_file_dialog.png)
+
+Peki, bu nasıl çalışır? İlk işlemede `use_state` kancası, bileşenle ilişkili bir yerel durum oluşturur ve bunu durumun ayarlayıcısıyla (setter) birlikte döndürür. Ayarlayıcı işlev çağrıldığında bileşenin yeniden işlenmesini planlar. Sonraki yeniden işlemelerde bileşen işlevi tekrar çağrılır ve `use_state` güncellenmiş durumu döndürür. Ardından, bileşen işlevinin döndürdüğü yeni görünüm bileşeni eskisiyle karşılaştırılır ve değişikliklerin saptandığı yerlerde arayüz güncellenir.
+
+Bu tepkisel yaklaşım, etkileşimli arayüzler oluşturmayı ve bunları eşzamanlı tutmayı büyük ölçüde basitleştirir: kullanıcı girdisinde etkilenen tüm arayüz bileşenlerini açıkça güncellemek yerine görünüm, girdinin (özellikler ve yerel durum) saf bir işlevi (pure function) olarak tanımlanır ve düzenleyici tüm güncellemeleri kendisi yönetir.
+
+### Tepkisellik kuralları
+
+Düzenleyici, tepkisel işlev bileşenlerinin çalışabilmesi için aşağıdaki kurallara uymasını bekler:
+
+1. Bileşen işlevleri saf olmalıdır. Bileşen işlevinin ne zaman veya ne sıklıkta çağrılacağı garanti edilmez. Tüm yan etkilerin işleme dışında, örneğin geri çağırımlarda gerçekleşmesi önerilir
+2. Özellikler ve yerel durum değiştirilemez olmalıdır. Özellikleri değiştirmeyin. Yerel durumunuz bir tabloysa onu yerinde değiştirmeyin; durumun değişmesi gerektiğinde yeni bir tablo oluşturup ayarlayıcıya geçirin.
+3. Bileşen işlevleri, her çağrıldıklarında aynı kancaları aynı sırayla çağırmalıdır. Kancaları döngülerin içinde, koşullu bloklarda, erken dönüşlerden sonra vb. çağırmayın. Kancaları bileşen işlevinin başında, diğer tüm kodlardan önce çağırmak iyi bir uygulamadır.
+4. Kancaları yalnızca bileşen işlevlerinden çağırın. Kancalar, tepkisel bir bileşenin bağlamında çalışır; bu nedenle yalnızca bileşen işlevinde (veya bileşen işlevinin doğrudan çağırdığı başka bir işlevde) çağrılmalarına izin verilir.
+
+### Kancalar
+
+::: sidenote
+[React](https://react.dev/) kütüphanesini biliyorsanız düzenleyicideki kancaların, kanca bağımlılıkları söz konusu olduğunda biraz farklı anlamlara sahip olduğunu fark edersiniz.
+:::
+
+Düzenleyici 2 kanca tanımlar: **`use_memo`** ve **`use_state`**.
+
+### **`use_state`**
+
+Yerel durum 2 şekilde oluşturulabilir: varsayılan bir değerle veya bir başlatıcı işlevle:
+```lua
+-- default value
+local enabled, set_enabled = editor.ui.use_state(true)
+-- initializer function + args
+local id, set_id = editor.ui.use_state(string.lower, props.name)
+```
+Benzer şekilde, ayarlayıcı yeni bir değerle veya bir güncelleyici işlevle çağrılabilir:
+```lua
+-- updater function
+local function increment_by(n, by)
+    return n + by
+end
+
+local counter = editor.ui.component(function(props)
+    local count, set_count = editor.ui.use_state(0)
+    
+    return editor.ui.horizontal({
+        spacing = editor.ui.SPACING.SMALL,
+        children = {
+            editor.ui.label({
+                text = tostring(count),
+                alignment = editor.ui.ALIGNMENT.LEFT,
+                grow = true
+            }),
+            editor.ui.text_button({
+                text = "+1",
+                on_pressed = function() set_count(increment_by, 1) end
+            }),
+            editor.ui.text_button({
+                text = "+5",
+                on_pressed = function() set_count(increment_by, 5) end
+            })
+        }
+    })
+end)
+```
+
+Son olarak durum **sıfırlanabilir**. `editor.ui.use_state()` işlevinin bağımsız değişkenlerinden herhangi biri değiştiğinde durum sıfırlanır; bu değişiklik `==` ile denetlenir. Bu nedenle `use_state` kancasının bağımsız değişkenleri olarak doğrudan yazılmış tabloları veya doğrudan tanımlanmış başlatıcı işlevleri kullanmayın: bu, her yeniden işlemede durumun sıfırlanmasına neden olur. Örnekle açıklayalım:
+```lua
+-- ❌ BAD: literal table initializer causes state reset on every re-render
+local user, set_user = editor.ui.use_state({ first_name = props.first_name, last_name = props.last_name})
+
+-- ✅ GOOD: use initializer function outside of component function to create table state
+local function create_user(first_name, last_name) 
+    return { first_name = first_name, last_name = last_name}
+end
+-- ...later, in component function:
+local user, set_user = editor.ui.use_state(create_user, props.first_name, props.last_name)
+
+
+-- ❌ BAD: literal initializer function causes state reset on every re-render
+local id, set_id = editor.ui.use_state(function() return string.lower(props.name) end)
+
+-- ✅ GOOD: use referenced initializer function to create the state
+local id, set_id = editor.ui.use_state(string.lower, props.name)
+```
+
+### **`use_memo`**
+
+Performansı iyileştirmek için `use_memo` kancasını kullanabilirsiniz. İşleme işlevlerinde, örneğin kullanıcı girdisinin geçerli olup olmadığını denetlemek için bazı hesaplamalar yapmak yaygındır. `use_memo` kancası, hesaplama işlevine verilen bağımsız değişkenlerin değişip değişmediğini denetlemenin hesaplama işlevini çağırmaktan daha düşük maliyetli olduğu durumlarda kullanılabilir. Kanca, hesaplama işlevini ilk işlemede çağırır ve `use_memo` kancasının tüm bağımsız değişkenleri değişmeden kalmışsa sonraki yeniden işlemelerde hesaplanan değeri tekrar kullanır:
+```lua
+-- validation function outside of component function
+local function validate_password(password)
+    if #password < 8 then
+        return false, "Password must be at least 8 characters long."
+    elseif not password:match("%l") then
+        return false, "Password must include at least one lowercase letter."
+    elseif not password:match("%u") then
+        return false, "Password must include at least one uppercase letter."
+    elseif not password:match("%d") then
+        return false, "Password must include at least one number."
+    else
+        return true, "Password is valid."
+    end
+end
+
+-- ...later, in component function
+local username, set_username = editor.ui.use_state('')
+local password, set_password = editor.ui.use_state('')
+local valid, message = editor.ui.use_memo(validate_password, password)
+```
+Bu örnekte parola doğrulaması, parola her değiştiğinde (örneğin bir parola alanına yazı yazıldığında) çalışır, ancak kullanıcı adı değiştiğinde çalışmaz.
+
+`use_memo` için başka bir kullanım alanı, daha sonra girdi bileşenlerinde kullanılan geri çağırımlar oluşturmaktır. Yerel olarak oluşturulmuş bir işlevin başka bir bileşene özellik değeri olarak verildiği durumlarda da kullanılır; bu, gereksiz yeniden işlemeleri önler.

--- a/docs/tr/manuals/editor-scripts.md
+++ b/docs/tr/manuals/editor-scripts.md
@@ -1,0 +1,797 @@
+---
+title: Düzenleyici betikleri
+brief: Bu kılavuz, Lua kullanarak düzenleyiciyi nasıl genişleteceğinizi açıklar
+---
+
+# Düzenleyici betikleri
+
+`.editor_script` özel uzantısına sahip Lua dosyalarını kullanarak özel menü öğeleri ve düzenleyici yaşam döngüsü kancaları (lifecycle hooks) oluşturabilirsiniz. Bu düzenleyici betiği (editor script) sistemiyle geliştirme iş akışınızı iyileştirmek için düzenleyiciyi özelleştirebilirsiniz.
+
+## Düzenleyici betiklerinin çalışma zamanı ortamı
+
+Düzenleyici betikleri, düzenleyicinin içinde, Java sanal makinesinin öykündüğü bir Lua sanal makinesinde çalışır. Tüm betikler tek bir ortak ortamı paylaşır; yani birbirleriyle etkileşim kurabilirler. Tıpkı `.script` dosyalarında olduğu gibi Lua modüllerini `require` ile yükleyebilirsiniz, ancak düzenleyicinin içinde çalışan Lua sürümü farklıdır; bu nedenle ortak kodunuzun uyumlu olduğundan emin olun. Düzenleyici Lua 5.2.x sürümünü, daha özel olarak da şu anda JVM üzerinde Lua çalıştırmak için uygulanabilir tek çözüm olan [luaj](https://github.com/luaj/luaj) çalışma zamanı ortamını kullanır. Bunun yanında bazı kısıtlamalar vardır:
+- `debug` paketi yoktur;
+- `os.execute` yoktur, ancak benzer bir işlev olan `editor.execute()` sunulur;
+- `os.tmpname` ve `io.tmpfile` yoktur — düzenleyici betikleri şu anda yalnızca proje dizininin içindeki dosyalara erişebilir;
+- eklemek istesek de şu anda `os.rename` yoktur;
+- `os.exit` ve `os.setlocale` yoktur.
+- düzenleyicinin betikten anında yanıt alması gereken bağlamlarda uzun süren bazı işlevlerin kullanılmasına izin verilmez; ayrıntılar için [Yürütme modları](#execution-modes) bölümüne bakın.
+
+Bir projeyi açtığınızda düzenleyici betiklerinde tanımlanan tüm düzenleyici uzantıları yüklenir. Kütüphaneleri getirdiğinizde uzantılar yeniden yüklenir; çünkü bağımlı olduğunuz kütüphanelerde yeni düzenleyici betikleri bulunabilir. Bu yeniden yükleme sırasında kendi düzenleyici betiklerinizdeki değişiklikler alınmaz; çünkü bunları değiştirmeyi henüz bitirmemiş olabilirsiniz. Bunları da yeniden yüklemek için **Project → Reload Editor Scripts** komutunu çalıştırmanız önerilir.
+
+## `.editor_script` dosyasının yapısı
+
+Her düzenleyici betiği aşağıdaki gibi bir modül döndürmelidir:
+```lua
+local M = {}
+
+function M.get_commands()
+  -- TODO - define editor commands
+end
+
+function M.get_language_servers()
+  -- TODO - define language servers
+end
+
+function M.get_prefs_schema()
+  -- TODO - define preferences
+end
+
+return M
+```
+Düzenleyici daha sonra projede ve kütüphanelerde tanımlanan tüm düzenleyici betiklerini toplar, bunları tek bir Lua sanal makinesine yükler ve gerektiğinde çağırır (bu konuda daha fazla bilgi [komutlar](#commands) ve [yaşam döngüsü kancaları](#lifecycle-hooks) bölümlerindedir).
+
+## Düzenleyici API'si
+
+Aşağıdaki API'yi tanımlayan `editor` paketini kullanarak düzenleyiciyle etkileşim kurabilirsiniz:
+- `editor.platform` — Windows için `"x86_64-win32"`, macOS için `"x86_64-macos"` veya Linux için `"x86_64-linux"` değerini alan bir dize.
+- `editor.version` — Defold sürüm adını içeren bir dize; örneğin `"1.4.8"`
+- `editor.engine_sha1` — Defold motorunun SHA1 değerini içeren bir dize
+- `editor.editor_sha1` — Defold düzenleyicisinin SHA1 değerini içeren bir dize
+- `editor.get(node_id, property)` — düzenleyicideki bir düğümün (node) değerini alır. Düzenleyicideki düğümler; betik veya koleksiyon (collection) dosyaları, koleksiyonların içindeki oyun nesneleri (game objects), kaynak (resource) olarak yüklenen JSON dosyaları gibi çeşitli öğelerdir. `node_id`, düzenleyici tarafından düzenleyici betiğine iletilen bir userdata değeridir. Alternatif olarak düğüm kimliği yerine bir kaynak yolu, örneğin `"/main/game.script"`, iletebilirsiniz. `property` bir dizedir. Şu anda aşağıdaki özellikler desteklenir:
+  - `"path"` — dosya veya dizin olarak var olan öğeler, yani *kaynaklar* için proje klasörüne göre dosya yolu. Döndürülen değere örnek: `"/main/game.script"`
+  - `"children"` — dizin kaynakları için alt kaynak yollarının listesi
+  - `"parent"` — üst düğümü olan bir Outline düğümünün üst düzenleyici düğümü
+  - `"text"` — metin olarak düzenlenebilen bir kaynağın (betik veya JSON dosyaları gibi) metin içeriği. Döndürülen değere örnek: `"function init(self)\nend"`. Bunun dosyayı `io.open()` ile okumakla aynı olmadığını unutmayın; çünkü bir dosyayı kaydetmeden düzenleyebilirsiniz ve bu düzenlemelere yalnızca `"text"` özelliğine erişildiğinde ulaşılabilir.
+  - atlaslar için: `images` (atlastaki görüntülere ait düzenleyici düğümlerinin listesi) ve `animations` (animasyon düğümlerinin listesi)
+  - atlas animasyonları için: `images` (atlastaki `images` ile aynı)
+  - karo haritaları (tilemaps) için: `layers` (karo haritasındaki katmanlara ait düzenleyici düğümlerinin listesi)
+  - karo haritası katmanları için: `tiles` (sınırsız bir 2B karo ızgarası); daha fazla bilgi için `tilemap.tiles.*` bölümüne bakın
+  - parçacık efektleri için: `emitters` (yayıcı düzenleyici düğümlerinin listesi) ve `modifiers` (değiştirici düzenleyici düğümlerinin listesi)
+  - parçacık efekti yayıcıları için: `modifiers` (değiştirici düzenleyici düğümlerinin listesi)
+  - çarpışma nesneleri için: `shapes` (çarpışma şekli düzenleyici düğümlerinin listesi)
+  - GUI dosyaları için: `layers`, `fonts`, `materials`, `textures`, `particlefxs`, `nodes` ve `layouts` gibi düğüm listeleri
+  - Outline görünümünde bir şey seçtiğinizde Properties görünümünde gösterilen bazı özellikler. Şu türdeki Outline özellikleri desteklenir:
+    - `strings`
+    - `booleans`
+    - `numbers`
+    - `vec2`/`vec3`/`vec4`
+    - `resources`
+    - `curves`
+    Bu özelliklerden bazılarının salt okunur olabileceğini ve bazılarının farklı bağlamlarda kullanılamayabileceğini unutmayın. Bu nedenle bunları okumadan önce `editor.can_get`, düzenleyicide ayarlamadan önce de `editor.can_set` kullanmanız önerilir. Özelliğin düzenleyici betiklerindeki adını açıklayan araç ipucunu görmek için Properties görünümünde özellik adının üzerine gelin. `""` değerini vererek kaynak özelliklerini `nil` olarak ayarlayabilirsiniz.
+- `editor.properties(node_id)` — bir düğümden okunabilen özellik adlarının sıralanmış, bağlama duyarlı bir listesini döndürür; örneğin `pprint(editor.properties("/game.project"))`. Listelenen bir özelliğin ayrıca değiştirilip değiştirilemeyeceğini, sıfırlanıp sıfırlanamayacağını, ona öğe eklenip eklenemeyeceğini veya öğelerinin yeniden sıralanıp sıralanamayacağını denetlemek için `editor.can_*` işlevlerini kullanın.
+- `editor.can_get(node_id, property)` — `editor.get()` işlevinin hata vermemesi için bu özelliği alıp alamayacağınızı denetler.
+- `editor.can_set(node_id, property)` — bu özellik ile kullanılan `editor.tx.set()` düzenleyici işlemi (transaction) adımının hata vermeyeceğini denetler.
+- `editor.create_directory(resource_path)` — bir dizin yoksa onu ve var olmayan tüm üst dizinlerini oluşturur.
+- `editor.create_resources(resources)` — şablonlardan veya özel içerikle 1 ya da daha fazla kaynak oluşturur
+- `editor.delete_directory(resource_path)` — bir dizin varsa onu ve var olan tüm alt dizinlerini ve dosyalarını siler.
+- `editor.execute(cmd, [...args], [options])` — bir kabuk komutu çalıştırır; isteğe bağlı olarak çıktısını yakalar.
+- `editor.save()` — kaydedilmemiş tüm değişiklikleri diske kaydeder.
+- `editor.transact(txs)` — `editor.tx.*` işlevleriyle oluşturulan 1 veya daha fazla işlem adımını kullanarak düzenleyicinin bellekteki durumunu değiştirir.
+- `editor.ui.*` — kullanıcı arayüzüyle ilgili çeşitli işlevler; [Kullanıcı arayüzü kılavuzuna](/manuals/editor-scripts-ui) bakın.
+- `editor.prefs.*` — düzenleyici tercihleriyle etkileşim kurma işlevleri; [tercihler](#preferences) bölümüne bakın.
+
+Düzenleyici API'sinin tüm başvuru belgelerini [burada](/ref/stable/editor/) bulabilirsiniz.
+
+## Komutlar {#commands}
+
+Bir düzenleyici betiği modülü `get_commands()` tanımlıyorsa uzantılar yeniden yüklendiğinde bu işlev çağrılır. Döndürülen komutlar, `locations` değerlerine bağlı olarak menü çubuğu menülerinde ve Assets, Outline, Scene ve Code bağlam menülerinde görünebilir. Örnek:
+
+```lua
+local M = {}
+
+function M.get_commands()
+  return {
+    {
+      label = "Remove Comments",
+      locations = {"Edit", "Assets"},
+      query = {
+        selection = {type = "resource", cardinality = "one"}
+      },
+      active = function(opts)
+        local path = editor.get(opts.selection, "path")
+        return ends_with(path, ".lua") or ends_with(path, ".script")
+      end,
+      run = function(opts)
+        local text = editor.get(opts.selection, "text")
+        editor.transact({
+          editor.tx.set(opts.selection, "text", strip_comments(text))
+        })
+      end
+    },
+    {
+      label = "Minify JSON",
+      locations = {"Assets"},
+      query = {
+        selection = {type = "resource", cardinality = "one"}
+      },
+      active = function(opts)
+        return ends_with(editor.get(opts.selection, "path"), ".json")
+      end,
+      run = function(opts)
+        local path = editor.get(opts.selection, "path")
+        editor.execute("./scripts/minify-json.sh", path:sub(2))
+      end
+    }
+  }
+end
+
+return M
+```
+Düzenleyici, `get_commands()` işlevinin her biri ayrı bir komutu açıklayan tablolardan oluşan bir dizi döndürmesini bekler. Komut açıklaması şunlardan oluşur:
+
+- `label` (zorunlu) — kullanıcıya gösterilecek menü öğesinin metni
+- `locations` (zorunlu) — bu komutun nerelerde kullanılabilmesi gerektiğini açıklayan bir dizi. Desteklenen değerler; ilgili menü çubuğu menüleri için `"Edit"`, `"View"`, `"Project"`, `"Debug"` ve `"Help"`; **Project → Bundle** alt menüsü için `"Bundle"`; ilgili bağlam menüleri için de `"Assets"`, `"Outline"`, `"Scene"` ve `"Code"` değerleridir.
+- `query` — komutun düzenleyiciden ilgili bilgileri istemesini ve hangi veriler üzerinde çalıştığını tanımlamasını sağlar. `query` tablosundaki her anahtar için `active` ve `run` geri çağırımlarının (callbacks) bağımsız değişken olarak aldığı `opts` tablosunda karşılık gelen bir anahtar bulunur. Desteklenen anahtarlar:
+  - `selection`, bu komutun bir şey seçili olduğunda geçerli olduğunu ve bu seçim üzerinde çalıştığını belirtir.
+    - `type`, komutun ilgilendiği seçili düğümlerin türüdür; şu anda aşağıdaki türlere izin verilir:
+      - `"resource"` — Assets ve Outline görünümlerinde kaynak, karşılık gelen bir dosyası olan seçili öğedir. Menü çubuğunda (Edit veya View) kaynak, o anda açık olan dosyadır;
+      - `"outline"` — Outline görünümünde gösterilebilen bir öğe. Outline görünümünde seçili öğedir; menü çubuğunda ise o anda açık olan dosyadır;
+      - `"scene"` — Scene görünümünde görüntüsü oluşturulabilen bir öğe.
+    - `cardinality`, kaç öğenin seçili olması gerektiğini tanımlar. `"one"` ise komut geri çağırımına iletilen seçim tek bir düğüm kimliği olur. `"many"` ise komut geri çağırımına iletilen seçim, bir veya daha fazla düğüm kimliğinden oluşan bir dizi olur.
+  - `active_view`, etkin düzenleyici görünümü istenen türle eşleştiğinde bu komutun geçerli olduğunu belirtir. Etkin görünüm, komut geri çağırımına `opts.active_view` olarak iletilir.
+    - `type`, komutun ilgilendiği etkin görünüm türüdür: `"code"`, `"scene"`, `"html"` veya `"form"`.
+    - Etkin görünüm `"type"`, `"resource"` ve `"dirty"` özelliklerini destekler. Görünümde gösterilen kaynağı almak için `editor.get(view, "resource")`, kaydedilmemiş değişiklikleri olup olmadığını denetlemek için de `editor.get(view, "dirty")` kullanın.
+  - `argument` — komut bağımsız değişkeni. Şu anda yalnızca `"Bundle"` konumundaki komutlar bir bağımsız değişken alır. Bu değer, paketleme komutu açıkça seçildiğinde `true`, yeniden paketleme sırasında ise `false` olur.
+- `id` - komut tanımlayıcısı dizesi; örneğin son kullanılan paketleme komutunu `prefs` içinde kalıcı olarak saklamak için kullanılır
+- `active` - komutun etkin olup olmadığını denetlemek için yürütülen ve mantıksal değer döndürmesi beklenen bir geri çağırım. `locations` içinde `"Assets"`, `"Scene"` veya `"Outline"` varsa `active`, bağlam menüsü gösterilirken çağrılır. Konumlar arasında `"Edit"` veya `"View"` varsa active, klavyede yazma veya fareyle tıklama gibi her kullanıcı etkileşiminde çağrılır; bu nedenle `active` geri çağırımının nispeten hızlı olduğundan emin olun.
+- `run` - kullanıcı menü öğesini seçtiğinde yürütülen bir geri çağırım.
+
+### Düzenleyicinin bellekteki durumunu değiştirmek için komutları kullanma
+
+`run` işleyicisinin içinde, düzenleyicinin bellekteki durumunu sorgulayabilir ve değiştirebilirsiniz. Sorgulama, `editor.get()` işleviyle yapılır; bu işlevle düzenleyiciye dosyaların ve seçimin (`query = {selection = ...}` kullanıyorsanız) geçerli durumunu sorabilirsiniz. Metin olarak düzenlenebilen kaynakların `"text"` özelliğini ve Properties görünümünde gösterilen bazı özellikleri alabilirsiniz — özelliğin düzenleyici betiklerindeki adını açıklayan araç ipucunu görmek için özellik adının üzerine gelin. Düzenleyicinin durumunu değiştirmek için `editor.transact()` kullanılır; bu işlevle 1 veya daha fazla değişikliği geri alınabilen tek bir adımda birleştirirsiniz. Örneğin bir oyun nesnesinin dönüşümünü sıfırlayabilmek istiyorsanız şöyle bir komut yazabilirsiniz:
+```lua
+{
+  label = "Reset transform",
+  locations = {"Outline"},
+  query = {selection = {type = "outline", cardinality = "one"}},
+  active = function(opts)
+    local node = opts.selection
+    return editor.can_set(node, "position") 
+       and editor.can_set(node, "rotation") 
+       and editor.can_set(node, "scale")
+  end,
+  run = function(opts)
+    local node = opts.selection
+    editor.transact({
+      editor.tx.set(node, "position", {0, 0, 0}),
+      editor.tx.set(node, "rotation", {0, 0, 0}),
+      editor.tx.set(node, "scale", {1, 1, 1})
+    })
+  end
+}
+```
+
+### Etkin düzenleyici görünümüyle komutları kullanma
+
+`"View"` gibi menü konumlarındaki komutlar, o anda etkin olan düzenleyici görünümünü sorgulayabilir. Bu, bir komutun kullanıcının o anda baktığı dosya veya sahne üzerinde çalışması gerektiğinde yararlıdır:
+
+```lua
+editor.command({
+  label = "Print Active View",
+  locations = {"View"},
+  query = {active_view = {type = "code"}},
+  run = function(opts)
+    local view = opts.active_view
+    local resource = editor.get(view, "resource")
+    print(editor.get(view, "type"))
+    print(editor.get(resource, "path"))
+    print(editor.get(view, "dirty"))
+  end
+})
+```
+
+#### Atlasları düzenleme
+
+Bir atlasın özelliklerini okuyup yazmanın yanı sıra atlas görüntülerini ve animasyonlarını da okuyabilir ve değiştirebilirsiniz. Atlaslar `images` ve `animations` düğüm listesi özelliklerini, animasyonlar ise `images` düğüm listesi özelliğini tanımlar: bu özelliklerle `editor.tx.add`, `editor.tx.remove` ve `editor.tx.clear` işlem adımlarını kullanabilirsiniz.
+
+Örneğin bir atlasa görüntü eklemek için komutun `run` işleyicisinde aşağıdaki kodu yürütün:
+```lua
+editor.transact({
+    editor.tx.add("/main.atlas", "images", {image="/assets/hero.png"})
+})
+```
+Bir atlastaki tüm görüntülerin kümesini bulmak için aşağıdaki kodu yürütün:
+```lua
+local all_images = {} ---@type table<string, true>
+-- first, collect all "bare" images
+local image_nodes = editor.get("/main.atlas", "images")
+for i = 1, #image_nodes do
+    all_images[editor.get(image_nodes[i], "image")] = true
+end
+-- second, collect all images used in animations
+local animation_nodes = editor.get("/main.atlas", "animations")
+for i = 1, #animation_nodes do
+    local animation_image_nodes = editor.get(animation_nodes[i], "images")
+    for j = 1, #animation_image_nodes do
+        all_images[editor.get(animation_image_nodes[j], "image")] = true
+    end
+end
+pprint(all_images)
+-- {
+--     ["/assets/hero.png"] = true,
+--     ["/assets/enemy.png"] = true,
+-- }}
+```
+Bir atlastaki tüm animasyonları değiştirmek için:
+```lua
+editor.transact({
+    editor.tx.clear("/main.atlas", "animations"),
+    editor.tx.add("/main.atlas", "animations", {
+        id = "hero_run",
+        images = {
+            {image = "/assets/hero_run_1.png"},
+            {image = "/assets/hero_run_2.png"},
+            {image = "/assets/hero_run_3.png"},
+            {image = "/assets/hero_run_4.png"}
+        }
+    })
+})
+```
+
+#### Karo kaynaklarını düzenleme
+
+Karo kaynakları (tile sources), Outline özelliklerine ek olarak aşağıdaki özellikleri tanımlar:
+- `animations` - karo kaynağının animasyon düğümlerinin listesi
+- `collision_groups` - karo kaynağının çarpışma grubu düğümlerinin listesi
+- `tile_collision_groups` - karo kaynağındaki karoların çarpışma grubu atamalarını içeren tablo
+
+Örneğin bir karo kaynağını şöyle yapılandırabilirsiniz:
+```lua
+local tilesource = "/game/world.tilesource"
+editor.transact({
+    editor.tx.add(tilesource, "animations", {id = "idle", start_tile = 1, end_tile = 1}),
+    editor.tx.add(tilesource, "animations", {id = "walk", start_tile = 2, end_tile = 6, fps = 10}),
+    editor.tx.add(tilesource, "collision_groups", {id = "player"}),
+    editor.tx.add(tilesource, "collision_groups", {id = "obstacle"}),
+    editor.tx.set(tilesource, "tile_collision_groups", {
+        [1] = "player",
+        [7] = "obstacle",
+        [8] = "obstacle"
+    })
+})
+```
+
+#### Karo haritalarını düzenleme
+
+Karo haritaları, karo haritası katmanlarının düğüm listesi olan `layers` özelliğini tanımlar. Her katman ayrıca, bu katmandaki sınırsız bir 2B karo ızgarasını tutan `tiles` özelliğini tanımlar. Bu, motordan farklıdır: karoların sınırları yoktur ve negatif koordinatlar dahil her yere eklenebilirler. Düzenleyici betiği API'si, karoları düzenlemek için aşağıdaki işlevleri içeren `tilemap.tiles` modülünü tanımlar:
+- `tilemap.tiles.new()`, sınırsız bir 2B karo ızgarasını tutan yeni bir veri yapısı oluşturur (motorun aksine, düzenleyicide karo haritası sınırsızdır ve koordinatlar negatif olabilir)
+- `tilemap.tiles.get_tile(tiles, x, y)`, belirli bir koordinattaki karo indeksini alır
+- `tilemap.tiles.get_info(tiles, x, y)`, belirli bir koordinattaki karo bilgilerinin tamamını alır (veri yapısı, motorun `tilemap.get_tile_info` işlevindekiyle aynıdır)
+- `tilemap.tiles.iterator(tiles)`, karo haritasındaki tüm karoları dolaşan bir yineleyici oluşturur
+- `tilemap.tiles.clear(tiles)`, karo haritasındaki tüm karoları kaldırır
+- `tilemap.tiles.set(tiles, x, y, tile_or_info)`, belirli bir koordinattaki karoyu ayarlar
+- `tilemap.tiles.remove(tiles, x, y)`, belirli bir koordinattaki karoyu kaldırır
+
+Örneğin tüm karo haritasının içeriğini şöyle yazdırabilirsiniz:
+```lua
+local layers = editor.get("/level.tilemap", "layers")
+for i = 1, #layers do
+    local layer = layers[i]
+    local id = editor.get(layer, "id")
+    local tiles = editor.get(layer, "tiles")
+    print("layer " .. id .. ": {")
+    for x, y, tile in tilemap.tiles.iterator(tiles) do
+        print("  [" .. x .. ", " .. y .. "] = " .. tile)
+    end
+    print("}")
+end
+```
+
+Aşağıdaki örnek, bir karo haritasına karolar içeren bir katmanın nasıl eklendiğini gösterir:
+```lua
+local tiles = tilemap.tiles.new()
+tilemap.tiles.set(tiles, 1, 1, 2)
+editor.transact({
+    editor.tx.add("/level.tilemap", "layers", {
+        id = "new_layer",
+        tiles = tiles
+    })
+})
+```
+
+#### Parçacık efektlerini düzenleme
+
+Parçacık efektlerini `modifiers` ve `emitters` özelliklerini kullanarak düzenleyebilirsiniz. Örneğin ivme değiştiricisi içeren bir daire yayıcı şöyle eklenir:
+```lua
+editor.transact({
+    editor.tx.add("/fire.particlefx", "emitters", {
+        type = "emitter-type-circle",
+        modifiers = {
+          {type = "modifier-type-acceleration"}
+        }
+    })
+})
+```
+Birçok parçacık efekti özelliği, eğri veya yayılımlı eğri (curve spread; yani eğri + bir rastgelelik değeri) biçimindedir. Eğriler, boş olmayan bir `points` listesi içeren tablo olarak gösterilir; listedeki her nokta, aşağıdaki özellikleri içeren bir tablodur:
+- `x` - noktanın x koordinatı; 0 ile başlayıp 1 ile bitmesi önerilir
+- `y` - noktanın değeri
+- `tx` (0 ile 1 arasında) ve `ty` (-1 ile 1 arasında) - noktanın teğetleri. Örneğin 80 derecelik bir açı için `tx` değerinin `math.cos(math.rad(80))`, `ty` değerinin ise `math.sin(math.rad(80))` olması önerilir.
+Yayılımlı eğriler ayrıca sayısal bir `spread` özelliğine sahiptir. 
+
+Örneğin mevcut bir yayıcı için parçacığın yaşam süresi boyunca alfa değerini belirleyen eğriyi ayarlamak şöyle görünebilir:
+```lua
+local emitter = editor.get("/fire.particlefx", "emitters")[1]
+editor.transact({
+    editor.tx.set(emitter, "particle_key_alpha", { points = {
+        {x = 0,   y = 0, tx = 0.1, ty = 1}, -- start at 0, go up quickly
+        {x = 0.2, y = 1, tx = 1,   ty = 0}, -- reach 1 at 20% of a lifetime
+        {x = 1,   y = 0, tx = 1,   ty = 0}  -- slowly go down to 0
+    }})
+})
+```
+Elbette, bir yayıcı oluştururken tablodaki `particle_key_alpha` anahtarını kullanmak da mümkündür. Ayrıca "statik" bir eğriyi göstermek için bunun yerine tek bir sayı kullanabilirsiniz.
+
+#### Çarpışma nesnelerini düzenleme
+
+Çarpışma nesneleri, varsayılan Outline özelliklerine ek olarak `shapes` düğüm listesi özelliğini tanımlar. Yeni çarpışma şekilleri şöyle eklenir:
+```lua
+editor.transact({
+    editor.tx.add("/hero.collisionobject", "shapes", {
+        type = "shape-type-box" -- or "shape-type-sphere", "shape-type-capsule"
+    })
+})
+```
+Şeklin `type` özelliği oluşturma sırasında zorunludur ve şekil eklendikten sonra değiştirilemez. 3 şekil türü vardır:
+- `shape-type-box` - `dimensions` özelliği olan kutu şekli
+- `shape-type-sphere` - `diameter` özelliği olan küre şekli
+- `shape-type-capsule` - `diameter` ve `height` özellikleri olan kapsül şekli
+
+#### GUI dosyalarını düzenleme
+
+GUI dosyaları, Outline özelliklerine ek olarak birkaç düğüm listesi özelliği tanımlar:
+
+- `layers` — katman düzenleyici düğümlerinin listesi (yeniden sıralanabilir)
+- `fonts` — yazı tipi düzenleyici düğümlerinin listesi
+- `materials` — materyal düzenleyici düğümlerinin listesi
+- `textures` — doku düzenleyici düğümlerinin listesi
+- `particlefxs` — Particle FX düzenleyici düğümlerinin listesi
+- `nodes` — GUI düğümlerine ait düzenleyici düğümlerinin listesi
+- `layouts` — GUI yerleşimi düzenleyici düğümlerinin listesi
+
+Düzenleyicinin `layers` özelliğini kullanarak GUI katmanlarını düzenleyebilirsiniz; örneğin:
+```lua
+editor.transact({
+    editor.tx.add("/main.gui", "layers", {name = "foreground"}),
+    editor.tx.add("/main.gui", "layers", {name = "background"})
+})
+```
+Ayrıca katmanları yeniden sıralamak da mümkündür:
+```lua
+local fg, bg = table.unpack(editor.get("/main.gui", "layers"))
+editor.transact({
+    editor.tx.reorder("/main.gui", "layers", {bg, fg})
+})
+```
+Benzer şekilde yazı tipleri, materyaller, dokular ve parçacık efektleri; `fonts`, `materials`, `textures` ve `particlefxs` özellikleri kullanılarak düzenlenir:
+```lua
+editor.transact({
+    editor.tx.add("/main.gui", "fonts", {font = "/main.font"}),
+    editor.tx.add("/main.gui", "materials", {name = "shine", material = "/shine.material"}),
+    editor.tx.add("/main.gui", "particlefxs", {particlefx = "/confetti.particlefx"}),
+    editor.tx.add("/main.gui", "textures", {texture = "/ui.atlas"})
+})
+```
+Bu özellikler yeniden sıralamayı desteklemez.
+
+Son olarak `nodes` liste özelliğini kullanarak GUI düğümlerini düzenleyebilirsiniz; örneğin:
+```lua
+editor.transact({
+    editor.tx.add("/main.gui", "nodes", {
+        type = "gui-node-type-box",
+        position = {20, 20, 20}
+    }),
+    editor.tx.add("/main.gui", "nodes", {
+        type = "gui-node-type-template",
+        template = "/button.gui"
+    }),
+})
+```
+Yerleşik düğüm türleri şunlardır:
+- `gui-node-type-box`
+- `gui-node-type-particlefx`
+- `gui-node-type-pie`
+- `gui-node-type-template`
+- `gui-node-type-text`
+
+Spine uzantısını kullanıyorsanız `gui-node-type-spine` düğüm türünü de kullanabilirsiniz.
+
+GUI dosyası yerleşimler tanımlıyorsa `layout:property` sözdizimini kullanarak yerleşimlerdeki değerleri alabilir ve ayarlayabilirsiniz; örneğin:
+```lua
+local node = editor.get("/main.gui", "nodes")[1]
+
+-- GET:
+local position = editor.get(node, "position")
+pprint(position) -- {20, 20, 20}
+local landscape_position = editor.get(node, "Landscape:position")
+pprint(landscape_position) -- {20, 20, 20}
+
+-- SET:
+editor.transact({
+    editor.tx.set(node, "Landscape:position", {30, 30, 30})
+})
+pprint(editor.get(node, "Landscape:position")) -- {30, 30, 30}
+```
+
+Ayarlanmış yerleşim özellikleri, `editor.tx.reset` kullanılarak varsayılan değerlerine sıfırlanabilir:
+```lua
+print(editor.can_reset(node, "Landscape:position")) -- true
+editor.transact({
+    editor.tx.reset(node, "Landscape:position")
+})
+```
+Şablon düğüm ağaçları okunabilir, ancak düzenlenemez — yalnızca şablon düğüm ağacındaki düğümlerin özelliklerini ayarlayabilirsiniz:
+```lua
+local template = editor.get("/main.gui", "nodes")[2]
+print(editor.can_add(template, "nodes")) -- false
+local node_in_template = editor.get(template, "nodes")[1]
+editor.transact({
+    editor.tx.set(node_in_template, "text", "Button text")
+})
+print(editor.can_reset(node_in_template, "text")) -- true (overrides a value in the template)
+```
+
+#### Oyun nesnelerini düzenleme
+
+Düzenleyici betiklerini kullanarak bir oyun nesnesi dosyasının bileşenlerini (components) düzenleyebilirsiniz. Bileşenler 2 çeşittir: başvuru yoluyla eklenen (referenced) ve gömülü (embedded). Başvuru yoluyla eklenen bileşenler `component-reference` türünü kullanır ve diğer kaynaklara başvuru görevi görür; yalnızca betiklerde tanımlanan oyun nesnesi özelliklerinin geçersiz kılınmasına izin verir. Gömülü bileşenler `sprite`, `label` vb. türleri kullanır. Bileşen türünde tanımlanan tüm özelliklerin düzenlenmesine ve çarpışma nesnelerinin şekilleri gibi alt bileşenlerin eklenmesine izin verir. Örneğin bir oyun nesnesini yapılandırmak için aşağıdaki kodu kullanabilirsiniz:
+```lua
+editor.transact({
+    editor.tx.add("/npc.go", "components", {
+        type = "sprite",
+        id = "view"
+    }),
+    editor.tx.add("/npc.go", "components", {
+        type = "collisionobject",
+        id = "collision",
+        shapes = {
+            {
+                type = "shape-type-box",
+                dimensions = {32, 32, 32}
+            }
+        }
+    }),
+    editor.tx.add("/npc.go", "components", {
+        type = "component-reference",
+        path = "/npc.script",
+        id = "controller",
+        __hp = 100 -- set a go property defined in the script
+    })
+})
+```
+
+#### Koleksiyonları düzenleme
+Düzenleyici betiklerini kullanarak koleksiyonları düzenleyebilirsiniz. Oyun nesneleri (gömülü veya başvuru yoluyla) ve koleksiyonlar (başvuru yoluyla) ekleyebilirsiniz. Örneğin:
+```lua
+local coll = "/char.collection"
+editor.transact({
+    editor.tx.add(coll, "children", {
+        -- embbedded game object
+        type = "go",
+        id = "root",
+        children = {
+            {
+                -- referenced game object
+                type = "go-reference",
+                path = "/char-view.go",
+                id = "view"
+            },
+            {
+                -- referenced collection
+                type = "collection-reference",
+                path = "/body-attachments.collection",
+                id = "attachments"
+            }
+        },
+        -- embedded gos can also have components
+        components = {
+            {
+                type = "collisionobject",
+                id = "collision",
+                shapes = {
+                    {type = "shape-type-box", dimensions = {2.5, 2.5, 2.5}}
+                }
+            },
+            {
+                type = "component-reference",
+                id = "controller",
+                path = "/char.script",
+                __hp = 100 -- set a go property defined in the script
+            }
+        }
+    })
+})
+```
+
+Düzenleyicide olduğu gibi, başvuru yoluyla eklenen koleksiyonlar yalnızca düzenlenen koleksiyonun köküne eklenebilir. Oyun nesneleri ise yalnızca gömülü veya başvuru yoluyla eklenen oyun nesnelerine eklenebilir; başvuru yoluyla eklenen koleksiyonlara ya da bu koleksiyonların içindeki oyun nesnelerine eklenemez.
+
+### Kabuk komutlarını kullanma
+
+`run` işleyicisinin içinde dosyalara yazabilir (`io` modülünü kullanarak) ve kabuk komutları yürütebilirsiniz (`editor.execute()` komutunu kullanarak). Kabuk komutları yürütülürken bir kabuk komutunun çıktısını dize olarak yakalayıp kodda kullanmak mümkündür. Örneğin sistem genelinde kurulu [`jq`](https://jqlang.github.io/jq/) programını kabuk üzerinden çağırarak JSON biçimlendiren bir komut oluşturmak istiyorsanız aşağıdaki komutu yazabilirsiniz:
+```lua
+{
+  label = "Format JSON",
+  locations = {"Assets"},
+  query = {selection = {type = "resource", cardinality = "one"}},
+  action = function(opts)
+    local path = editor.get(opts.selection, "path")
+    return path:match(".json$") ~= nil
+  end,
+  run = function(opts)
+    local text = editor.get(opts.selection, "text")
+    local new_text = editor.execute("jq", "-n", "--argjson", "data", text, "$data", {
+      reload_resources = false, -- don't reload resources since jq does not touch disk
+      out = "capture" -- return text output instead of nothing
+    })
+    editor.transact({ editor.tx.set(opts.selection, "text", new_text) })
+  end
+}
+```
+Bu komut kabuk programını salt okunur biçimde çağırdığı (ve `reload_resources = false` kullanarak düzenleyiciye bunu bildirdiği) için bu eylemi geri alınabilir hale getirmenin avantajından yararlanırsınız.
+
+::: sidenote
+Düzenleyici betiğinizi kütüphane olarak dağıtmak istiyorsanız düzenleyicinin çalıştığı platformlar için ikili programı bağımlılığın içinde paketlemek isteyebilirsiniz. Bunun nasıl yapılacağına ilişkin ayrıntılar için [Kütüphanelerdeki düzenleyici betikleri](#editor-scripts-in-libraries) bölümüne bakın.
+:::
+
+## Yaşam döngüsü kancaları {#lifecycle-hooks}
+
+Özel olarak ele alınan bir düzenleyici betiği dosyası vardır: projenizin kökünde, *game.project* ile aynı dizinde bulunan `hooks.editor_script`. Düzenleyiciden yaşam döngüsü olaylarını yalnızca bu düzenleyici betiği alır. Böyle bir dosyaya örnek:
+```lua
+local M = {}
+
+function M.on_build_started(opts)
+  local file = io.open("assets/build.json", "w")
+  file:write('{"build_time": "' .. os.date() .. '"}')
+  file:close()
+end
+
+return M
+```
+Yaşam döngüsü kancalarını tek bir düzenleyici betiği dosyasıyla sınırlamaya karar verdik; çünkü derleme kancalarının gerçekleşme sırası, yeni bir derleme adımı eklemenin kolaylığından daha önemlidir. Komutlar birbirinden bağımsızdır, bu nedenle menüde hangi sırayla gösterildiklerinin pek önemi yoktur; sonuçta kullanıcı seçtiği belirli bir komutu yürütür. Farklı düzenleyici betiklerinde derleme kancaları belirtmek mümkün olsaydı şu sorun ortaya çıkardı: kancalar hangi sırayla yürütülür? Büyük olasılıkla içeriğin sağlama toplamlarını onu sıkıştırdıktan sonra oluşturmak istersiniz... Her adımın işlevini açıkça çağırarak derleme adımlarının sırasını belirleyen tek bir dosyaya sahip olmak, bu sorunu çözmenin bir yoludur.
+
+`/hooks.editor_script` dosyasının belirtebileceği mevcut yaşam döngüsü kancaları:
+- `on_build_started(opts)` — oyun, Project Build veya Debug Start seçeneklerinden biri kullanılarak yerel olarak ya da uzak bir hedefte çalıştırılmak üzere derlendiğinde yürütülür. Değişiklikleriniz derlenen oyuna yansır. Bu kancanın hata vermesi derlemeyi durdurur. `opts`, aşağıdaki anahtarları içeren bir tablodur:
+  - `platform` — hangi platform için derlendiğini açıklayan, `%arch%-%os%` biçiminde bir dize; şu anda her zaman `editor.platform` ile aynı değerdir.
+- `on_build_finished(opts)` — başarılı veya başarısız olmasına bakılmaksızın derleme bittiğinde yürütülür. `opts`, aşağıdaki anahtarları içeren bir tablodur:
+  - `platform` — `on_build_started` içindekiyle aynı
+  - `success` — derlemenin başarılı olup olmadığı; `true` veya `false`
+- `on_bundle_started(opts)` — bir dağıtım paketi (bundle) oluşturduğunuzda veya oyunun HTML5 sürümünü derlediğinizde yürütülür. `on_build_started` için olduğu gibi, bu kancanın tetiklediği değişiklikler dağıtım paketine yansır ve hatalar paketlemeyi durdurur. `opts` şu anahtarlara sahip olur:
+  - `output_directory` — dağıtım paketi çıktısını içeren dizini gösteren bir dosya yolu. **Project ▸ Build HTML5**, `build/default` altındaki normal Build çıktısından ayrı olarak kendi çıktı ağacını, örneğin `"/path/to/project/build/default_html5/__htmlLaunchDir"` yolunu kullanır.
+  - `platform` — oyunun hangi platform için paketlendiği. Olası platform değerlerinin listesi için [Bob kılavuzuna](/manuals/bob) bakın.
+  - `variant` — dağıtım paketi çeşidi; `"debug"`, `"release"` veya `"headless"`
+- `on_bundle_finished(opts)` — başarılı olup olmamasına bakılmaksızın paketleme bittiğinde yürütülür. `opts`, `on_bundle_started` içindeki `opts` ile aynı verileri ve ayrıca derlemenin başarılı olup olmadığını belirten `success` anahtarını içeren bir tablodur.
+- `on_target_launched(opts)` — kullanıcı bir oyunu başlattığında ve oyun başarıyla çalışmaya başladığında yürütülür. `opts`, başlatılmış motor hizmetini gösteren bir `url` anahtarı içerir; örneğin `"http://127.0.0.1:35405"`
+- `on_target_terminated(opts)` — başlatılmış oyun kapatıldığında yürütülür; `on_target_launched` ile aynı opts değerine sahiptir
+
+Yaşam döngüsü kancalarının şu anda yalnızca düzenleyicide kullanılabilen bir özellik olduğunu ve komut satırından paketleme yapılırken Bob tarafından yürütülmediğini unutmayın.
+
+## Dil sunucuları
+
+Düzenleyici, [Dil Sunucusu Protokolü'nün](https://microsoft.github.io/language-server-protocol/) (Language Server Protocol) bir alt kümesini destekler: tanılama (statik kod denetimleri), tamamlama, üzerine gelindiğinde gösterilen bilgiler, Structure bölmesinde belge simgeleri, tanıma gitme, başvuruları bulma, simgeyi yeniden adlandırma ve belgeyi/aralığı biçimlendirme. Dil sunucusundan gelen bilgileri görmek için bir simgenin üzerine gelin. İmleç bir simgenin üzerindeyken simgeyi yeniden adlandırmak için <kbd>F2</kbd>, tanımına gitmek için <kbd>F12</kbd> veya başvurularını bulmak için <kbd>Shift+F12</kbd> kullanın. Bu eylemlere <kbd>Edit</kbd> menüsünden de erişebilirsiniz. Biçimlendirme komutu ve kaydederken biçimlendirme tercihi için [kod biçimlendirme](/manuals/writing-code/#formatting-code) bölümüne bakın.
+
+Birlikte gelen Lua dil sunucusu, çalışma zamanı ve düzenleyici betiği API'leri için Defold tür ek açıklamalarını içerir. `.editor_script` dosyalarında tamamlama ve tanılama, `editor.*` işlevlerini ve bunların bağımsız değişken ve dönüş türlerini tanır. [Kod tamamlama](/manuals/writing-code/#code-completion) bölümüne bakın.
+
+Ek bir dil sunucusu kaydetmek için düzenleyici betiğinizin `get_language_servers` işlevini şöyle tanımlayın:
+
+```lua
+function M.get_language_servers()
+  local command = 'build/plugins/my-ext/plugins/bin/' .. editor.platform .. '/lua-lsp'
+  if editor.platform == 'x86_64-win32' then
+    command = command .. '.exe'
+  end
+  return {
+    {
+      languages = {'lua'},
+      watched_files = {
+        { pattern = '**/.luacheckrc' }
+      },
+      command = {command, '--stdio'}
+    }
+  }
+end
+```
+Düzenleyici, belirtilen `command` değerini kullanarak dil sunucusunu başlatır ve iletişim için sunucu sürecinin standart girdisini ve çıktısını kullanır.
+
+Dil sunucusu tanım tablosunda şunlar belirtilebilir:
+- `languages` (zorunlu) — sunucunun ilgilendiği, [burada](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers) tanımlanan dillerin listesi (dosya uzantıları da kullanılabilir);
+- `command` (zorunlu) - komuttan ve bağımsız değişkenlerinden oluşan bir dizi
+- `watched_files` - sunucunun [izlenen dosyalar değişti](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles) bildirimini tetikleyecek `pattern` anahtarlarını (glob kalıbı) içeren tablolardan oluşan bir dizi.
+
+## HTTP sunucusu {#http-server}
+
+Düzenleyicinin çalışan her örneğinde (instance) bir HTTP sunucusu çalışır. Sunucu, düzenleyici betikleri kullanılarak genişletilebilir. Düzenleyici HTTP sunucusunu genişletmek için `get_http_server_routes` düzenleyici betiği işlevini eklemeniz gerekir — bu işlev ek rotaları döndürmelidir:
+```lua
+print("My route: " .. http.server.url .. "/my-extension")
+
+function M.get_http_server_routes()
+  return {
+    http.server.route("/my-extension", "GET", function(request)
+      return http.server.response(200, "Hello world!")
+    end)
+  }
+end
+```
+Düzenleyici betiklerini yeniden yükledikten sonra konsolda şu çıktıyı görürsünüz: `My route: http://0.0.0.0:12345/my-extension`. Bu bağlantıyı tarayıcıda açarsanız `"Hello world!"` iletinizi görürsünüz.
+
+Girdi olarak alınan `request` bağımsız değişkeni, istek hakkında bilgi içeren basit bir Lua tablosudur. `path` (`/` ile başlayan URL yol bölümü), isteğin `method` değeri (örneğin `"GET"`), `headers` (küçük harfli üstbilgi adlarını içeren bir tablo) ve isteğe bağlı olarak `query` (sorgu dizesi) ve `body` (rota, gövdenin nasıl yorumlanacağını tanımlıyorsa) gibi anahtarlar içerir. Örneğin JSON gövdesi kabul eden bir rota oluşturmak istiyorsanız bunu `"json"` dönüştürücü parametresiyle tanımlarsınız:
+```lua
+http.server.route("/my-extension/echo-request", "POST", "json", function(request)
+  return http.server.json_response(request)
+end)
+```
+Bu uç noktayı komut satırında `curl` ve `jq` kullanarak test edebilirsiniz:
+```sh
+curl 'http://0.0.0.0:12345/my-extension/echo-request?q=1' -X POST --data '{"input": "json"}' | jq
+{
+  "path": "/my-extension/echo-request",
+  "method": "POST",
+  "query": "q=1",
+  "headers": {
+    "host": "0.0.0.0:12345",
+    "content-type": "application/x-www-form-urlencoded",
+    "accept": "*/*",
+    "user-agent": "curl/8.7.1",
+    "content-length": "17"
+  },
+  "body": {
+    "input": "json"
+  }
+}
+```
+Rota yolu, istek yolundan çıkarılıp isteğin bir parçası olarak işleyici işlevine iletilebilen kalıpları destekler; örneğin:
+```lua
+http.server.route("/my-extension/setting/{category}.{key}", function(request)
+  return http.server.response(200, tostring(editor.get("/game.project", request.category .. "." .. request.key)))
+end)
+```
+Şimdi örneğin `http://0.0.0.0:12345/my-extension/setting/project.title` adresini açarsanız `/game.project` dosyasından alınan oyununuzun başlığını görürsünüz.
+
+Tek bir yol bölümünü eşleştiren kalıba ek olarak, `{*name}` sözdizimini kullanarak URL yolunun geri kalanını da eşleştirebilirsiniz. Örneğin proje kökündeki dosyaları sunan basit bir dosya sunucusu uç noktası şöyledir:
+```lua
+http.server.route("/my-extension/files/{*file}", function(request)
+  local attrs = editor.external_file_attributes(request.file)
+  if attrs.is_file then
+    return http.server.external_file_response(request.file)
+  else
+    return 404
+  end
+end)
+```
+Şimdi örneğin `http://0.0.0.0:12345/my-extension/files/main/main.collection` adresini tarayıcıda açarsanız `main/main.collection` dosyasının içeriği görüntülenir.
+
+## Kütüphanelerdeki düzenleyici betikleri {#editor-scripts-in-libraries}
+
+Başkalarının kullanması için komutlar içeren kütüphaneler yayımlayabilirsiniz; bu komutlar düzenleyici tarafından otomatik olarak alınır. Ancak kancalar otomatik olarak alınamaz; çünkü proje kök klasöründeki bir dosyada tanımlanmaları gerekir, kütüphaneler ise yalnızca alt klasörleri sunar. Bunun amacı derleme süreci üzerinde daha fazla denetim sağlamaktır: yaşam döngüsü kancalarını yine de `.lua` dosyalarında basit işlevler olarak oluşturabilirsiniz; böylece kütüphanenizin kullanıcıları bunları kendi `/hooks.editor_script` dosyalarında yükleyip kullanabilir.
+
+Ayrıca, bağımlılıklar Assets görünümünde gösterilseler de dosya olarak mevcut olmadıklarını (bir zip arşivinin içindeki girdiler olduklarını) unutmayın. Düzenleyicinin bağımlılıklardaki bazı dosyaları `build/plugins/` klasörüne çıkarmasını sağlamak mümkündür. Bunun için kütüphane klasörünüzde bir `ext.manifest` dosyası oluşturmanız, ardından bu `ext.manifest` dosyasının bulunduğu klasörde bir `plugins/bin/${platform}` klasörü oluşturmanız gerekir. Bu klasördeki dosyalar otomatik olarak `/build/plugins/${extension-path}/plugins/bin/${platform}` klasörüne çıkarılır; böylece düzenleyici betikleriniz bunlara başvurabilir.
+
+## Tercihler {#preferences}
+
+Düzenleyici betikleri, kullanıcının bilgisayarında saklanan kalıcı ve sürüm kontrolüne kaydedilmeyen veri parçaları olan tercihleri tanımlayabilir ve kullanabilir. Bu tercihlerin üç temel özelliği vardır:
+- tür belirtilir: her tercih, veri türünü ve varsayılan değer gibi diğer üst verileri içeren bir şema tanımına sahiptir
+- kapsam belirtilir: tercihler proje veya kullanıcı bazında kapsama sahiptir
+- iç içedir: her tercih anahtarı, noktalarla ayrılmış bir dizedir; ilk yol bölümü bir düzenleyici betiğini, kalan bölümler ise bu betik içindeki grupları ve tek tek tercihleri tanımlar
+
+Tüm tercihler, şemaları tanımlanarak kaydedilmelidir:
+```lua
+function M.get_prefs_schema()
+  return {
+    ["my_json_formatter.jq_path"] = editor.prefs.schema.string(),
+    ["my_json_formatter.indent.size"] = editor.prefs.schema.integer({default = 2, scope = editor.prefs.SCOPE.PROJECT}),
+    ["my_json_formatter.indent.type"] = editor.prefs.schema.enum({values = {"spaces", "tabs"}, scope = editor.prefs.SCOPE.PROJECT}),
+  }
+end
+```
+Böyle bir düzenleyici betiği yeniden yüklendikten sonra düzenleyici bu şemayı kaydeder. Ardından düzenleyici betiği tercihleri alabilir ve ayarlayabilir; örneğin:
+```lua
+-- Get a specific preference
+editor.prefs.get("my_json_formatter.indent.type")
+-- Returns: "spaces"
+
+-- Get an entire preference group
+editor.prefs.get("my_json_formatter")
+-- Returns:
+-- {
+--   jq_path = "",
+--   indent = {
+--     size = 2,
+--     type = "spaces"
+--   }
+-- }
+
+-- Set multiple nested preferences at once
+editor.prefs.set("my_json_formatter.indent", {
+    type = "tabs",
+    size = 1
+})
+```
+
+## Yürütme modları {#execution-modes}
+
+Düzenleyici betiklerinin çalışma zamanı ortamı, düzenleyici betiklerinin çoğunlukla ayrıca ele alması gerekmeyen 2 yürütme modu kullanır: **anında (immediate)** ve **uzun süren (long-running)**. 
+
+**Anında** modu, düzenleyicinin betikten mümkün olan en hızlı şekilde yanıt alması gerektiğinde kullanılır. Örneğin menü komutlarının `active` geri çağırımları anında modunda yürütülür; çünkü bu denetimler, kullanıcının düzenleyiciyle etkileşimine yanıt olarak düzenleyicinin kullanıcı arayüzü iş parçacığında yapılır ve kullanıcı arayüzünü aynı kare içinde güncellemelidir. 
+
+**Uzun süren** modu, düzenleyicinin betikten anında yanıt alması gerekmediğinde kullanılır. Örneğin menü komutlarının `run` geri çağırımları **uzun süren** modunda yürütülür; böylece betik, işini tamamlamak için daha fazla zaman kullanabilir.
+
+Düzenleyici betiklerinin kullanabildiği bazı işlevlerin çalışması uzun sürebilir. Örneğin `editor.execute("git", "status", {reload_resources=false, out="capture"})` yeterince büyük projelerde bir saniyeye kadar sürebilir. Düzenleyicinin hızlı yanıt vermesini ve performansını korumak için zaman alabilecek işlevlere, düzenleyicinin anında yanıt gerektirdiği bağlamlarda izin verilmez. Böyle bir işlevi anında yanıt gerektiren bir bağlamda kullanmaya çalışmak bir hatayla sonuçlanır: `Cannot use long-running editor function in immediate context`. Bu hatayı gidermek için bu tür işlevleri anında yanıt gerektiren bağlamlarda kullanmaktan kaçının.
+
+Aşağıdaki işlevler uzun süren olarak kabul edilir ve anında modunda kullanılamaz:
+- `editor.create_directory()`, `editor.create_resources()`, `editor.delete_directory()`, `editor.save()`, `os.remove()` ve `file:write()`: bu işlevler diskteki dosyaları değiştirir; bunun sonucunda düzenleyici, bellekteki kaynak ağacını diskteki durumla eşitler ve bu işlem büyük projelerde saniyeler sürebilir.
+- `editor.execute()`: kabuk komutlarının yürütülmesi öngörülemeyen bir süre alabilir.
+- `editor.transact()`: birçok yerden başvurulan düğümlerdeki büyük işlemler yüzlerce milisaniye sürebilir; bu da kullanıcı arayüzünün hızlı yanıt vermesi için çok yavaştır.
+
+Aşağıdaki kod yürütme bağlamları anında modunu kullanır:
+- Menü komutlarının `active` geri çağırımları: düzenleyicinin aynı kullanıcı arayüzü karesi içinde betikten yanıt alması gerekir.
+- Düzenleyici betiklerinin üst düzeyi: düzenleyici betiklerini yeniden yükleme işleminin herhangi bir yan etkisi olmasını beklemiyoruz.
+
+## Eylemler
+
+::: sidenote
+Önceden düzenleyici, Lua sanal makinesiyle engelleyici bir şekilde etkileşim kuruyordu. Bazı etkileşimlerin düzenleyicinin kullanıcı arayüzü iş parçacığından yapılması gerektiği için düzenleyici betiklerinin yürütmeyi engellememesi kesin bir gereklilikti. Bu nedenle örneğin `editor.execute()` ve `editor.transact()` yoktu. Betiklerin yürütülmesi ve düzenleyici durumunun değiştirilmesi, bunların yerine kancalardan ve komutların `run` işleyicilerinden bir "eylemler" dizisi döndürülerek tetikleniyordu.
+
+Artık düzenleyici, Lua sanal makinesiyle engelleyici olmayan bir şekilde etkileşim kuruyor; bu nedenle bu eylemlere artık gerek yok: `editor.execute()` gibi işlevleri kullanmak daha kullanışlı, kısa ve güçlüdür. Bu eylemlerin **KULLANIMI ARTIK ÖNERİLMİYOR**, ancak bunları kaldırma planımız yok.
+:::
+
+Düzenleyici betikleri, bir komutun `run` işlevinden veya `/hooks.editor_script` dosyasının kanca işlevlerinden bir eylem dizisi döndürebilir. Bu eylemler daha sonra düzenleyici tarafından gerçekleştirilir.
+
+Eylem, düzenleyicinin ne yapması gerektiğini açıklayan bir tablodur. Her eylemin bir `action` anahtarı vardır. Eylemler 2 çeşittir: geri alınabilir ve geri alınamaz.
+
+### Geri alınabilir eylemler
+
+::: sidenote
+`editor.transact()` kullanmayı tercih edin.
+:::
+
+Geri alınabilir bir eylem, yürütüldükten sonra geri alınabilir. Bir komut birden fazla geri alınabilir eylem döndürürse bunlar birlikte gerçekleştirilir ve birlikte geri alınır. Mümkünse geri alınabilir eylemler kullanmanız önerilir. Dezavantajları, daha sınırlı olmalarıdır.
+
+Mevcut geri alınabilir eylemler:
+- `"set"` — düzenleyicideki bir düğümün özelliğini belirli bir değere ayarlar. Örnek:
+  ```lua
+  {
+    action = "set",
+    node_id = opts.selection,
+    property = "text",
+    value = "current time is " .. os.date()
+  }
+  ```
+  `"set"` eylemi şu anahtarları gerektirir:
+  - `node_id` — düğüm kimliğini içeren userdata değeri. Alternatif olarak burada düzenleyiciden aldığınız düğüm kimliği yerine bir kaynak yolu, örneğin `"/main/game.script"`, kullanabilirsiniz;
+  - `property` — düğümün ayarlanacak özelliği; örneğin `"text"`;
+  - `value` — özelliğin yeni değeri. `"text"` özelliği için bir dize olması önerilir.
+
+### Geri alınamaz eylemler
+
+::: sidenote
+`editor.execute()` kullanmayı tercih edin.
+:::
+
+Geri alınamaz bir eylem geri alma geçmişini temizler; bu nedenle böyle bir eylemi geri almak istiyorsanız sürüm kontrolü gibi başka yöntemler kullanmanız gerekir.
+
+Mevcut geri alınamaz eylemler:
+- `"shell"` — bir kabuk betiği yürütür. Örnek:
+  ```lua
+  {
+    action = "shell",
+    command = {
+      "./scripts/minify-json.sh",
+      editor.get(opts.selection, "path"):sub(2) -- trim leading "/"
+    }
+  }
+  ```
+  `"shell"` eylemi, komuttan ve bağımsız değişkenlerinden oluşan bir dizi olan `command` anahtarını gerektirir.
+
+### Eylemleri ve yan etkileri birleştirme
+
+Geri alınabilir ve geri alınamaz eylemleri bir arada kullanabilirsiniz. Eylemler sırayla yürütülür; dolayısıyla eylemlerin sırasına bağlı olarak komutun bazı bölümlerini geri alma olanağını kaybedersiniz.
+
+Eylem bekleyen işlevlerden eylem döndürmek yerine, doğrudan `io.open()` kullanarak dosyaları okuyabilir ve onlara yazabilirsiniz. Bu, geri alma geçmişini temizleyecek bir kaynak yeniden yüklemesini tetikler.

--- a/docs/tr/manuals/editor-styling.md
+++ b/docs/tr/manuals/editor-styling.md
@@ -1,0 +1,129 @@
+---
+title: Düzenleyici stilini değiştirme
+brief: Özel bir stil sayfası kullanarak düzenleyicinin renklerini, tipografisini ve diğer görsel özelliklerini değiştirebilirsiniz.
+---
+
+# Düzenleyici stilini değiştirme
+
+Özel bir stil sayfası (stylesheet) kullanarak düzenleyicinin renklerini, tipografisini ve diğer görsel özelliklerini değiştirebilirsiniz:
+
+* Kullanıcı ana dizininizde `.defold` adlı bir klasör oluşturun.
+  * Windows'ta `C:\Users\**Your Username**\.defold`
+  * macOS'te `/Users/**Your Username**/.defold`
+  * Linux'ta `~/.defold`
+* `.defold` klasöründe bir `editor.css` dosyası oluşturun
+
+Düzenleyici, başlatıldığında özel stil sayfanızı yükler ve varsayılan stilin üzerine uygular. Düzenleyici, kullanıcı arayüzü için JavaFX kullanır. Stil sayfaları, tarayıcıda bir web sayfasının öğelerine stil öznitelikleri uygulamak için kullanılan CSS dosyalarıyla neredeyse aynıdır. Düzenleyicinin varsayılan stil sayfalarını [GitHub üzerinde inceleyebilirsiniz](https://github.com/defold/defold/tree/editor-dev/editor/styling/stylesheets/base).
+
+## Renkleri değiştirme
+
+Varsayılan renkler [`_palette.scss`](https://github.com/defold/defold/blob/editor-dev/editor/styling/stylesheets/base/_palette.scss) dosyasında tanımlanır ve şöyledir:
+
+```
+* {
+	// Background
+	-df-background-darker:    derive(#212428, -10%);
+	-df-background-dark:      derive(#212428, -5%);
+	-df-background:           #212428;
+	-df-background-light:     derive(#212428, 10%);
+	-df-background-lighter:   derive(#212428, 20%);
+
+	// Component
+	-df-component-darker:     derive(#464c55, -20%);
+	-df-component-dark:       derive(#464c55, -10%);
+	-df-component:            #464c55;
+	-df-component-light:      derive(#464c55, 10%);
+	-df-component-lighter:    derive(#464c55, 20%);
+
+	// Text & icons
+	-df-text-dark:            derive(#b4bac1, -10%);
+	-df-text:                 #b4bac1;
+	-df-text-selected:        derive(#b4bac1, 20%);
+
+  and so on...
+```
+
+Temel tema, daha koyu ve daha açık çeşitleriyle birlikte üç renk grubuna ayrılır:
+
+* Arka plan rengi - panellerin, pencerelerin ve iletişim kutularının arka plan rengi
+* Bileşen rengi - düğmeler, kaydırma çubuğu tutamaçları, metin alanlarının kenarlıkları
+* Metin rengi - metin ve simgeler
+
+Örneğin, kullanıcı ana dizininizdeki `.defold` klasöründe bulunan özel `editor.css` stil sayfanıza şunları eklerseniz:
+
+```
+* {
+	-df-background-darker:    derive(#0a0a42, -10%);
+	-df-background-dark:      derive(#0a0a42, -5%);
+	-df-background:           #0a0a42;
+	-df-background-light:     derive(#0a0a42, 10%);
+	-df-background-lighter:   derive(#0a0a42, 20%);
+}
+```
+
+Düzenleyicinizde aşağıdaki görünümü elde edersiniz:
+
+![](images/editor/editor-styling-color.png)
+
+
+## Yazı tiplerini değiştirme
+
+Düzenleyici iki yazı tipi kullanır: kod ve sabit genişlikli metin (hatalar) için `Dejavu Sans Mono`, arayüzün geri kalanı için `Source Sans Pro`. Yazı tipi tanımları ağırlıklı olarak [`_typography.scss`](https://github.com/defold/defold/blob/editor-dev/editor/styling/stylesheets/base/_typography.scss) dosyasında bulunur ve şöyledir:
+
+```
+@font-face {
+  src: url("SourceSansPro-Light.ttf");
+}
+
+@font-face {
+  src: url("DejaVuSansMono.ttf");
+}
+
+$default-font-mono: 'Dejavu Sans Mono';
+$default-font: 'Source Sans Pro';
+$default-font-bold: 'Source Sans Pro Semibold';
+$default-font-italic: 'Source Sans Pro Italic';
+$default-font-light: 'Source Sans Pro Light';
+
+.root {
+    -fx-font-size: 13px;
+    -fx-font-family: $default-font;
+}
+
+Text.strong {
+  -fx-font-family: $default-font-bold;
+}
+
+and so on...
+```
+
+Ana yazı tipi bir kök öğede tanımlanır; bu da çoğu yerde yazı tipini değiştirmeyi oldukça kolaylaştırır. `editor.css` dosyanıza şunları ekleyin:
+
+```
+@import url('https://fonts.googleapis.com/css2?family=Architects+Daughter&display=swap');
+
+.root {
+    -fx-font-family: "Architects Daughter";
+}
+```
+
+Düzenleyicinizde aşağıdaki görünümü elde edersiniz:
+
+![](images/editor/editor-styling-fonts.png)
+
+Web yazı tipi yerine yerel bir yazı tipi kullanmak da mümkündür:
+
+```
+@font-face {
+  font-family: 'Comic Sans MS';
+  src: local("cs.ttf");
+}
+
+.root {
+  -fx-font-family: 'Comic Sans MS';
+}
+```
+
+::: sidenote
+Kod düzenleyicisinin yazı tipi, düzenleyicinin Preferences ayarlarında ayrıca tanımlanır!
+:::

--- a/docs/tr/manuals/editor-templates.md
+++ b/docs/tr/manuals/editor-templates.md
@@ -1,0 +1,46 @@
+---
+title: Düzenleyici şablonları
+brief: New Project penceresine kendi özel proje şablonlarınızı ekleyebilirsiniz.
+---
+
+# Düzenleyici şablonları
+
+New Project penceresine kendi özel proje şablonlarınızı (project templates) ekleyebilirsiniz:
+
+![özel proje şablonları](images/editor/custom_project_templates.png)
+
+Özel proje şablonları içeren bir veya daha fazla yeni sekme eklemek için kullanıcı ana dizininizdeki `.defold` klasörüne bir `welcome.edn` dosyası eklemeniz gerekir:
+
+* Kullanıcı ana dizininizde `.defold` adlı bir klasör oluşturun.
+  * Windows'ta `C:\Users\**Your Username**\.defold`
+  * macOS'te `/Users/**Your Username**/.defold`
+  * Linux'ta `~/.defold`
+* `.defold` klasöründe bir `welcome.edn` dosyası oluşturun
+
+`welcome.edn` dosyası Extensible Data Notation biçimini kullanır. Örnek:
+
+```
+{:new-project
+  {:categories [
+    {:label "My Templates"
+     :templates [
+          {:name "My project"
+           :description "My template with everything set up the way I want it."
+           :image "empty.svg"
+           :zip-url "https://github.com/britzl/template-project/archive/master.zip"
+           :skip-root? true},
+          {:name "My other project"
+           :description "My other template with everything set up the way I want it."
+           :image "empty.svg"
+           :zip-url "https://github.com/britzl/template-other-project/archive/master.zip"
+           :skip-root? true}]
+    }]
+  }
+}
+```
+
+Bu, yukarıdaki ekran görüntüsünde görülen şablon listesini oluşturur.
+
+::: sidenote
+Yalnızca [düzenleyiciyle birlikte gelen](https://github.com/defold/defold/tree/dev/editor/resources/welcome/images) şablon görsellerini kullanabilirsiniz.
+:::

--- a/docs/tr/manuals/editor.md
+++ b/docs/tr/manuals/editor.md
@@ -1,0 +1,291 @@
+---
+title: Düzenleyiciye genel bakış
+brief: Bu kılavuz, Defold düzenleyicisinin görünümüne, işleyişine ve içinde nasıl gezinileceğine genel bir bakış sunar.
+---
+
+# Düzenleyiciye genel bakış
+
+Düzenleyici, oyun projenizdeki tüm dosya ve klasörlere göz atmanızı ve bunlar üzerinde verimli bir şekilde işlem yapmanızı sağlar. Bir dosyayı düzenlemeye başladığınızda uygun düzenleyici açılır ve dosyayla ilgili tüm bilgiler ayrı görünümlerde gösterilir.
+
+## Düzenleyiciyi başlatma
+
+Defold düzenleyicisini çalıştırdığınızda proje seçme ve oluşturma ekranı açılır. Yapmak istediğiniz işlemi tıklayarak seçin:
+
+MY PROJECTS
+: Yakın zamanda açtığınız projeler, onlara hızlıca erişebilmeniz için burada bulunur. Bu, başlangıç ekranının varsayılan görünümüdür.
+
+  Daha önce hiç proje açmadıysanız (veya tümünü kaldırdıysanız) iki düğme gösterilir. Sistem dosya tarayıcısıyla bir proje bulup açmak için `Open From Disk…` düğmesine tıklayabilir veya `Create New Project` düğmesine tıklayarak `TEMPLATES` sekmesine geçebilirsiniz.
+
+  ![Projelerim](images/editor/start_no_projects.png)
+
+
+  Daha önce proje açtıysanız aşağıdaki resimdeki gibi projelerinizin listesi gösterilir:
+
+  ![Projelerim](images/editor/start_my_projects.png)
+
+TEMPLATES
+: Belirli platformlar için veya belirli eklentileri kullanarak yeni bir Defold projesine hızlıca başlamanız amacıyla hazırlanmış boş ya da neredeyse boş temel projeleri içerir.
+
+
+TUTORIALS
+: Bir öğreticiyi izlemek istiyorsanız öğrenebileceğiniz, oynayabileceğiniz ve değiştirebileceğiniz, adım adım yönlendiren öğreticiler içeren projeler sunar.
+
+
+SAMPLES
+: Belirli kullanım senaryolarını göstermek için hazırlanmış projeler içerir.
+
+  ![Yeni proje](images/editor/start_templates.png)
+
+Yeni bir proje oluşturduğunuzda proje yerel sürücünüzde saklanır ve yaptığınız tüm değişiklikler yerel olarak kaydedilir.
+
+Farklı seçenekler hakkında daha fazla bilgiyi [Proje kurulumu kılavuzunda](https://www.defold.com/manuals/project-setup/) bulabilirsiniz.
+
+## Düzenleyici dili
+
+Başlangıç ekranının sol alt köşesinde dil seçimini görebilirsiniz. Mevcut yerelleştirmelerden birini seçin. Bu ayara düzenleyicide `File ▸ Preferences ▸ General ▸ Editor Language` yolundan da erişebilirsiniz.
+
+![Diller](images/editor/languages.png)
+
+## Düzenleyici bölmeleri {#the-editor-views}
+
+Defold düzenleyicisi, belirli bilgileri gösteren bölmelerden veya görünümlerden oluşur.
+
+![Düzenleyici 2](images/editor/editor_overview.png)
+
+### 1. Assets bölmesi
+Projenizdeki tüm dosya ve klasörleri, diskinizdeki yapıyla aynı olan bir ağaç yapısında listeler. Listede gezinmek için tıklayın ve kaydırın. Dosyalarla ilgili tüm işlemleri bu görünümde yapabilirsiniz:
+
+   - Herhangi bir dosya veya klasörü seçmek için <kbd>sol tıklayın</kbd>; <kbd>⇧ Shift</kbd> tuşunu basılı tutarak seçimi genişletebilir veya <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> tuşunu basılı tutarak tıkladığınız öğeyi seçebilir ya da seçimden çıkarabilirsiniz.
+   - Bir dosyayı, dosya türüne özgü düzenleyicide açmak için dosyaya <kbd>çift tıklayın</kbd>.
+   - Diskinizdeki başka konumlardan projeye dosya eklemek veya dosya ve klasörleri proje içinde yeni konumlara taşımak için <kbd>sürükleyip bırakın</kbd>.
+   - Yeni dosya veya klasör oluşturabileceğiniz, yeniden adlandırma, silme, dosya bağımlılıklarını izleme ve başka işlemler yapabileceğiniz _bağlam menüsünü_ açmak için <kbd>sağ tıklayın</kbd>.
+
+*Assets* bölmesinden silinen dosya ve klasörler, platform destekliyorsa sistemin Trash veya Recycle Bin klasörüne taşınır. Bir öğeyi çöp kutusuna taşıma desteklenmiyorsa veya başarısız olursa düzenleyici öğeyi kalıcı olarak siler.
+
+### 2. Scene Editor bölmesi {#the-scene-editor}
+
+Bir koleksiyon (collection), oyun nesnesi (game object) veya görsel bileşen (component) dosyasına çift tıkladığınızda, sahne oluşturmak ve düzenlemek için kullanılan görsel düzenleyici olan *Scene Editor* açılır. Betik dosyaları ve görsel olmayan diğer kaynaklar (resource) ise kendilerine özgü düzenleyicilerde açılır.
+
+![Scene Editor görünümü](images/editor/2d_scene.png)
+
+Scene Editor tarafından sunulan temel özelliklerden bazıları:
+
+- Ortografik ve perspektif kamera modlarıyla [2B ve 3B sahnelerde gezinme](/manuals/scene-editing/#2d-and-3d-scene-orientation)
+- Nesneleri taşımak, döndürmek ve ölçeklemek için [dönüşüm araçları](/manuals/scene-editing/#manipulating-objects)
+- Birinci şahıs bakış açısıyla 3B gezinme için [serbest kamera modu](/manuals/scene-editing/#free-camera-mode)
+- Boyutu, düzlemi ve görünümü yapılandırılabilen [ızgara ayarları](/manuals/scene-editing/#grid-settings)
+- Bileşen türlerinin ve kılavuzların görünürlüğünü değiştirmek için [görünürlük filtreleri](/manuals/scene-editing/#visibility-filters)
+
+Daha fazla bilgiyi [Sahne düzenleyicisi kılavuzunda](/manuals/scene-editing/) bulabilirsiniz.
+
+### 3. Outline bölmesi
+
+Bu görünüm, düzenlemekte olduğunuz dosyanın içeriğini hiyerarşik bir ağaç yapısında gösterir. Outline, düzenleyici görünümünü yansıtır ve öğeleriniz üzerinde işlem yapmanızı sağlar:
+
+   - Bir öğeyi seçmek için <kbd>sol tıklayın</kbd>; <kbd>⇧ Shift</kbd> tuşunu basılı tutarak seçimi genişletebilir veya <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> tuşunu basılı tutarak tıkladığınız öğeyi seçebilir ya da seçimden çıkarabilirsiniz.
+   - Öğeleri taşımak için <kbd>sürükleyip bırakın</kbd>. Üst-alt nesne ilişkisi oluşturmak için bir koleksiyondaki oyun nesnesini başka bir oyun nesnesinin üzerine bırakın.
+   - Öğe ekleyebileceğiniz, seçili öğeleri silebileceğiniz ve benzeri işlemler yapabileceğiniz _bağlam menüsünü_ açmak için <kbd>sağ tıklayın</kbd>.
+
+Listedeki bir öğenin sağında bulunan küçük `👁` göz simgesine tıklayarak oyun nesnelerinin ve görsel bileşenlerin görünürlüğünü değiştirebilirsiniz.
+
+![Outline bölmesi](images/editor/outline.png)
+
+### 4. Properties bölmesi
+
+Bu görünüm, seçili öğeyle ilişkili Id, URL, Position, Rotation, Scale gibi özellikleri ve/veya bileşene özgü diğer özellikleri, ayrıca betiklerin özel özelliklerini gösterir.
+
+Sayısal bir özelliğin değerini, `↕` yukarı-aşağı okunu <kbd>sürükleyerek</kbd> ve fareyi hareket ettirerek de değiştirebilirsiniz.
+
+![Properties bölmesi](images/editor/properties.png)
+
+### 5. Tools bölmesi
+
+Bu görünümde birkaç sekme bulunur.
+
+*Console* sekmesi: oyununuz çalışırken motorun ürettiği hata, uyarı ve bilgi çıktılarını veya sizin özellikle yazdırdığınız çıktıları gösterir,
+
+*Build Errors*: proje derleme sürecindeki hataları gösterir,
+
+*Search Results*: `Keep Results` düğmesine tıklarsanız projenin tamamında yaptığınız aramanın (<kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd>) sonuçlarını gösterir
+
+*Curve Editor*: [Parçacık düzenleyicisinde](/manuals/particlefx/) eğrileri düzenlerken kullanılır.
+
+Tools bölmesi, tümleşik hata ayıklayıcıyla etkileşim kurmak için de kullanılır. Daha fazla bilgiyi [Hata ayıklama kılavuzunda](/manuals/debugging/) bulabilirsiniz.
+
+### 6. Changed Files bölmesi
+
+Projenizde Git kullanılıyorsa bu görünüm, geçerli Git kaydına (commit) (`HEAD`) kıyasla yerel olarak değiştirilen, eklenen, yeniden adlandırılan veya silinen dosyaları listeler. Uzak bir depoyla eşitlemek için harici bir Git istemcisi veya komut satırını kullanın. Daha fazla bilgiyi [Sürüm kontrolü kılavuzunda](/manuals/version-control/) bulabilirsiniz. Dosyalarla ilgili bazı işlemleri bu görünümde yapabilirsiniz:
+
+   - Bir dosyayı seçmek için <kbd>sol tıklayın</kbd>; <kbd>⇧ Shift</kbd> tuşunu basılı tutarak seçimi genişletebilir veya <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> tuşunu basılı tutarak tıkladığınız öğeyi seçebilir ya da seçimden çıkarabilirsiniz. Değiştirilmiş tek bir dosya seçiliyse farkları göstermek için `Diff` düğmesine tıklayabilirsiniz. Seçili tüm dosyalardaki değişiklikleri geri almak için `Revert` düğmesine tıklayabilirsiniz.
+   - Bir dosyanın görünümünü açmak için dosyaya <kbd>sol tuşla çift tıklayın</kbd>. Düzenleyici, Assets görünümünde olduğu gibi dosyayı uygun düzenleyicide açar.
+   - Fark görünümünü açabileceğiniz, dosyada yapılan tüm değişiklikleri geri alabileceğiniz, dosyayı dosya sisteminde bulabileceğiniz ve başka işlemler yapabileceğiniz açılır menüyü açmak için dosyaya <kbd>sağ tıklayın</kbd>.
+
+### Menü çubuğu
+
+Düzenleyici görünümünün üst kısmında veya Mac'te sistem çubuğunda, 6 menü içeren menü çubuğunu bulabilirsiniz: `File`, `Edit`, `View`, `Project`, `Debug`, `Help`. Bu menülerin işlevleri kılavuzlarda açıklanacaktır.
+
+### Durum çubuğu
+
+Düzenleyicinin alt çubuğunda, durumun gösterildiği dar bir alan bulunur. Örneğin:
+- Yeni bir güncelleme mevcut olduğunda tıklanabilir `Update Available` düğmesi görünür. Bu kılavuzun aşağıdaki Düzenleyiciyi güncelleme bölümüne bakın.
+- Proje derlenirken veya paketlenirken ilerleme burada gösterilir.
+
+## Bölme boyutu ve görünürlüğü
+
+Düzenleyicide bölmelerin boyutunu, yukarıda açıklanan 6 bölme arasındaki sınırları <kbd>sürükleyerek</kbd> ayarlayabilirsiniz.
+
+Düzenleyicide bölmelerin görünürlüğünü `View` menüsündeki seçenekleri veya belirtilen kısayolları kullanarak değiştirebilirsiniz:
+- `Toggle Assets Pane` (<kbd>F6</kbd>), Assets ve Changed Files bölmelerinin görünürlüğünü değiştirir
+- `Toggle Changed Files`, yalnızca Changed Files bölmesinin görünürlüğünü değiştirir
+- `Toggle Tools Pane` (<kbd>F7</kbd>), Tools bölmesinin görünürlüğünü değiştirir
+- `Toggle Properties Pane` (<kbd>F8</kbd>), Outline ve Properties bölmelerinin görünürlüğünü değiştirir
+
+![Bölme görünürlüğü](images/editor/editor_panes.png)
+
+`View` menüsünden Grid, Guides veya Camera gibi görünürlükle ilgili diğer ayarları da açıp kapatabilir ya da değiştirebilir, görünümü seçime sığdırabilir (`Frame Selection` veya <kbd>F</kbd> tuşu) ve varsayılan 2B ve 3B görünümler arasında geçiş yapabilirsiniz (`Realign Camera` veya <kbd>.</kbd> tuşu). Bunların çoğuna araç çubuğundan veya kısayollarla da erişilebilir.
+
+## Sekmeler
+
+Birden fazla dosya açıksa düzenleyici görünümünün üst kısmında her dosya için ayrı bir sekme gösterilir. Aynı bölmedeki sekmelerin yerini değiştirebilirsiniz; sekme çubuğundaki konumlarını değiştirmek için <kbd>sürükleyip bırakın</kbd>. Ayrıca şunları yapabilirsiniz:
+
+- Bir _bağlam menüsü_ açmak için sekmeye <kbd>sağ tıklayın</kbd>,
+- Tek bir sekmeyi kapatmak için `Close` (<kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> + <kbd>W</kbd>) seçeneğine tıklayın,
+- Seçili sekme dışındaki tüm sekmeleri kapatmak için `Close Others` seçeneğine tıklayın,
+- Etkin bölmedeki tüm sekmeleri kapatmak için `Close All` (<kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> + <kbd>Shift</kbd>+<kbd>W</kbd>) seçeneğine tıklayın,
+- Varsayılan düzenleyici dışında bir düzenleyici veya `File ▸ Preferences ▸ Code ▸ Custom Editor` altında ayarlanmış ilişkili harici aracı kullanmak için `➝| Open As` seçeneğini seçin. Daha fazla bilgiyi [Tercihler kılavuzunda](/manuals/editor-preferences) bulabilirsiniz.
+
+![Sekmeler](images/editor/tabs_custom.png)
+
+## Yan yana düzenleme
+
+2 düzenleyici görünümünü yan yana açabilirsiniz.
+
+- Taşımak istediğiniz düzenleyicinin sekmesine <kbd>sağ tıklayın</kbd> ve `Move to Other Tab Pane` seçeneğini seçin.
+
+![2 bölme](images/editor/2-panes.png)
+
+Sekme menüsündeki `Swap with Other Tab Pane` seçeneğiyle bir sekmeyi bölmeler arasında taşıyabilir veya `Join Tab Panes` seçeneğiyle bölmeleri tek bir bölmede birleştirebilirsiniz.
+
+## Yeni proje dosyaları oluşturma {#creating-new-project-files}
+
+Yeni kaynak dosyaları oluşturmak için `File ▸ New…` seçeneğini seçip menüden dosya türünü belirleyin veya bağlam menüsünü kullanın:
+
+`Assets` tarayıcısında hedef konuma <kbd>sağ tıklayın</kbd>, ardından `New… ▸ [file type]` seçeneğini seçin:
+
+![Dosya oluşturma](images/editor/create_file.png)
+
+Yeni dosya için *Name* alanına uygun bir ad yazın ve gerekirse *Location* alanındaki konumu değiştirin. Dosya türü uzantısı dahil tam dosya adı, iletişim kutusundaki *Preview* alanında gösterilir:
+
+![Oluşturulacak dosyanın adı](images/editor/create_file_name.png)
+
+## Şablonlar
+
+Her proje için özel şablonlar belirleyebilirsiniz. Bunun için projenin kök dizininde `templates` adlı yeni bir klasör oluşturun ve `/templates/default.gui` veya `/templates/default.script` gibi istediğiniz uzantılara sahip, `default.*` biçiminde adlandırılmış yeni dosyalar ekleyin. Ayrıca bu dosyalarda `{{NAME}}` belirteci kullanılırsa yerine dosya oluşturma penceresinde belirtilen dosya adı konur.
+
+Belirli bir dosya türü için şablon varsa bu türde yeni bir dosya oluşturulduğunda dosyanın başlangıç içeriği `templates` klasöründeki dosyadan alınır.
+
+
+![Şablonlar](images/editor/templates.png)
+
+## Dosyaları projenize içe aktarma
+
+Projenize varlık (asset) dosyaları (görüntüler, sesler, modeller vb.) eklemek için dosyaları *Assets* tarayıcısında uygun konuma sürükleyip bırakmanız yeterlidir. Böylece proje dosya yapısında seçilen konumda dosyaların _kopyaları_ oluşturulur. Daha fazla bilgiyi [varlıkları içe aktarma kılavuzumuzda](/manuals/importing-assets/) bulabilirsiniz.
+
+![Dosyaları içe aktarma](images/editor/import.png)
+
+## Düzenleyiciyi güncelleme
+
+Düzenleyici, internete bağlıyken güncellemeleri otomatik olarak denetler. Bir güncelleme algılandığında proje seçme ekranının sol alt köşesinde veya düzenleyici penceresinin sağ alt köşesinde, tıklanabilir mavi `Update Available` bağlantısı gösterilir.
+
+![Proje seçim ekranından güncelleme](images/editor/update_start.png)
+![Düzenleyiciden güncelleme](images/editor/update_available.png)
+
+İndirmek ve güncellemek için tıklanabilir `Update Available` bağlantısına basın. Bilgi içeren bir onay penceresi açılır; devam etmek için `Download Update` düğmesine tıklayın.
+
+![Düzenleyiciyi güncelleme penceresi](images/editor/update.png)
+
+İndirme ilerlemesini alttaki durum çubuğunda görebilirsiniz:
+
+![İndirme ilerlemesi](images/editor/download_status.png)
+
+Güncelleme indirildikten sonra mavi bağlantı `Restart to Update` olarak değişir. Yeniden başlatmak ve güncellenmiş düzenleyiciyi açmak için bu bağlantıya tıklayın.
+
+![Güncellemek için yeniden başlatma](images/editor/restart_to_update.png)
+
+## Tercihler
+
+Düzenleyicinin ayarlarını `Preferences` penceresinde değiştirebilirsiniz. Bu pencereyi açmak için `File ▸ Preferences…` seçeneğine tıklayın veya <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> + <kbd>,</kbd> kısayolunu kullanın
+
+Daha fazla ayrıntıyı [Tercihler kılavuzunda](/manuals/editor-preferences) bulabilirsiniz
+
+![Preferences penceresi](images/editor/preferences.png)
+
+## Düzenleyici günlükleri {#editor-logs}
+Düzenleyicide bir sorunla karşılaşıp bunu bildirmeniz gerektiğinde (`Help  ▸ Report Issue`), düzenleyicinin günlük dosyalarını da sağlamanız iyi olur. Günlüklerin konumunu sisteminizin dosya tarayıcısında açmak için `Help ▸ Show Logs` seçeneğine tıklayın.
+
+Daha fazla bilgiyi [Yardım alma kılavuzunda](/manuals/getting-help/#getting-help) bulabilirsiniz.
+
+![Show Logs seçeneği](images/editor/show_logs.png)
+
+Düzenleyici günlük dosyalarını şu konumlarda bulabilirsiniz:
+
+  * Windows: `C:\Users\ **Your Username** \AppData\Local\Defold`
+  * macOS: `/Users/ **Your Username** /Library/Application Support/` veya `~/Library/Application Support/Defold`
+  * Linux: `$XDG_STATE_HOME/Defold` veya `~/.local/state/Defold`
+
+Düzenleyici bir terminalden/komut isteminden başlatıldıysa çalışırken de düzenleyici günlüklerine erişebilirsiniz. Düzenleyiciyi başlatmak için şu komutu kullanın:
+
+```shell
+# Linux:
+$ ./path/to/Defold/Defold
+
+# macOS:
+$ > ./path/to/Defold.app/Contents/MacOS/Defold
+```
+
+## Düzenleyici sunucusu
+
+Düzenleyici bir proje açtığında rastgele bir bağlantı noktasında web sunucusu başlatır. Bu sunucu, diğer uygulamalardan düzenleyiciyle etkileşim kurmak için kullanılabilir. Bağlantı noktası `.internal/editor.port` dosyasına yazılır.
+
+Sunucu, `http://localhost:$(cat .internal/editor.port)/openapi.json` adresinde bir OpenAPI belirtimi sunar. Bu, ajanların yürüttüğü iş akışları için yararlı ve temel bir başlangıç noktasıdır.
+
+Ayrıca düzenleyicinin yürütülebilir dosyası, başlatma sırasında bağlantı noktası belirtmenizi sağlayan `--port` (veya `-p`) komut satırı seçeneğine sahiptir. Örneğin::
+```shell
+# Windows
+.\path\to\Defold\Defold.exe --port 8181
+
+# Linux:
+./path/to/Defold/Defold --port 8181
+
+# macOS:
+./path/to/Defold/Defold.app/Contents/MacOS/Defold --port 8181
+```
+
+## Düzenleyici kurulum üst verileri {#editor-installation-metadata}
+
+Düzenleyici başlatıldığında, başlatıcı ve kurulum yolları hakkındaki bilgileri bilinen bir konuma yazar. Üçüncü taraf IDE tümleştirmeleri ve diğer araçlar bu bilgileri kurulu Defold düzenleyicilerini bulmak için kullanabilir:
+
+| İşletim sistemi | Konum |
+|---------|----------|
+| macOS   | `~/Library/Application Support/Defold/installations.json` |
+| Linux   | `${XDG_STATE_HOME:-~/.local/state}/Defold/installations.json` |
+| Windows | `%LOCALAPPDATA%\Defold\installations.json` |
+
+Dosya, bilinen her kurulum için bir nesne içeren bir JSON dizisi içerir:
+
+```json
+[
+  {
+    "launcherPath": "/Applications/Defold.app/Contents/MacOS/Defold",
+    "installPath": "/Applications/Defold.app",
+    "lastLaunchedAt": "2026-07-06T12:34:56.789Z"
+  }
+]
+```
+
+## Düzenleyici biçimlendirmesi
+
+Düzenleyicinin görünümü özel biçimlendirmeyle değiştirilebilir. Daha fazla bilgiyi [Düzenleyici biçimlendirme kılavuzunda](/manuals/editor-styling) bulabilirsiniz.
+
+## Sık sorulan sorular
+:[Editor FAQ](../shared/editor-faq.md)

--- a/docs/tr/manuals/engine-service.md
+++ b/docs/tr/manuals/engine-service.md
@@ -1,0 +1,125 @@
+---
+title: Motor hizmeti ve çalışma zamanı HTTP API'leri
+brief: Bu kılavuz, çalışan bir Defold hata ayıklama motorundaki geliştirme HTTP hizmetini ve çalışma zamanı eklentilerinin veya harici araçların bu hizmeti nasıl kullanabileceğini açıklar.
+---
+
+# Motor hizmeti ve çalışma zamanı HTTP API'leri
+
+Bir projeyi Debug modunda çalıştırmak, motorun belirli bir çalışma zamanı örneği (runtime instance) için oyununuzu ve özel bir motor hizmetini (engine service) içeren bir süreç oluşturur. Bu hizmete geliştirme ve profil çıkarma altyapısı, çalışma zamanı mantığı ve iletileri, motor durumu ve eklentiler için erişilebilir.
+
+Motor hizmeti, çalışan bir hata ayıklama motoruna (`dmengine`) ait bir geliştirme HTTP hizmetidir.
+
+Defold düzenleyicisine ait olan ve açık projeyi kontrol eden [düzenleyici sunucusundan](/manuals/editor-http-api) ayrıdır.
+
+İki hizmet farklı bağlantı noktaları kullanır. Düzenleyicinin bağlantı noktasına bağlanan bir araç, orada çalışma zamanı eklentilerinin rotalarını çağıramaz; bunun tersi de geçerlidir - motor hizmetine bağlanan bir araç düzenleyici işlemlerini çağıramaz.
+
+Motor hizmeti, hata ayıklama, geliştirme ve profil çıkarma altyapısının bir parçasıdır. Release motor örnekleri bu hizmeti oluşturmaz.
+
+## Kullanılabilirlik ve bağlantı noktası keşfi
+
+Düzenleyici bir hata ayıklama motoru başlatırken dinamik olarak atanan bir hizmet bağlantı noktası ister. Motor, seçilen bağlantı noktasını `Console` görünümünde (`bir CLI üzerinden çalıştırılıyorsa günlüğünde de) bildirir:
+
+![Defold hata ayıklama derlemesinde motor hizmetinin bağlantı noktası bilgisi](images/automation/engine-service.png)
+
+```text
+INFO:ENGINE: Engine service started on port <port>
+```
+
+Oyun düzenleyiciden başlatıldığında bu satır düzenleyici konsolunda görünür. Basit bir yerel denetleyici bu satırı ayrıştırabilir, ancak yeniden kullanılabilir bir tümleştirmede motor örneğini ve kayıtlı bağlantı noktasını düzenleyicinin veya onun sarmalayıcısının takip etmesi önerilir. Bu, eski bir bağlantı noktasının yeni başlatılmış veya yeniden kullanılan bir süreçle karıştırılmasını önler.
+
+Motor, desteklenen platformlarda hizmet keşfi (service discovery) aracılığıyla geliştirme hedeflerini de duyurur. Bu mekanizma öncelikle Defold araçları tarafından kullanılır; bunun yerine koda kalıcı olarak sabitlenmiş bir bağlantı noktası kullanılması önerilmez.
+
+Sunucuya yerel makinede, localhost (`127.0.0.1`) adresinde belirli bir bağlantı noktası üzerinden erişilebilir:
+
+![Motor sunucusuna erişim](images/automation/engine-server.png)
+
+## Yerleşik uç noktalar
+
+Mevcut hata ayıklama motoru az sayıda temel rota kaydeder.
+
+| Uç nokta | Amaç |
+| --- | --- |
+| `GET /ping` | Motor hizmetinin yanıt verdiğini kontrol etmek |
+| `GET /info` | Motor sürümünü, platformu, derleme tanımlayıcısını ve günlük hizmeti bilgilerini okumak |
+| `GET /state` | Defold araçlarının kullandığı geliştirme bağlantısı durumunu okumak |
+| `POST /post/<socket>/<message-type>` | Adlandırılmış bir motor soketine Protobuf ile kodlanmış bir Defold iletisi göndermek |
+
+Örneğin:
+
+```sh
+curl -sS "$ENGINE_URL/ping"
+curl -sS "$ENGINE_URL/info" | jq
+curl -sS "$ENGINE_URL/state" | jq
+```
+
+`/post` rotası çalışma sırasında yeniden yükleme (hot reload), yeniden başlatma, yeniden boyutlandırma ve süreç kontrolü gibi geliştirme işlemleri tarafından kullanılır. Gövdesi, rotada adı belirtilen türde bir ikili Protobuf iletisidir; bu bir JSON ileti API'si değildir. Protobuf iletisinin serileştirilmiş hâli 1024 bayttan büyük olamaz; aksi takdirde `400 Too large message` döndürülür.
+
+Bu rotalar geliştirme altyapısını oluşturur; motorun kodunda ek profil çıkarıcı ve kaynak inceleme rotaları da bulunur.
+
+## Eklentilerin tanımladığı çalışma zamanı rotaları
+
+Hata ayıklama derlemelerinde, yerel kod eklentisi (native extension) SDK'sı motorun web sunucusuna erişim sağlayabilir. Bir eklenti bu sunucuda bir rota öneki kaydedebilir ve çalışma zamanı verilerine bağlı işlemler sunabilir.
+
+Bu, geliştirme araçları için yararlıdır; çünkü bir eklenti başka bir HTTP sunucusu açmak yerine mevcut motor hizmetini paylaşabilir.
+
+Bir eklentinin tanımladığı çalışma zamanı otomasyon API'sinin şunları yapması önerilir:
+
+* ayrı, sürümlendirilmiş bir rota öneki kullanmak;
+* desteklenen yetenekleri sunmak;
+* yapılandırılmış hatalar döndürmek;
+* kullanılamayan platform veya motor özelliklerini açıkça ele almak;
+* işlemleri yerel geliştirme ve test ortamlarıyla sınırlamak;
+* yayıma yönelik derlemelerden çıkarılıp çıkarılmadığını belgelemek.
+
+## Automation Bridge eklentisi {#automation-bridge-extension}
+
+Resmî Defold [Automation Bridge](https://github.com/defold/extension-automation-bridge) eklentisi, motor hizmeti üzerine kurulmuş ve yalnızca hata ayıklama derlemelerinde kullanılan bir yerel kod eklentisidir. Şu adres altında sürümlendirilmiş bir çalışma zamanı otomasyon API'si kaydeder:
+
+```text
+http://127.0.0.1:<engine-service-port>/automation-bridge/v1
+```
+
+Çalışma zamanı API'si sahne ve düğüm inceleme, girdi, ekran bilgisi, ekran görüntüleri, kayıt, yaşam döngüsü bilgisi ve isteğe bağlı olarak uygulamanın tanımladığı eşzamanlama gibi yetenekler sağlar. Bazı işlemler şunlardır:
+
+| İşlem | Eylem |
+| --- | --- |
+| `GET  /automation-bridge/v1/health` | sağlık raporu, API yetenekleri ve uyumluluk |
+| `POST /automation-bridge/v1/input/click` | çalışma sırasındaki girdi etkileşimleri için |
+| `GET  /automation-bridge/v1/screenshot` | çalışma sırasında ekran görüntüleri almak için |
+
+Eklentinin projede kurulu sürümüne ait [yerel API belgelerini](https://github.com/defold/extension-automation-bridge/tree/master/automation_bridge) ve [Python yardımcı araçları belgelerini](https://github.com/defold/extension-automation-bridge/tree/master/automation_bridge/automation-bridge-python) kullanın.
+
+Automation Bridge, yayıma yönelik derlemelerde ne HTTP API'sini ne de Lua modülünü sunar.
+
+### Düzenleyici ve çalışma zamanı istemcileri
+
+Automation Bridge Python yardımcı araçları, iki istemcili mimariyi gösterir. `editor.open_project()` işlevi bir düzenleyici proje istemcisi, `project.build_and_run()` ise ayrı bir motor istemcisi döndürür.
+
+| İstemci | Amaç |
+| --- | --- |
+| Proje | Düzenleyici HTTP API'si, komutlar, hata ayıklayıcı, konsol, tercihler, başvuru belgeleri, önizlemeler, proje derleme ve bağlantı noktası keşfi |
+| Oyun - motor hizmeti | Sahne, girdi, ekran görüntüleri, çalışma zamanı durumu ve eşzamanlama |
+
+`project` ve `game` arasındaki ayrım, süreç sınırını açıkça ortaya koyar. Düzenleyici işlemleri düzenleyici sunucusunda kalırken çalışan oyuna yönelik gözlemler ve eylemler motor hizmetinde kalır.
+
+```python
+from automation_bridge import editor
+
+project = editor.open_project(".")
+game = project.build_and_run()
+```
+
+## Sınırlamalar ve güvenlik
+
+Motor hizmeti ve eklentilerin tanımladığı rotalar geliştirme araçlarıdır ve buna uygun şekilde ele alınmaları önerilir.
+
+::: important
+Motor hizmeti şu anda bir OpenAPI belgesi yayımlamaz. Tümleştirmelerin belgelenmiş davranışlarla veya bir eklentinin sürümlendirilmiş API'siyle sınırlı kalması önerilir.
+:::
+
+Çalışma zamanı betikleri, fizik, girdi, dinamik olarak oluşturulan nesneler ve platforma özgü işleme, çalışan bir motor gerektirir ve [otomatik çalışma zamanı testleri](/manuals/automated-testing) aracılığıyla doğrulanmaları önerilir.
+
+* Hizmeti bir yönlendirici, genel erişime açık bir arayüz veya güvenilmeyen bir tünel üzerinden yayımlamayın.
+* Motor hizmeti rotalarının kimlik doğrulama gerektirdiğini varsaymayın.
+* Çalışma zamanı rotaları, eklenti sürümüne, platforma, grafik arka ucuna ve motor yeteneklerine göre değişebilir.
+* Eklentilerin tanımladığı güncel API'ler için sürüm veya yetenek uzlaşması kullanın.

--- a/docs/tr/manuals/extender-docker-images.md
+++ b/docs/tr/manuals/extender-docker-images.md
@@ -1,0 +1,46 @@
+---
+title: Kullanılabilir Docker imajları
+brief: Bu belge, kullanılabilir Docker imajlarını ve bu imajları kullanan Defold sürümlerini açıklar.
+---
+
+# Kullanılabilir Docker imajları
+Aşağıda, herkese açık kayıt deposunda (registry) bulunan tüm Docker imajlarının (Docker images) listesi yer alır. Bu imajlar, artık desteklenmeyen eski yazılım geliştirme kitlerinin (SDK) bulunduğu bir ortamda Extender'ı çalıştırmak için kullanılabilir.
+
+|SDK               |İmaj etiketi                                                                                             |Platform adı (Extender yapılandırmasında) |İmajı kullanan Defold sürümü |
+|------------------|---------------------------------------------------------------------------------------------------------|-------------------------------------|-------------------------------|
+|Linux son sürüm   |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-linux-env:latest`         |`linux-latest`                       |Tüm Defold sürümleri           |
+|Android NDK25     |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-android-ndk25-env:latest` |`android-ndk25`                      |1.4.3'ten itibaren             |
+|Emscripten 2.0.11 |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-2011-env:latest`    |`emsdk-2011`                         |1.7.0'a kadar                  |
+|Emscripten 3.1.55 |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-3155-env:latest`    |`emsdk-3155`                         |[1.8.0-1.9.3]                  |
+|Emscripten 3.1.65 |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-3165-env:latest`    |`emsdk-3165`                         |1.9.4'ten itibaren             |
+|Winsdk 2019       |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-winsdk-2019-env:latest`   |`winsdk-2019`                        |1.6.1'e kadar                  |
+|Winsdk 2022       |`europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-winsdk-2022-env:latest`   |`winsdk-2022`                        |1.6.2'den itibaren             |
+
+# Eski Docker imajlarını kullanma
+Eski ortamı kullanmak için aşağıdaki adımları izleyin:
+1. Extender deposundaki `docker-compose.yml` dosyasını değiştirin: [bağlantı](https://github.com/defold/extender/blob/dev/server/docker/docker-compose.yml). Gerekli Docker imajını içeren bir hizmet tanımı daha eklemeniz gerekir. Örneğin, Emscripten 2.0.11 içeren Docker imajını kullanmak istiyorsak aşağıdaki hizmet tanımını eklememiz gerekir:
+    ```yml
+    emscripten_2011-dev:
+        image: europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-2011-env:latest
+        extends:
+        file: common-services.yml
+        service: remote_builder
+        profiles:
+        - all
+        - web
+        networks:
+        default:
+            aliases:
+            - emsdk-2011
+    ```
+    Önemli alanlar şunlardır:
+    * **profiles** - hizmetin başlatılmasını tetikleyen profillerin listesi. Profil adları, `--profile <profile_name>` bağımsız değişkeni aracılığıyla `docker compose` komutuna iletilir.
+    * **networks** - Docker konteynerinin kullanması gereken ağların listesi. Extender'ı çalıştırmak için `default` adlı ağ kullanılır. Hizmetin ağ takma adlarını ayarlamak önemlidir (bunlar daha sonra Extender yapılandırmasında kullanılacaktır).
+2. [`application-local-dev-app.yml`](https://github.com/defold/extender/blob/dev/server/configs/application-local-dev-app.yml) dosyasının `extender.remote-builder.platforms` bölümüne uzak derleme sunucusu (remote builder) tanımını ekleyin. Örneğimizde tanım şöyle görünür:
+    ```yml
+        emsdk-2011:
+            url: http://emsdk-2011:9000
+            instanceId: emsdk-2011
+    ```
+    URL şu biçimde olmalıdır: `http://<service_network_alias>:9000`; burada `service_network_alias`, 1. adımdaki ağ takma adıdır. 9000, Extender'ın standart bağlantı noktasıdır (özel bir Extender yapılandırması kullanıyorsanız farklı olabilir).
+3. Yerel Extender'ı [Önceden yapılandırılmış çıktı dosyalarıyla yerel Extender'ı çalıştırma](/manuals/extender-local-setup#how-to-run-local-extender-with-preconfigured-artifacts) bölümünde açıklandığı gibi çalıştırın.

--- a/docs/tr/manuals/extender-local-setup.md
+++ b/docs/tr/manuals/extender-local-setup.md
@@ -1,0 +1,133 @@
+---
+title: Yerel derleme sunucusu kurulumu
+brief: Bu kılavuz, yerel bir derleme sunucusunun nasıl kurulup çalıştırılacağını açıklar.
+---
+
+# Derleme sunucusunun yerel kurulumu
+
+Yerel derleme sunucusunu (build server, diğer adıyla 'Extender') çalıştırmanın iki yolu vardır:
+1. Yerel derleme sunucusunu önceden yapılandırılmış çıktı dosyalarıyla (artifact) çalıştırmak.
+2. Yerel derleme sunucusunu yerel olarak derlenmiş çıktı dosyalarıyla çalıştırmak.
+
+## Yerel Extender'ı önceden yapılandırılmış çıktı dosyalarıyla çalıştırma {#how-to-run-local-extender-with-preconfigured-artifacts}
+
+Bir bulut derleyicisini yerel olarak çalıştırabilmeniz için aşağıdaki yazılımları kurmanız gerekir:
+
+* [Docker](https://www.docker.com/) - Docker, yazılımı konteyner (container) adı verilen paketler içinde sunmak için işletim sistemi düzeyinde sanallaştırma kullanan bir hizmet olarak platform ürünleri kümesidir. Bulut derleyicilerini yerel geliştirme makinenizde çalıştırmak için [Docker Desktop](https://www.docker.com/products/docker-desktop/) kurmanız gerekir.
+* Google Cloud CLI - Google Cloud CLI, Google Cloud kaynaklarını oluşturmak ve yönetmek için kullanılan bir araç kümesidir. Araçlar [doğrudan Google'dan](https://cloud.google.com/sdk/docs/install) veya Brew, Chocolatey ya da Snap gibi bir paket yöneticisinden kurulabilir.
+* Platforma özgü derleme sunucularını içeren konteynerleri indirmek için bir Google hesabına da ihtiyacınız vardır.
+
+Yukarıda belirtilen yazılımları kurduktan sonra Defold bulut derleyicilerini kurmak ve çalıştırmak için şu adımları izleyin:
+
+**Windows kullanıcıları için not**: aşağıdaki komutları çalıştırmak için git bash terminalini kullanın.
+
+1. __Google Cloud'da yetkilendirme yapın ve uygulamanın varsayılan kimlik bilgilerini (Application default credentials) oluşturun__ - Herkese açık konteyner kayıt deposunun adil kullanımını izleyip sağlayabilmemiz ve aşırı sayıda imaj indiren hesapları geçici olarak askıya alabilmemiz için Docker konteyner imajlarını indirirken bir Google hesabınızın olması gerekir.
+
+   ```sh
+   gcloud auth login
+   ```
+2. __Docker'ı çıktı dosyası kayıt depolarını (Artifact registries) kullanacak şekilde yapılandırın__ - Docker'ın kimlik bilgisi yardımcısı olarak `gcloud` kullanacak şekilde yapılandırılması gerekir; bu yardımcı, `europe-west1-docker.pkg.dev` adresindeki herkese açık konteyner kayıt deposundan konteyner imajları indirilirken kullanılır.
+
+   ```sh
+   gcloud auth configure-docker europe-west1-docker.pkg.dev
+   ```
+3. __Docker ve Google Cloud'un doğru yapılandırıldığını doğrulayın__ - Tüm derleme sunucusu konteyner imajlarının kullandığı temel imajı indirerek Docker ve Google Cloud'un başarıyla kurulduğunu doğrulayın. Aşağıdaki komutu çalıştırmadan önce Docker Desktop'ın çalıştığından emin olun:
+   ```sh
+   docker pull --platform linux/amd64 europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:latest
+   ```
+4. __Extender deposunu klonlayın__ - Docker ve Google Cloud doğru şekilde kurulduktan sonra sunucuları başlatmaya neredeyse hazırız. Sunucuyu başlatmadan önce derleme sunucusunu içeren Git deposunu klonlamamız gerekir:
+   ```sh
+   git clone https://github.com/defold/extender.git
+   cd extender
+   ```
+5. __Önceden derlenmiş jar dosyalarını indirin__ - Sonraki adım, önceden derlenmiş sunucuyu (`extender.jar`) ve bildirim birleştirme aracını (`manifestmergetool.jar`) indirmektir:
+   ```sh
+    TMP_DIR=$(pwd)/server/_tmp
+    APPLICATION_DIR=$(pwd)/server/app
+    # set necessary version of Extender and Manifest merge tool
+    # versions can be found at Github release page https://github.com/defold/extender/releases
+    # or you can pull latest version (see code sample below)
+    EXTENDER_VERSION=2.6.5
+    MANIFESTMERGETOOL_VERSION=1.3.0
+    echo "Download prebuild jars to ${APPLICATION_DIR}"
+    rm -rf ${TMP_DIR}
+    mkdir -p ${TMP_DIR}
+    rm -rf ${APPLICATION_DIR}
+    mkdir -p ${APPLICATION_DIR}
+
+    gcloud artifacts files download \
+    --project=extender-426409 \
+    --location=europe-west1 \
+    --repository=extender-maven \
+    --destination=${TMP_DIR} \
+    com/defold/extender/server/${EXTENDER_VERSION}/server-${EXTENDER_VERSION}.jar
+
+    gcloud artifacts files download \
+    --project=extender-426409 \
+    --location=europe-west1 \
+    --repository=extender-maven \
+    --destination=${TMP_DIR} \
+    com/defold/extender/manifestmergetool/${MANIFESTMERGETOOL_VERSION}/manifestmergetool-${MANIFESTMERGETOOL_VERSION}.jar
+
+    cp ${TMP_DIR}/$(ls ${TMP_DIR} | grep server-${EXTENDER_VERSION}.jar) ${APPLICATION_DIR}/extender.jar
+    cp ${TMP_DIR}/$(ls ${TMP_DIR} | grep manifestmergetool-${MANIFESTMERGETOOL_VERSION}.jar) ${APPLICATION_DIR}/manifestmergetool.jar
+   ```
+6. __Sunucuyu başlatın__ - Artık ana docker compose komutunu çalıştırarak sunucuyu başlatabiliriz:
+```sh
+docker compose -p extender -f server/docker/docker-compose.yml --profile <profile> up
+```
+Burada *profile* şu değerlerden biri olabilir:
+* **all** - her platform için uzak örnekleri (instance) çalıştırır
+* **android** - Android sürümünü derlemek için ön uç örneğini + uzak örnekleri çalıştırır
+* **web** - Web sürümünü derlemek için ön uç örneğini + uzak örnekleri çalıştırır
+* **linux** - Linux sürümünü derlemek için ön uç örneğini + uzak örnekleri çalıştırır
+* **windows** - Windows sürümünü derlemek için ön uç örneğini + uzak örnekleri çalıştırır
+* **consoles** - Nintendo Switch/PS4/PS5 sürümlerini derlemek için ön uç örneğini + uzak örnekleri çalıştırır
+* **nintendo** - Nintendo Switch sürümünü derlemek için ön uç örneğini + uzak örnekleri çalıştırır
+* **playstation** - PS4/PS5 sürümlerini derlemek için ön uç örneğini + uzak örnekleri çalıştırır
+* **metrics** - ölçüm verileri için arka uç ve görselleştirme aracı olarak VictoriaMetrics + Grafana'yı çalıştırır
+`docker compose` bağımsız değişkenleri hakkında daha fazla bilgi için https://docs.docker.com/reference/cli/docker/compose/ adresine bakın.
+
+docker compose çalışmaya başladığında **http://localhost:9000** adresini düzenleyici tercihlerinde `Build server address` olarak veya projeyi derlemek için Bob kullanıyorsanız `--build-server` değeri olarak kullanabilirsiniz.
+
+Komut satırına birden fazla profil verilebilir. Örneğin:
+```sh
+docker compose -p extender -f server/docker/docker-compose.yml --profile android --profile web --profile windows up
+```
+Yukarıdaki örnek ön uç, Android, Web ve Windows örneklerini çalıştırır.
+
+Hizmetleri durdurmak için docker compose terminale bağlı modda çalışıyorsa Ctrl+C tuşlarına basın veya 
+```sh
+docker compose -p extender down
+```
+docker compose arka planda çalıştırıldıysa (örneğin `docker compose up` komutuna '-d' seçeneği verildiyse) yukarıdaki komutu çalıştırın.
+
+jar dosyalarının en son sürümlerini indirmek istiyorsanız en son sürümü belirlemek için aşağıdaki komutu kullanabilirsiniz
+```sh
+    EXTENDER_VERSION=$(gcloud artifacts versions list \
+        --project=extender-426409 \
+        --location=europe-west1 \
+        --repository=extender-maven \
+        --package="com.defold.extender:server" \
+        --sort-by="~createTime" \
+        --limit=1 \
+        --format="value(name)")
+
+    MANIFESTMERGETOOL_VERSION=$(gcloud artifacts versions list \
+        --project=extender-426409 \
+        --location=europe-west1 \
+        --repository=extender-maven \
+        --package="com.defold.extender:manifestmergetool" \
+        --sort-by="~createTime" \
+        --limit=1 \
+        --format="value(name)")
+```
+
+### Peki ya macOS ve iOS?
+
+macOS ve iOS derlemeleri, Docker olmadan bağımsız modda çalışan bir derleme sunucusu kullanılarak gerçek Apple donanımında yapılır. XCode, Java ve diğer gerekli araçlar doğrudan makineye kurulur ve derleme sunucusu normal bir Java süreci olarak çalışır. Bunun nasıl kurulacağını [GitHub'daki derleme sunucusu belgelerinden](https://github.com/defold/extender?tab=readme-ov-file#running-as-a-stand-alone-server-on-macos) öğrenebilirsiniz.
+
+
+## Yerel Extender'ı yerel olarak derlenmiş çıktı dosyalarıyla çalıştırma
+
+Yerel bir derleme sunucusunu elle derlemek ve çalıştırmak için [GitHub'daki Extender deposunda yer alan yönergeleri](https://github.com/defold/extender) izleyin.

--- a/docs/tr/manuals/extensions-best-practices.md
+++ b/docs/tr/manuals/extensions-best-practices.md
@@ -1,0 +1,129 @@
+---
+title: Yerel kod eklentileri - En iyi uygulamalar
+brief: Bu kılavuz, yerel kod eklentileri geliştirirken izlenebilecek en iyi uygulamaları açıklar.
+---
+
+# En iyi uygulamalar
+
+Birden çok platformda çalışan kod yazmak zor olabilir, ancak bu tür kodları hem geliştirmeyi hem de bakımını yapmayı kolaylaştırmanın bazı yolları vardır.
+
+
+## Proje yapısı
+
+Bir yerel kod eklentisi (native extension) oluştururken, hem geliştirme hem de bakım sürecinde yardımcı olan birkaç nokta vardır.
+
+### Lua API
+
+Yalnızca bir Lua API'si ve bunun tek bir uygulaması olmalıdır. Bu, tüm platformlarda aynı davranışı sağlamayı çok daha kolaylaştırır.
+
+Söz konusu platform eklentiyi desteklememeliyse, Lua modülünü hiç kaydetmemeniz önerilir. Böylece `nil` kontrolü yaparak desteği saptayabilirsiniz:
+
+```lua
+    if myextension ~= nil then
+        myextension.do_something()
+    end
+```
+
+### Klasör yapısı
+
+Eklentiler için aşağıdaki klasör yapısı sıkça kullanılır:
+
+```
+    /root
+        /input
+        /main                            -- All the files for the actual example project
+            /...
+        /myextension                     -- The actual root folder of the extension
+            ext.manifest
+            /include                     -- External includes, used by other extensions
+            /libs
+                /<platform>              -- External libraries for all supported platforms
+            /src
+                myextension.cpp          -- The extension Lua api and the extension life cycle functions
+                                            Also contains generic implementations of your Lua api functions.
+                myextension_private.h    -- Your internal api that each platform will implement (I.e. `myextension_Init` etc)
+                myextension.mm           -- If native calls are needed for iOS/macOS. Implements `myextension_Init` etc for iOS/macOS
+                myextension_android.cpp  -- If JNI calls are needed for Android. Implements `myextension_Init` etc for Android
+                /java
+                    /<platform>          -- Any java files needed for Android
+            /res                         -- Any resources needed for a platform
+            /external
+                README.md                -- Notes/scripts on how to build or package any external libraries
+        /bundleres                       -- Resources that should be bundles for (see game.project and the [bundle_resources setting]([physics scale setting](/manuals/project-settings/#project))
+            /<platform>
+        game.project
+        game.appmanifest                 -- Any extra app configuration info
+```
+
+`myextension.mm` ve `myextension_android.cpp` dosyalarının yalnızca ilgili platforma özgü yerel kod çağrıları yapıyorsanız gerekli olduğunu unutmayın.
+
+#### Platform klasörleri
+
+Belirli yerlerde, uygulamanın kodunu derlerken veya uygulamayı paketlerken hangi dosyaların kullanılacağını belirlemek için platform mimarisi klasör adı olarak kullanılır. Bu adlar şu biçimdedir:
+
+    <architecture>-<platform>
+
+Güncel liste şöyledir:
+
+    arm64-ios, arm64_sim-ios, arm64-android, armv7-android, x86_64-android, x86_64-linux, x86_64-osx, x86_64-win32, x86-win32
+
+Örneğin, platforma özgü kütüphaneleri şu klasörlerin altına yerleştirin:
+
+    /libs
+        /arm64-ios
+                            /libFoo.a
+        /arm64-android
+                            /libFoo.a
+
+
+## Yerel kod yazma
+
+Defold kaynak kodunda C++ çok sınırlı kullanılır ve kodun büyük bölümü C'ye çok benzer. Birkaç kapsayıcı sınıf dışında neredeyse hiç şablon (template) kullanılmaz; çünkü şablonlar hem kod derleme sürelerini hem de yürütülebilir dosya boyutunu artırır.
+
+### C++ sürümü
+
+Çekirdek motoru derlerken C++11 kullanıyoruz, ancak Windows'ta C++14 kullanıyoruz. Konsol derlemeleri artık genellikle C++14 veya üzerini gerektiriyor.
+
+Yerel kod eklentileri için sabitlenmiş bir C++ sürümü kullanmıyoruz; platformun araç zincirinin varsayılan sürümüne dayanıyoruz.
+
+Defold kaynak kodunda C++ dilinin en yeni özelliklerini veya sürümlerini kullanmaktan kaçınılır. Bunun temel nedeni, bir oyun motoru geliştirirken yeni özelliklere ihtiyaç duyulmamasıdır. Ayrıca C++ dilinin en yeni özelliklerini takip etmek zaman alan bir iştir ve bu özelliklere tam olarak hâkim olmak çok fazla değerli zaman gerektirir.
+
+Bunun eklenti geliştiricileri için ek bir yararı da Defold'un kararlı bir ABI sağlamasıdır. Ayrıca en yeni C++ özelliklerini kullanmanın, destek düzeylerinin değişmesi nedeniyle kodun farklı platformlarda derlenmesini engelleyebileceğini de belirtmek gerekir.
+
+### C++ özel durumları kullanılmaz
+
+Defold, motorda hiçbir özel durum (exception) kullanmaz. Oyun motorlarında özel durumlardan genellikle kaçınılır; çünkü veriler (çoğunlukla) geliştirme sırasında önceden bilinir. C++ özel durum desteğini kaldırmak, yürütülebilir dosya boyutunu küçültür ve çalışma zamanı performansını iyileştirir.
+
+### Standart şablon kütüphaneleri - STL
+
+Defold motoru bazı algoritmalar ve matematik işlemleri (`std::sort`, `std::upper_bound` vb.) dışında STL kodu kullanmadığından, eklentinizde STL kullanmak sizin için işe yarayabilir.
+
+Yine de eklentinizi diğer eklentiler veya üçüncü taraf kütüphanelerle birlikte kullanırken ABI uyumsuzluklarının size engel olabileceğini unutmayın.
+
+Yoğun biçimde şablon kullanan STL kütüphanelerinden kaçınmak, derleme sürelerimizi de kısaltır ve daha da önemlisi yürütülebilir dosya boyutunu küçültür.
+
+#### Dizeler
+
+Defold motorunda `std::string` yerine `const char*` kullanılır. Farklı C++ sürümlerini veya derleyici sürümlerini bir arada kullanırken `std::string` kullanımı sık karşılaşılan bir tuzaktır; çünkü ABI uyumsuzluğuna yol açabilir. `const char*` ve birkaç yardımcı işlev kullanmak bunu önler.
+
+### İşlevleri gizleyin
+
+Mümkünse yalnızca kendi derleme birimi içinde kullanılan işlevlerde `static` anahtar sözcüğünü kullanın. Bu, derleyicinin bazı optimizasyonlar yapmasını sağlar ve hem performansı iyileştirebilir hem de yürütülebilir dosya boyutunu küçültebilir.
+
+## Üçüncü taraf kütüphaneler
+
+Kullanılacak bir üçüncü taraf kütüphanesi seçerken (dilinden bağımsız olarak) aşağıdakileri göz önünde bulundurun:
+
+* İşlevsellik - Yaşadığınız belirli sorunu çözüyor mu?
+* Performans - Çalışma sırasında performans maliyeti oluşturuyor mu?
+* Kütüphane boyutu - Son yürütülebilir dosya ne kadar büyüyecek? Bu kabul edilebilir mi?
+* Bağımlılıklar - Ek kütüphaneler gerektiriyor mu?
+* Destek - Kütüphane ne durumda? Çok sayıda açık sorunu var mı? Bakımı hâlâ yapılıyor mu?
+* Lisans - Bu projede kullanılmasına izin veriliyor mu?
+
+
+## Açık kaynak bağımlılıkları
+
+Bağımlılıklarınıza erişiminiz olduğundan her zaman emin olun. Örneğin, GitHub'daki bir projeye bağımlıysanız, o deponun kaldırılmasını, aniden yön değiştirmesini veya el değiştirmesini engelleyen bir şey yoktur. Depoyu çatallayıp (fork) asıl proje yerine kendi çatalınızı kullanarak bu riski azaltabilirsiniz.
+
+Kütüphanedeki kodun oyununuza ekleneceğini unutmayın; bu nedenle kütüphanenin yalnızca yapması gerekeni yaptığından emin olun!

--- a/docs/tr/manuals/extensions-cocoapods.md
+++ b/docs/tr/manuals/extensions-cocoapods.md
@@ -1,0 +1,27 @@
+---
+title: iOS ve macOS derlemelerinde CocoaPods bağımlılıklarını kullanma
+brief: Bu kılavuz, iOS ve macOS derlemelerinde bağımlılıkları çözümlemek için CocoaPods'un nasıl kullanılacağını açıklar.
+---
+
+# CocoaPods
+
+[CocoaPods](https://cocoapods.org/), Swift ve Objective-C ile geliştirilen Cocoa projeleri için bir bağımlılık yöneticisidir. CocoaPods genellikle Xcode projelerindeki bağımlılıkları yönetmek ve projeye dahil etmek için kullanılır. Defold, iOS ve macOS için derleme yaparken Xcode kullanmaz, ancak derleme sunucusundaki bağımlılıkları çözümlemek için yine de CocoaPods kullanır.
+
+
+## Bağımlılıkları çözümleme
+
+Yerel kod eklentileri (native extension), eklenti bağımlılıklarını belirtmek için `manifests/ios` ve `manifests/osx` klasörlerinde bir `Podfile` dosyası içerebilir. Örnek:
+
+```
+platform :ios '11.0'
+
+pod 'FirebaseCore', '10.22.0'
+pod 'FirebaseInstallations', '10.22.0'
+```
+
+Derleme sunucusu, tüm eklentilerdeki `Podfile` dosyalarını toplar ve bu dosyaları kullanarak tüm bağımlılıkları çözümler ve yerel kodu derlerken bunları dahil eder.
+
+Örnekler:
+
+* [Firebase](https://github.com/defold/extension-firebase/blob/master/firebase/manifests/ios/Podfile)
+* [Facebook](https://github.com/defold/extension-facebook/blob/master/facebook/manifests/ios/Podfile)

--- a/docs/tr/manuals/extensions-debugging-android.md
+++ b/docs/tr/manuals/extensions-debugging-android.md
@@ -1,0 +1,6 @@
+---
+title: Android'de hata ayıklama
+brief: Bu kılavuz, Android cihazında çalışan bir derleme çıktısında nasıl hata ayıklanacağını açıklar.
+---
+
+[Android'de yerel kodda hata ayıklama](/manuals/debugging-native-code-android) sayfasına taşındı

--- a/docs/tr/manuals/extensions-debugging-ios.md
+++ b/docs/tr/manuals/extensions-debugging-ios.md
@@ -1,0 +1,6 @@
+---
+title: iOS/macOS üzerinde hata ayıklama
+brief: Bu kılavuz, Xcode kullanarak bir derleme çıktısında nasıl hata ayıklayacağınızı açıklar.
+---
+
+Bu içerik [iOS üzerinde yerel kodda hata ayıklama](/manuals/debugging-native-code-ios) sayfasına taşındı.

--- a/docs/tr/manuals/extensions-debugging.md
+++ b/docs/tr/manuals/extensions-debugging.md
@@ -1,0 +1,6 @@
+---
+title: Eklentilerde hata ayıklama
+brief: Bu kılavuz, yerel kod eklentileri (native extensions) içeren bir uygulamada hata ayıklamak için kullanılabilecek bazı yöntemleri açıklar.
+---
+
+Daha fazla bilgi için [Yerel kodda hata ayıklama kılavuzuna](/manuals/debugging-native-code) bakın.

--- a/docs/tr/manuals/extensions-defold-sdk.md
+++ b/docs/tr/manuals/extensions-defold-sdk.md
@@ -1,0 +1,26 @@
+---
+title: Yerel kod eklentileri - Defold SDK
+brief: Bu kılavuz, yerel kod eklentileri oluştururken Defold SDK ile nasıl çalışılacağını açıklar.
+---
+
+# Defold SDK
+
+Defold yazılım geliştirme kiti (SDK), bir yerel kod eklentisini (native extension) bildirmek için gereken işlevlerin yanı sıra uygulamanın çalıştığı düşük düzeyli yerel platform katmanıyla ve oyun mantığının oluşturulduğu yüksek düzeyli Lua katmanıyla etkileşim kurmak için gereken işlevleri içerir.
+
+## Kullanım
+
+C++ eklentileri, diğer başlıkları bir araya getiren `dmsdk/sdk.h` başlık dosyasını (header file) dahil edebilir:
+
+```cpp
+#include <dmsdk/sdk.h>
+```
+
+Birleştirilmiş başlık dosyası, C++ bildirimleri içerir ve bir C kaynak dosyasından dahil edilemez. C kaynak dosyalarına, gereken C uyumlu `.h` başlık dosyalarını ayrı ayrı dahil etmeniz önerilir; örneğin:
+
+```c
+#include <dmsdk/extension/extension.h>
+#include <dmsdk/dlib/configfile.h>
+#include <dmsdk/resource/resource.h>
+```
+
+Şu anda dmSDK'nin yalnızca bir bölümünde saf C arayüzü bulunur; her C++ alt sisteminin C karşılığı yoktur. Kullanılabilir işlevler ve türler, [C API'sine genel bakış](/ref/overview_defoldc/) ve [C++ API'sine genel bakış](/ref/overview_defoldcpp/) sayfalarında belgelenmiştir. Defold SDK başlık dosyaları, ayrı bir `defoldsdk_headers.zip` arşivi olarak Defold'un [GitHub'da yayımlanan her sürümüne](https://github.com/defold/defold/releases) dahil edilir. Bu başlık dosyalarını, tercih ettiğiniz düzenleyicide kod tamamlama için kullanabilirsiniz.

--- a/docs/tr/manuals/extensions-ext-manifests.md
+++ b/docs/tr/manuals/extensions-ext-manifests.md
@@ -1,0 +1,75 @@
+---
+title: Yerel kod eklentileri - eklenti bildirimleri
+brief: Bu kılavuz, eklenti bildirimini ve bunun uygulama ve motor bildirimleriyle ilişkisini açıklar.
+---
+
+# Eklenti, uygulama ve motor bildirim dosyaları
+
+Eklenti bildirimi (extension manifest), tek bir eklentinin derleme sürecinde kullanılan bayrakları (flags) ve tanımları (defines) içeren bir yapılandırma dosyasıdır. Bu yapılandırma, uygulama düzeyindeki bir yapılandırmayla ve Defold motorunun kendisi için temel düzeyde bir yapılandırmayla birleştirilir.
+
+## Uygulama bildirimi
+
+Uygulama bildirimi (application manifest, dosya uzantısı `.appmanifest`), oyununuzun derleme sunucularında nasıl derleneceğini belirleyen uygulama düzeyinde bir yapılandırmadır. Uygulama bildirimi, motorun kullanmadığınız bölümlerini kaldırmanızı sağlar. Bir fizik motoruna ihtiyacınız yoksa yürütülebilir dosyanın boyutunu küçültmek için fizik motorunu dosyadan kaldırabilirsiniz. Kullanılmayan özelliklerin nasıl dışlanacağını [uygulama bildirimi kılavuzundan](/manuals/app-manifest) öğrenin.
+
+## Motor bildirimi
+
+Motorun ve Defold yazılım geliştirme kitinin (SDK) her sürümü, Defold motoruna ait bir derleme bildirimi (`build.yml`) içerir. Bildirim, hangi SDK sürümlerinin kullanılacağını, hangi derleyicilerin, bağlayıcıların (linkers) ve diğer araçların çalıştırılacağını ve bu araçlara hangi varsayılan derleme ve bağlama bayraklarının aktarılacağını belirler. Bildirimi [GitHub üzerinde](https://github.com/defold/defold/blob/dev/share/extender/build_input.yml) share/extender/build_input.yml dosyasında bulabilirsiniz.
+
+## Eklenti bildirimi
+
+Eklenti bildirimi (`ext.manifest`) ise bir eklentiye özel yapılandırma dosyasıdır. Eklenti bildirimi, eklentinin kaynak kodunun nasıl derlenip bağlanacağını ve hangi ek kütüphanelerin dahil edileceğini belirler. 
+
+Üç farklı bildirim dosyasının tümü aynı sözdizimini kullanır. Böylece birleştirilebilir ve eklentilerin ve oyunun nasıl derleneceğini tamamen belirleyebilirler.
+
+Derlenen her eklenti için bildirimler aşağıdaki gibi birleştirilir:
+
+	manifest = merge(game.appmanifest, ext.manifest, build.yml)
+
+Bu, kullanıcının motorun ve her bir eklentinin varsayılan davranışını geçersiz kılmasını sağlar. Son bağlama aşamasında ise uygulama bildirimini Defold bildirimiyle birleştiririz:
+
+	manifest = merge(game.appmanifest, build.yml)
+
+
+### ext.manifest dosyası
+
+Bildirim dosyası, eklentinin adının yanı sıra platforma özgü kod derleme bayrakları, bağlama bayrakları, kütüphaneler ve framework'ler içerebilir. *ext.manifest* dosyasında bir "platforms" bölümü yoksa veya listede bir platform eksikse, dağıtım paketi oluşturduğunuz platform için derleme yine yapılır, ancak hiçbir ek bayrak ayarlanmaz.
+
+Aşağıda bir örnek verilmiştir:
+
+```yaml
+name: "AdExtension"
+
+platforms:
+    arm64-ios:
+        context:
+            frameworks: ["CoreGraphics", "CFNetwork", "GLKit", "CoreMotion", "MessageUI", "MediaPlayer", "StoreKit", "MobileCoreServices", "AdSupport", "AudioToolbox", "AVFoundation", "CoreGraphics", "CoreMedia", "CoreMotion", "CoreTelephony", "CoreVideo", "Foundation", "GLKit", "JavaScriptCore", "MediaPlayer", "MessageUI", "MobileCoreServices", "OpenGLES", "SafariServices", "StoreKit", "SystemConfiguration", "UIKit", "WebKit"]
+            flags:      ["-stdlib=libc++"]
+            linkFlags:  ["-ObjC"]
+            libs:       ["z", "c++", "sqlite3"]
+            defines:    ["MY_DEFINE"]
+
+    arm64_sim-ios:
+        context:
+            frameworks: ["CoreGraphics", "CFNetwork", "GLKit", "CoreMotion", "MessageUI", "MediaPlayer", "StoreKit", "MobileCoreServices", "AdSupport", "AudioToolbox", "AVFoundation", "CoreGraphics", "CoreMedia", "CoreMotion", "CoreTelephony", "CoreVideo", "Foundation", "GLKit", "JavaScriptCore", "MediaPlayer", "MessageUI", "MobileCoreServices", "OpenGLES", "SafariServices", "StoreKit", "SystemConfiguration", "UIKit", "WebKit"]
+            flags:      ["-stdlib=libc++"]
+            linkFlags:  ["-ObjC"]
+            libs:       ["z", "c++", "sqlite3"]
+            defines:    ["MY_DEFINE"]
+```
+
+#### İzin verilen anahtarlar
+
+Platforma özgü kod derleme bayrakları için izin verilen anahtarlar şunlardır:
+
+* `frameworks` - Derleme sırasında dahil edilecek Apple framework'leri (iOS ve macOS)
+* `weakFrameworks` - Derleme sırasında isteğe bağlı olarak dahil edilecek Apple framework'leri (iOS ve macOS)
+* `flags` - Derleyiciye aktarılacak bayraklar
+* `linkFlags` - Bağlayıcıya aktarılacak bayraklar
+* `libs` - Bağlama sırasında dahil edilecek ek kütüphaneler
+* `defines` - Derleme sırasında ayarlanacak tanımlar
+* `aaptExtraPackages` - Oluşturulacak ek paket adı (Android)
+* `aaptExcludePackages` - Dışlanacak paketleri belirten düzenli ifade (regexp) veya paketlerin tam adları (Android)
+* `aaptExcludeResourceDirs` - Dışlanacak kaynak dizinlerini belirten düzenli ifade veya dizinlerin tam adları (Android)
+* `excludeLibs`, `excludeJars`, `excludeSymbols` - Bu bayraklar, platform bağlamında daha önce tanımlanmış öğeleri kaldırmak için kullanılır.
+
+Tüm anahtar sözcüklere bir izin listesi filtresi uygularız. Bunun amacı, geçersiz yol işlemlerini ve derleme için yüklenen dosyaların bulunduğu klasörün dışındaki dosyalara erişimi önlemektir.

--- a/docs/tr/manuals/extensions-gradle.md
+++ b/docs/tr/manuals/extensions-gradle.md
@@ -1,0 +1,31 @@
+---
+title: Android derlemelerinde Gradle bağımlılıklarını kullanma
+brief: Bu kılavuz, Android derlemelerindeki bağımlılıkları çözümlemek için Gradle'ın nasıl kullanılacağını açıklar.
+---
+
+# Android için Gradle
+
+Android uygulamalarının derlenmesinde yaygın olan yaklaşımın aksine Defold, tüm proje derleme süreci için [Gradle](https://gradle.org/) kullanmaz. Bunun yerine yerel proje derlemesinde `aapt2` ve `bundletool` gibi Android komut satırı araçlarını doğrudan kullanır ve Gradle'dan yalnızca derleme sunucusunda bağımlılıkları çözümlerken yararlanır.
+
+
+## Bağımlılıkları çözümleme
+
+Yerel kod eklentileri (native extensions), eklentinin bağımlılıklarını belirtmek için `manifests/android` klasöründe bir `build.gradle` dosyası içerebilir. Örnek:
+
+```
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.google.firebase:firebase-installations:17.2.0'
+    implementation 'com.google.android.gms:play-services-base:18.2.0'
+}
+```
+
+Derleme sunucusu, tüm eklentilerin `build.gradle` dosyalarını toplar ve bunları kullanarak tüm bağımlılıkları çözümler ve yerel kod derlenirken bu bağımlılıkları derlemeye dahil eder.
+
+Örnekler:
+
+* [Firebase](https://github.com/defold/extension-firebase/blob/master/firebase/manifests/android/)build.gradle
+* [Facebook](https://github.com/defold/extension-facebook/blob/master/facebook/manifests/android/build.gradle)

--- a/docs/tr/manuals/extensions-manifest-merge-tool.md
+++ b/docs/tr/manuals/extensions-manifest-merge-tool.md
@@ -1,0 +1,359 @@
+---
+title: Yerel kod eklentileri - Bildirim birleştirme araçları
+brief: Bu kılavuz, uygulama bildirimlerinin birleştirilmesinin nasıl çalıştığını açıklar
+---
+
+# Uygulama bildirimleri
+
+Bazı platformlarda, eklentilerin (extension) uygulama bildirimi (application manifest) parçaları (snippet veya stub) sağlamasını destekliyoruz.
+Bu, bir `AndroidManifest.xml`, `Info.plist` veya `engine_template.html` dosyasının bir bölümü olabilir
+
+Her eklentinin bildirim parçası, uygulamanın temel bildiriminden başlanarak sırayla uygulanır.
+Temel bildirim, varsayılan bildirim (`builtins\manifests\<platforms>\...` konumundaki) veya kullanıcının sağladığı özel bir bildirimdir.
+
+## Adlandırma ve yapı
+
+Eklentinin amaçlandığı gibi çalışabilmesi için eklenti bildirimlerinin belirli bir yapıya göre yerleştirilmesi gerekir.
+
+    /myextension
+        ext.manifest
+        /manifests
+            /android
+                AndroidManifest.xml
+            /ios
+                Info.plist
+            /osx
+                Info.plist
+            /web
+                engine_template.html
+
+
+## Android
+
+Android platformunda zaten bir bildirim birleştirme aracı (`ManifestMerger2` tabanlı) vardır ve bildirimleri birleştirmek için bu aracı `bob.jar` içinde kullanıyoruz.
+Android bildirimlerinizi nasıl değiştireceğinize ilişkin tüm yönergeler için [Android belgelerine](https://developer.android.com/studio/build/manifest-merge) bakın
+
+::: important
+Eklenti bildiriminizde uygulamanızın `android:targetSdkVersion` değerini ayarlamazsanız şu izinler otomatik olarak eklenir:  `WRITE_EXTERNAL_STORAGE`, `READ_PHONE_STATE`, `READ_EXTERNAL_STORAGE`. Bu konuda daha fazla bilgiyi [buradaki](https://developer.android.com/studio/build/manifest-merge#implicit_system_permissions) resmî belgelerde bulabilirsiniz.
+Şunu kullanmanızı öneririz: `<uses-sdk android:targetSdkVersion="{{android.target_sdk_version}}" />`
+:::
+### Örnek
+
+Temel bildirim
+
+```xml
+    <?xml version='1.0' encoding='utf-8'?>
+    <manifest xmlns:android='http://schemas.android.com/apk/res/android'
+            package='com.defold.testmerge'
+            android:versionCode='14'
+            android:versionName='1.0'
+            android:installLocation='auto'>
+        <uses-feature android:required='true' android:glEsVersion='0x00020000' />
+        <uses-sdk android:minSdkVersion='21' android:targetSdkVersion='26' />
+        <application android:label='Test Project' android:hasCode='true'>
+        </application>
+        <uses-permission android:name='android.permission.VIBRATE' />
+    </manifest>
+```
+
+Eklenti bildirimi:
+
+```xml
+    <?xml version='1.0' encoding='utf-8'?>
+    <manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.defold.testmerge'>
+         <uses-sdk android:targetSdkVersion="{{android.target_sdk_version}}" />
+        <uses-feature android:required='true' android:glEsVersion='0x00030000' />
+        <application>
+            <meta-data android:name='com.facebook.sdk.ApplicationName'
+                android:value='Test Project' />
+            <activity android:name='com.facebook.FacebookActivity'
+              android:theme='@android:style/Theme.Translucent.NoTitleBar'
+              android:configChanges='keyboard|keyboardHidden|screenLayout|screenSize|orientation'
+              android:label='Test Project' />
+        </application>
+    </manifest>
+```
+
+Sonuç
+
+```xml
+    <?xml version='1.0' encoding='utf-8'?>
+    <manifest xmlns:android='http://schemas.android.com/apk/res/android'
+        package='com.defold.testmerge'
+        android:installLocation='auto'
+        android:versionCode='14'
+        android:versionName='1.0' >
+        <uses-sdk
+            android:minSdkVersion='21'
+            android:targetSdkVersion='26' />
+        <uses-permission android:name='android.permission.VIBRATE' />
+        <uses-feature
+            android:glEsVersion='0x00030000'
+            android:required='true' />
+        <application
+            android:hasCode='true'
+            android:label='Test Project' >
+            <meta-data
+                android:name='com.facebook.sdk.ApplicationName'
+                android:value='Test Project' />
+            <activity
+                android:name='com.facebook.FacebookActivity'
+                android:configChanges='keyboard|keyboardHidden|screenLayout|screenSize|orientation'
+                android:label='Test Project'
+                android:theme='@android:style/Theme.Translucent.NoTitleBar' />
+        </application>
+    </manifest>
+```
+
+## iOS / macOS
+
+`Info.plist` dosyasında listeleri ve sözlükleri birleştirmek için kendi uygulamamızı kullanıyoruz. Anahtarlarda birleştirme işaretçisi öznitelikleri olarak `merge`, `keep` veya `replace` belirtilebilir; varsayılan değer `merge` olur.
+
+### Örnek
+
+Temel bildirim
+
+```xml
+    <?xml version='1.0' encoding='UTF-8'?>
+    <!DOCTYPE plist PUBLIC '-//Apple//DTD PLIST 1.0//EN' 'http://www.apple.com/DTDs/PropertyList-1.0.dtd'>
+    <plist version='1.0'>
+    <dict>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSExceptionDomains</key>
+            <dict>
+                <key>foobar.net</key>
+                <dict>
+                    <key>testproperty</key>
+                    <true/>
+                </dict>
+            </dict>
+        </dict>
+        <key>INT</key>
+        <integer>8</integer>
+
+        <key>REAL</key>
+        <real>8.0</real>
+
+        <!-- Keep this value even if an extension manifest contains the same key -->
+        <key merge='keep'>BASE64</key>
+        <data>SEVMTE8gV09STEQ=</data>
+
+        <!-- If an extension manifest also has an array with this key then any dictionary values will be merged with the first dictionary value of the base array -->
+        <key>Array1</key>
+        <array>
+            <dict>
+                <key>Foobar</key>
+                <array>
+                    <string>a</string>
+                </array>
+            </dict>
+        </array>
+
+        <!-- Do not attempt to merge the values of this array, instead values from extension manifests should be added to the end of the array -->
+        <key merge='keep'>Array2</key>
+        <array>
+            <dict>
+                <key>Foobar</key>
+                <array>
+                    <string>a</string>
+                </array>
+            </dict>
+        </array>
+    </dict>
+    </plist>
+```
+
+Eklenti bildirimi:
+
+```xml
+    <?xml version='1.0' encoding='UTF-8'?>
+    <!DOCTYPE plist PUBLIC '-//Apple//DTD PLIST 1.0//EN' 'http://www.apple.com/DTDs/PropertyList-1.0.dtd'>
+    <plist version='1.0'>
+    <dict>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSExceptionDomains</key>
+            <dict>
+                <key>facebook.com</key>
+                <dict>
+                    <key>NSIncludesSubdomains</key>
+                    <true/>
+                    <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+                    <false/>
+                </dict>
+            </dict>
+        </dict>
+        <key>INT</key>
+        <integer>42</integer>
+
+        <!-- Replace the existing value in the base manifest -->
+        <key merge='replace'>REAL</key>
+        <integer>16.0</integer>
+
+        <key>BASE64</key>
+        <data>Rk9PQkFS</data>
+
+        <key>Array1</key>
+        <array>
+            <dict>
+                <key>Foobar</key>
+                <array>
+                    <string>b</string>
+                </array>
+            </dict>
+        </array>
+
+        <key>Array2</key>
+        <array>
+            <dict>
+                <key>Foobar</key>
+                <array>
+                    <string>b</string>
+                </array>
+            </dict>
+        </array>
+    </dict>
+    </plist>
+```
+
+Sonuç:
+
+```xml
+    <?xml version='1.0'?>
+    <!DOCTYPE plist SYSTEM 'file://localhost/System/Library/DTDs/PropertyList.dtd'>
+    <plist version='1.0'>
+        <!-- Nested merge of dictionaries from base and extension manifests -->
+        <dict>
+            <key>NSAppTransportSecurity</key>
+            <dict>
+                <key>NSExceptionDomains</key>
+                <dict>
+                    <key>foobar.net</key>
+                    <dict>
+                        <key>testproperty</key>
+                        <true/>
+                    </dict>
+                    <key>facebook.com</key>
+                    <dict>
+                        <key>NSIncludesSubdomains</key>
+                        <true/>
+                        <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+                        <false/>
+                    </dict>
+                </dict>
+            </dict>
+
+            <!-- From the base manifest -->
+            <key>INT</key>
+            <integer>8</integer>
+
+            <!-- The value from the base manifest was replaced since the merge marker was set to "replace" in the extension manifest -->
+            <key>REAL</key>
+            <real>16.0</real>
+
+            <!-- The value from the base manifest was used since the merge marker was set to "keep" in the base manifest -->
+            <key>BASE64</key>
+            <data>SEVMTE8gV09STEQ=</data>
+
+            <!-- The value from the extender manifest was added since no merge marker was specified -->
+            <key>INT</key>
+            <integer>42</integer>
+
+            <!-- The dictionary values of the array were merged since the base manifest defaults to "merge" -->
+            <key>Array1</key>
+            <array>
+                <dict>
+                    <key>Foobar</key>
+                    <array>
+                        <string>a</string>
+                        <string>b</string>
+                    </array>
+                </dict>
+            </array>
+
+            <!-- The dictionary values were added to the array since the base manifest used "keep" -->
+            <key>Array2</key>
+            <array>
+                <dict>
+                    <key>Foobar</key>
+                    <array>
+                        <string>a</string>
+                    </array>
+                </dict>
+                <dict>
+                    <key>Foobar</key>
+                    <array>
+                        <string>b</string>
+                    </array>
+                </dict>
+            </array>
+        </dict>
+    </plist>
+```
+
+
+## HTML5
+
+HTML şablonunda, bölümleri eşleştirebilmek için her birine bir ad verdik (örneğin "engine-start").
+Ardından `merge` veya `keep` özniteliklerini belirtebilirsiniz. Varsayılan değer `merge` olur.
+
+### Örnek
+
+Temel bildirim
+
+```html
+    <!DOCTYPE html>
+    <html>
+    <body>
+     <script id='engine-loader' type='text/javascript' src='dmloader.js'></script>
+     <script id='engine-setup' type='text/javascript'>
+     function load_engine() {
+         var engineJS = document.createElement('script');
+         engineJS.type = 'text/javascript';
+         engineJS.src = '{{exe-name}}_wasm.js';
+         document.head.appendChild(engineJS);
+     }
+     </script>
+     <script id='engine-start' type='text/javascript'>
+         load_engine();
+     </script>
+    </body>
+    </html>
+```
+
+Eklenti bildirimi
+
+```html
+    <html>
+    <body>
+     <script id='engine-loader' type='text/javascript' src='mydmloader.js'></script>
+     <script id='engine-start' type='text/javascript' merge='keep'>
+         my_load_engine();
+     </script>
+    </body>
+    </html>
+```
+
+Sonuç
+
+```html
+    <!doctype html>
+    <html>
+    <head></head>
+    <body>
+        <script id='engine-loader' type='text/javascript' src='mydmloader.js'></script>
+        <script id='engine-setup' type='text/javascript'>
+            function load_engine() {
+                var engineJSdocument.createElement('script');
+                engineJS.type = 'text/javascript';
+                engineJS.src = '{{exe-name}}_wasm.js';
+                document.head.appendChild(engineJS);
+            }
+        </script>
+        <script id='engine-start' type='text/javascript' merge='keep'>
+            my_load_engine(
+        </script>
+    </body>
+    </html>
+```

--- a/docs/tr/manuals/extensions-script-api.md
+++ b/docs/tr/manuals/extensions-script-api.md
@@ -1,0 +1,54 @@
+---
+title: Yerel kod eklentilerine düzenleyicide otomatik tamamlama ekleme
+brief: Bu kılavuz, Defold düzenleyicisinin bir eklentinin kullanıcılarına otomatik tamamlama sunabilmesi için betik API tanımının nasıl oluşturulacağını açıklar.
+---
+
+# Yerel kod eklentileri için otomatik tamamlama
+
+Defold düzenleyicisi, tüm Defold API işlevleri için otomatik tamamlama (auto-complete) önerileri sunar ve betiklerinizin gerektirdiği Lua modülleri için öneriler oluşturur. Ancak düzenleyici, yerel kod eklentilerinin (native extension) sunduğu işlevler için kendiliğinden otomatik tamamlama önerileri sunamaz. Bir yerel kod eklentisi, kendi API'si için de otomatik tamamlama önerilerini etkinleştirmek üzere ayrı bir dosyada API tanımı sağlayabilir.
+
+
+## Betik API tanımı oluşturma
+
+Betik API tanım dosyasının uzantısı `.script_api` şeklindedir. Dosyanın [YAML biçiminde](https://yaml.org/) olması ve eklenti dosyalarıyla birlikte bulunması gerekir. Betik API tanımı için beklenen biçim şöyledir:
+
+```yml
+- name: The name of the extension
+  type: table
+  desc: Extension description
+  members:
+  - name: Name of the first member
+    type: Member type
+    desc: Member description
+    # if member type is "function"
+    parameters:
+    - name: Name of the first parameter
+      type: Parameter type
+      desc: Parameter description
+    - name: Name of the second parameter
+      type: Parameter type
+      desc: Parameter description
+    # if member type is "function"
+    returns:
+    - name: Name of first return value
+      type: Return value type
+      desc: Return value description
+    examples:
+    - desc: First example of member usage
+    - desc: Second example of member usage
+
+  - name: Name of the second member
+    ...
+```
+
+Türler, `table, string , boolean, number, function` türlerinden herhangi biri olabilir. Bir değer birden fazla türde olabiliyorsa `[type1, type2, type3]` biçiminde yazılır.
+::: sidenote
+Türler şu anda düzenleyicide gösterilmez. Düzenleyici tür bilgilerini göstermeyi desteklediğinde kullanılabilmeleri için bunları yine de belirtmeniz önerilir.
+:::
+
+## Örnekler
+
+Gerçek kullanım örnekleri için aşağıdaki projelere bakın:
+
+* [Facebook eklentisi](https://github.com/defold/extension-facebook/tree/master/facebook/api)
+* [WebView eklentisi](https://github.com/defold/extension-webview/blob/master/webview/api/webview.script_api)

--- a/docs/tr/manuals/extensions.md
+++ b/docs/tr/manuals/extensions.md
@@ -1,0 +1,297 @@
+---
+title: Defold için yerel kod eklentileri yazma
+brief: Bu kılavuz, Defold oyun motoru için yerel kod eklentisi yazmayı ve kurulum gerektirmeyen bulut derleme araçlarıyla eklentinin kodunu derlemeyi açıklar.
+---
+
+# Yerel kod eklentileri
+
+Lua'nın yeterli olmadığı durumlarda harici yazılım veya donanımla düşük düzeyde özel bir etkileşim kurmanız gerekiyorsa Defold SDK, hedef platforma bağlı olarak motor için C, C++, C#, Objective-C, Java veya JavaScript ile eklentiler yazmanıza olanak tanır. Yerel kod eklentilerinin (native extension) yaygın kullanım alanları şunlardır:
+
+- Belirli donanımlarla, örneğin cep telefonlarının kamerasıyla etkileşim.
+- Harici düşük düzeyli API'lerle, örneğin Luasocket kullanılabilecek ağ API'leri üzerinden etkileşime izin vermeyen reklam ağı API'leriyle etkileşim.
+- Yüksek performanslı hesaplamalar ve veri işleme.
+
+::: sidenote
+C# desteği deneyseldir ve Defold betik bileşenleri (script component) için değil, yerel kod eklentileri için tasarlanmıştır. Statik bir kütüphane üretmek için .NET 9 NativeAOT kullanır; eklentinin `src` klasörüne `.cs` kaynak dosyalarını eklediğinizde derleme hizmeti proje dosyasını oluşturur. Hedef desteği, NativeAOT ve derleme hizmetinin mevcut yeteneklerine bağlıdır. Güncel iş akışı ve test edilmiş kurulum için resmî [yerel kod eklentisi dil örneğine](https://github.com/defold/example-languages) bakın.
+:::
+
+## Derleme sunucusu
+
+Defold, bulut tabanlı bir derleme çözümüyle yerel kod eklentilerini kullanmaya kurulum gerektirmeden başlamanızı sağlar. Geliştirilip bir oyun projesine doğrudan veya bir [kütüphane projesi](/manuals/libraries/) aracılığıyla eklenen her yerel kod eklentisi, olağan proje içeriğinin bir parçası olur. Motorun özel sürümlerini derleyip ekip üyelerine dağıtmanız gerekmez; bu işlem otomatik olarak yapılır---projeyi derleyip çalıştıran her ekip üyesi, motorun tüm yerel kod eklentilerini içeren, projeye özgü yürütülebilir dosyasını alır.
+
+![Bulutta derleme](images/extensions/cloud_build.png)
+
+Defold, bulut derleme sunucusunu herhangi bir kullanım kısıtlaması olmadan ücretsiz sunar. Sunucu Avrupa'da barındırılır ve yerel kodun gönderildiği URL, [düzenleyici tercihleri penceresinde](/manuals/editor-preferences/#extensions) veya [bob](/manuals/bob/#usage) aracının `--build-server` komut satırı seçeneğiyle yapılandırılır. Kendi sunucunuzu kurmak istiyorsanız lütfen [bu yönergeleri izleyin](/manuals/extender-local-setup).
+
+## Proje düzeni
+
+Yeni bir eklenti oluşturmak için projenin kök dizininde bir klasör oluşturun. Bu klasör, eklentiyle ilişkili tüm ayarları, kaynak kodu, kütüphaneleri ve kaynakları içerecektir. Eklenti derleme aracı klasör yapısını tanır ve tüm kaynak dosyaları ile kütüphaneleri toplar.
+
+```
+ myextension/
+ │
+ ├── ext.manifest
+ │
+ ├── src/
+ │
+ ├── include/
+ │
+ ├── lib/
+ │   └──[platforms]
+ │
+ ├── manifests/
+ │   └──[platforms]
+ │
+ └── res/
+     └──[platforms]
+
+```
+*ext.manifest*
+: Eklenti klasörü bir *ext.manifest* dosyası _içermek zorundadır_. Bu dosya, tek bir eklenti derlenirken kullanılan bayrakları ve tanımları içeren bir yapılandırma dosyasıdır. Dosya biçiminin tanımını [Eklenti bildirimi kılavuzunda](https://defold.com/manuals/extensions-ext-manifests/) bulabilirsiniz.
+
+*src*
+: Bu klasörün tüm kaynak kod dosyalarını içermesi önerilir.
+
+*include*
+: Bu isteğe bağlı klasör, dahil etme (include) dosyalarını içerir.
+
+*lib*
+: Bu isteğe bağlı klasör, eklentinin bağımlı olduğu derlenmiş kütüphaneleri içerir. Kütüphane dosyalarının, kütüphanelerinizin desteklediği mimarilere bağlı olarak `platform` veya `architecture-platform` biçiminde adlandırılan alt klasörlere yerleştirilmesi önerilir.
+
+  :[platforms](../shared/platforms.md)
+
+*manifests*
+: Bu isteğe bağlı klasör, derleme veya paketleme sürecinde kullanılan ek dosyaları içerir. Ayrıntılar için aşağıya bakın.
+
+*res*
+: Bu isteğe bağlı klasör, eklentinin bağımlı olduğu ek kaynakları içerir. Kaynak dosyalarının, `lib` alt klasörlerinde olduğu gibi `platform` veya `architecture-platform` biçiminde adlandırılan alt klasörlere yerleştirilmesi önerilir. Tüm platformlar için ortak kaynak dosyaları içeren `common` adlı bir alt klasöre de izin verilir.
+
+### Bildirim dosyaları
+
+Bir eklentinin isteğe bağlı *manifests* klasörü, derleme ve paketleme sürecinde kullanılan ek dosyaları içerir. Dosyaların `platform` biçiminde adlandırılan alt klasörlere yerleştirilmesi önerilir:
+
+* `android` - Bu klasör, ana uygulamayla birleştirilecek bir bildirim parçası dosyası kabul eder ([burada açıklandığı gibi](/manuals/extensions-manifest-merge-tool)).
+  * Klasör, [Gradle tarafından çözümlenecek](/manuals/extensions-gradle) bağımlılıkları içeren bir `build.gradle` dosyası da içerebilir.
+  * Java kodu içeren eklentilerin, çalışma sırasında ihtiyaç duydukları sınıflar için bir [R8 koruma kuralı dosyası](#r8-keep-rules-for-android) (`.keep`) içermesi önerilir.
+* `ios` - Bu klasör, ana uygulamayla birleştirilecek bir bildirim parçası dosyası kabul eder ([burada açıklandığı gibi](/manuals/extensions-manifest-merge-tool)).
+  * Klasör, [Cocoapods tarafından çözümlenecek](/manuals/extensions-cocoapods) bağımlılıkları içeren bir `Podfile` dosyası da içerebilir.
+* `osx` - Bu klasör, ana uygulamayla birleştirilecek bir bildirim parçası dosyası kabul eder ([burada açıklandığı gibi](/manuals/extensions-manifest-merge-tool)).
+* `web` - Bu klasör, ana uygulamayla birleştirilecek bir bildirim parçası dosyası kabul eder ([burada açıklandığı gibi](/manuals/extensions-manifest-merge-tool)).
+
+
+### Android için R8 koruma kuralları {#r8-keep-rules-for-android}
+
+Eklentinin `manifests/android` dizinine, `build.gradle` dosyasının yanına bir `.keep` dosyası ekleyin. Örneğin `/myextension/manifests/android/myextension.keep`, aşağıdaki kuralla eklentinin Java sınıflarını koruyabilir:
+
+```proguard
+-keep,allowoptimization class com.example.myextension.** { *; }
+```
+
+`com.example.myextension` yerine eklentinizin Java sınıflarını içeren paketi yazın. Bu kural, R8'in kodlarını optimize etmesine izin verirken sınıfları ve üyelerini korur. R8 bu kullanımları otomatik olarak keşfedemeyebileceğinden, Java Native Interface (JNI) veya yansıma (reflection) aracılığıyla erişilen diğer sınıflar için de kurallar ekleyin.
+
+Eklenti çalışma sırasında ek açıklamalara (annotation) dayanıyorsa şunu da ekleyin:
+
+```proguard
+-keepattributes *Annotation*
+```
+
+Bu kurallar, [R8 etkinleştirildiğinde](/manuals/android/#enabling-r8) projenin seçilen koruma dosyasıyla birleştirilir.
+
+
+## Özel kaynaklar {#custom-resources}
+
+Bir eklenti, `ext.manifest` dosyasının yanındaki bir `ext.properties` dosyasında özel kaynaklar (custom resource) tanımlayarak oyun arşivine veri dahil edebilir:
+
+```ini
+[project]
+custom_resources.default = /myextension/data
+```
+
+Örneğin `/myextension/data/settings.json` konumuna bir JSON dosyası yerleştirin. Yol, eklenti klasörünü de içerir ve projenin kök dizinine göredir. Eklentiyi kütüphane olarak paylaşırken, kütüphaneyi kullanan projelerin eklentiyi ve verilerini alması için kütüphanenin [Include Dirs](/manuals/libraries/#setting-up-library-sharing) ayarına `myextension` ekleyin.
+
+Bu yollar, *game.project* dosyasındaki `project.custom_resources` ve diğer eklentilerin eklediği kaynaklarla birleştirilir. Projede özel kaynaklar ayarlamak, eklentilerin eklediği kaynakların yerini almaz. Hem düzenleyicide yapılan derlemeler hem de Bob arşivleri, çalışma sırasında yüklenebilen bu dosyaları içerir:
+
+```lua
+local data, err = sys.load_resource("/myextension/data/settings.json")
+if data then
+    local settings = json.decode(data)
+    pprint(settings)
+else
+    print(err)
+end
+```
+
+Özel kaynakların dağıtım paketine eklenen kaynaklardan nasıl farklılaştığını öğrenmek için [dosya erişimi](/manuals/file-access/#custom-resources) bölümüne bakın.
+
+## Eklenti paylaşma
+
+Eklentiler, projenizdeki diğer varlıklarla aynı şekilde ele alınır ve aynı şekilde paylaşılabilir. Bir yerel kod eklentisi klasörü, kütüphane klasörü olarak eklenirse paylaşılabilir ve başkaları tarafından proje bağımlılığı olarak kullanılabilir. Daha fazla bilgi için [Kütüphane projesi kılavuzuna](/manuals/libraries/) bakın.
+
+
+## Basit bir eklenti örneği
+
+Çok basit bir eklenti oluşturalım. Önce kök dizinde yeni bir *`myextension`* klasörü oluşturup eklentinin "`MyExtension`" adını içeren bir *`ext.manifest`* dosyası ekliyoruz. Adın bir C++ simgesi olduğunu ve `DM_DECLARE_EXTENSION` makrosunun ilk bağımsız değişkeniyle eşleşmesi gerektiğini unutmayın (aşağıya bakın).
+
+![Bildirim](images/extensions/manifest.png)
+
+```yaml
+# C++ symbol in your extension
+name: "MyExtension"
+```
+
+Eklenti, "`src`" klasöründe oluşturulan tek bir C++ dosyasından, *`myextension.cpp`* dosyasından oluşur.
+
+![C++ dosyası](images/extensions/cppfile.png)
+
+Eklentinin kaynak dosyası aşağıdaki kodu içerir:
+
+```cpp
+// myextension.cpp
+// Extension lib defines
+#define LIB_NAME "MyExtension"
+#define MODULE_NAME "myextension"
+
+// include the Defold SDK
+#include <dmsdk/sdk.h>
+
+static int Reverse(lua_State* L)
+{
+    // The number of expected items to be on the Lua stack
+    // once this struct goes out of scope
+    DM_LUA_STACK_CHECK(L, 1);
+
+    // Check and get parameter string from stack
+    char* str = (char*)luaL_checkstring(L, 1);
+
+    // Reverse the string
+    int len = strlen(str);
+    for(int i = 0; i < len / 2; i++) {
+        const char a = str[i];
+        const char b = str[len - i - 1];
+        str[i] = b;
+        str[len - i - 1] = a;
+    }
+
+    // Put the reverse string on the stack
+    lua_pushstring(L, str);
+
+    // Return 1 item
+    return 1;
+}
+
+// Functions exposed to Lua
+static const luaL_reg Module_methods[] =
+{
+    {"reverse", Reverse},
+    {0, 0}
+};
+
+static void LuaInit(lua_State* L)
+{
+    int top = lua_gettop(L);
+
+    // Register lua names
+    luaL_register(L, MODULE_NAME, Module_methods);
+
+    lua_pop(L, 1);
+    assert(top == lua_gettop(L));
+}
+
+dmExtension::Result AppInitializeMyExtension(dmExtension::AppParams* params)
+{
+    return dmExtension::RESULT_OK;
+}
+
+dmExtension::Result InitializeMyExtension(dmExtension::Params* params)
+{
+    // Init Lua
+    LuaInit(params->m_L);
+    printf("Registered %s Extension\n", MODULE_NAME);
+    return dmExtension::RESULT_OK;
+}
+
+dmExtension::Result AppFinalizeMyExtension(dmExtension::AppParams* params)
+{
+    return dmExtension::RESULT_OK;
+}
+
+dmExtension::Result FinalizeMyExtension(dmExtension::Params* params)
+{
+    return dmExtension::RESULT_OK;
+}
+
+
+// Defold SDK uses a macro for setting up extension entry points:
+//
+// DM_DECLARE_EXTENSION(symbol, name, app_init, app_final, init, update, on_event, final)
+
+// MyExtension is the C++ symbol that holds all relevant extension data.
+// It must match the name field in the `ext.manifest`
+DM_DECLARE_EXTENSION(MyExtension, LIB_NAME, AppInitializeMyExtension, AppFinalizeMyExtension, InitializeMyExtension, 0, 0, FinalizeMyExtension)
+```
+
+Eklenti kodundaki çeşitli giriş noktalarını tanımlamak için kullanılan `DM_DECLARE_EXTENSION` makrosuna dikkat edin. İlk bağımsız değişken olan `symbol`, *ext.manifest* dosyasında belirtilen adla eşleşmelidir. Bu basit örnekte `update` veya `on_event` giriş noktalarına gerek olmadığından, makroya bu konumlarda `0` verilir.
+
+Şimdi geriye yalnızca projeyi derlemek kalıyor (<kbd>Project ▸ Build</kbd>). Bu işlem, eklentiyi eklenti derleme aracına gönderir; araç da yeni eklentiyi içeren özel bir motor üretir. Derleme aracı herhangi bir hatayla karşılaşırsa derleme hatalarını içeren bir iletişim kutusu gösterilir.
+
+Eklentiyi test etmek için bir oyun nesnesi (game object) oluşturun ve test kodu içeren bir betik bileşeni ekleyin:
+
+```lua
+local s = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+local reverse_s = myextension.reverse(s)
+print(reverse_s) --> ZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedcba
+```
+
+İşte bu kadar! Tamamen çalışan bir yerel kod eklentisi oluşturduk.
+
+
+## Eklentinin yaşam döngüsü
+
+Yukarıda gördüğümüz gibi, `DM_DECLARE_EXTENSION` makrosu eklenti kodundaki çeşitli giriş noktalarını tanımlamak için kullanılır:
+
+`DM_DECLARE_EXTENSION(symbol, name, app_init, app_final, init, update, on_event, final)`
+
+Giriş noktaları, eklentinin yaşam döngüsünün çeşitli aşamalarında kod çalıştırmanıza olanak tanır:
+
+* Motorun başlatılması
+  * Motor sistemleri başlatılır
+  * Eklentinin `app_init` giriş noktası
+  * Eklentinin `init` giriş noktası - Tüm Defold API'lerinin başlangıç işlemleri tamamlanmıştır. Eklenti yaşam döngüsünde, eklenti koduna yönelik Lua bağlarının (binding) oluşturulması için önerilen aşama budur.
+  * Betiğin başlangıç işlemleri - Betik dosyalarının `init()` işlevi çağrılır.
+* Motor döngüsü
+  * Motorun güncellenmesi
+    * Eklentinin `update` giriş noktası
+    * Betiğin güncellenmesi - Betik dosyalarının `update()` işlevi çağrılır.
+  * Motor olayları (pencereyi küçültme/büyütme vb.)
+    * Eklentinin `on_event` giriş noktası
+* Motorun kapatılması (veya yeniden başlatılması)
+  * Betiğin sonlandırma işlemleri - Betik dosyalarının `final()` işlevi çağrılır.
+  * Eklentinin `final` giriş noktası
+  * Eklentinin `app_final` giriş noktası
+
+## Tanımlanan platform tanımlayıcıları
+
+Aşağıdaki tanımlayıcılar, ilgili platformların her birinde derleme aracı tarafından tanımlanır:
+
+* `DM_PLATFORM_WINDOWS`
+* `DM_PLATFORM_OSX`
+* `DM_PLATFORM_IOS`
+* `DM_PLATFORM_ANDROID`
+* `DM_PLATFORM_LINUX`
+* `DM_PLATFORM_HTML5`
+
+## Derleme sunucusu günlükleri {#build-server-logs}
+
+Proje yerel kod eklentileri kullanıyorsa derleme sunucusu günlüklerine erişilebilir. Derleme sunucusu günlüğü (`log.txt`), proje derlenirken özel motorla birlikte indirilir ve `.internal/%platform%/build.zip` dosyasının içinde saklanır; ayrıca arşivden çıkarılarak projenizin derleme klasörüne yerleştirilir.
+
+## Eklenti örnekleri
+
+* [Temel eklenti örneği](https://github.com/defold/template-native-extension) (bu kılavuzdaki eklenti)
+* [Android eklentisi örneği](https://github.com/defold/extension-android)
+* [HTML5 eklentisi örneği](https://github.com/defold/extension-html5)
+* [macOS, iOS ve Android video oynatıcı eklentisi](https://github.com/defold/extension-videoplayer)
+* [macOS ve iOS kamera eklentisi](https://github.com/defold/extension-camera)
+* [iOS ve Android uygulama içi satın alma eklentisi](https://github.com/defold/extension-iap)
+* [iOS ve Android Firebase Analytics eklentisi](https://github.com/defold/extension-firebase-analytics)
+
+[Defold Asset Portal](https://www.defold.com/assets/) ayrıca birden çok yerel kod eklentisi içerir.

--- a/docs/tr/manuals/facebook.md
+++ b/docs/tr/manuals/facebook.md
@@ -1,0 +1,6 @@
+---
+title: Defold'da Facebook
+brief: Defold'da Facebook.
+---
+
+[Bu kılavuz taşındı](/extension-facebook)

--- a/docs/tr/manuals/factory.md
+++ b/docs/tr/manuals/factory.md
@@ -1,0 +1,274 @@
+---
+title: Fabrika bileşeni kılavuzu
+brief: Bu kılavuz, oyun nesnelerini çalışma sırasında dinamik olarak oluşturmak için fabrika bileşenlerinin nasıl kullanılacağını açıklar.
+---
+
+# Fabrika bileşenleri
+
+Fabrika bileşenleri (factory components), çalışan bir oyunda bir nesne havuzundan oyun nesnelerini (game object) dinamik olarak oluşturmak için kullanılır.
+
+Bir oyun nesnesine fabrika bileşeni eklediğinizde, fabrikanın oluşturacağı tüm yeni oyun nesneleri için hangi oyun nesnesi dosyasını prototip (prototype; diğer motorlarda "prefabs" veya "blueprints" olarak da bilinir) olarak kullanacağını *Prototype* özelliğinde belirtirsiniz.
+
+![Fabrika bileşeni](images/factory/factory_collection.png)
+
+![Fabrika bileşeni](images/factory/factory_component.png)
+
+Bir oyun nesnesinin oluşturulmasını tetiklemek için `factory.create()` işlevini çağırın:
+
+```lua
+-- factory.script
+local p = go.get_position()
+p.y = vmath.lerp(math.random(), min_y, max_y)
+local component = "#star_factory"
+factory.create(component, p)
+```
+
+![Çalışma sırasında oluşturulan oyun nesnesi](images/factory/factory_spawned.png)
+
+`factory.create()` 5 parametre alır:
+
+`url`
+: Yeni bir oyun nesnesi oluşturacak fabrika bileşeninin tanımlayıcısı.
+
+`[position]`
+: (isteğe bağlı) Yeni oyun nesnesinin dünya uzayındaki konumu. Bu değer `vector3` türünde olmalıdır. Konum belirtmezseniz oyun nesnesi, `factory.create()` işlevini çağıran oyun nesnesinin konumunda oluşturulur.
+
+`[rotation]`
+: (isteğe bağlı) Yeni oyun nesnesinin dünya uzayındaki dönme değeri. Bu değer `quat` türünde olmalıdır.
+
+`[properties]`
+: (isteğe bağlı) Oyun nesnesini başlatırken kullanılacak betik özelliği değerlerini içeren bir Lua tablosu. Betik özellikleri hakkında bilgi için [Betik özellikleri kılavuzuna](/manuals/script-properties) bakın.
+
+`[scale]`
+: (isteğe bağlı) Oluşturulan oyun nesnesinin ölçeği. Ölçek, tüm eksenlerde aynı oranda ölçeklendirmeyi belirten bir `number` (0'dan büyük) olarak ifade edilebilir. Her bileşenin ilgili eksendeki ölçeklendirmeyi belirttiği bir `vector3` de verebilirsiniz.
+
+Örneğin:
+
+```lua
+-- factory.script
+local p = go.get_position()
+p.y = vmath.lerp(math.random(), min_y, max_y)
+local component = "#star_factory"
+-- Spawn with no rotation but double scale.
+-- Set the score of the star to 10.
+factory.create(component, p, nil, { score = 10 }, 2.0) -- <1>
+```
+1. Yıldız oyun nesnesinin "score" özelliğini ayarlar.
+
+```lua
+-- star.script
+go.property("score", 1) -- <1>
+
+local speed = -240
+
+function update(self, dt)
+    local p = go.get_position()
+    p.x = p.x + speed * dt
+    if p.x < -32 then
+        go.delete()
+    end
+    go.set_position(p)
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("collision_response") then
+        msg.post("main#gui", "add_score", {amount = self.score}) -- <2>
+        go.delete()
+    end
+end
+```
+1. "score" betik özelliği varsayılan bir değerle tanımlanır.
+2. "score" betik özelliğine, "self" içinde saklanan bir değer olarak başvurun.
+
+![Özellik ve ölçeklendirme ile oluşturulan oyun nesnesi](images/factory/factory_spawned2.png)
+
+::: sidenote
+Defold şu anda çarpışma şekillerinin eksenlere göre farklı oranlarda ölçeklendirilmesini desteklemiyor. Örneğin `vmath.vector3(1.0, 2.0, 1.0)` gibi eksenlere göre farklı oranlar içeren bir ölçek değeri verirseniz sprite bileşeni doğru şekilde ölçeklenir ancak çarpışma şekilleri doğru şekilde ölçeklenmez.
+:::
+
+
+## Fabrikayla oluşturulan nesneleri adresleme
+
+Defold'un adresleme mekanizması, çalışan bir oyundaki her nesneye ve bileşene erişmenizi sağlar. [Adresleme kılavuzu](/manuals/addressing/), sistemin nasıl çalıştığını oldukça ayrıntılı olarak açıklar. Aynı adresleme mekanizmasını çalışma sırasında oluşturulan oyun nesneleri ve bunların bileşenleri için de kullanabilirsiniz. Örneğin bir ileti gönderirken, oluşturulan nesnenin tanımlayıcısını kullanmak çoğu zaman yeterlidir:
+
+```lua
+local function create_hunter(target_id)
+    local id = factory.create("#hunterfactory")
+    msg.post(id, "hunt", { target = target_id })
+    return id
+end
+```
+
+::: sidenote
+İletiyi belirli bir bileşen yerine oyun nesnesinin kendisine göndermek, aslında iletiyi tüm bileşenlere gönderir. Bu genellikle bir sorun oluşturmaz ancak nesnenin çok sayıda bileşeni varsa bunu aklınızda bulundurmanızda yarar vardır.
+:::
+
+Peki, örneğin bir çarpışma nesnesini devre dışı bırakmak veya sprite görüntüsünü değiştirmek için, çalışma sırasında oluşturulan bir oyun nesnesinin belirli bir bileşenine erişmeniz gerekirse? Çözüm, oyun nesnesinin tanımlayıcısı ile bileşenin tanımlayıcısından bir URL oluşturmaktır.
+
+```lua
+local function create_guard(unarmed)
+    local id = factory.create("#guardfactory")
+    if unarmed then
+        local weapon_sprite_url = msg.url(nil, id, "weapon")
+        msg.post(weapon_sprite_url, "disable")
+
+        local body_sprite_url = msg.url(nil, id, "body")
+        sprite.play_flipbook(body_sprite_url, hash("red_guard"))
+    end
+end
+```
+
+
+## Oluşturulan nesneleri ve üst nesneleri takip etme
+
+`factory.create()` işlevini çağırdığınızda yeni oyun nesnesinin tanımlayıcısı döndürülür; bu tanımlayıcıyı daha sonra başvurmak üzere saklayabilirsiniz. Yaygın bir kullanım, nesneler oluşturup tanımlayıcılarını bir tabloya eklemektir. Böylece, örneğin bir bölümün düzenini sıfırlarken, daha sonra hepsini silebilirsiniz:
+
+```lua
+-- spawner.script
+self.spawned_coins = {}
+
+...
+
+-- Spawn a coin and store it in the "coins" table.
+local id = factory.create("#coinfactory", coin_position)
+table.insert(self.spawned_coins, id)
+```
+
+Daha sonra:
+
+```lua
+-- spawner.script
+-- Delete all spawned coins.
+for _, coin_id in ipairs(self.spawned_coins) do
+    go.delete(coin_id)
+end
+
+-- or alternatively
+go.delete(self.spawned_coins)
+```
+
+Oluşturulan nesnenin, kendisini oluşturan oyun nesnesinden haberdar olmasını istemek de yaygındır. Örneğin, aynı anda yalnızca bir örneği oluşturulabilen bir otonom nesne türü söz konusu olabilir. Bu durumda oluşturulan nesnenin, yeni bir nesne oluşturulabilmesi için silindiğinde veya devre dışı bırakıldığında kendisini oluşturan nesneye haber vermesi gerekir:
+
+```lua
+-- spawner.script
+-- Spawn a drone and set its parent to the url of this script component
+self.spawned_drone = factory.create("#dronefactory", drone_position, nil, { parent = msg.url() })
+
+...
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("drone_dead") then
+        self.spawned_drone = nil
+    end
+end
+```
+
+Oluşturulan nesnenin mantığı ise şöyledir:
+
+```lua
+-- drone.script
+go.property("parent", msg.url())
+
+...
+
+function final(self)
+    -- I'm dead.
+    msg.post(self.parent, "drone_dead")
+end
+```
+
+## Fabrika kaynaklarını dinamik olarak yükleme {#dynamic-loading-of-factory-resources}
+
+Fabrika özelliklerindeki *Load Dynamically* onay kutusunu işaretlediğinizde motor, fabrikayla ilişkili kaynakların yüklenmesini erteler.
+
+![Dinamik yükleme](images/factory/load_dynamically.png)
+
+Kutu işaretli değilken motor, fabrika bileşeni yüklendiğinde prototip kaynaklarını yükler; böylece bunlar nesne oluşturmak için hemen hazır olur.
+
+Kutu işaretliyken iki kullanım seçeneğiniz vardır:
+
+Eşzamanlı yükleme
+: Nesneler oluşturmak istediğinizde [`factory.create()`](/ref/factory/#factory.create) işlevini çağırın. Bu işlem önce kaynakları eşzamanlı olarak yükler, ardından yeni örnekler oluşturur. Yükleme kısa bir takılmaya neden olabilir.
+
+  ```lua
+  function init(self)
+      -- No factory resources are loaded when the factory’s parent
+      -- collection is loaded. Calling create without having called
+      -- load will create the resources synchronously.
+      self.go_id = factory.create("#factory")
+  end
+
+  function final(self)  
+      -- Delete game objects. Will decref resources.
+      -- In this case resources are deleted since the factory component
+      -- holds no reference.
+      go.delete(self.go_id)
+
+      -- Calling unload will do nothing since factory holds no references
+      factory.unload("#factory")
+  end
+  ```
+
+Eşzamansız yükleme
+: Kaynakları açıkça eşzamansız olarak yüklemek için [`factory.load()`](/ref/factory/#factory.load) işlevini çağırın. Kaynaklar nesne oluşturmak için hazır olduğunda bir geri çağırım (callback) alınır.
+
+  ```lua
+  function load_complete(self, url, result)
+      -- Loading is complete, resources are ready to spawn
+      self.go_id = factory.create(url)
+  end
+
+  function init(self)
+      -- No factory resources are loaded when the factory’s parent
+      -- collection is loaded. Calling load will load the resources.
+      factory.load("#factory", load_complete)
+  end
+
+  function final(self)
+      -- Delete game object. Will decref resources.
+      -- In this case resources aren’t deleted since the factory component
+      -- still holds a reference.
+      go.delete(self.go_id)
+
+      -- Calling unload will decref resources held by the factory component,
+      -- resulting in resources being destroyed.
+      factory.unload("#factory")
+  end
+  ```
+
+## Dinamik prototip
+
+Fabrika özelliklerindeki *Dynamic Prototype* onay kutusunu işaretleyerek fabrikanın hangi *Prototype* değerini kullanarak nesne oluşturabileceğini değiştirebilirsiniz.
+
+![Dinamik prototip](images/factory/dynamic_prototype.png)
+
+*Dynamic Prototype* seçeneği işaretliyken fabrika bileşeni, `factory.set_prototype()` işlevini kullanarak prototipini değiştirebilir. Örnek:
+
+```lua
+factory.unload("#factory") -- unload the previous resources
+factory.set_prototype("#factory", "/main/levels/enemyA.goc")
+local enemy_id = factory.create("#factory")
+```
+
+::: important
+*Dynamic Prototype* seçeneği etkinleştirildiğinde koleksiyonun (collection) bileşen sayısı optimize edilemez ve fabrika bileşenini içeren koleksiyon, *game.project* dosyasındaki varsayılan bileşen sayılarını kullanır.
+:::
+
+
+## Örnek sınırları
+
+*Collection* altındaki *Max Instances* proje ayarı, her koleksiyondaki (dünyadaki) oyun nesnesi sayısının üst sınırıdır. Defold, proje derleme sırasında güvenli olduğunu belirleyebildiğinde daha küçük bir kapasite ayırabilir. Düzenleyicide yerleştirilmiş veya çalışma sırasında oluşturulmuş olsun, bir dünyada aynı anda var olan tüm oyun nesneleri kapasiteye dahil edilir.
+
+![En fazla örnek sayısı](images/factory/factory_max_instances.png)
+
+Gerçekte ayrılan kapasite, proje derleme sırasında yapılan analize bağlıdır:
+
+* Proje derleme sırasında sabit bir oyun nesnesi sayısı belirlenebildiğinde kapasite, derlenmiş nesne sayısıdır ve *Max Instances* ile sınırlıdır. Bu genellikle koleksiyonda fabrika veya koleksiyon fabrikası (collection factory) bulunmadığında gerçekleşir.
+* Fabrika veya koleksiyon fabrikası içeren bir koleksiyon, oyun nesnesi kapasitesi için *Max Instances* değerini kullanır. Statik olarak başvurulan bir prototip için, proje derleme işlemi fabrikanın oluşturabileceği bileşen türlerini belirler. Bu türler, projede kendileri için belirlenen en yüksek sayıları kullanırken etkilenmeyen bileşen türleri yine tam olarak belirlenen sayıları kullanabilir.
+* *Dynamic Prototype* seçeneğini etkinleştirmek, fabrika bileşenini içeren koleksiyon için bileşen sayısı analizini devre dışı bırakır; bu nedenle koleksiyon, *Max Instances* değerini ve bileşen başına yapılandırılmış en yüksek sayıları kullanır.
+
+*Max Instances* değerini, dinamik bir dünyada aynı anda var olabilecek en fazla oyun nesnesi sayısına göre planlayın. Diğer bileşen sınırlarının nasıl hesaplandığını öğrenmek için [Bileşen sayısı üst sınırı optimizasyonları](/manuals/project-settings/#component-max-count-optimizations) bölümüne bakın.
+
+## Oyun nesnelerini havuzda tutma
+
+Çalışma sırasında oluşturulan oyun nesnelerini bir havuzda saklayıp yeniden kullanmak iyi bir fikir gibi görünebilir. Ancak motor zaten kendi içinde nesne havuzlama işlemini yaptığı için ek işlem yükü yalnızca işleri yavaşlatır. Oyun nesnelerini silip yenilerini oluşturmak hem daha hızlı hem de daha temizdir.

--- a/docs/tr/manuals/file-access.md
+++ b/docs/tr/manuals/file-access.md
@@ -1,0 +1,147 @@
+---
+title: Dosyalarla çalışma
+brief: Bu kılavuz, dosyaların nasıl kaydedilip yükleneceğini ve diğer dosya işlemlerinin nasıl gerçekleştirileceğini açıklar.
+---
+
+# Dosyalarla çalışma
+Dosya oluşturmanın ve/veya dosyalara erişmenin birçok farklı yolu vardır. Dosya yolları ve dosyalara erişme yöntemleri, dosyanın türüne ve konumuna göre değişir.
+
+## Dosya ve klasör erişimi için işlevler
+Defold, dosyalarla çalışmak için çeşitli işlevler sunar:
+
+* Dosyaları okumak ve yazmak için standart [`io.*` işlevlerini](https://defold.com/ref/stable/io/) kullanabilirsiniz. Bu işlevler, giriş/çıkış (I/O) sürecinin tamamı üzerinde çok ayrıntılı denetim sağlar.
+
+```lua
+-- open myfile.txt for writing in binary mode
+-- returns nil plus error message on failure
+local f, err = io.open("path/to/myfile.txt", "wb")
+if not f then
+	print("Something went wrong while opening the file", err)
+	return
+end
+
+-- write to the file, flush it to disk and then close the file
+f:write("Foobar")
+f:flush()
+f:close()
+
+-- open myfile.txt for reading in binary mode
+-- returns nil plus error message on failure
+local f, err = io.open("path/to/myfile.txt", "rb")
+if not f then
+	print("Something went wrong while opening the file", err)
+	return
+end
+
+-- read the entire file as a string
+-- returns nil on failure
+local s = f:read("*a")
+if not s then
+	print("Error while reading file")
+	return
+end
+
+print(s) -- Foobar
+```
+
+* Dosyaları yeniden adlandırmak ve silmek için [`os.rename()`](https://defold.com/ref/stable/os/#os.rename:oldname-newname) ve [`os.remove()`](https://defold.com/ref/stable/os/#os.remove:filename) işlevlerini kullanabilirsiniz.
+
+* Lua tablolarını okumak ve yazmak için [`sys.save()`](https://defold.com/ref/stable/sys/#sys.save:filename-table) ve [`sys.load()`](https://defold.com/ref/stable/sys/#sys.load:filename) işlevlerini kullanabilirsiniz. Dosya yollarını platformdan bağımsız olarak çözümlemeye yardımcı olan başka [`sys.*`](https://defold.com/ref/stable/sys/) işlevleri de vardır.
+
+```lua
+-- get a platform independent path to the file "highscore" for application "mygame"
+local path = sys.get_save_file("mygame", "highscore")
+
+-- save a Lua table with some data
+local ok = sys.save(path, { highscore = 100 })
+if not ok then
+	print("Failed to save", path)
+	return
+end
+
+-- load the data
+local ok, data = pcall(sys.load, path)
+if not ok then
+	-- The file exists, but is corrupt, foreign, or uses an unsupported format.
+	print("Failed to load save data:", data)
+	data = {}
+end
+print(data.highscore) -- 100
+```
+
+`sys.load()`, dosya yoksa boş bir tablo döndürür. Dosya varsa ancak `sys.save()` ile oluşturulmamışsa, bozuksa veya desteklenmeyen bir serileştirilmiş tablo biçimi kullanıyorsa `sys.load()` bir Lua hatası oluşturur. Bozulmuş veya dışarıdan değiştirilmiş kayıt verilerinin kurtarılabilmesi gerektiğinde yukarıdaki gibi `pcall()` kullanın.
+
+
+## Dosya ve klasör konumları
+Dosya ve klasör konumları üç kategoriye ayrılabilir:
+
+* Uygulamanızın oluşturduğu uygulamaya özgü dosyalar
+* Uygulamanızın dağıtım paketine eklenen dosya ve klasörler
+* Uygulamanızın eriştiği sisteme özgü dosyalar
+
+### Uygulamaya özgü dosyaları kaydetme ve yükleme
+En yüksek puanlar, kullanıcı ayarları ve oyun durumu gibi uygulamaya özgü dosyaları kaydederken ve yüklerken işletim sisteminin bu amaç için ayırdığı bir konumu kullanmanız önerilir. Bir dosyanın işletim sistemine özgü mutlak yolunu almak için [`sys.get_save_file()`](https://defold.com/ref/stable/sys/#sys.get_save_file:application_id-file_name) işlevini kullanabilirsiniz. Mutlak yolu aldıktan sonra `sys.*`, `io.*` ve `os.*` işlevlerini kullanabilirsiniz (yukarıya bakın).
+
+[`sys.save()` ve `sys.load()` işlevlerinin kullanımını gösteren örneği inceleyin](/examples/file/sys_save_load/).
+
+### Uygulamanın dağıtım paketine eklenen dosyalara erişme {#how-to-access-files-bundled-with-the-application}
+Dağıtım paketine eklenen kaynakları (bundle resources) ve özel kaynakları (custom resources) kullanarak uygulamanıza dosya ekleyebilirsiniz.
+
+#### Özel kaynaklar {#custom-resources}
+:[Custom Resources](../shared/custom-resources.md)
+
+Eklentiler de `ext.properties` aracılığıyla bu dosyaları ekleyebilir. Bu dosyaların yolları, hem düzenleyici derlemelerinde hem de Bob arşivlerinde projenin özel kaynaklarıyla birleştirilir. [Eklentilerde özel kaynaklar](/manuals/extensions/#custom-resources) bölümüne bakın.
+
+```lua
+-- Load level data into a string
+local data, error = sys.load_resource("/assets/level_data.json")
+-- Decode json string to a Lua table
+if data then
+  local data_table = json.decode(data)
+  pprint(data_table)
+else
+  print(error)
+end
+```
+
+#### Dağıtım paketine eklenen kaynaklar
+:[Bundle Resources](../shared/bundle-resources.md)
+
+```lua
+local path = sys.get_application_path()
+local f = io.open(path .. "/mycommonfile.txt", "rb")
+local txt, err = f:read("*a")
+if not txt then
+	print(err)
+	return
+end
+print(txt)
+```
+
+::: sidenote
+Güvenlik nedeniyle tarayıcıların (ve dolayısıyla tarayıcıda çalışan tüm JavaScript kodlarının) sistem dosyalarına erişmesi engellenir. Defold HTML5 derlemelerinde dosya işlemleri çalışmaya devam eder, ancak yalnızca tarayıcıdaki IndexedDB API üzerinden bir "sanal dosya sistemi" üzerinde çalışır. Bu, dağıtım paketine eklenen kaynaklara `io.*` veya `os.*` işlevleriyle erişilemeyeceği anlamına gelir. Ancak bu kaynaklara `http.request()` ile erişebilirsiniz.
+:::
+
+
+#### Özel kaynaklar ve dağıtım paketine eklenen kaynaklar - karşılaştırma
+
+| Özellik                     | Özel kaynaklar                            | Dağıtım paketine eklenen kaynaklar              |
+|-----------------------------|-------------------------------------------|------------------------------------------------|
+| Yükleme hızı                | Daha hızlı - dosyalar ikili arşivden yüklenir | Daha yavaş - dosyalar dosya sisteminden yüklenir |
+| Dosyanın bir kısmını yükleme | Hayır - yalnızca dosyaların tamamı yüklenir | Evet - dosyadan istediğiniz baytları okuyabilirsiniz |
+| Paketlemeden sonra dosyaları değiştirme | Hayır - dosyalar ikili bir arşiv içinde saklanır | Evet - dosyalar yerel dosya sisteminde saklanır |
+| HTML5 desteği               | Evet                                      | Evet - ancak erişim dosya I/O işlemleriyle değil, http üzerinden sağlanır |
+
+
+### Sistem dosyalarına erişim
+Sistem dosyalarına erişim, güvenlik nedeniyle işletim sistemi tarafından kısıtlanabilir. Yaygın kullanılan bazı sistem dizinlerinin (örneğin `documents`, `resource`, `temp`) mutlak yolunu almak için [`extension-directories`](https://defold.com/assets/extensiondirectories/) yerel kod eklentisini (native extension) kullanabilirsiniz. Bu dosyaların mutlak yolunu aldıktan sonra dosyalara erişmek için `io.*` ve `os.*` işlevlerini kullanabilirsiniz (yukarıya bakın).
+
+::: sidenote
+Güvenlik nedeniyle tarayıcıların (ve dolayısıyla tarayıcıda çalışan tüm JavaScript kodlarının) sistem dosyalarına erişmesi engellenir. Defold HTML5 derlemelerinde dosya işlemleri çalışmaya devam eder, ancak yalnızca tarayıcıdaki IndexedDB API üzerinden bir "sanal dosya sistemi" üzerinde çalışır. Bu, HTML5 derlemelerinde sistem dosyalarına erişmenin mümkün olmadığı anlamına gelir.
+:::
+
+## Eklentiler
+[Asset Portal](https://defold.com/assets/), dosya ve klasör erişimini kolaylaştıran çeşitli varlıklar içerir. Bazı örnekler:
+
+* [Lua File System (LFS)](https://defold.com/assets/luafilesystemlfs/) - Dizinler, dosya izinleri ve benzeri öğelerle çalışmak için işlevler
+* [DefSave](https://defold.com/assets/defsave/) - Oturumlar arasında yapılandırma ve oyuncu verilerini kaydetmenize / yüklemenize yardımcı olan bir modül.

--- a/docs/tr/manuals/flash.md
+++ b/docs/tr/manuals/flash.md
@@ -1,0 +1,355 @@
+---
+title: Flash kullanıcıları için Defold
+brief: Bu kılavuz, Defold'u Flash oyunu geliştiricileri için bir alternatif olarak tanıtır. Flash ile oyun geliştirmede kullanılan bazı temel kavramları ele alır ve bunlara karşılık gelen Defold araçlarını ve yöntemlerini açıklar.
+---
+
+# Flash kullanıcıları için Defold
+
+Bu kılavuz, Defold'u Flash oyunu geliştiricileri için bir alternatif olarak tanıtır. Flash ile oyun geliştirmede kullanılan bazı temel kavramları ele alır ve bunlara karşılık gelen Defold araçlarını ve yöntemlerini açıklar.
+
+## Giriş
+
+Flash'ın başlıca avantajlarından bazıları erişilebilirliği ve kullanmaya başlamanın kolaylığıydı. Yeni kullanıcılar programı hızla öğrenebilir ve az zaman ayırarak temel oyunlar oluşturmaya başlayabilirdi. Defold, oyun tasarımına özel bir araç kümesi sunarak benzer bir avantaj sağlar; aynı zamanda deneyimli geliştiricilerin daha karmaşık gereksinimler için gelişmiş çözümler oluşturmasına olanak tanır (örneğin geliştiricilerin varsayılan işleme betiğini (render script) düzenlemesine izin vererek).
+
+Flash oyunları ActionScript ile (en son sürümü 3.0) programlanırken Defold betikleri Lua ile yazılır. Bu kılavuzda Lua ile ActionScript 3.0 ayrıntılı olarak karşılaştırılmayacaktır. [Defold kılavuzu](/manuals/lua), Defold'da Lua programlamaya iyi bir giriş sunar ve çevrimiçi olarak ücretsiz erişilebilen, son derece yararlı [Programming in Lua](https://www.lua.org/pil/) kitabının ilk baskısına başvurur.
+
+Jesse Warden'ın bir makalesi, iyi bir başlangıç noktası olabilecek [ActionScript ve Lua'nın temel bir karşılaştırmasını](http://jessewarden.com/2011/01/lua-for-actionscript-developers.html) sunar. Ancak Defold ile Flash'ın yapıları arasında, dil düzeyinde görülenden daha derin farklar olduğunu unutmayın. ActionScript ve Flash, sınıfları ve kalıtımıyla klasik anlamda nesne yönelimlidir. Defold'da sınıflar da kalıtım da yoktur. Görsel ve işitsel gösterimi, davranışı ve verileri barındırabilen *oyun nesnesi* (game object) kavramı vardır. Oyun nesneleri üzerindeki işlemler, Defold API'lerinde bulunan *işlevlerle* gerçekleştirilir. Ayrıca Defold, nesneler arasında iletişim kurmak için *iletilerin* (message) kullanılmasını teşvik eder. İletiler, yöntem çağrılarından daha yüksek düzeyli bir yapıdır ve yöntem çağrısı olarak kullanılmak üzere tasarlanmamıştır. Bu farklar önemlidir ve bunlara alışmak biraz zaman alır; ancak bu kılavuzda ayrıntılı olarak ele alınmayacaktır.
+
+Bunun yerine bu kılavuz, Flash ile oyun geliştirmenin bazı temel kavramlarını inceler ve bunların Defold'daki en yakın karşılıklarını ana hatlarıyla açıklar. Flash'tan Defold'a geçişe hızlı bir başlangıç yapabilmeniz için benzerlikler ve farklar, sık karşılaşılan sorunlarla birlikte ele alınır.
+
+## Film klipleri ve oyun nesneleri
+
+Film klipleri (movie clip), Flash ile oyun geliştirmenin temel öğelerinden biridir. Her biri kendine özgü bir zaman çizelgesi içeren sembollerdir. Defold'daki en yakın karşılıkları oyun nesnesidir.
+
+![oyun nesnesi ve film klibi](images/flash/go_movieclip.png)
+
+Flash film kliplerinin aksine, Defold oyun nesnelerinin zaman çizelgeleri yoktur. Bunun yerine bir oyun nesnesi birden çok bileşenden (component) oluşur. Bileşenler arasında sprite bileşenleri, sesler ve betikler---ve daha birçok tür bulunur (kullanılabilir bileşenler hakkında daha fazla ayrıntı için [yapı taşları belgelerine](/manuals/building-blocks) ve ilgili yazılara bakın). Aşağıdaki ekran görüntüsündeki oyun nesnesi bir sprite ve bir betikten oluşur. Betik bileşeni, oyun nesnelerinin yaşam döngüsü boyunca davranışlarını ve görünümlerini denetlemek için kullanılır:
+
+![betik bileşeni](images/flash/script_component.png)
+
+Film klipleri başka film klipleri içerebilirken oyun nesneleri başka oyun nesnelerini *içeremez*. Ancak oyun nesneleri diğer oyun nesnelerine *alt nesne olarak bağlanabilir*; böylece birlikte taşınabilen, ölçeklenebilen veya döndürülebilen hiyerarşiler oluşturulur.
+
+## Flash—elle film klibi oluşturma
+
+Flash'ta film klibi örneklerini kütüphaneden zaman çizelgesine sürükleyerek sahnenize elle ekleyebilirsiniz. Aşağıdaki ekran görüntüsü bunu gösterir; her Flash logosu, `logo` film klibinin bir örneğidir:
+
+![elle oluşturulan film klipleri](images/flash/manual_movie_clips.png)
+
+## Defold—elle oyun nesnesi oluşturma
+
+Daha önce belirtildiği gibi, Defold'da zaman çizelgesi kavramı yoktur. Bunun yerine oyun nesneleri koleksiyonlarda (collection) düzenlenir. Koleksiyonlar, oyun nesnelerini ve diğer koleksiyonları tutan kapsayıcılardır (veya yeniden kullanılabilir nesne tanımları olan prefablardır). En temel düzeyde bir oyun yalnızca tek bir koleksiyondan oluşabilir. Defold oyunları daha çok, başlangıç koleksiyonu (bootstrap collection) `main` içine elle eklenen veya [koleksiyon vekilleri (collection proxy)](/manuals/collection-proxy) aracılığıyla dinamik olarak yüklenen birden çok koleksiyon kullanır. Bu "bölüm" veya "ekran" yükleme kavramının Flash'ta doğrudan bir karşılığı yoktur.
+
+Aşağıdaki örnekte `main` koleksiyonu, `logo` oyun nesnesinin (solda *Assets* tarayıcı penceresinde görülüyor) üç örneğini (sağda *Outline* penceresinde listeleniyor) içerir:
+
+![elle oluşturulan oyun nesneleri](images/flash/manual_game_objects.png)
+
+## Flash—elle oluşturulan film kliplerine başvurma
+
+Flash'ta elle oluşturulan film kliplerine başvurmak için elle tanımlanmış bir örnek adı kullanılması gerekir:
+
+![Flash örnek adı](images/flash/flash_instance_name.png)
+
+## Defold—oyun nesnesi tanımlayıcısı
+
+Defold'da tüm oyun nesnelerine ve bileşenlere bir adres aracılığıyla başvurulur. Çoğu durumda yalnızca basit bir ad veya kısa gösterim yeterlidir. Örneğin:
+
+- `"."` geçerli oyun nesnesini adresler.
+- `"#"` geçerli bileşeni (betiği) adresler.
+- `"logo"` tanımlayıcısı `logo` olan oyun nesnesini adresler.
+- `"#script"` geçerli oyun nesnesindeki, tanımlayıcısı `script` olan bileşeni adresler.
+- `"logo#script"` tanımlayıcısı `script` olan bileşeni, tanımlayıcısı `logo` olan oyun nesnesi içinde adresler.
+
+Elle yerleştirilen oyun nesnelerinin adresi, atanan *Id* özelliğiyle belirlenir (ekran görüntüsünün sağ alt köşesine bakın). Tanımlayıcının, üzerinde çalıştığınız geçerli koleksiyon dosyasında benzersiz olması gerekir. Düzenleyici sizin için otomatik olarak bir tanımlayıcı ayarlar; ancak oluşturduğunuz her oyun nesnesi örneği için bunu değiştirebilirsiniz.
+
+![oyun nesnesi tanımlayıcısı](images/flash/game_object_id.png)
+
+::: sidenote
+Bir oyun nesnesinin tanımlayıcısını, betik bileşeninde şu kodu çalıştırarak bulabilirsiniz: `print(go.get_id())`. Bu kod, geçerli oyun nesnesinin tanımlayıcısını konsola yazdırır.
+:::
+
+Adresleme modeli ve ileti aktarımı, Defold ile oyun geliştirmenin temel kavramlarıdır. [Adresleme kılavuzu](/manuals/addressing) ve [ileti aktarımı kılavuzu](/manuals/message-passing) bunları ayrıntılı olarak açıklar.
+
+## Flash—dinamik olarak film klibi oluşturma
+
+Flash'ta dinamik olarak film klibi oluşturmak için önce ActionScript Linkage ayarının yapılması gerekir:
+
+![ActionScript Linkage](images/flash/actionscript_linkage.png)
+
+Bu işlem bir sınıf (bu örnekte `Logo`) oluşturur ve ardından bu sınıfın yeni örneklerinin oluşturulmasına olanak tanır. `Logo` sınıfının bir örneğini Stage'e eklemek için aşağıdaki kod kullanılabilir:
+
+```as
+var logo:Logo = new Logo();
+addChild(logo);
+```
+
+## Defold—fabrikalarla oyun nesnesi oluşturma
+
+Defold'da oyun nesnelerinin dinamik olarak oluşturulması *fabrikalar* (factory) aracılığıyla gerçekleştirilir. Fabrikalar, belirli bir oyun nesnesinin kopyalarını çalışma sırasında oluşturmak için kullanılan bileşenlerdir. Bu örnekte, prototip olarak `logo` oyun nesnesini kullanan bir fabrika oluşturulmuştur:
+
+![logo fabrikası](images/flash/logo_factory.png)
+
+Fabrikaların, tüm bileşenler gibi, kullanılabilmeleri için önce bir oyun nesnesine eklenmesi gerektiğini unutmayın. Bu örnekte, fabrika bileşenimizi tutmak için `factories` adlı bir oyun nesnesi oluşturduk:
+
+![fabrika bileşeni](images/flash/factory_component.png)
+
+`logo` oyun nesnesinin bir örneğini oluşturmak için çağrılacak işlev şudur:
+
+```lua
+local logo_id = factory.create("factories#logo_factory")
+```
+
+URL, `factory.create()` işlevinin zorunlu bir parametresidir. Ayrıca konumu, dönmeyi, özellikleri ve ölçeği ayarlamak için isteğe bağlı parametreler ekleyebilirsiniz. Fabrika bileşeni hakkında daha fazla bilgi için [fabrika kılavuzuna](/manuals/factory) bakın. `factory.create()` çağrısının, oluşturulan oyun nesnesinin tanımlayıcısını döndürdüğünü unutmayın. Bu tanımlayıcı, daha sonra başvurmak üzere bir tabloda (dizinin Lua'daki karşılığı) saklanabilir.
+
+## Flash—sahne
+
+Flash'ta Timeline (aşağıdaki ekran görüntüsünün üst bölümü) ve Stage (Timeline altında görünen alan) bize tanıdıktır:
+
+![zaman çizelgesi ve sahne](images/flash/stage.png)
+
+Yukarıdaki film klipleri bölümünde ele alındığı gibi, Stage temelde bir Flash oyununun en üst düzey kapsayıcısıdır ve bir proje her dışa aktarıldığında oluşturulur. Stage varsayılan olarak tek bir alt nesneye, *`MainTimeline`* nesnesine sahiptir. Projede oluşturulan her film klibinin kendi zaman çizelgesi olur ve diğer semboller (film klipleri dahil) için kapsayıcı görevi görebilir.
+
+## Defold—koleksiyonlar
+
+Flash Stage'in Defold'daki karşılığı bir koleksiyondur. Motor başlatıldığında bir koleksiyon dosyasının içeriğine dayalı yeni bir oyun dünyası oluşturur. Bu dosyanın varsayılan adı `main.collection` olsa da, her Defold projesinin kökünde bulunan *game.project* ayar dosyasını açarak başlangıçta hangi koleksiyonun yükleneceğini değiştirebilirsiniz:
+
+![game.project](images/flash/game_project.png)
+
+Koleksiyonlar, düzenleyicide oyun nesnelerini ve diğer koleksiyonları düzenlemek için kullanılan kapsayıcılardır. Bir koleksiyonun içeriği, normal bir oyun nesnesi fabrikasıyla aynı şekilde çalışan [koleksiyon fabrikası (collection factory)](/manuals/collection-factory/#spawning-a-collection) kullanılarak betik aracılığıyla çalışma sırasında da oluşturulabilir. Bu, örneğin düşman grupları veya belirli bir düzende toplanabilir madeni paralar oluşturmak için yararlıdır. Aşağıdaki ekran görüntüsünde `logos` koleksiyonunun iki örneğini `main` koleksiyonuna elle yerleştirdik.
+
+![koleksiyon](images/flash/collection.png)
+
+Bazı durumlarda tamamen yeni bir oyun dünyası yüklemek istersiniz. [Koleksiyon vekili](/manuals/collection-proxy/) bileşeni, bir koleksiyon dosyasının içeriğine dayalı yeni bir oyun dünyası oluşturmanıza olanak tanır. Bu; yeni oyun bölümleri, mini oyunlar veya ara sahneler yükleme gibi durumlarda yararlı olur.
+
+## Flash—zaman çizelgesi
+
+Flash zaman çizelgesi, öncelikle çeşitli kare kare animasyon teknikleri veya şekil/hareket ara geçiş animasyonları (tween) kullanılarak animasyon oluşturmak için kullanılır. Projenin genel FPS (saniyedeki kare sayısı) ayarı, bir karenin ne kadar süreyle gösterileceğini belirler. Deneyimli kullanıcılar oyunun genel FPS değerini, hatta tek tek film kliplerinin FPS değerini değiştirebilir.
+
+Şekil ara geçiş animasyonları, vektör grafiklerinin iki durumu arasında ara değerleme yapılmasına olanak tanır. Aşağıdaki bir kareyi üçgene dönüştüren şekil ara geçiş animasyonu örneğinin gösterdiği gibi, bunlar çoğunlukla yalnızca basit şekiller ve uygulamalar için yararlıdır:
+
+![zaman çizelgesi](images/flash/timeline.png)
+
+Hareket ara geçiş animasyonları, bir nesnenin boyut, konum ve dönme dahil çeşitli özelliklerine animasyon uygulanmasına olanak tanır. Aşağıdaki örnekte, listelenen tüm özellikler değiştirilmiştir.
+
+![hareket ara geçiş animasyonu](images/flash/tween.png)
+
+## Defold—özellik animasyonu
+
+Defold vektör grafikleri yerine piksel görüntüleriyle çalışır; bu nedenle şekil ara geçiş animasyonunun bir karşılığı yoktur. Ancak hareket ara geçiş animasyonunun [özellik animasyonu (property animation)](/ref/go/#go.animate) biçiminde güçlü bir karşılığı vardır. Bu, betik aracılığıyla `go.animate()` işlevi kullanılarak gerçekleştirilir. `go.animate()` işlevi, kullanılabilir birçok geçiş eğrisi işlevinden (easing function) birini (özel işlevler dahil) kullanarak bir özelliği (renk, ölçek, dönme veya konum gibi) başlangıç değerinden istenen son değere geçirir. Flash'ta daha gelişmiş geçiş eğrisi işlevlerini kullanıcının uygulaması gerekirken Defold, motora yerleşik [birçok geçiş eğrisi işlevi](/manuals/property-animation/#easing) içerir.
+
+Flash, animasyon için bir zaman çizelgesindeki grafik anahtar karelerini kullanırken Defold'da grafik animasyonunun başlıca yöntemlerinden biri, içe aktarılan görüntü dizileriyle kare dizisi animasyonu (flipbook animation) oluşturmaktır. Animasyonlar, atlas olarak bilinen bir oyun nesnesi bileşeninde düzenlenir. Bu örnekte, bir oyun karakteri için `run` adlı animasyon dizisi içeren bir atlasımız var. Animasyon dizisi, bir dizi png dosyasından oluşur:
+
+![kare dizisi animasyonu](images/flash/flipbook.png)
+
+## Flash—derinlik indeksi
+
+Flash'ta görüntüleme listesi (display list), neyin hangi sırayla gösterileceğini belirler. Bir kapsayıcıdaki (Stage gibi) nesnelerin sıralaması bir indeksle yönetilir. `addChild()` yöntemi kullanılarak bir kapsayıcıya eklenen nesneler, 0'dan başlayan ve eklenen her nesneyle artan indeksin en üst konumuna otomatik olarak yerleşir. Aşağıdaki ekran görüntüsünde `logo` film klibinin üç örneğini oluşturduk:
+
+![derinlik indeksi](images/flash/depth_index.png)
+
+Görüntüleme listesindeki konumlar, her `logo` örneğinin yanındaki sayılarla belirtilir. Film kliplerinin x/y konumunu ayarlayan kodu dikkate almazsak yukarıdaki sonuç şöyle oluşturulabilir:
+
+```as
+var logo1:Logo = new Logo();
+var logo2:Logo = new Logo();
+var logo3:Logo = new Logo();
+
+addChild(logo1);
+addChild(logo2);
+addChild(logo3);
+```
+
+Bir nesnenin başka bir nesnenin üstünde mi yoksa altında mı gösterileceği, görüntüleme listesi indeksindeki göreli konumlarıyla belirlenir. Örneğin iki nesnenin indeks konumlarını değiştirmek bunu açıkça gösterir:
+
+```as
+swapChildren(logo2,logo3);
+```
+
+Sonuç aşağıdaki gibi görünür (indeks konumu güncellenmiştir):
+
+![derinlik indeksi](images/flash/depth_index_2.png)
+
+## Defold—z konumu
+
+Defold'da oyun nesnelerinin konumları, x, y ve z olmak üzere üç değişkenden oluşan vektörlerle temsil edilir. z konumu, bir oyun nesnesinin derinliğini belirler. Varsayılan [işleme betiğinde](/manuals/render), kullanılabilir z konumları -1 ile 1 arasındadır.
+
+::: sidenote
+z konumu -1 ile 1 aralığının dışında olan oyun nesneleri işlenmez ve bu nedenle görünmez. Bu, Defold'a yeni başlayan geliştiricilerin sık karşılaştığı bir sorundur; bir oyun nesnesi görünmesini beklediğiniz hâlde görünmüyorsa bunu aklınızda bulundurun.
+:::
+
+Flash düzenleyicisinde derinlik indekslemesi yalnızca dolaylı olarak gösterilirken (ve *Bring Forward* ile *Send Backward* gibi komutlarla değiştirilebilirken), Defold nesnelerin z konumunu doğrudan düzenleyicide ayarlamanıza olanak tanır. Aşağıdaki ekran görüntüsünde `logo3` nesnesinin en üstte gösterildiğini ve z konumunun 0.2 olduğunu görebilirsiniz. Diğer oyun nesnelerinin z konumları 0.0 ve 0.1'dir.
+
+![z sırası](images/flash/z_order.png)
+
+Bir veya daha fazla koleksiyonun içinde yer alan bir oyun nesnesinin z konumunun, kendi z konumuyla birlikte tüm üst nesnelerinin z konumları tarafından belirlendiğini unutmayın. Örneğin yukarıdaki `logo` oyun nesnelerinin bir `logos` koleksiyonuna yerleştirildiğini, bu koleksiyonun da `main` içine yerleştirildiğini düşünün (aşağıdaki ekran görüntüsüne bakın). `logos` koleksiyonunun z konumu 0.9 olsaydı, içindeki oyun nesnelerinin z konumları 0.9, 1.0 ve 1.1 olurdu. Dolayısıyla `logo3`, z konumu 1'den büyük olduğu için işlenmezdi.
+
+![z sırası](images/flash/z_order_outline.png)
+
+Bir oyun nesnesinin z konumu betikle de değiştirilebilir. Aşağıdaki kodun bir oyun nesnesinin betik bileşeninde bulunduğunu varsayın:
+
+```lua
+local pos = go.get_position()
+pos.z  = 0.5
+go.set_position(pos)
+```
+
+## Flash'ta `hitTestObject` ve `hitTestPoint` ile çarpışma algılama
+
+Flash'ta temel çarpışma algılama, `hitTestObject()` yöntemi kullanılarak gerçekleştirilir. Bu örnekte iki film klibimiz var: `bullet` ve `bullseye`. Bunlar aşağıdaki ekran görüntüsünde gösterilmiştir. Flash düzenleyicisinde semboller seçildiğinde mavi sınırlayıcı kutu görünür ve `hitTestObject()` yönteminin sonucunu bu sınırlayıcı kutular belirler.
+
+![isabet testi](images/flash/hittest.png)
+
+`hitTestObject()` kullanılarak çarpışma algılama şu şekilde yapılır:
+
+```as
+bullet.hitTestObject(bullseye);
+```
+
+Bu durumda sınırlayıcı kutuların kullanılması uygun olmaz; çünkü aşağıdaki senaryoda bir isabet algılanır:
+
+![sınırlayıcı kutuyla isabet testi](images/flash/hitboundingbox.png)
+
+`hitTestObject()` yönteminin bir alternatifi `hitTestPoint()` yöntemidir. Bu yöntem, isabet testlerinin sınırlayıcı kutu yerine nesnenin gerçek piksellerine karşı yapılmasını sağlayan bir `shapeFlag` parametresi içerir. `hitTestPoint()` kullanılarak çarpışma algılama aşağıdaki gibi yapılabilir:
+
+```as
+bullseye.hitTestPoint(bullet.x, bullet.y, true);
+```
+
+Bu satır, merminin x ve y konumunu (bu senaryoda sol üst köşesi) hedefin şekline karşı kontrol eder. `hitTestPoint()` bir noktayı bir şekle karşı kontrol ettiğinden, hangi noktanın (veya noktaların!) kontrol edileceği önemli bir konudur.
+
+## Defold—çarpışma nesneleri
+
+Defold, çarpışmaları algılayabilen ve bir betiğin bunlara tepki vermesine olanak tanıyan bir fizik motoru içerir. Defold'da çarpışma algılama, oyun nesnelerine çarpışma nesnesi (collision object) bileşenleri atanmasıyla başlar. Aşağıdaki ekran görüntüsünde `bullet` oyun nesnesine bir çarpışma nesnesi ekledik. Çarpışma nesnesi, kırmızı saydam kutuyla gösterilir (bu kutu yalnızca düzenleyicide görünür):
+
+![çarpışma nesnesi](images/flash/collision_object.png)
+
+Defold, gerçekçi çarpışmaları otomatik olarak simüle edebilen Box2D fizik motorunun değiştirilmiş bir sürümünü içerir. Bu kılavuz, Flash'taki çarpışma algılamaya en çok benzedikleri için kinematik çarpışma nesnelerinin kullanıldığını varsayar. Dinamik çarpışma nesneleri hakkında daha fazla bilgiyi Defold [fizik kılavuzunda](/manuals/physics) bulabilirsiniz.
+
+Çarpışma nesnesi aşağıdaki özellikleri içerir:
+
+![çarpışma nesnesi özellikleri](images/flash/collision_object_properties.png)
+
+Mermi görseline en uygun şekil olduğu için kutu kullanılmıştır. 2B çarpışmalar için kullanılan diğer şekil olan küre ise hedef için kullanılacaktır. Türün Kinematic olarak ayarlanması, çarpışmaların çözümünün yerleşik fizik motoru yerine betiğiniz tarafından yapılacağı anlamına gelir (diğer türler hakkında daha fazla bilgi için [fizik kılavuzuna](/manuals/physics) bakın). *Group* ve *Mask* özellikleri, sırasıyla nesnenin hangi çarpışma grubuna ait olduğunu ve hangi çarpışma grubuna karşı kontrol edilmesi gerektiğini belirler. Geçerli ayarlar, bir `bullet` nesnesinin yalnızca bir `target` nesnesiyle çarpışabileceği anlamına gelir. Ayarların aşağıdaki gibi değiştirildiğini düşünün:
+
+![çarpışma grubu/maskesi](images/flash/collision_groupmask.png)
+
+Artık mermiler hedeflerle ve diğer mermilerle çarpışabilir. Karşılaştırma için hedefe aşağıdaki gibi görünen bir çarpışma nesnesi ekledik:
+
+![mermi çarpışma nesnesi](images/flash/collision_object_bullet.png)
+
+*Group* özelliğinin `target`, *Mask* özelliğinin ise `bullet` olarak ayarlandığına dikkat edin.
+
+Flash'ta çarpışma algılama yalnızca betik tarafından açıkça çağrıldığında gerçekleşir. Defold'da ise bir çarpışma nesnesi etkin kaldığı sürece çarpışma algılama arka planda sürekli gerçekleşir. Bir çarpışma olduğunda oyun nesnesinin tüm bileşenlerine (özellikle betik bileşenlerine) iletiler gönderilir. Bunlar, çarpışmayı istendiği şekilde çözmek için gereken tüm bilgileri içeren [`collision_response` ve `contact_point_response`](/manuals/physics-messages) iletileridir.
+
+Defold'un çarpışma algılamasının avantajı, Flash'takinden daha gelişmiş olması ve çok az ayarlama ile nispeten karmaşık şekiller arasındaki çarpışmaları algılayabilmesidir. Çarpışma algılama otomatiktir; dolayısıyla farklı çarpışma gruplarındaki çeşitli nesneleri döngüyle dolaşmak ve açıkça isabet testleri yapmak gerekmez. Başlıca eksikliği, Flash'taki `shapeFlag` parametresinin bir karşılığının olmamasıdır. Ancak çoğu kullanım için temel kutu ve küre şekillerinin birleşimleri yeterlidir. Daha karmaşık senaryolarda özel şekiller kullanmak [mümkündür](//forum.defold.com/t/does-defold-support-only-three-shapes-for-collision-solved/1985).
+
+## Flash—olay işleme
+
+Olay (event) nesneleri ve bunlarla ilişkili dinleyiciler; çeşitli olayları (örneğin fare tıklamaları, düğmeye basılması, kliplerin yüklenmesi) algılamak ve bunlara yanıt olarak eylemleri tetiklemek için kullanılır. Kullanabileceğiniz çeşitli olaylar vardır.
+
+## Defold—geri çağırım işlevleri ve ileti alışverişi
+
+Flash'ın olay işleme sisteminin Defold'daki karşılığı birkaç unsurdan oluşur. Öncelikle, her betik bileşeni belirli olayları algılayan bir dizi geri çağırım işleviyle (callback function) gelir. Bunlar şunlardır:
+
+init
+:   Betik bileşeninin başlangıç işlemleri yapıldığında çağrılır. Flash'taki kurucu işlevin karşılığıdır.
+
+final
+:   Betik bileşeni yok edildiğinde (örneğin çalışma sırasında oluşturulan bir oyun nesnesi kaldırıldığında) çağrılır.
+
+update
+:   Her karede çağrılır. Flash'taki `enterFrame` karşılığıdır.
+
+on_message
+:   Betik bileşeni bir ileti aldığında çağrılır.
+
+on_input
+:   Kullanıcı girdisi (örneğin fare veya klavye), [girdi odağına (input focus)](/ref/go/#acquire_input_focus) sahip bir oyun nesnesine gönderildiğinde çağrılır; girdi odağı, nesnenin tüm girdileri aldığı ve bunlara tepki verebildiği anlamına gelir.
+
+on_reload
+:   Betik bileşeni yeniden yüklendiğinde çağrılır.
+
+Yukarıda listelenen geri çağırım işlevlerinin tümü isteğe bağlıdır ve kullanılmıyorsa kaldırılabilir. Girdinin nasıl ayarlanacağıyla ilgili ayrıntılar için [girdi kılavuzuna](/manuals/input) bakın. Koleksiyon vekilleriyle çalışırken sık karşılaşılan bir sorun vardır; daha fazla bilgi için girdi kılavuzunun [bu bölümüne](/manuals/input/#input-dispatch-and-on_input) bakın.
+
+Çarpışma algılama bölümünde ele alındığı gibi, çarpışma olayları ilgili oyun nesnelerine iletiler gönderilerek işlenir. Bu nesnelerin betik bileşenleri, iletiyi kendi `on_message` geri çağırım işlevlerinde alır.
+
+## Flash—düğme sembolleri
+
+Flash, düğmeler için özel bir sembol türü kullanır. Düğmeler, kullanıcı etkileşimi algılandığında eylemleri gerçekleştirmek için belirli olay işleyici yöntemleri (örneğin `click` ve `buttonDown`) kullanır. Düğme sembolünün "Hit" bölümündeki düğme görselinin şekli, düğmenin isabet alanını belirler.
+
+![düğme](images/flash/button.png)
+
+## Defold—GUI sahneleri ve betikleri
+
+Defold, yerleşik bir düğme bileşeni içermez; ayrıca Flash'ta düğmelerin ele alınışına benzer biçimde belirli bir oyun nesnesinin şekline yapılan tıklamalar kolayca algılanamaz. Bir [GUI](/manuals/gui) bileşeni kullanmak en yaygın çözümdür; bunun nedenlerinden biri, Defold GUI bileşenlerinin konumlarının oyun içi kameradan (kullanılıyorsa) etkilenmemesidir. GUI API'si ayrıca tıklama ve dokunma olayları gibi kullanıcı girdilerinin bir GUI öğesinin sınırları içinde olup olmadığını algılayan işlevler içerir.
+
+## Hata ayıklama
+
+Flash'ta hata ayıklarken `trace()` komutu yardımcınızdır. Defold'daki karşılığı `print()` işlevi olup `trace()` ile aynı şekilde kullanılır:
+
+```lua
+print("Hello world!"")
+```
+
+Tek bir `print()` işlevi kullanarak birden çok değişkeni yazdırabilirsiniz:
+
+```lua
+print(score, health, ammo)
+```
+
+Tablolarla çalışırken yararlı olan `pprint()` (biçimlendirilmiş yazdırma) işlevi de vardır. Bu işlev, iç içe tablolar dahil tabloların içeriğini yazdırır. Aşağıdaki betiği inceleyin:
+
+```lua
+factions = {"red", "green", "blue"}
+world = {name = "Terra", teams = factions}
+pprint(world)
+```
+
+Bu betikte, `factions` tablosu `world` tablosunun içine yerleştirilmiştir. Normal `print()` komutu kullanıldığında tablonun gerçek içeriği yerine benzersiz tanımlayıcısı yazdırılır:
+
+```
+DEBUG:SCRIPT: table: 0x7ff95de63ce0
+```
+
+Yukarıda gösterildiği gibi `pprint()` işlevi kullanıldığında daha anlamlı sonuçlar elde edilir:
+
+```
+DEBUG:SCRIPT:
+{
+  name = Terra,
+  teams = {
+    1 = red,
+    2 = green,
+    3 = blue,
+  }
+}
+```
+
+Oyununuz çarpışma algılama kullanıyorsa, aşağıdaki iletiyi göndererek fizik hata ayıklamasını açıp kapatabilirsiniz:
+
+```lua
+msg.post("@system:", "toggle_physics_debug")
+```
+
+Fizik hata ayıklaması proje ayarlarından da etkinleştirilebilir. Fizik hata ayıklamasını açmadan önce projemiz şöyle görünür:
+
+![hata ayıklama kapalı](images/flash/no_debug.png)
+
+Fizik hata ayıklaması açıldığında oyun nesnelerimize eklenen çarpışma nesneleri gösterilir:
+
+![hata ayıklama açık](images/flash/with_debug.png)
+
+Çarpışmalar gerçekleştiğinde ilgili çarpışma nesneleri aydınlanır. Ayrıca çarpışma vektörü gösterilir:
+
+![çarpışma](images/flash/collision.png)
+
+Son olarak, CPU ve bellek kullanımını nasıl izleyeceğiniz hakkında bilgi için [profil çıkarıcı belgelerine](/ref/profiler/) bakın. Gelişmiş hata ayıklama teknikleri hakkında daha fazla bilgi için Defold kılavuzunun [hata ayıklama bölümüne](/manuals/debugging) bakın.
+
+## Sonraki adımlar
+
+- [Defold örnekleri](/examples)
+- [Öğreticiler](/tutorials)
+- [Kılavuzlar](/manuals)
+- [Başvuru](/ref/go)
+- [Sık sorulan sorular](/faq/faq)
+
+Sorularınız varsa veya bir noktada takılırsanız, [Defold forumları](//forum.defold.com) yardım istemek için harika bir yerdir.

--- a/docs/tr/manuals/flipbook-animation.md
+++ b/docs/tr/manuals/flipbook-animation.md
@@ -1,0 +1,107 @@
+---
+title: Defold kare dizisi animasyonları kılavuzu
+brief: Bu kılavuz, Defold'da kare dizisi animasyonlarının nasıl kullanılacağını açıklar.
+---
+
+# Kare dizisi animasyonu
+
+Kare dizisi animasyonu (flipbook animation), art arda gösterilen bir dizi durağan görüntüden oluşur. Bu teknik, geleneksel selüloit animasyonuna çok benzer (bkz. http://en.wikipedia.org/wiki/Traditional_animation). Her kare ayrı ayrı değiştirilebildiği için bu teknik sınırsız olanak sunar. Ancak her kare ayrı bir görüntüde saklandığından bellekte kaplanan alan yüksek olabilir. Animasyonun akıcılığı da saniyede gösterilen görüntü sayısına bağlıdır, ancak görüntü sayısını artırmak genellikle gereken iş miktarını da artırır. Defold kare dizisi animasyonları, bir [atlasa](/manuals/atlas) eklenen ayrı görüntüler olarak ya da tüm karelerin yatay bir sıra halinde yerleştirildiği bir [karo kaynağı](/manuals/tilesource) (tile source) olarak saklanır.
+
+  ![Animasyon sayfası](images/animation/animsheet.png){.inline}
+  ![Koşma döngüsü](images/animation/runloop.gif){.inline}
+
+## Kare dizisi animasyonlarını oynatma
+
+Sprite bileşenleri ve GUI kutu düğümleri (GUI box nodes) kare dizisi animasyonlarını oynatabilir ve çalışma sırasında bu animasyonlar üzerinde geniş bir denetiminiz vardır.
+
+Sprite bileşenleri
+: Çalışma sırasında bir animasyonu oynatmak için [`sprite.play_flipbook()`](/ref/sprite/?q=play_flipbook#sprite.play_flipbook:url-id-[complete_function]-[play_properties]) işlevini kullanın. Aşağıdaki örneğe bakın.
+
+GUI kutu düğümleri
+: Çalışma sırasında bir animasyonu oynatmak için [`gui.play_flipbook()`](/ref/gui/?q=play_flipbook#gui.play_flipbook:node-animation-[complete_function]-[play_properties]) işlevini kullanın. Aşağıdaki örneğe bakın.
+
+::: sidenote
+`Once Ping Pong` oynatma modu, animasyonu son kareye kadar oynatır, ardından sırayı tersine çevirerek ilk kareye değil, animasyonun **ikinci** karesine kadar geri oynatır. Bu davranış, animasyonları birbirine bağlamayı kolaylaştırır.
+:::
+
+### Sprite örneği
+
+Oyununuzda, oyuncunun belirli bir düğmeye basarak kaçınmasını sağlayan bir "dodge" (kaçınma) özelliği olduğunu varsayalım. Bu özelliği görsel geri bildirimle desteklemek için dört animasyon oluşturdunuz:
+
+"idle"
+: Oyuncu karakterinin boşta durduğu, döngüde oynatılan bir animasyon.
+
+"dodge_idle"
+: Oyuncu karakterinin kaçınma duruşunda boşta durduğu, döngüde oynatılan bir animasyon.
+
+"start_dodge"
+: Oyuncu karakterini ayakta durma durumundan kaçınma duruşuna geçiren, bir kez oynatılan bir geçiş animasyonu.
+
+"stop_dodge"
+: Oyuncu karakterini kaçınma duruşundan tekrar ayakta durma durumuna geçiren, bir kez oynatılan bir geçiş animasyonu.
+
+Aşağıdaki betik bu mantığı uygular:
+
+```lua
+
+local function play_idle_animation(self)
+    if self.dodge then
+        sprite.play_flipbook("#sprite", hash("dodge_idle"))
+    else
+        sprite.play_flipbook("#sprite", hash("idle"))
+    end
+end
+
+function on_input(self, action_id, action)
+    -- "dodge" is our input action
+    if action_id == hash("dodge") then
+        if action.pressed then
+            sprite.play_flipbook("#sprite", hash("start_dodge"), play_idle_animation)
+            -- remember that we are dodging
+            self.dodge = true
+        elseif action.released then
+            sprite.play_flipbook("#sprite", hash("stop_dodge"), play_idle_animation)
+            -- we are not dodging anymore
+            self.dodge = false
+        end
+    end
+end
+```
+
+### GUI kutu düğümü örneği
+
+Bir düğüm için animasyon veya görüntü seçtiğinizde, aslında görüntü kaynağını (atlas veya karo kaynağı) ve varsayılan animasyonu tek seferde atarsınız. Görüntü kaynağı düğümde statik olarak belirlenir, ancak oynatılacak geçerli animasyon çalışma sırasında değiştirilebilir. Durağan görüntüler tek karelik animasyonlar olarak ele alındığından, çalışma sırasında bir görüntüyü değiştirmek, düğüm için farklı bir kare dizisi animasyonu oynatmakla eşdeğerdir:
+
+```lua
+function init(self)
+    local character_node = gui.get_node("character")
+    -- This requires that the node has a default animation in the same atlas or tile source as
+    -- the new animation/image we're playing.
+    gui.play_flipbook(character_node, "jump_left")
+end
+```
+
+
+## Tamamlanma geri çağırımları
+
+`sprite.play_flipbook()` ve `gui.play_flipbook()` işlevleri, son bağımsız değişken olarak isteğe bağlı bir Lua geri çağırım işlevini (callback function) destekler. Bu işlev, animasyon sonuna kadar oynatıldığında çağrılır. Döngüde oynatılan animasyonlar için bu işlev hiçbir zaman çağrılmaz. Geri çağırım, animasyon tamamlandığında olayları tetiklemek veya birden çok animasyonu birbirine bağlamak için kullanılabilir. Örnekler:
+
+```lua
+local function flipbook_done(self)
+    msg.post("#", "jump_completed")
+end
+
+function init(self)
+    sprite.play_flipbook("#character", "jump_left", flipbook_done)
+end
+```
+
+```lua
+local function flipbook_done(self)
+    msg.post("#", "jump_completed")
+end
+
+function init(self)
+    gui.play_flipbook(gui.get_node("character"), "jump_left", flipbook_done)
+end
+```

--- a/docs/tr/manuals/font-richtext.md
+++ b/docs/tr/manuals/font-richtext.md
@@ -1,0 +1,666 @@
+---
+title: Defold'da zengin metin işaretlemesi
+brief: Bu kılavuz, etiket bileşenlerini ve GUI metin düğümlerini zengin metin işaretlemesiyle nasıl biçimlendireceğinizi, bağlantıları ve sprite nesnelerini Lua'dan nasıl inceleyeceğinizi açıklar.
+---
+
+# Zengin metin işaretlemesi
+
+İç içe görsel stiller ve efektler uygulamak, bağlantıları ve sprite nesnelerini Lua'dan incelemek için etiket bileşenlerinde (Label component) ve GUI metin düğümlerinde (GUI text node) işaretleme (markup) kullanın.
+
+```lua
+go.set("#label", "text", "Score: <color=#69D2E7>1200</color>")
+```
+
+Alternatif olarak, yazı tipinde yeniden kullanılabilir, adlandırılmış bir nesne stili tanımlayın ve bu stili bir bağlantıdan seçin:
+
+```lua
+local fontpath = "/fonts/ui.fontc"
+font.set_style(fontpath, "menu_link", "<color=#69D2E7>")
+go.set("#label", "text", "Open <link style=menu_link src=inventory>inventory</link>")
+```
+
+## Etiket başvurusu
+
+| Etiket | Amaç | Örnek |
+| --- | --- | --- |
+| [`color`](#color) | Glifin (glyph) dolgu rengini ayarlayın. | <img src="/manuals/images/richtext/color_green.webp" alt="Yeşil metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`size`](#size) | Glif şekillendirme ve yerleşim boyutunu değiştirin. | <img src="/manuals/images/richtext/size_24.webp" alt="24 piksel boyutunda metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`gradient`](#gradient) | Sabit veya animasyonlu bir renk geçişi uygulayın. | <img src="/manuals/images/richtext/gradient_horizontal.webp" alt="Yatay renk geçişli metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`ul`](#ul) | Metnin altını çizin. | <img src="/manuals/images/richtext/underline_solid.webp" alt="Altı çizili metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`strike`](#strike) | Metnin üstünü çizin. | <img src="/manuals/images/richtext/strike_solid.webp" alt="Üstü çizili metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`outline`](#outline) | Glif dış çizgisinin genişliğini ve rengini ayarlayın. | <img src="/manuals/images/richtext/outline.webp" alt="Dış çizgili metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`shadow`](#shadow) | Metne gölge ekleyin. | <img src="/manuals/images/richtext/shadow.webp" alt="Gölgeli metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`shake`](#shake) | Animasyonlu rastgele bir kaydırma uygulayın. | <img src="/manuals/images/richtext/shake_glyph.webp" alt="Titreyen metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`wave`](#wave) | Metni animasyonlu bir sinüs dalgasıyla hareket ettirin. | <img src="/manuals/images/richtext/wave_glyph.webp" alt="Dalgalanan metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`sprite`](#sprite) | Satır içi bir sprite nesnesi ekleyin. | <img src="/manuals/images/richtext/sprite.webp" alt="Satır içi sprite" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+| [`link`](#link) | Etkileşimli bir bağlantı nesnesi ekleyin. | <img src="/manuals/images/richtext/link.webp" alt="Bağlantılı metin" style="height:1.75em;width:auto;max-width:none;display:inline-block;margin:0;vertical-align:middle;"> |
+
+## Sözdizimi
+
+Etiketler ve öznitelik adları büyük/küçük harfe duyarlıdır. Açılış ve kapanış etiketinden oluşan bir çift, arasındaki görünür UTF-32 metnine uygulanır. Sprite nesneleri kendiliğinden kapanan etiketler kullanır.
+
+```text
+<color=#69D2E7>colored text</color>
+<ul pattern=dashed>underlined text</ul>
+<outline size=2 color=#000000>outlined text</outline>
+<shadow x=2 y=-2 color=#00000080>shadowed text</shadow>
+<sprite src=images/icon.png width=2em/>
+```
+
+### Öznitelikler
+
+Öznitelikler, boşluk karakteri içermediklerinde tırnaksız yazılabilir ya da tek veya çift tırnak içine alınabilir. `color` ve `size`, adlandırılmış `value` biçiminin yanı sıra kısaltılmış bir ilk değeri de destekler.
+
+```text
+<color=#FF8800>Orange</color>
+<color value="#FF8800">Orange</color>
+<size='120%'>Larger</size>
+```
+
+### İç içe yerleştirme
+
+Etiketler son giren ilk çıkar sırasıyla kapatılmalıdır. İçteki stil değerleri, dıştaki stilin aynı özelliğini geçersiz kılar. Farklı özellikler birleşir. Metin aralığı (span) efektleri birbirinden bağımsız olarak etkin kalır; bu nedenle iç içe renk geçişleri renkleri çarpar, iç içe konum efektleri ise kaydırmalarını toplar.
+
+```text
+<color=#FFCC00>
+    Gold <outline size=2 color=#000000>with a black outline</outline>
+</color>
+```
+
+### Karakter başvuruları
+
+Görünür metindeki ayrılmış karakterler için `&amp;`, `&apos;`, `&gt;`, `&lt;` ve `&quot;` kullanın. Sayısal karakter başvuruları şu anda desteklenmez.
+
+## Etiketler
+
+Zengin metin etiketleri, çevreledikleri bir metin aralığını biçimlendirir veya Lua'dan incelenebilen bir nesneyi tanımlar. Stil etiketleri eşleşen bir kapanış etiketi kullanır. `sprite` nesnesi kendiliğinden kapanırken `link`, bağlantı verilen metni çevreler.
+
+### `color`
+
+Glifin dolgu rengini ayarlar. Renkler `#RRGGBB` veya `#RRGGBBAA` biçimini kullanır. Kare işareti öneki zorunludur; `0xFF0000` ve `FF0000` geçersizdir. Sonuç, etiketin veya görüntüyü oluşturan işleyicinin (renderer) temel rengiyle çarpılır.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `=color` veya `value=color` | Evet | Varsayılan yok | Onaltılık RGB veya RGBA biçiminde dolgu rengi. |
+
+```text
+<color=#00FF00>Opaque green</color>
+<color=#00FF0080>Half-alpha green</color>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*#00FF00*
+
+![Opak yeşil renkte işlenmiş örnek metin](images/richtext/color_green.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*#00FF0080*
+
+![Yarı alfa değerli yeşil renkte işlenmiş örnek metin](images/richtext/color_green_alpha.webp)
+
+</div>
+</div>
+
+### `size`
+
+Yalnızca köşe ölçeğini değil, glif şekillendirme ve yerleşim (layout) boyutunu da değiştirir. Göreli değerler her zaman yerleşimin temel yazı tipi boyutunu kullanır. Çevreleyen bir `size` etiketinin etkisiyle birleşmezler.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `=size` veya `value=size` | Evet | Varsayılan yok | Aşağıdaki biçimlerden biriyle belirtilen mutlak boyut, yüzde, temel boyutun katı veya temel boyuta göre işaretli fark. |
+
+| Biçim | 32 px için örnek | Hesaplanan boyut |
+| --- | --- | --- |
+| Yalın sayı veya `px` | `24`, `24px` | 24 px |
+| Temel boyutun yüzdesi | `120%` | 38,4 px |
+| Temel boyutun katı | `2em` | 64 px |
+| Temel boyuta göre işaretli fark | `+4`, `-4` | 36 px, 28 px |
+
+```text
+<size=24px>Exactly 24 pixels</size>
+<size=120%>120% of the layout base size</size>
+<size=2em>Twice the layout base size</size>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*24px*
+
+![24 piksel boyutunda işlenmiş örnek metin](images/richtext/size_24.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*32px değerinin %120'si*
+
+![32 pikselin yüzde 120'si boyutunda işlenmiş örnek metin](images/richtext/size_120.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*32px temel boyutuna göre 2em*
+
+![32 piksellik temel boyutun iki katında işlenmiş örnek metin](images/richtext/size_2em.webp)
+
+</div>
+</div>
+
+### `gradient`
+
+Bir renk geçişi (gradient), eksiksiz olarak belirtilmiş tek bir öznitelik kümesini kabul eder. Kümeleri karıştırmak veya bir üyeyi atlamak geçersizdir.
+
+| Mod | Zorunlu öznitelikler | Ara değerleme |
+| --- | --- | --- |
+| Yatay | `left`, `right` | Yatay yöndeki iki renk arasında ara değerleme yapar. |
+| Dikey | `bottom`, `top` | Alt ve üst renkler arasında ara değerleme yapar. |
+| Dört köşe | `tl`, `tr`, `bl`, `br` | Dört köşe rengi arasında ara değerleme yapar. |
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `left`, `right` | Yatay mod için | Yok | `#RRGGBB` veya `#RRGGBBAA` biçiminde yatay uç nokta renkleri. İkisi de bulunmalıdır. |
+| `bottom`, `top` | Dikey mod için | Yok | Dikey uç nokta renkleri. İkisi de bulunmalıdır. |
+| `tl`, `tr`, `bl`, `br` | Dört köşe modu için | Yok | Sol üst, sağ üst, sol alt ve sağ alt renkleri. Dördü de bulunmalıdır. |
+| `fit` | Hayır | `span` | `glyph`, şekillendirilmiş metindeki her konumu örnekler; `span`, renk geçişini etiketlenmiş metnin tamamına dağıtır. |
+| `hz` | Hayır | `0` | `[0,)` aralığında, saniyedeki tam akış döngüsü sayısı; sıfır, renk geçişini sabit tutar. |
+| `direction` | Hayır | `forward` | `forward` veya `reverse`. `hz` sıfırdan farklı olduğunda akış yönünü belirler. |
+
+`fit` belirtilmediğinde `fit=span`, renk geçişini etiketlenmiş metnin tamamına dağıtır. `fit=glyph`, şekillendirilmiş metindeki her konumu bağımsız olarak örnekler. İsteğe bağlı `hz`, saniyedeki tam akış animasyonu döngülerinin sayısını belirtir; varsayılan sıfır değeri renk geçişini sabit tutar. Yansıtılarak yinelenen renk geçişi sürekli akar ve renk sıçraması olmadan başa döner. Varsayılan `direction=forward` değeridir; akışı tersine çevirmek için `direction=reverse` kullanın.
+
+```text
+<gradient left=#FF00FF right=#FFFFFF>Horizontal Gradient</gradient>
+
+<gradient hz=0.25 fit=glyph bottom=#182848 top=#4B6CB7>Animated vertical glyphs</gradient>
+
+<gradient hz=0.25 direction=reverse left=#FF0000 right=#0000FF>Reverse flow</gradient>
+
+<gradient hz=0.25 direction=reverse fit=span left=#FF0000 right=#0000FF>One animated span color</gradient>
+
+<gradient fit=glyph tl=#FF0000 tr=#00FF00 bl=#0000FF br=#FFFFFF>
+    Four corners
+</gradient>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Yatay*
+
+![Macentadan beyaza yatay renk geçişli örnek metin](images/richtext/gradient_horizontal.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Dikey*
+
+![Dikey mavi renk geçişli örnek metin](images/richtext/gradient_vertical.webp)
+
+</div>
+</div>
+
+**Dört köşe**
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=glyph`*
+
+![Her glife sığdırılmış dört köşeli renk geçişine sahip örnek metin](images/richtext/gradient_four_glyph.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=span`*
+
+![Metin aralığına sığdırılmış dört köşeli renk geçişine sahip örnek metin](images/richtext/gradient_four_text.webp)
+
+</div>
+</div>
+
+**Animasyonlu**
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=glyph`*
+
+![Her glife sığdırılmış, animasyonlu akan renk geçişi](images/richtext/gradient_flow_glyph.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=span`*
+
+![Metin aralığına sığdırılmış, animasyonlu akan renk geçişi](images/richtext/gradient_flow_span.webp)
+
+</div>
+</div>
+
+Renk geçişinin renkleri geçerli dolgu rengiyle çarpılır. Bu nedenle `color=#808080` içindeki bir renk geçişi, bu temel çarpandan daha parlak bir kanal değeri üretemez.
+
+### `ul`
+
+Varsa yazı tipinin alt çizgi ölçülerini kullanarak bir alt çizgi çizer. Etiketin bağımsız bir rengi yoktur: çizgi, yatay, dikey ve dört köşeli renk geçişleri dahil olmak üzere etkin dolgu rengini devralır.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `pattern` | Hayır | `solid` | `solid` veya `dashed`. |
+
+```text
+<ul>Solid underline</ul>
+<ul pattern=dashed>Dashed underline</ul>
+<ul><gradient left=#FF00FF right=#FFFFFF>Gradient line</gradient></ul>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Kesintisiz*
+
+![Kesintisiz alt çizgili örnek metin](images/richtext/underline_solid.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Kesikli*
+
+![Kesikli alt çizgili örnek metin](images/richtext/underline_dashed.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Renk geçişi*
+
+![Renk geçişli alt çizgisi olan örnek metin](images/richtext/underline_gradient.webp)
+
+</div>
+</div>
+
+### `strike`
+
+Çevrelenen metnin üstünü çizer. `pattern` için `ul` ile aynı değerleri kabul eder ve benzer şekilde etkin dolgu rengini devralır.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `pattern` | Hayır | `solid` | `solid` veya `dashed`. |
+
+```text
+<strike>No longer available</strike>
+<strike pattern=dashed>Dashed strikethrough</strike>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Kesintisiz*
+
+![Üstü kesintisiz bir çizgiyle çizilmiş örnek metin](images/richtext/strike_solid.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Kesikli*
+
+![Üstü kesikli bir çizgiyle çizilmiş örnek metin](images/richtext/strike_dashed.webp)
+
+</div>
+</div>
+
+### `outline`
+
+Dış çizgi genişliğini, dış çizgi rengini veya her ikisini ayarlar. En az bir öznitelik zorunludur. Sıfır genişlik, metin aralığı için dış çizgiyi açıkça devre dışı bırakır.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `size` | size/color özniteliklerinden biri | Devralınır; varsayılan bir yazı tipinde `0` | Yerleşim birimleri cinsinden genişlik; aralık `[0,)`. Birim son ekleri kabul edilmez. |
+| `color` | size/color özniteliklerinden biri | Devralınır; varsayılan bir etikette `#000000` | Onaltılık RGB (`#RRGGBB`) veya RGBA (`#RRGGBBAA`) biçiminde tek bir dış çizgi rengi; alfa bileşeni opaklığı belirler. |
+
+```text
+<outline size=3 color=#000000>Black outline</outline>
+<outline color=#FF0000>Keep inherited width, change color</outline>
+<outline size=0>Disable inherited outline</outline>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Dışa doğru siyah dış çizgi*
+
+![Dışa doğru siyah dış çizgili örnek metin](images/richtext/outline.webp)
+
+</div>
+</div>
+
+### `shadow`
+
+Çevrelenen metne keskin kenarlı bir gölge ekler. En az bir öznitelik zorunludur. İç içe yerleştirilmiş bir etikette belirtilmeyen öznitelikler, çevreleyen gölgenin değerini korur; en dıştaki etikette belirtilmeyen öznitelikler ise yazı tipinin temel gölge değerini korur.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `color` | Hayır | Devralınır; varsayılan bir etikette `#000000` | `#RRGGBB` veya `#RRGGBBAA` biçiminde gölge rengi. |
+| `x` | Hayır | Devralınır; varsayılan bir yazı tipinde `0` | Yerleşim birimleri cinsinden yatay gölge kaydırması. Pozitif değerler gölgeyi sağa taşır. |
+| `y` | Hayır | Devralınır; varsayılan bir yazı tipinde `0` | Yerleşim birimleri cinsinden dikey gölge kaydırması. Pozitif değerler gölgeyi yukarı taşır. |
+| `blur` | Hayır | Devralınır; varsayılan bir yazı tipinde `0` | Yerleşim birimleri cinsinden bulanıklık yarıçapı; aralık `[0,)`. |
+
+```text
+<shadow x=6 y=-6 blur=4 color=#000000A0>Shadow</shadow>
+<shadow x=-2>Override only the horizontal offset</shadow>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*x=6, y=-6, blur=4*
+
+![Kaydırılmış gölgesi olan örnek metin](images/richtext/shadow.webp)
+
+</div>
+</div>
+
+::: sidenote
+Gölge bulanıklığı glif atlasında oluşturulur ve saklanır. Bir metin aralığı, yazı tipinde önceden hesaplanan bulanıklıktan daha küçük bir bulanıklık isteyebilir; daha büyük değerler yerleşimde korunur ancak şu anda atlastaki en büyük bulanıklık kullanılarak işlenir.
+:::
+
+### `shake`
+
+Satır kaydırmayı veya yerleşim sınırlarını değiştirmeden, belirlenimci ve animasyonlu rastgele bir kaydırma uygular. Efekt zamanı kendi içinde takip eder; betiklerin her animasyon karesinde etiket metnini değiştirmesi gerekmez.
+
+| Öznitelik | Zorunlu | Varsayılan | Geçerli değerler | Anlamı |
+| --- | --- | --- | --- | --- |
+| `hz` | Hayır | 20 | `[0,)` | Saniyedeki rastgele hedef geçişi sayısı. Sıfır, efekti duraklatır. |
+| `amplitude` | Hayır | 0.5 | `[0,)` | Yerleşim birimleri cinsinden en büyük yer değiştirme. |
+| `fit` | Hayır | `glyph` | `glyph` veya `span` | `glyph`, şekillendirilmiş her glif birimi için karakter kümelerinin bütünlüğünü koruyan bir kaydırma örnekler. `span`, etiketlenmiş metin aralığının tamamını tek bir katı birim olarak hareket ettirir. |
+
+```text
+<shake>Default shake</shake>
+<shake hz=12 amplitude=0.8 fit=glyph>Glyph shake</shake>
+<shake hz=12 amplitude=0.8 fit=span>Rigid span shake</shake>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=glyph`*
+
+![Her glifi animasyonla titreyen örnek metin](images/richtext/shake_glyph.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=span`*
+
+![Metin aralığının tamamı animasyonla titreyen örnek metin](images/richtext/shake_span.webp)
+
+</div>
+</div>
+
+### `wave`
+
+Satır kaydırmayı veya yerleşim sınırlarını değiştirmeden, karakterleri animasyonlu bir sinüs dalgasıyla yukarı ve aşağı hareket ettirir. Yerleşim, güncellendiğinde animasyon süresini biriktirir.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `amplitude` | Hayır | 1 | Yerleşim birimleri cinsinden en büyük dikey yer değiştirme; aralık `[0,)`. |
+| `hz` | Hayır | 1 | Saniyedeki tam zamansal döngü sayısı; aralık `[0,)`. Sıfır, dalgayı duraklatır. |
+| `wavelength` | Hayır | 6 | Tam bir uzamsal döngüdeki görünür UTF-32 metin konumlarının sayısı; aralık `[1,)`. Bir temel karakter ve onunla birleşen aksan işareti gibi, yazı tipinin birlikte şekillendirdiği karakterler tek bir birim olarak hareket eder. |
+| `fit` | Hayır | `glyph` | `glyph`, uzamsal dalgayı metin boyunca uygular. `span`, etiketlenmiş metin aralığının tamamına sinüs dalgasına göre tek bir ortak dikey kaydırma uygular. |
+| `direction` | Hayır | `forward` | `forward`, normal yönde ilerler. `reverse`, dalganın ilerleme yönünü tersine çevirir. |
+
+```text
+<wave>Animated character wave</wave>
+<wave amplitude=4 hz=3 wavelength=8 fit=glyph>Travelling wave</wave>
+<wave amplitude=4 hz=3 wavelength=8 fit=glyph direction=reverse>Reverse travelling wave</wave>
+<wave amplitude=4 hz=1 fit=span>Whole span moves together</wave>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=glyph`*
+
+![Her glifi animasyonla dalgalanan örnek metin](images/richtext/wave_glyph.webp)
+
+</div>
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`fit=span`*
+
+![Tek bir metin aralığı olarak animasyonla hareket eden örnek metin](images/richtext/wave_span.webp)
+
+</div>
+</div>
+
+### `sprite`
+
+Görünür metindeki geçerli konuma, kendiliğinden kapanan bir sprite nesnesi ekler. Öznitelikleri, `label.get_layout_objects()` ve `gui.get_layout_objects()` için üst veri olarak korunur.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `id` | Hayır | Oluşturulur | Döndürülen yerleşim nesnesinin `id` alanına karma değeri olarak kaydedilen, sabit kalan tanımlayıcı. |
+| `src` | Hayır | Yok | Bir görüntünün veya atlasın proje yolu gibi, uygulama tanımlı sprite kaynağı tanımlayıcısı. |
+| `animation` | Hayır | Yok | Kaynak içindeki uygulama tanımlı animasyon tanımlayıcısı. |
+| `width` | Hayır | `1em` | Hesaplanan sprite genişliği. |
+| `height` | Hayır | `1em` | Hesaplanan sprite yüksekliği. |
+| Diğer herhangi bir öznitelik | Hayır | Bulunmaz | Nesne çözümleyicisi ve yerleşim nesnesi API'leri için korunan, uygulama tanımlı üst veriler. |
+
+```text
+A <sprite src=engine/engine/content/builtins/assets/images/logo/logo_256.png/> logo
+<sprite src=images/banner.png width=4em height=2em/>
+<sprite src=images/icons.atlas animation=coin width=2em/>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*Çözümlenmiş satır içi sprite nesnesi*
+
+![Metinle aynı satırda işlenmiş bir Defold logosu](images/richtext/sprite.webp)
+
+</div>
+</div>
+
+Boyutlar, pozitif yalın yerleşim birimlerini, `px`, `em` veya `%` kabul eder. Hem `em` hem de `%`, metin yerleşiminin temel yazı tipi boyutunu kullanır.
+
+Belirtilmeyen her boyut, birbirinden bağımsız olarak varsayılan `1em` değerini alır. İkisinin de belirtilmemesi `1em × 1em` boyutunda bir nesne oluşturur; yalnızca genişliğin belirtilmesi, yüksekliği bir kaynağın en boy oranından otomatik olarak türetmez.
+
+::: important
+Sprite etiketi, geliştiricinin o konuma istediği nesneyi yerleştirebilmesi için yalnızca bir yer tutucudur!
+:::
+
+### `link`
+
+Görünür metindeki bir aralığı bağlantı nesnesi olarak tanımlar. Çevrelenen metin normal şekilde yerleştirilir ve varsayılan olarak `link` adlı stili alır. Etiket ve GUI bileşenleri, metni yeniden şekillendirmeden girdiye yanıt olarak `link:hover` ve `link:active` stillerini seçer. Bağlantı girdisinin ürettiği iletiler için [Etkileşim iletileri](#interaction-messages) bölümüne bakın.
+
+| Öznitelik | Zorunlu | Varsayılan | Anlamı |
+| --- | --- | --- | --- |
+| `src` | Hayır | Yok | Uygulama tanımlı bağlantı hedefi. Değer, otomatik doğrulama veya gezinme yapılmadan bir dize olarak döndürülür. |
+| `id` | Hayır | Oluşturulur | Döndürülen yerleşim nesnesinin `id` alanına karma değeri olarak kaydedilen, sabit kalan tanımlayıcı. |
+| `style` | Hayır | `link` | Bağlantı metni için adlandırılmış varsayılan stil. |
+| Diğer herhangi bir öznitelik | Hayır | Bulunmaz | Tanımlayıcı, eylem, araç ipucu veya analitik değeri gibi uygulama tanımlı üst veriler. |
+
+```text
+<ul><link id=website src=https://www.defold.com>www.defold.com</link></ul>
+<link id=inventory style=menu_link action=open_inventory item=sword>Iron sword</link>
+```
+
+<div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start;margin:1rem 0 2rem;" markdown="1">
+<div style="flex:1 1 280px;max-width:426px;" markdown="1">
+
+*`style=link`*
+
+![Varsayılan bağlantı stiliyle ve alt çizgiyle işlenmiş www.defold.com](images/richtext/link.webp)
+
+</div>
+</div>
+
+Bileşen, her bağlantının işaretçi durumunu izler. İşaretçi bağlantının üzerindeyken `link:hover`, işaretçi basılıyken `link:active` stilini uygular. Bu durumlardan hiçbiri geçerli olmadığında bileşen, bağlantının `style` özniteliğinde adlandırılan stili veya öznitelik yoksa `link` stilini geri yükler.
+
+### Etkileşim iletileri {#interaction-messages}
+
+Bağlantı etkileşimi, Defold'un normal girdi sistemini kullanır. `MOUSE_BUTTON_LEFT` için bir Mouse Trigger eşlemesi ekleyin; bu, tek dokunuşlu girdiyi de etkinleştirir. Oyun nesnesinin (game object) betiğinde veya GUI betiğinde girdi odağını (input focus) alın:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus")
+end
+```
+
+Kurulum ayrıntıları için [Girdi odağı](/manuals/input/#input-focus) ve [Fare ve dokunma girdisi](/manuals/input-mouse-and-touch) bölümlerine bakın.
+
+Bir etiket veya GUI bileşeni işaretçi girdisi aldığında bağlantılar aşağıdaki iletileri üretir. Etiket iletileri, etiketin sahibi olan oyun nesnesine; GUI iletileri ise GUI betiğine gönderilir.
+
+| İleti | Gönderilme zamanı |
+| --- | --- |
+| `text_object_hovered` | İşaretçi bir bağlantının üzerine geldiğinde. |
+| `text_object_unhovered` | İşaretçi bir bağlantının üzerinden ayrıldığında. |
+| `text_object_clicked` | Basılı girdi aynı bağlantının üzerinde bırakıldığında. |
+
+Her ileti şu alanları içerir:
+
+| Alan | Tür | Açıklama |
+| --- | --- | --- |
+| `id` | `hash` | Nesnenin `id` özniteliği veya oluşturulan yerleşim nesnesi tanımlayıcısı. |
+| `type` | `hash` | Yerleşim nesnesinin türü; şu anda `hash("link")`. |
+| `src` | `string` | Nesnenin `src` özniteliğinin uygulama tanımlı değeri veya öznitelik yoksa boş dize. |
+
+```lua
+function on_message(self, message_id, message)
+    if message_id == hash("text_object_clicked") then
+        assert(message.type == hash("link"))
+        print(message.id, message.src)
+    end
+end
+```
+
+## Adlandırılmış stiller
+
+Her yazı tipi koleksiyonu (font collection), yalnızca işlemeyi (rendering), yani görüntü oluşturmayı etkileyen adlandırılmış nesne stilleri içerir. Bir bağlantı, `style` özniteliğinde adlandırılan stili veya öznitelik yoksa `link` stilini kullanır. Genel amaçlı bir `<style>` metin aralığı etiketi yoktur.
+
+Defold aşağıdaki varsayılanları sağlar:
+
+| Stil | Dolgu rengi çarpanı | Süsleme |
+| --- | --- | --- |
+| `link` | `(0.10, 0.45, 0.90, 1.0)` | Kesintisiz alt çizgi |
+| `link:hover` | `(0.30, 0.65, 1.00, 1.0)` | Yok |
+| `link:active` | `(0.05, 0.30, 0.70, 1.0)` | Yok |
+
+Açılış etiketlerini içeren bir metin dizesiyle stil tanımlayın. Etiketler ters sırayla örtük olarak kapatılır; bu nedenle kapanış etiketlerine ve görünür metne izin verilmez.
+
+```lua
+font.set_style("/fonts/ui.fontc", "link",
+    "<color=#2673ff><outline color=#000000 size=1>")
+
+font.set_style("/fonts/ui.fontc", "link:hover",
+    "<color=#66b3ff><shake amplitude=0.2 hz=20>")
+```
+
+Etiketler, nesne metninin çevresinde iç içe yerleştirilmiş gibi soldan sağa uygulanır. Çağıran kodun seçtiği nesne stili, varsayılan stilden sonra uygulanır. Birden çok etiket aynı işleme özelliğini ayarladığında, daha sonra uygulanan değer önceki değerleri geçersiz kılar. Efektler soldan sağa sırayla eklenir.
+
+::: sidenote
+`font.set_style()` çağrısı, belirtilen adlı stilin işleme özelliklerini ve efektlerini yenileriyle değiştirir. Kaynakta tanımlı süslemeler değişmez; dolayısıyla `link` stilini yeniden tanımlamak varsayılan alt çizgisini kaldırmaz. Adlandırılmış stiller `color`, `outline`, `shadow`, `gradient`, `wave` ve `shake` gibi yalnızca işlemeyi etkileyen etiketleri kabul eder. Yerleşimi değiştiren etiketler, süsleme etiketleri ve nesne etiketleri reddedilir.
+:::
+
+## Yerleşim nesnesi API'si
+
+`label.get_layout_objects()` veya `gui.get_layout_objects()` kullanarak yerleştirilmiş metindeki `sprite` ve `link` nesnelerini alın.
+
+### `label.get_layout_objects()`
+
+```lua
+objects = label.get_layout_objects(url)
+```
+
+| Bağımsız değişken | Tür | Açıklama |
+| --- | --- | --- |
+| `url` | `string`, `hash` veya `url` | İncelenecek etiket bileşeni; örneğin `"#label"`. |
+
+### `gui.get_layout_objects()`
+
+```lua
+objects = gui.get_layout_objects(node)
+```
+
+| Bağımsız değişken | Tür | Açıklama |
+| --- | --- | --- |
+| `node` | `node` | İncelenecek GUI metin düğümü; örneğin `gui.get_node("rich_text")`. |
+
+Her iki işlev de geçerli yerleşim nesnelerini kaynak sırasıyla içeren, yeni oluşturulmuş bir dizi döndürür. Metin nesne etiketi içermediğinde boş bir dizi döndürürler. Nesneler ve öznitelikleri her çağrıda Lua'ya kopyalandığından, sonucu önbelleğe alın ve metni veya yerleşimini değiştiren başka bir özelliği değiştirdikten sonra yeniden sorgulayın.
+
+### Döndürülen nesnenin alanları
+
+| Alan | Tür | Açıklama |
+| --- | --- | --- |
+| `type` | `string` | `"sprite"` veya `"link"`. |
+| `id` | `hash` | Etkileşim iletilerinde kullanılan nesne tanımlayıcısı. |
+| `text_offset` | `number` | Görünür metindeki, Unicode kod noktalarıyla ölçülen sıfır tabanlı konum. İşaretleme dahil edilmez ve karakter başvuruları, çözümlendikleri karakterler olarak sayılır. Bir sprite için bu, ekleme noktasıdır. |
+| `text_length` | `number` | Çevrelenen görünür metnin Unicode kod noktaları cinsinden uzunluğu. Bir sprite nesnesinin uzunluğu, nesneyi temsil etmek için eklenen U+FFFC kod noktası nedeniyle birdir. |
+| `width` | `number` | Metin yerleşimi birimleri cinsinden hesaplanan genişlik. Bağlantıların genişliği şu anda sıfırdır. |
+| `height` | `number` | Metin yerleşimi birimleri cinsinden hesaplanan yükseklik. Bağlantıların yüksekliği şu anda sıfırdır. |
+| `x` | `number` | Nesnenin sol alt köşesinin, metin yerleşiminin sol üst başlangıç noktasına göre yatay konumu. |
+| `y` | `number` | Nesnenin sol alt köşesinin, metin yerleşiminin sol üst başlangıç noktasına göre dikey konumu. |
+| `attributes` | `table` | Dize türünde anahtar/değer çiftleri olarak tüm etiket öznitelikleri. Öznitelik değerleri, `"2em"` gibi kaynak gösterimlerini korur. Kısaltılmış biçimdeki adsız değer, `value` anahtarı altında saklanır. |
+
+::: sidenote
+`text_offset` ve `text_length`, UTF-8 bayt uzaklıkları değildir. `å` veya `猫` gibi ASCII dışı bir karakter, tek bir konum olarak sayılır.
+:::
+
+### Lua örneği
+
+```lua
+local text = [[
+Read the <link src=https://defold.com/manuals/ id=manual>manual</link>
+or inspect <sprite src=images/info.png width=2em/> for more information.
+]]
+
+go.set("#label", "text", text)
+
+local objects = label.get_layout_objects("#label")
+for _, object in ipairs(objects) do
+    if object.type == "link" then
+        print("link", object.attributes.src)
+        print("visible range", object.text_offset, object.text_length)
+        print("position", object.x, object.y)
+    elseif object.type == "sprite" then
+        print("sprite", object.x, object.y, object.width, object.height)
+        pprint(object.attributes)
+    end
+end
+
+local gui_objects = gui.get_layout_objects(gui.get_node("rich_text"))
+```
+
+## Yararlı birleşimler
+
+### Yatay renk geçişli, renkli dış çizgi
+
+```text
+<outline size=2 color=#101820>
+    <gradient left=#FEE715 right=#FF6F61>Gradient title</gradient>
+</outline>
+```
+
+Renk geçişi yalnızca dolgu rengiyle çarpılır; dış çizgi kendi rengini korur.
+
+### Bir cümleyi titretme, bir sözcüğe renk geçişi uygulama
+
+```text
+<shake hz=20 amplitude=0.5>
+    This <gradient left=#FF00FF right=#FFFFFF>whole</gradient> text shakes!
+</shake>
+```
+
+Dıştaki konum efekti her glife uygulanır. İç içe yerleştirilmiş renk efekti yalnızca "whole" sözcüğüne uygulanır.
+
+### Diğerlerini kaybetmeden tek bir özelliği geçersiz kılma
+
+```text
+<color=#FFFFFF><outline size=2 color=#000000>
+    Normal <color=#FF4040>warning</color> normal
+</outline></color>
+```
+
+İçteki renk, devralınan dış çizgi genişliğini ve rengini korurken dolgu rengini değiştirir.

--- a/docs/tr/manuals/font.md
+++ b/docs/tr/manuals/font.md
@@ -1,0 +1,279 @@
+---
+title: Defold'da yazı tipleri kılavuzu
+brief: Bu kılavuz, Defold'un yazı tiplerini nasıl kullandığını ve oyunlarınızda yazı tiplerini ekranda nasıl görüntüleyebileceğinizi açıklar.
+---
+
+# Yazı tipi dosyaları
+
+Yazı tipleri (font), etiket bileşenlerinde (Label component) ve GUI metin düğümlerinde (GUI text node) metnin görüntüsünü oluşturmak için işleme (rendering) sırasında kullanılır. Defold çeşitli yazı tipi dosya biçimlerini destekler:
+
+- TrueType
+- OpenType
+- BMFont
+
+Defold 1.13.2'den itibaren hem eski hem de tam metin yerleşimi motorları, `.ttf` ve `.otf` kaynaklarından çalışma sırasında üretim de dahil olmak üzere TrueType dış hatlarını ve OpenType CFF1/CFF2 dış hatlarını destekler.
+
+Metnin ayrı bölümlerini biçimlendirme, bağlantılar ve satır içi sprite bileşenleriyle çalışma hakkında bilgi için [Zengin metin işaretleme kılavuzuna](/manuals/font-richtext) bakın.
+
+Projenize eklenen yazı tipleri, Defold'un işleyebileceği bir doku (texture) biçimine otomatik olarak dönüştürülür. Her birinin kendine özgü avantajları ve dezavantajları olan iki yazı tipi işleme tekniği bulunur:
+
+- Bit eşlem (Bitmap)
+- Uzaklık alanı (Distance field)
+
+## Çevrimdışı veya çalışma zamanı yazı tipleri
+
+Varsayılan olarak, rasterleştirilmiş glif (glyph) görüntülerine dönüştürme işlemi proje derlenirken (çevrimdışı) gerçekleşir. Bunun dezavantajı, her yazı tipinin olası tüm gliflerinin derleme aşamasında rasterleştirilmesi gerekmesidir. Bu işlem, bellek tüketen ve dağıtım paketinin boyutunu da artıran çok büyük dokular üretebilir.
+
+"Çalışma zamanı yazı tipleri" (runtime fonts) kullanıldığında, `.ttf` ve `.otf` yazı tipleri olduğu gibi paketlenir ve rasterleştirme çalışma sırasında ihtiyaç duyuldukça gerçekleşir. Bu, hem çalışma zamanındaki bellek kullanımını hem de dağıtım paketinin boyutunu en aza indirir.
+
+## Metin yerleşimi desteği (ör. sağdan sola) {#text-layout-support-eg-right-to-left}
+
+Çalışma zamanı yazı tipleri, sağdan sola gibi tam metin yerleşimlerini destekleme avantajına da sahiptir.
+Şu anda [HarfBuzz](https://github.com/harfbuzz/harfbuzz), [SheenBidi](https://github.com/Tehreer/SheenBidi), [libunibreak](https://github.com/adah1972/libunibreak) ve [SkriBidi](https://github.com/memononen/Skribidi) kütüphanelerini kullanıyoruz.
+
+[Çalışma zamanı yazı tiplerini etkinleştirme](/manuals/font#enabling-runtime-fonts) bölümüne bakın.
+
+Düzenleyici, yazı tipi ve sahne metni önizlemeleri için motorun yazı tipi işleyicisini kullanır. Metin şekillendirme ve sağdan sola yerleşim, [çalışma zamanı yazı tiplerini](#enabling-runtime-fonts) ve App Manifest içindeki **Use full text layout system** seçeneğini gerektirir. Çevrimdışı yazı tiplerinde önizleme, yazı tipinin **Characters** ve **All Chars** ayarlarını dikkate alır.
+
+## Yazı tipi koleksiyonu
+
+`.fontc` dosya biçimi, yazı tipi koleksiyonu (font collection) olarak da bilinir. Çevrimdışı modda bu koleksiyonla yalnızca bir yazı tipi ilişkilendirilir.
+Çalışma zamanı yazı tiplerini kullanırken yazı tipi koleksiyonuyla birden fazla yazı tipi dosyasını (`.ttf` veya `.otf`) ilişkilendirebilirsiniz.
+
+Bu, bellek kullanımını düşük tutarken farklı dillerdeki birden fazla metni işlemek için bir yazı tipi koleksiyonu kullanmanızı sağlar.
+Örneğin, Japonca yazı tipini içeren bir koleksiyon yükleyebilir, ardından bu yazı tipini geçerli ana yazı tipiyle ilişkilendirebilir ve sonrasında Japonca yazı tipi koleksiyonunu bellekten kaldırabilirsiniz.
+
+## Yazı tipi oluşturma
+
+Defold'da kullanmak üzere bir yazı tipi oluşturmak için menüden <kbd>File ▸ New...</kbd> seçeneğini, ardından <kbd>Font</kbd> seçeneğini seçerek yeni bir yazı tipi dosyası oluşturun. Ayrıca *Assets* tarayıcısında bir konuma <kbd>sağ tıklayıp</kbd> <kbd>New... ▸ Font</kbd> seçeneğini seçebilirsiniz.
+
+![Yeni yazı tipinin adı](images/font/new_font_name.png)
+
+Yeni yazı tipi dosyasına bir ad verin ve <kbd>Ok</kbd> düğmesine tıklayın. Yeni yazı tipi dosyası düzenleyicide açılır.
+
+![Yeni yazı tipi](images/font/new_font.png)
+
+Kullanmak istediğiniz yazı tipini *Assets* tarayıcısına sürükleyin ve uygun bir konuma bırakın.
+
+*Font* özelliğini yazı tipi dosyasına ayarlayın ve yazı tipi özelliklerini gerektiği gibi düzenleyin.
+
+## Özellikler {#properties}
+
+*Font*
+: Yazı tipi verilerini üretmek için kullanılacak TTF, OTF veya *`.fnt`* dosyası.
+
+*Material*
+: Bu yazı tipini işlerken kullanılacak materyal (material). Uzaklık alanı yazı tipleri ve BMFont yazı tipleri için bu özelliği değiştirdiğinizden emin olun (ayrıntılar için aşağıya bakın).
+
+*Output Format*
+: Üretilen yazı tipi verilerinin türü.
+
+  - `TYPE_BITMAP`, içe aktarılan OTF veya TTF dosyasını, metin düğümlerini işlemek için bit eşlem verilerinin kullanıldığı bir yazı tipi sayfası dokusuna dönüştürür. Renk kanalları; glifin ana şeklini, dış çizgisini ve düşen gölgesini kodlamak için kullanılır. *`.fnt`* dosyalarında kaynak dokunun bit eşlemi olduğu gibi kullanılır.
+  - `TYPE_DISTANCE_FIELD` İçe aktarılan yazı tipi, piksel verilerinin ekran pikselleri yerine yazı tipinin kenarına olan uzaklıkları temsil ettiği bir yazı tipi sayfası dokusuna dönüştürülür. Ayrıntılar için aşağıya bakın.
+
+*Render Mode*
+: Glifleri işlemek için kullanılacak işleme modu.
+
+  - `MODE_SINGLE_LAYER`, her karakter için tek bir dörtgen üretir.
+  - `MODE_MULTI_LAYER`, sırasıyla glifin şekli, dış çizgisi ve gölgeleri için ayrı dörtgenler üretir. Katmanlar arkadan öne doğru işlenir. Böylece dış çizgi, glifler arasındaki mesafeden daha geniş olduğunda bir karakterin önceden işlenmiş karakterleri kapatması önlenir. Bu işleme modu, yazı tipi kaynağındaki Shadow X/Y özelliklerinde belirtildiği gibi düşen gölgenin doğru şekilde kaydırılmasını da sağlar.
+
+*Size*
+: Gliflerin piksel cinsinden hedef boyutu.
+
+*Antialias*
+: Yazı tipi hedef bit eşleme dönüştürülürken kenar yumuşatma uygulanıp uygulanmayacağı. Yazı tipinin pikselleri bire bir korunarak işlenmesini istiyorsanız 0 olarak ayarlayın.
+
+*Alpha*
+: Glifin saydamlığı. 0.0--1.0 aralığındadır; 0.0 saydam, 1.0 ise opak anlamına gelir.
+
+*Outline Alpha*
+: Üretilen dış çizginin saydamlığı. 0.0--1.0.
+
+*Outline Width*
+: Üretilen dış çizginin piksel cinsinden genişliği. Dış çizgi olmaması için 0 olarak ayarlayın.
+
+*Shadow Alpha*
+: Üretilen gölgenin saydamlığı. 0.0--1.0.
+
+::: sidenote
+Gölge desteği, yerleşik yazı tipi materyali gölgelendiricileri (shader) tarafından sağlanır ve hem tek hem de çok katmanlı işleme modunu destekler. Katmanlı yazı tipi işlemeye veya gölge desteğine ihtiyacınız yoksa *`builtins/font-singlelayer.fp`* gibi daha basit bir gölgelendirici kullanmanız önerilir.
+:::
+
+*Shadow Blur*
+: Bit eşlem yazı tiplerinde bu ayar, her yazı tipi glifine küçük bir bulanıklaştırma çekirdeğinin kaç kez uygulanacağını belirtir. Uzaklık alanı yazı tiplerinde ise bu ayar, bulanıklığın piksel cinsinden gerçek genişliğine eşittir.
+
+*Shadow X/Y*
+: Üretilen gölgenin piksel cinsinden yatay ve dikey kaydırılması. Bu ayar, glif gölgesini yalnızca Render Mode değeri `MODE_MULTI_LAYER` olarak ayarlandığında etkiler.
+
+*Characters*
+: Yazı tipine dahil edilecek karakterler. Varsayılan olarak bu alan, yazdırılabilir ASCII karakterlerini (32-126 karakter kodları) içerir. Yazı tipine daha fazla veya daha az karakter dahil etmek için bu alana karakter ekleyebilir veya alandan karakter kaldırabilirsiniz.
+
+Çalışma zamanı yazı tiplerinde bu metin, önbelleği uygun gliflerle önceden hazırlamak için kullanılır. Bu işlem yükleme sırasında gerçekleşir. `font.prewarm_text()` işlevine bakın.
+
+::: sidenote
+Yazdırılabilir ASCII karakterleri şunlardır:
+space ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ \` a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~
+:::
+
+*All Chars*
+: Bu özelliği işaretlerseniz kaynak dosyada bulunan tüm glifler çıktıya dahil edilir.
+
+*Cache Width/Height*
+: Glif önbelleği (glyph cache) bit eşleminin boyutunu sınırlar. Motor metni işlerken glifi önbellek bit eşleminde arar. Glif burada yoksa işlenmeden önce önbelleğe eklenir. Önbellek bit eşlemi, motorun işlemesi istenen tüm glifleri barındıramayacak kadar küçükse bir hata bildirilir (`ERROR:RENDER: Out of available cache cells! Consider increasing cache_width or cache_height for the font.`).
+
+  0 olarak ayarlanırsa önbellek boyutu otomatik olarak belirlenir ve en fazla 2048x4096 boyutuna kadar büyür.
+
+## Uzaklık alanı yazı tipleri
+
+Uzaklık alanı yazı tipleri, dokuda bit eşlem verileri yerine glifin kenarına olan uzaklığı saklar. Motor yazı tipini işlerken uzaklık verilerini yorumlamak ve bunları kullanarak glifi çizmek için özel bir gölgelendirici gerekir. Uzaklık alanı yazı tipleri, bit eşlem yazı tiplerinden daha fazla kaynak tüketir ancak boyutlandırmada daha fazla esneklik sağlar.
+
+![Uzaklık alanı yazı tipi](images/font/df_font.png)
+
+Yazı tipini oluştururken *Material* özelliğini *`builtins/fonts/font-df.material`* (veya uzaklık alanı verilerini işleyebilen başka bir materyal) olarak değiştirdiğinizden emin olun; aksi takdirde yazı tipi ekranda işlenirken doğru gölgelendirici kullanılmaz.
+
+## Bit eşlem BMFont yazı tipleri {#bitmap-bmfonts}
+
+Defold, üretilen bit eşlemlere ek olarak önceden hazırlanmış bit eşlem "BMFont" biçimindeki yazı tiplerini de destekler. Bu yazı tipleri, tüm glifleri içeren bir PNG yazı tipi sayfasından oluşur. Ayrıca bir *`.fnt`* dosyası, her glifin sayfanın neresinde bulunduğunu, boyutunu ve karakter çifti aralığı (kerning) bilgilerini içerir. (Defold'un, Phaser ve bazı diğer araçların kullandığı *`.fnt`* biçiminin XML sürümünü desteklemediğini unutmayın.)
+
+Bu tür yazı tipleri, TrueType veya OpenType yazı tipi dosyalarından üretilen bit eşlem yazı tiplerine göre performans artışı sağlamaz; ancak doğrudan görüntü içinde istediğiniz grafikleri, renklendirmeleri ve gölgeleri barındırabilir.
+
+Üretilen *`.fnt`* ve *`.png`* dosyalarını Defold projenize ekleyin. Bu dosyalar aynı klasörde bulunmalıdır. Yeni bir yazı tipi dosyası oluşturun ve *font* özelliğini *`.fnt`* dosyasına ayarlayın. *output_format* değerinin `TYPE_BITMAP` olarak ayarlandığından emin olun. Defold bir bit eşlem üretmez; PNG'de sağlanan bit eşlemi kullanır.
+
+::: sidenote
+BMFont oluşturmak için uygun dosyaları üretebilen bir araç kullanmanız gerekir. Çeşitli seçenekler bulunur:
+
+* [Bitmap Font Generator](http://www.angelcode.com/products/bmfont/), AngelCode tarafından sağlanan, yalnızca Windows'ta çalışan bir araç.
+* [Shoebox](http://renderhjs.net/shoebox/), Windows ve macOS için ücretsiz, Adobe Air tabanlı bir uygulama.
+* [Hiero](https://libgdx.com/wiki/tools/hiero), açık kaynaklı, Java tabanlı bir araç.
+* [Glyph Designer](https://71squared.com/glyphdesigner), 71 Squared tarafından geliştirilen ticari bir macOS aracı.
+* [bmGlyph](https://www.bmglyph.com), Sovapps tarafından geliştirilen ticari bir macOS aracı.
+:::
+
+![BMfont](images/font/bm_font.png)
+
+Yazı tipinin doğru işlenmesi için yazı tipini oluştururken materyal özelliğini *`builtins/fonts/font-fnt.material`* olarak ayarlamayı unutmayın.
+
+## Görüntü kusurları ve önerilen uygulamalar
+
+Genel olarak bit eşlem yazı tipleri, yazı tipi ölçeklenmeden işlendiğinde en iyi sonucu verir. Ekrana işlenmeleri, uzaklık alanı yazı tiplerine göre daha hızlıdır.
+
+Uzaklık alanı yazı tipleri büyütüldüğünde çok iyi sonuç verir. Bit eşlem yazı tipleri ise yalnızca piksellerden oluşan görüntüler olduğundan yazı tipi ölçeklenip büyütüldükçe pikseller de büyür ve bloklu görüntü kusurları oluşur. Aşağıdaki örnekte, 48 piksel boyutundaki bir yazı tipi 4 kat büyütülmüştür.
+
+![Büyütülmüş yazı tipleri](images/font/scale_up.png)
+
+Küçültme sırasında GPU, bit eşlem dokularını iyi bir sonuç verecek şekilde ve verimli olarak küçültebilir ve kenarlarını yumuşatabilir. Bit eşlem yazı tipi, rengini uzaklık alanı yazı tipinden daha iyi korur. Aşağıda, aynı örnek yazı tipinin 48 piksel boyutundan 1/5'ine küçültülmüş halinin yakınlaştırılmış görünümü bulunur:
+
+![Küçültülmüş yazı tipleri](images/font/scale_down.png)
+
+Uzaklık alanı yazı tiplerinin, gliflerin eğrilerini ifade edebilecek uzaklık bilgilerini barındıracak kadar büyük bir hedef boyutta işlenmesi gerekir. Aşağıdaki, yukarıdakiyle aynı yazı tipidir; ancak 18 piksel boyutundadır ve 10 kat büyütülmüştür. Bu boyutun, bu yazı tipinin şekillerini kodlamak için çok küçük olduğu açıktır:
+
+![Uzaklık alanı görüntü kusurları](images/font/df_artifacts.png)
+
+Gölge veya dış çizgi desteği istemiyorsanız bunlara ait alfa değerlerini sıfıra ayarlayın. Aksi takdirde gölge ve dış çizgi verileri yine üretilir ve gereksiz yere bellek tüketir.
+
+## Yazı tipi önbelleği
+Defold'daki bir yazı tipi kaynağı, çalışma sırasında iki şey oluşturur: bir doku ve yazı tipi verileri.
+
+* Yazı tipi verileri, her biri temel karakter çifti aralığı bilgileri ve ilgili glifin bit eşlem verilerini içeren glif kayıtlarının listesinden oluşur.
+* Doku, motor içinde "glif önbelleği dokusu" olarak adlandırılır ve belirli bir yazı tipindeki metni işlerken kullanılır.
+
+Çalışma sırasında metin işlenirken motor, hangi gliflerin doku önbelleğinde bulunduğunu kontrol etmek için önce işlenecek glifler üzerinde dolaşır. Glif doku önbelleğinde bulunmayan her glif, yazı tipi verilerinde saklanan bit eşlem verilerinden dokuya aktarım yapılmasını tetikler.
+
+Her glif, önbelleğe yazı tipinin taban çizgisine göre yerleştirilir. Bu, bir gölgelendiricide glifin karşılık gelen önbellek hücresi içindeki yerel doku koordinatlarının hesaplanmasını sağlar. Böylece renk geçişleri veya doku kaplamaları gibi belirli metin efektlerini dinamik olarak elde edebilirsiniz. Motor, önbellekle ilgili ölçüleri gölgelendiriciye `texture_size_recip` adlı özel bir gölgelendirici sabiti aracılığıyla sunar. Bu sabitin vektör bileşenleri aşağıdaki bilgileri içerir:
+
+* `texture_size_recip.x`, önbellek genişliğinin çarpmaya göre tersidir
+* `texture_size_recip.y`, önbellek yüksekliğinin çarpmaya göre tersidir
+* `texture_size_recip.z`, önbellek hücresi genişliğinin önbellek genişliğine oranıdır
+* `texture_size_recip.w`, önbellek hücresi yüksekliğinin önbellek yüksekliğine oranıdır
+
+Örneğin, bir gölgelendirici parçasında renk geçişi oluşturmak için şunu yazmanız yeterlidir:
+
+`float horizontal_gradient = fract(var_texcoord0.y / texture_size_recip.w);`
+
+Gölgelendirici uniform parametreleri hakkında daha fazla bilgi için [Gölgelendirici kılavuzuna](/manuals/shader) bakın.
+
+## Çalışma zamanı yazı tiplerini etkinleştirme {#enabling-runtime-fonts}
+
+TrueType (`.ttf`) veya OpenType (`.otf`) yazı tipleri kullanıldığında, SDF türündeki yazı tipleri için çalışma sırasında üretim kullanılabilir. `.otf` kaynaklarından çalışma sırasında üretim, Defold 1.13.2'den itibaren desteklenir.
+Bu yaklaşım, bir Defold oyununun indirme boyutunu ve çalışma zamanındaki bellek tüketimini önemli ölçüde azaltabilir.
+Küçük dezavantajı, her glifin üretiminin eşzamansız olmasıdır.
+
+* Özelliği etkinleştirmek için game.project dosyasında `font.runtime_generation` ayarını yapın.
+
+* Bir [App Manifest](/manuals/app-manifest) ekleyin ve `Use full text layout system` seçeneğini etkinleştirin.
+Bu işlem, söz konusu özelliğin etkin olduğu özel bir motor derler.
+
+::: sidenote
+Bu özellik şu anda deneyseldir, ancak gelecekte varsayılan iş akışı olarak kullanılması amaçlanmaktadır.
+:::
+
+::: important
+`font.runtime_generation` ayarı, projedeki tüm `.ttf` ve `.otf` yazı tiplerini etkiler.
+:::
+
+
+### Yazı tiplerini betikle yönetme
+
+#### Glif önbelleğini önceden hazırlama
+
+Çalışma zamanı yazı tiplerinin kullanımını kolaylaştırmak için glif önbelleğinin önceden hazırlanması desteklenir.
+Bu, yazı tipinin *Characters* alanında listelenen gliflerin üretileceği anlamına gelir.
+
+::: sidenote
+`All Chars` seçiliyse önceden hazırlama yapılmaz; çünkü bu, tüm glifleri aynı anda üretmek zorunda kalmama amacına aykırıdır.
+:::
+
+`Characters` alanı `.fontc` dosyasında ayarlanmışsa glif önbelleğinde hangi gliflerin güncellenmesi gerektiğini belirlemek için bu alan metin olarak kullanılır.
+
+`font.prewarm_text(font_collection, text, callback)` çağrısıyla glif önbelleğini elle güncellemek de mümkündür. Bu işlev, eksik gliflerin tümü glif önbelleğine eklendiğinde ve metni ekranda güvenle gösterebileceğinizde size haber vermek için bir geri çağırım (callback) sağlar.
+
+### Yazı tipi koleksiyonuna yazı tipi ekleme ve koleksiyondan kaldırma
+
+Çalışma zamanı yazı tiplerinde, bir yazı tipi koleksiyonuna yazı tipi (`.ttf`) eklemek veya koleksiyondan kaldırmak mümkündür.
+Bu, büyük bir yazı tipi farklı karakter kümeleri (ör. CJK) için birden fazla dosyaya bölündüğünde kullanışlıdır.
+
+::: important
+Bir yazı tipi koleksiyonuna yazı tipi eklemek, tüm glifleri otomatik olarak yüklemez veya işlemez.
+:::
+
+```lua
+function init(self)
+    -- Get the target font collection.
+    self.font_collection = go.get("#label", "font")
+
+    -- Get the first font assigned to the selected language collection.
+    local language_collection = go.get("localization_japanese#label", "font")
+    local font_info = font.get_info(language_collection)
+    self.language_ttf_hash = font_info.fonts[1].path_hash
+
+    -- Associate it with the target collection and increase its reference count.
+    font.add_font(self.font_collection, self.language_ttf_hash)
+end
+```
+
+```lua
+function final(self)
+    -- Remove the association and release the font reference.
+    font.remove_font(self.font_collection, self.language_ttf_hash)
+end
+```
+
+### Glifleri önceden hazırlama
+
+Çalışma zamanı yazı tipiyle bir metni düzgün gösterebilmek için gliflerin çözümlenmesi gerekir. `font.prewarm_text()` işlevi bunu sizin için yapar.
+Bu işlem eşzamansızdır. İşlem tamamlanıp geri çağırım alındığında, söz konusu glifleri içeren herhangi bir iletiyi güvenle gösterebilirsiniz.
+
+::: important
+Glif önbelleği dolarsa önbellekteki en eski glif çıkarılır.
+:::
+
+```lua
+font.prewarm_text(self.font_collection, info.text, function (self, request_id, result, err)
+    if result then
+      print("PREWARMING OK!")
+      go.set(self.label, "text", info.text)
+    else
+      print("Error prewarming text:", err)
+    end
+  end)
+```

--- a/docs/tr/manuals/getting-help.md
+++ b/docs/tr/manuals/getting-help.md
@@ -1,0 +1,99 @@
+---
+title: Nasıl yardım alınır
+brief: Bu kılavuz, Defold kullanırken bir sorunla karşılaşırsanız nasıl yardım alabileceğinizi açıklar.
+---
+
+# Yardım alma {#getting-help}
+
+Defold kullanırken bir sorunla karşılaşırsanız, sorunu düzeltebilmemiz ve/veya geçici bir çözüm bulmanıza yardımcı olabilmemiz için bize bildirmenizi isteriz! Sorunları tartışmanın ve bildirmenin birkaç yolu vardır. Size en uygun seçeneği seçin:
+
+## Forumda sorun bildirme
+
+Bir sorunu tartışmanın ve yardım almanın iyi bir yolu, [forumumuzda](https://forum.defold.com) soru sormaktır. Yaşadığınız sorunun türüne göre [Questions](https://forum.defold.com/c/questions) veya [Bugs](https://forum.defold.com/c/bugs) kategorisinde gönderi oluşturun. Sorununuzun çözümü zaten bulunmuş olabileceğinden, soru sormadan önce sorunuz veya sorununuz hakkında [arama yapmayı](https://forum.defold.com/search) unutmayın.
+
+Birden fazla sorunuz varsa ayrı gönderiler oluşturun. Aynı gönderide birbiriyle ilgisiz sorular sormayın.
+
+### Gerekli bilgiler
+Gerekli bilgileri sağlamadığınız sürece destek veremeyiz:
+
+**Başlık**
+Kısa ve açıklayıcı bir başlık kullanmaya özen gösterin. "Bir oyun nesnesini (game object) dönük olduğu yönde nasıl hareket ettiririm?" veya "Bir sprite bileşenini nasıl yavaşça görünmez hâle getiririm?" iyi başlık örnekleridir. "Defold kullanırken biraz yardıma ihtiyacım var!" veya "Oyunum çalışmıyor!" ise kötü başlık örnekleridir.
+
+**Hatayı açıklayın (ZORUNLU)**
+Hatanın ne olduğunu açık ve öz bir şekilde açıklayın.
+
+**Yeniden oluşturma (ZORUNLU)**
+Davranışı yeniden oluşturma adımları:
+1. '...' konumuna gidin
+2. '....' öğesine tıklayın
+3. '....' öğesine kadar aşağı kaydırın
+4. Hatayı görün
+
+**Beklenen davranış (ZORUNLU)**
+Ne olmasını beklediğinizi açık ve öz bir şekilde açıklayın.
+
+**Defold sürümü (ZORUNLU):**
+  - Sürüm [ör. 1.2.155]
+
+**Platformlar (ZORUNLU):**
+ - Platformlar: [ör. iOS, Android, Windows, macOS, Linux, HTML5]
+ - İşletim sistemi: [ör. iOS8.1, Windows 10, High Sierra]
+ - Cihaz: [ör. iPhone6]
+
+**Hatayı yeniden oluşturmak için gereken en küçük proje (İSTEĞE BAĞLI):**
+Lütfen hatanın yeniden oluştuğu en küçük projeyi ekleyin. Bu, hatayı incelemeye ve düzeltmeye çalışan kişiye büyük ölçüde yardımcı olacaktır.
+
+**Günlükler (İSTEĞE BAĞLI):**
+Lütfen motordan, düzenleyiciden veya derleme sunucusundan ilgili günlükleri sağlayın. Günlüklerin nerede saklandığını [buradan](#log-files) öğrenin.
+
+**Geçici çözüm (İSTEĞE BAĞLI):**
+Geçici bir çözüm varsa lütfen burada açıklayın.
+
+**Ekran görüntüleri (İSTEĞE BAĞLI):**
+Uygunsa, sorununuzu açıklamaya yardımcı olacak ekran görüntüleri ekleyin.
+
+**Ek bilgiler (İSTEĞE BAĞLI):**
+Sorunla ilgili diğer bilgileri buraya ekleyin.
+
+
+### Kod paylaşma
+Kod paylaşırken ekran görüntüsü yerine metin olarak paylaşmanız önerilir. Metin olarak paylaşmak, kodda arama yapmayı, hataları işaretlemeyi, değişiklik önermeyi ve uygulamayı kolaylaştırır. Kodu \`\`\` biçimindeki üç ters tırnak arasına alarak veya 4 boşlukla girintileyerek paylaşın.
+
+Örnek:
+
+\`\`\`
+print("Hello code!")
+\`\`\`
+
+Sonuç:
+
+```
+print("Hello code!")
+```
+
+
+## Düzenleyiciden sorun bildirme {#report-a-problem-from-the-editor}
+
+Düzenleyici, sorun bildirmek için pratik bir yol sunar. Bir sorunu bildirmek için düzenleyicide <kbd>Help->Report Issue</kbd> menü seçeneğini seçin.
+
+![](images/getting_help/report_issue.png)
+
+Bu menü seçeneği sizi GitHub'daki bir sorun takip sistemine götürür. [Günlük dosyalarını](#log-files), işletim sisteminizle ilgili bilgileri, sorunu yeniden oluşturma adımlarını, olası geçici çözümleri vb. sağlayın.
+
+::: sidenote
+Bu şekilde hata bildirimi göndermek için bir GitHub hesabına ihtiyacınız vardır.
+:::
+
+
+## Discord'da sorun tartışma
+
+Defold kullanırken bir sorunla karşılaşırsanız soruyu [Discord'da](https://www.defold.com/discord/) sormayı deneyebilirsiniz. Ancak karmaşık soruların ve ayrıntılı tartışmaların forumda paylaşılmasını öneririz. Ayrıca Discord üzerinden gönderilen hata bildirimlerini kabul etmediğimizi unutmayın.
+
+
+# Günlük dosyaları {#log-files}
+
+Motor, düzenleyici ve derleme sunucusu, yardım isterken ve bir hatayı ayıklarken çok değerli olabilecek günlük bilgileri üretir. Bir sorun bildirirken her zaman günlük dosyalarını sağlayın:
+
+* [Motor günlükleri](/manuals/debugging-game-and-system-logs)
+* [Düzenleyici günlükleri](/manuals/editor#editor-logs)
+* [Derleme sunucusu günlükleri](/manuals/extensions#build-server-logs)

--- a/docs/tr/manuals/glossary.md
+++ b/docs/tr/manuals/glossary.md
@@ -1,0 +1,172 @@
+---
+title: Defold terim sözlüğü
+brief: Bu kılavuz, Defold ile çalışırken karşılaşacağınız her şeyi kısa açıklamalarla listeler.
+---
+
+# Defold terim sözlüğü
+
+Bu sözlük, Defold'da karşılaşacağınız her şeyin kısa bir açıklamasını verir. Çoğu maddede daha ayrıntılı belgelere giden bir bağlantı bulabilirsiniz.
+
+## Animasyon kümesi
+
+![Animasyon kümesi](images/icons/animationset.png){.left} Animasyon kümesi (animation set) kaynağı, animasyonların okunacağı glTF dosyalarının veya diğer .animationset dosyalarının bir listesini içerir. Birden fazla model arasında animasyon kümelerinin bir bölümünü paylaşıyorsanız bir .animationset dosyasını diğerine eklemek kullanışlıdır. Ayrıntılar için [model animasyonu kılavuzuna](/manuals/model-animation/) bakın.
+
+## Atlas
+
+![Atlas](images/icons/atlas.png){.left} Atlas, performans ve bellek kullanımı nedeniyle daha büyük bir sayfada birleştirilen ayrı görüntülerden oluşan bir kümedir. Atlaslar, sabit görüntüler veya kare dizisi animasyonu (flip-book animation) oluşturan görüntü dizileri içerebilir. Çeşitli bileşenler (component), grafik kaynaklarını paylaşmak için atlasları kullanır. Daha fazla bilgi için [atlas belgelerine](/manuals/atlas) bakın.
+
+## Builtins
+
+![Builtins](images/icons/builtins.png){.left} builtins proje klasörü, kullanışlı varsayılan kaynaklar içeren salt okunur bir klasördür. Burada varsayılan işleyiciyi (renderer), işleme betiğini (render script), materyalleri ve daha fazlasını bulabilirsiniz. Bu kaynaklardan herhangi birinde özel değişiklikler yapmanız gerekiyorsa kaynağı projenize kopyalayın ve uygun gördüğünüz şekilde düzenleyin.
+
+## Kamera
+
+![Kamera](images/icons/camera.png){.left} Kamera bileşeni (camera), oyun dünyasının hangi bölümünün görünür olacağını ve nasıl izdüşürüleceğini belirlemeye yardımcı olur. Yaygın bir kullanım, oyuncunun oyun nesnesine (game object) bir kamera eklemek veya bir yumuşatma algoritmasıyla oyuncuyu takip eden kameraya sahip ayrı bir oyun nesnesi kullanmaktır. Daha fazla bilgi için [kamera belgelerine](/manuals/camera) bakın.
+
+## Çarpışma nesnesi
+
+![Çarpışma nesnesi](images/icons/collision-object.png){.left} Çarpışma nesneleri (collision object), oyun nesnelerine fiziksel özellikler (uzamsal şekil, ağırlık, sürtünme ve geri sekme katsayısı gibi) ekleyen bileşenlerdir. Bu özellikler, çarpışma nesnesinin diğer çarpışma nesneleriyle nasıl çarpışacağını belirler. En yaygın çarpışma nesnesi türleri kinematik nesneler, dinamik nesneler ve tetikleyicilerdir. Kinematik nesne ayrıntılı çarpışma bilgileri sağlar ve çarpışmaya tepkiyi sizin uygulamanız gerekir; dinamik nesne ise Newton'un fizik yasalarına uyacak şekilde fizik motoru tarafından otomatik olarak simüle edilir. Tetikleyiciler, diğer şekillerin tetikleyiciye girip girmediğini veya tetikleyiciden çıkıp çıkmadığını algılayan basit şekillerdir. Bunun nasıl çalıştığına ilişkin ayrıntılar için [fizik belgelerine](/manuals/physics) bakın.
+
+## Bileşen
+
+Bileşenler, oyun nesnelerine grafik, animasyon, kodlanmış davranış ve ses gibi belirli bir görünüm ve/veya işlevsellik kazandırmak için kullanılır. Kendi başlarına var olamazlar; oyun nesnelerinin içinde bulunmaları gerekir. Defold'da birçok bileşen türü bulunur. Bileşenlerin açıklaması için [yapı taşları kılavuzuna](/manuals/building-blocks) bakın.
+
+## Koleksiyon
+
+![Koleksiyon](images/icons/collection.png){.left} Koleksiyonlar (collection), Defold'un oyun nesnesi hiyerarşilerinin yeniden kullanılabildiği şablonlar oluşturma mekanizmasıdır; diğer motorlarda bunlara "prefab" denir. Koleksiyonlar, oyun nesnelerini ve diğer koleksiyonları barındıran ağaç yapılarıdır. Bir koleksiyon her zaman dosyada saklanır ve düzenleyicide elle yerleştirilerek statik biçimde ya da çalışma sırasında oluşturularak dinamik biçimde oyuna eklenir. Koleksiyonların açıklaması için [yapı taşları kılavuzuna](/manuals/building-blocks) bakın.
+
+## Koleksiyon fabrikası
+
+![Koleksiyon fabrikası](images/icons/collection-factory.png){.left} Koleksiyon fabrikası (collection factory) bileşeni, çalışan bir oyunda oyun nesnesi hiyerarşilerini dinamik olarak oluşturmak için kullanılır. Ayrıntılar için [koleksiyon fabrikası kılavuzuna](/manuals/collection-factory) bakın.
+
+## Koleksiyon vekili
+
+![Koleksiyon](images/icons/collection.png){.left} Koleksiyon vekili (collection proxy), uygulama veya oyun çalışırken koleksiyonları anında yüklemek ve etkinleştirmek için kullanılır. Koleksiyon vekillerinin en yaygın kullanım amacı, bölümleri oynanacakları sırada yüklemektir. Ayrıntılar için [koleksiyon vekili belgelerine](/manuals/collection-proxy) bakın.
+
+## Küp haritası
+
+![Küp haritası](images/icons/cubemap.png){.left} Küp haritası (cubemap), bir küpün yüzlerine eşlenen 6 farklı dokudan oluşan özel bir doku türüdür. Gök kutularını (skybox) ve çeşitli yansıma ve aydınlatma haritalarını işlemek (rendering), yani görüntülerini oluşturmak için kullanışlıdır.
+
+## Hata ayıklama
+
+Bir noktada oyununuz beklenmedik şekilde davranacak ve sorunun ne olduğunu bulmanız gerekecektir. Hata ayıklamayı (debugging) öğrenmek bir sanattır; neyse ki Defold, size yardımcı olacak yerleşik bir hata ayıklayıcıyla gelir. Daha fazla bilgi için [hata ayıklama kılavuzuna](/manuals/debugging) bakın.
+
+## Ekran profilleri
+
+![Ekran profilleri](images/icons/display-profiles.png){.left} Ekran profilleri (display profiles) kaynak dosyası, yönelime, en boy oranına veya cihaz modeline bağlı GUI yerleşimlerini belirtmek için kullanılır. Kullanıcı arayüzünüzü her türlü cihaza uyarlamanıza yardımcı olur. [Yerleşimler kılavuzunda](/manuals/gui-layouts) daha fazla bilgi bulabilirsiniz.
+
+## Fabrika
+
+![Fabrika](images/icons/factory.png){.left} Bazı durumlarda gereken tüm oyun nesnelerini bir koleksiyona elle yerleştiremezsiniz; oyun nesnelerini dinamik olarak, çalışma sırasında oluşturmanız gerekir. Örneğin oyuncu mermi ateşleyebilir ve oyuncu tetiğe her bastığında her merminin dinamik olarak oluşturulup fırlatılması gerekir. Oyun nesnelerini dinamik olarak (önceden bellek ayrılmış bir nesne havuzundan) oluşturmak için fabrika (factory) bileşeni kullanırsınız. Ayrıntılar için [fabrika kılavuzuna](/manuals/factory) bakın.
+
+## Yazı tipi
+
+![Yazı tipi dosyası](images/icons/font.png){.left} Yazı tipi (font) kaynağı, bir TrueType veya OpenType yazı tipi dosyasından oluşturulur. Yazı tipi kaynağı, yazı tipinin hangi boyutta işleneceğini ve işlenen yazı tipinde hangi tür süslemelerin (dış çizgi ve gölge) bulunacağını belirtir. Yazı tipleri, GUI ve etiket bileşenleri tarafından kullanılır. Ayrıntılar için [yazı tipi kılavuzuna](/manuals/font/) bakın.
+
+## Parça gölgelendiricisi
+
+![Parça gölgelendiricisi](images/icons/fragment-shader.png){.left} Bu, bir çokgen ekrana çizilirken çokgendeki her piksel (parça) için grafik işlemcisinde çalıştırılan bir programdır. Parça gölgelendiricisinin (fragment shader) amacı, sonuçta oluşan her parçanın rengini belirlemektir. Bu işlem, hesaplamayla, dokudan bir veya daha fazla değer okumayla ya da değer okuma ve hesaplamanın birleşimiyle yapılır. Daha fazla bilgi için [gölgelendirici kılavuzuna](/manuals/shader) bakın.
+
+## Oyun kumandaları
+
+![Oyun kumandaları](images/icons/gamepad.png){.left} Oyun kumandaları (gamepads) kaynak dosyası, belirli bir oyun kumandası cihazından gelen girdinin belirli bir platformdaki oyun kumandası girdi tetikleyicileriyle nasıl eşleneceğini tanımlar. Ayrıntılar için [girdi kılavuzuna](/manuals/input) bakın.
+
+## Oyun nesnesi
+
+![Oyun nesnesi](images/icons/game-object.png){.left} Oyun nesneleri, oyununuzun çalışması sırasında ayrı yaşam sürelerine sahip basit nesnelerdir. Oyun nesneleri kapsayıcılardır ve genellikle ses veya sprite bileşeni gibi görsel ya da işitsel bileşenler içerir. Betik bileşenleri aracılığıyla davranış da kazanabilirler. Oyun nesnelerini düzenleyicide oluşturup koleksiyonlara yerleştirebilir veya fabrikalarla çalışma sırasında dinamik olarak oluşturabilirsiniz. Oyun nesnelerinin açıklaması için [yapı taşları kılavuzuna](/manuals/building-blocks) bakın.
+
+## GUI
+
+![GUI bileşeni](images/icons/gui.png){.left} GUI bileşeni, kullanıcı arayüzlerini oluşturmak için kullanılan öğeleri içerir: metinler ve renkli ve/veya dokulu bloklar. Öğeler hiyerarşik yapılarda düzenlenebilir, betiklerle yönetilebilir ve animasyonla canlandırılabilir. GUI bileşenleri genellikle oyun içi bilgi göstergeleri, menü sistemleri ve ekran bildirimleri oluşturmak için kullanılır. GUI bileşenleri, GUI davranışını tanımlayan ve kullanıcının onunla etkileşimini yöneten GUI betikleriyle kontrol edilir. [GUI belgelerinde](/manuals/gui) daha fazla bilgi bulabilirsiniz.
+
+## GUI betiği
+
+![GUI betiği](images/icons/script.png){.left} GUI betikleri (GUI script), GUI bileşenlerinin davranışını kontrol etmek için kullanılır. GUI animasyonlarını ve kullanıcının GUI ile nasıl etkileşim kurduğunu kontrol ederler. Lua betiklerinin Defold'da nasıl kullanıldığına ilişkin ayrıntılar için [Defold'da Lua kılavuzuna](/manuals/lua) bakın.
+
+## Çalışma sırasında yeniden yükleme
+
+Defold düzenleyicisi, masaüstünde ve cihazda zaten çalışmakta olan bir oyunun içeriğini güncellemenizi sağlar. Çalışma sırasında yeniden yükleme (hot reload) adı verilen bu özellik son derece güçlüdür ve geliştirme iş akışını büyük ölçüde iyileştirebilir. Daha fazla bilgi için [çalışma sırasında yeniden yükleme kılavuzuna](/manuals/hot-reload) bakın.
+
+## Girdi eşlemesi
+
+![Girdi eşlemesi](images/icons/input-binding.png){.left} Girdi eşlemesi (input binding) dosyaları, oyunun donanım girdisini (fare, klavye, dokunmatik ekran ve oyun kumandası) nasıl yorumlayacağını tanımlar. Dosya, donanım girdisini "jump" ve "move_forward" gibi üst düzey girdi _eylemlerine_ bağlar. Girdiyi dinleyen betik bileşenlerinde, belirli bir girdi karşısında oyunun veya uygulamanın gerçekleştirmesi gereken eylemleri kodlayabilirsiniz. Ayrıntılar için [girdi belgelerine](/manuals/input) bakın.
+
+## Etiket
+
+![Etiket](images/icons/label.png){.left} Etiket (label) bileşeni, herhangi bir oyun nesnesine metin içeriği eklemenizi sağlar. Belirli bir yazı tipiyle yazılmış bir metni, oyun uzayında ekrana işler. Daha fazla bilgi için [etiket kılavuzuna](/manuals/label) bakın.
+
+## Kütüphane
+
+![Oyun nesnesi](images/icons/builtins.png){.left} Defold, güçlü bir kütüphane (library) mekanizmasıyla projeler arasında veri paylaşmanızı sağlar. Bunu kullanarak kendiniz veya tüm ekibiniz için bütün projelerinizden erişilebilen ortak kütüphaneler oluşturabilirsiniz. Kütüphane mekanizması hakkında daha fazla bilgiyi [kütüphaneler belgelerinde](/manuals/libraries) bulabilirsiniz.
+
+## Lua dili
+
+Lua programlama dili, Defold'da oyun mantığı oluşturmak için kullanılır. Lua güçlü, verimli ve çok küçük bir betik dilidir. Yordamsal programlamayı, nesne yönelimli programlamayı, fonksiyonel programlamayı, veri odaklı programlamayı ve veri tanımlamayı destekler. Dil hakkında daha fazla bilgiyi https://www.lua.org/ adresindeki resmî Lua ana sayfasında ve [Defold'da Lua kılavuzunda](/manuals/lua) bulabilirsiniz.
+
+## Lua modülü
+
+![Lua modülü](images/icons/lua-module.png){.left} Lua modülleri, projenizi yapılandırmanızı ve yeniden kullanılabilir kütüphane kodu oluşturmanızı sağlar. [Lua modülleri kılavuzunda](/manuals/modules/) daha fazla bilgi bulabilirsiniz
+
+## Materyal
+
+![Materyal](images/icons/material.png){.left} Materyaller (material), gölgelendiricileri ve özelliklerini belirterek farklı nesnelerin nasıl işleneceğini tanımlar. Daha fazla bilgi için [materyal kılavuzuna](/manuals/material) bakın.
+
+## İleti
+
+Bileşenler, ileti aktarımı (message passing) aracılığıyla birbirleriyle ve diğer sistemlerle iletişim kurar. Bileşenler ayrıca kendilerini değiştiren veya belirli eylemleri tetikleyen önceden tanımlanmış bir ileti (message) kümesine yanıt verir. Grafikleri gizlemek veya fizik nesnelerini hafifçe itmek için iletiler gönderirsiniz. Motor da örneğin fizik şekilleri çarpıştığında, bileşenlere olayları bildirmek için iletileri kullanır. İleti aktarımı mekanizması, gönderilen her ileti için bir alıcıya ihtiyaç duyar. Bu nedenle oyundaki her şeyin benzersiz bir adresi vardır. Nesneler arasında iletişimi sağlamak için Defold, Lua'yı ileti aktarımıyla genişletir. Defold ayrıca kullanışlı işlevlerden oluşan bir kütüphane sunar.
+
+Örneğin bir oyun nesnesindeki sprite bileşenini gizlemek için gereken Lua kodu şöyle görünür:
+
+```lua
+msg.post("#weapon", "disable")
+```
+
+Burada `"#weapon"`, geçerli nesnenin sprite bileşeninin adresidir. `"disable"` ise sprite bileşenlerinin yanıt verdiği bir iletidir. İleti aktarımının nasıl çalıştığına ilişkin ayrıntılı açıklama için [ileti aktarımı belgelerine](/manuals/message-passing) bakın.
+
+## Model
+
+![Model](images/icons/model.png){.left} 3B model bileşeni, glTF örgü, iskelet ve animasyon varlıklarını oyununuza içe aktarabilir. Daha fazla bilgi için [model kılavuzuna](/manuals/model/) bakın.
+
+## ParticleFX
+
+![ParticleFX](images/icons/particlefx.png){.left} Parçacıklar (particle), özellikle oyunlarda güzel görsel efektler oluşturmak için çok kullanışlıdır. Bunları sis, duman, ateş, yağmur veya düşen yapraklar oluşturmak için kullanabilirsiniz. Defold, efektleri oyununuzda gerçek zamanlı çalıştırırken oluşturmanıza ve ayarlamanıza olanak tanıyan güçlü bir parçacık efektleri düzenleyicisi içerir. [ParticleFX belgeleri](/manuals/particlefx), bunun nasıl çalıştığını ayrıntılarıyla açıklar.
+
+## Profil çıkarma
+
+Oyunlarda iyi performans çok önemlidir. Oyununuzu ölçmek, düzeltilmesi gereken performans darboğazlarını ve bellek sorunlarını belirlemek için performans ve bellek profili çıkarma (profiling) işlemini yapabilmeniz hayati önem taşır. Defold için sunulan profil çıkarma araçları hakkında daha fazla bilgi için [profil çıkarma kılavuzuna](/manuals/profiling) bakın.
+
+## İşleme
+
+![İşleme](images/icons/render.png){.left} İşleme dosyaları (render), oyun ekrana işlenirken kullanılan ayarları içerir. İşleme dosyaları, işleme için hangi işleme betiğinin ve hangi materyallerin kullanılacağını tanımlar. Daha fazla ayrıntı için [işleme kılavuzuna](/manuals/render/) bakın.
+
+## İşleme betiği
+
+![İşleme betiği](images/icons/script.png){.left} İşleme betiği, oyunun veya uygulamanın ekrana nasıl işleneceğini kontrol eden bir Lua betiğidir. En yaygın durumları kapsayan varsayılan bir işleme betiği bulunur; ancak özel aydınlatma modellerine ve başka efektlere ihtiyaç duyarsanız kendi betiğinizi yazabilirsiniz. İşleme hattının nasıl çalıştığına ilişkin daha fazla ayrıntı için [işleme kılavuzuna](/manuals/render/), Lua betiklerinin Defold'da nasıl kullanıldığına ilişkin ayrıntılar için [Defold'da Lua kılavuzuna](/manuals/lua) bakın.
+
+## Betik
+
+![Betik](images/icons/script.png){.left}  Betik (script), oyun nesnelerinin davranışlarını tanımlayan bir program içeren bileşendir. Betiklerle oyununuzun kurallarını ve nesnelerin çeşitli etkileşimlere (hem oyuncuyla hem de diğer nesnelerle) nasıl yanıt vereceğini belirleyebilirsiniz. Tüm betikler Lua programlama dilinde yazılır. Defold ile çalışabilmek için sizin veya ekibinizdeki birinin Lua'da programlama yapmayı öğrenmesi gerekir. Lua'ya genel bir bakış ve Lua betiklerinin Defold'da nasıl kullanıldığına ilişkin ayrıntılar için [Defold'da Lua kılavuzuna](/manuals/lua) bakın.
+
+## Ses
+
+![Ses](images/icons/sound.png){.left} Ses bileşeni (sound), belirli bir sesi çalmaktan sorumludur. Defold, WAV, Ogg Vorbis ve Ogg Opus dosyalarını destekler. Opus desteğinin App Manifest içinde etkinleştirilmesi gerekir. Daha fazla bilgi için [ses kılavuzuna](/manuals/sound) bakın.
+
+## Sprite
+
+![Sprite](images/icons/sprite.png){.left} Sprite, oyun nesnelerine grafik ekleyen bir bileşendir. Karo kaynağından veya atlastan alınan bir görüntüyü gösterir. Sprite bileşenleri, kare dizisi animasyonu ve kemik animasyonu için yerleşik desteğe sahiptir. Sprite bileşenleri genellikle karakterler ve eşyalar için kullanılır.
+
+## Doku profilleri
+
+![Doku profilleri](images/icons/texture-profiles.png){.left} Doku profilleri (texture profiles) kaynak dosyası, paketleme sürecinde görüntü verilerini (atlaslarda, karo kaynaklarında, küp haritalarında ve modeller, GUI vb. için kullanılan bağımsız dokularda) otomatik olarak işlemek ve sıkıştırmak için kullanılır. [Doku profilleri kılavuzunda](/manuals/texture-profiles) daha fazla bilgi bulabilirsiniz.
+
+## Karo haritası
+
+![Karo haritası](images/icons/tilemap.png){.left} Karo haritası (tile map) bileşenleri, karo kaynağındaki görüntüleri üst üste yerleştirilmiş bir veya daha fazla ızgarada gösterir. En yaygın kullanım alanları oyun ortamlarını oluşturmaktır: zemin, duvarlar, binalar ve engeller. Bir karo haritası, belirtilen bir harmanlama moduyla üst üste hizalanmış birden fazla katmanı gösterebilir. Bu, örneğin çimenli arka plan karolarının üzerine bitki örtüsü yerleştirmek için kullanışlıdır. Bir karoda gösterilen görüntüyü dinamik olarak değiştirmek de mümkündür. Böylece örneğin yalnızca karoları yıkılmış köprüyü gösteren ve karşılık gelen fizik şeklini içeren karolarla değiştirerek bir köprüyü yıkabilir ve geçilmez hâle getirebilirsiniz. Daha fazla bilgi için [karo haritası belgelerine](/manuals/tilemap) bakın.
+
+## Karo kaynağı
+
+![Karo kaynağı](images/icons/tilesource.png){.left} Karo kaynağı (tile source), her biri aynı boyutta olan birden fazla küçük görüntüden oluşan bir dokuyu tanımlar. Bir karo kaynağındaki görüntü dizisinden kare dizisi animasyonları tanımlayabilirsiniz. Karo kaynakları ayrıca görüntü verilerinden çarpışma şekillerini otomatik olarak hesaplayabilir. Bu, nesnelerin çarpışabileceği ve etkileşim kurabileceği karolardan oluşan bölümler hazırlamak için çok kullanışlıdır. Karo haritası bileşenleri (ayrıca Sprite ve ParticleFX), grafik kaynaklarını paylaşmak için karo kaynaklarını kullanır. Atlasların çoğu zaman karo kaynaklarından daha uygun olduğunu unutmayın. Daha fazla bilgi için [karo haritası belgelerine](/manuals/tilemap) bakın.
+
+## Köşe gölgelendiricisi
+
+![Köşe gölgelendiricisi](images/icons/vertex-shader.png){.left} Köşe gölgelendiricisi (vertex shader), bir bileşenin temel çokgen şekillerinin ekran geometrisini hesaplar. Sprite, karo haritası veya model gibi her türlü görsel bileşenin şekli, bir dizi çokgen köşesi konumuyla temsil edilir. Köşe gölgelendiricisi programı, her köşeyi (dünya uzayında) işler ve temel bir şeklin her köşesinin sonuçta sahip olması gereken koordinatı hesaplar. Daha fazla bilgi için [gölgelendirici kılavuzuna](/manuals/shader) bakın.

--- a/docs/tr/manuals/gpgs.md
+++ b/docs/tr/manuals/gpgs.md
@@ -1,0 +1,6 @@
+---
+title: Defold'da Google Play Game Services
+brief: Bu belge, Google Play Game Services hizmetinin nasıl kurulacağını ve kullanılacağını açıklar
+---
+
+[Bu kılavuz taşındı](/extension-gpgs)

--- a/docs/tr/manuals/graphics.md
+++ b/docs/tr/manuals/graphics.md
@@ -1,0 +1,10 @@
+---
+title: Defold grafik kılavuzu
+brief: Bu kılavuz, Defold'un grafik öğeleri için sunduğu desteği ana hatlarıyla açıklar.
+---
+
+Bu kılavuzun kullanımı artık önerilmiyor!
+
+* [2B grafiklerin nasıl içe aktarılacağı ve kullanılacağı](/manuals/importing-graphics) hakkında buradan daha fazla bilgi edinin
+* [Doku filtreleme](/manuals/texture-filtering) hakkında daha fazla bilgi edinin
+* [Materyaller](/manuals/material) hakkında daha fazla bilgi edinin

--- a/docs/tr/manuals/gui-box.md
+++ b/docs/tr/manuals/gui-box.md
@@ -1,0 +1,28 @@
+---
+title: Defold'da GUI kutu düğümleri
+brief: Bu kılavuz, GUI kutu düğümlerinin nasıl kullanılacağını açıklar.
+---
+
+# GUI kutu düğümleri
+
+Kutu düğümü (box node), bir renk, doku (texture) veya animasyonla doldurulmuş bir dikdörtgendir.
+
+## Kutu düğümleri ekleme
+
+Yeni kutu düğümleri eklemek için *Outline* görünümünde <kbd>sağ tıklayın</kbd> ve <kbd>Add ▸ Box</kbd> seçeneğini seçin ya da <kbd>A</kbd> tuşuna basıp <kbd>Box</kbd> seçeneğini seçin.
+
+GUI'ye eklenmiş atlaslardan veya karo kaynaklarından (tile source) görüntü ve animasyon kullanabilirsiniz. Doku eklemek için *Outline* görünümündeki *Textures* klasör simgesine <kbd>sağ tıklayın</kbd> ve <kbd>Add ▸ Textures...</kbd> seçeneğini seçin. Ardından kutu düğümündeki *Texture* özelliğini ayarlayın:
+
+![Dokular](images/gui-box/create.png)
+
+Kutu düğümünün renginin, grafiklere renk çarpanı (tint) olarak uygulandığını unutmayın. Bu renk, görüntü verileriyle çarpılır; dolayısıyla rengi beyaz (varsayılan) olarak ayarlarsanız görüntünün rengi değişmez.
+
+![Renk çarpanı uygulanmış doku](images/gui-box/tinted.png)
+
+Kutu düğümleri, kendilerine bir doku atanmamış olsa, alfa değerleri `0` olarak ayarlanmış olsa veya boyutları `0, 0, 0` olsa bile her zaman işleme (rendering) sürecine dahil edilir. İşleyicinin bunları düzgün biçimde toplu olarak çizebilmesi ve çizim çağrısı sayısını azaltabilmesi için kutu düğümlerine her zaman bir doku atanması önerilir.
+
+## Animasyonları oynatma
+
+Kutu düğümleri, atlaslardaki veya karo kaynaklarındaki animasyonları oynatabilir. Daha fazla bilgi için [kare dizisi animasyonu kılavuzuna](/manuals/flipbook-animation) bakın.
+
+:[Slice-9](../shared/slice-9-texturing.md)

--- a/docs/tr/manuals/gui-clipping.md
+++ b/docs/tr/manuals/gui-clipping.md
@@ -1,0 +1,75 @@
+---
+title: GUI kırpma kılavuzu
+brief: Bu kılavuz, şablonla kırpma yoluyla diğer düğümleri maskeleyen GUI düğümlerinin nasıl oluşturulacağını açıklar.
+---
+
+# Kırpma
+
+GUI düğümleri (GUI nodes), *kırpma* (clipping) düğümleri olarak kullanılabilir; bunlar, diğer düğümlerin işleme (rendering) sırasında nasıl görüntülendiğini denetleyen maskelerdir. Bu kılavuz, bu özelliğin nasıl çalıştığını açıklar.
+
+## Kırpma düğümü oluşturma
+
+Kutu (Box), metin (Text) ve daire dilimi (Pie) düğümleri kırpma için kullanılabilir. Bir kırpma düğümü oluşturmak için GUI sahnenize bir düğüm ekleyin, ardından özelliklerini buna göre ayarlayın:
+
+Clipping Mode
+: Kırpma için kullanılan mod.
+  - `None`, düğümü herhangi bir kırpma yapmadan işler.
+  - `Stencil`, düğümün geçerli şablon maskesine yazmasını sağlar.
+
+Clipping Visible
+: Düğümün içeriğini işlemek için işaretleyin.
+
+Clipping Inverted
+: Düğümün şeklinin tersini maskeye yazmak için işaretleyin.
+
+Ardından kırpılmasını istediğiniz düğümleri kırpma düğümüne alt düğüm olarak ekleyin.
+
+![Kırpma oluşturma](images/gui-clipping/create.png)
+
+## Şablon maskesi
+
+Kırpma, düğümlerin bir *şablon arabelleğine* (stencil buffer) yazmasıyla çalışır. Bu arabellek, grafik kartına bir pikselin işlenip işlenmemesi gerektiğini bildiren bilgiler olan kırpma maskelerini içerir.
+
+- Kırpıcı bir üst düğümü olmayan ancak kırpma modu `Stencil` olarak ayarlanmış bir düğüm, şeklini (veya şeklinin tersini) şablon arabelleğinde saklanan yeni bir kırpma maskesine yazar.
+- Bir kırpma düğümünün kırpıcı bir üst düğümü varsa bunun yerine üst düğümün kırpma maskesini kırpar. Kırpma yapan bir alt düğüm, geçerli kırpma maskesini hiçbir zaman _genişletemez_; yalnızca daha fazla kırpabilir.
+- Kırpıcılara alt düğüm olarak bağlı olan ve kendileri kırpma yapmayan düğümler, üst düğüm hiyerarşisinin oluşturduğu kırpma maskesiyle işlenir.
+
+![Kırpma hiyerarşisi](images/gui-clipping/setup.png)
+
+Burada üç düğüm bir hiyerarşi içinde düzenlenmiştir:
+
+- Altıgen ve kare şekillerin ikisi de şablonla kırpma yapar.
+- Altıgen yeni bir kırpma maskesi oluşturur, kare ise bu maskeyi daha fazla kırpar.
+- Daire düğümü sıradan bir daire dilimi düğümüdür; bu nedenle kırpma yapan üst düğümlerinin oluşturduğu kırpma maskesiyle işlenir.
+
+Bu hiyerarşi için normal ve ters çevrilmiş kırpıcıların dört birleşimi mümkündür. Yeşil alan, dairenin işlenen bölümünü gösterir. Geri kalanı maskelenir:
+
+![Şablon maskeleri](images/gui-clipping/modes.png)
+
+## Şablon sınırlamaları
+
+- Şablonla kırpma yapan düğümlerin toplam sayısı 256'yı aşamaz.
+- _Şablon_ kullanan alt düğümlerin en fazla iç içe geçme derinliği 8 düzeydir. (Yalnızca şablonla kırpma yapan düğümler sayılır.)
+- Aynı üst düğüme bağlı şablon düğümlerinin sayısı en fazla 127 olabilir. Şablon hiyerarşisinde aşağıya doğru her düzeyde bu üst sınır yarıya iner.
+- Ters çevrilmiş düğümlerin maliyeti daha yüksektir. En fazla 8 ters çevrilmiş kırpma düğümüne izin verilir ve bunların her biri, ters çevrilmemiş kırpma düğümleri için izin verilen en yüksek sayıyı yarıya indirir.
+- Şablonlar, şablon maskesini düğümün _geometrisini_ (dokusunu değil) işleyerek oluşturur. *Inverted clipper* özelliği ayarlanarak maske ters çevrilebilir.
+
+
+## Katmanlar
+
+Katmanlar (layers), düğümlerin işleme sırasını (ve toplu çizimini) denetlemek için kullanılabilir. Katmanlar ve kırpma düğümleri birlikte kullanıldığında olağan katman sırası geçersiz kılınır. Katman sırası her zaman kırpma sırasından önceliklidir---katman atamaları kırpma düğümleriyle birlikte kullanılırsa, kırpması etkin bir üst düğüm alt düğümlerinden daha yüksek bir katmana ait olduğunda kırpma sırası bozulabilir. Katman atanmamış alt düğümler yine hiyerarşiye uyar ve dolayısıyla üst düğümden sonra çizilip kırpılır.
+
+::: sidenote
+Bir kırpma düğümü ve hiyerarşisi, düğüme bir katman atanmışsa önce, katman atanmamışsa normal sırada çizilir.
+:::
+
+![Katmanlar ve kırpma](images/gui-clipping/layers.png)
+
+Bu örnekte, "`Donut BG`" ve "`BG`" kırpma düğümlerinin ikisi de aynı katmanı, katman 1'i kullanır. Aralarındaki işleme sırası hiyerarşideki sırayla aynı olur; "`Donut BG`", "`BG`" düğümünden önce işlenir. Ancak "`Donut Shadow`" alt düğümü, katman sırası daha yüksek olan katman 2'ye atanmıştır ve bu nedenle her iki kırpma düğümünden sonra işlenir. Bu durumda işleme sırası şöyle olur:
+
+- `Donut BG`
+- `BG`
+- `BG Frame`
+- `Donut Shadow`
+
+Burada "`Donut Shadow`" nesnesinin, yalnızca birinin alt düğümü olmasına rağmen, katmanlama nedeniyle her iki kırpma düğümü tarafından kırpılacağını görebilirsiniz.

--- a/docs/tr/manuals/gui-layouts.md
+++ b/docs/tr/manuals/gui-layouts.md
@@ -1,0 +1,139 @@
+---
+title: Defold'da GUI yerleşimleri
+brief: Defold, mobil cihazlarda ekran yönelimi değişikliklerine otomatik olarak uyum sağlayan GUI'leri destekler. Bu belge, özelliğin nasıl çalıştığını açıklar.
+---
+
+# Yerleşimler
+
+Defold, mobil cihazlarda ekran yönelimi değişikliklerine otomatik olarak uyum sağlayan grafik kullanıcı arayüzlerini (GUI) destekler. Bu özelliği kullanarak çeşitli ekran boyutlarının yönelimine ve en boy oranına uyum sağlayan GUI tasarlayabilirsiniz. Belirli cihaz modellerine uyan yerleşimler (layout) oluşturmak da mümkündür.
+
+## Ekran profilleri oluşturma {#creating-display-profiles}
+
+Varsayılan olarak *game.project* ayarları, ekran profilleri (display profiles) için yerleşik bir ayar dosyasının ("builtins/render/default.display_profiles") kullanılacağını belirtir. Varsayılan profiller "Landscape" (1280 piksel genişlik ve 720 piksel yükseklik) ve "Portrait" (720 piksel genişlik ve 1280 piksel yükseklik) olarak tanımlanmıştır. Profillerde herhangi bir cihaz modeli ayarlanmadığından bu profiller her cihazla eşleşir.
+
+Yeni bir profil ayar dosyası oluşturmak için "builtins" klasöründeki dosyayı kopyalayın veya *Assets* görünümünde uygun bir konuma <kbd>sağ tıklayın</kbd> ve <kbd>New... ▸ Display Profiles</kbd> seçeneğini seçin. Yeni dosyaya uygun bir ad verin ve <kbd>Ok</kbd> düğmesine tıklayın.
+
+Düzenleyici şimdi yeni dosyayı düzenlemek üzere açar. *Profiles* listesindeki <kbd>+</kbd> düğmesine tıklayarak yeni profiller ekleyin. Her profile bir *niteleyici* (qualifier) kümesi ekleyin:
+
+Width
+: Niteleyicinin piksel cinsinden genişliği.
+
+Height
+: Niteleyicinin piksel cinsinden yüksekliği.
+
+Device Models
+: Virgülle ayrılmış cihaz modelleri listesi. Cihaz modeli, cihaz modeli adının başlangıcıyla eşleştirilir; örneğin `iPhone10`, "iPhone10,\*" modelleriyle eşleşir. Virgül içeren model adları tırnak içine alınmalıdır; örneğin `"iPhone10,3", "iPhone10,6"`, iPhone X modelleriyle eşleşir ([iPhone vikisine](https://www.theiphonewiki.com/wiki/Models) bakın). `sys.get_sys_info()` çağrıldığında cihaz modeli bildiren tek platformların Android ve iOS olduğunu unutmayın. Diğer platformlar boş bir dize döndürür ve bu nedenle cihaz modeli niteleyicisi olan bir ekran profilini hiçbir zaman seçmez.
+
+![Yeni ekran profilleri](images/gui-layouts/new_profiles.png)
+
+Motorun yeni profillerinizi kullanması gerektiğini de belirtmeniz gerekir. *game.project* dosyasını açın ve *display* altındaki *Display Profiles* ayarında ekran profilleri dosyasını seçin:
+
+![Ayarlar](images/gui-layouts/settings.png)
+
+Cihaz döndürüldüğünde motorun dikey ve yatay yerleşimler arasında otomatik geçiş yapmasını istiyorsanız *Dynamic Orientation* kutusunu işaretleyin. Motor, eşleşen bir yerleşimi dinamik olarak seçer ve cihazın yönelimi değişirse seçimi de değiştirir.
+
+### Auto Layout Selection (Display Profiles)
+
+Display Profiles kaynağında "Auto Layout Selection" seçeneği bulunur (varsayılan olarak ON). ON olduğunda motor, hem sahne oluşturulduğunda hem de pencere/ekran boyutu değiştiğinde en iyi eşleşen GUI yerleşimini otomatik olarak seçer. OFF olduğunda motor yerleşimleri otomatik olarak değiştirmez; yerleşimler arasında elle geçiş yapmak için GUI betiğinizden `gui.set_layout()` işlevini kullanın. Bu ayar Display Profiles dosyasında saklanır ve tüm GUI sahnelerini etkiler.
+
+## GUI yerleşimleri
+
+Geçerli ekran profilleri kümesi, GUI düğümü (GUI node) düzeninizin yerleşim çeşitlerini oluşturmak için kullanılabilir. Bir GUI sahnesine yeni bir yerleşim eklemek için *Outline* görünümündeki *Layouts* simgesine sağ tıklayın ve <kbd>Add ▸ Layout ▸ ...</kbd> seçeneğini seçin:
+
+![Sahneye yerleşim ekleme](images/gui-layouts/add_layout.png)
+
+Bir GUI sahnesi düzenlenirken tüm düğümler belirli bir yerleşimde düzenlenir. O anda seçili yerleşim, araç çubuğundaki GUI sahnesi yerleşimi açılır listesinde gösterilir. Hiçbir yerleşim seçilmemişse düğümler *Default* yerleşiminde düzenlenir.
+
+![Yerleşimler araç çubuğu](images/gui-layouts/toolbar.png)
+
+![Dikey yerleşimi düzenleme](images/gui-layouts/portrait.png)
+
+Bir yerleşim seçiliyken bir düğüm özelliğinde yaptığınız her değişiklik, özelliğin *Default* yerleşimindeki değerini o yerleşim için _geçersiz kılar_ (override). Geçersiz kılınan özellikler maviyle işaretlenir. Geçersiz kılınan özellikleri olan düğümler de maviyle işaretlenir. Geçersiz kılınan herhangi bir özelliği özgün değerine döndürmek için yanındaki sıfırlama düğmesine tıklayabilirsiniz.
+
+![Yatay yerleşimi düzenleme](images/gui-layouts/landscape.png)
+
+Bir yerleşim düğümleri silemez veya yeni düğüm oluşturamaz; yalnızca özellikleri geçersiz kılabilir. Bir düğümü bir yerleşimden kaldırmanız gerekiyorsa düğümü ekran dışına taşıyabilir veya betik mantığıyla silebilirsiniz. O anda seçili yerleşime de dikkat etmeniz önerilir. Projenize bir yerleşim eklerseniz yeni yerleşim, o anda seçili yerleşime göre ayarlanır. Ayrıca düğümler kopyalanıp yapıştırılırken, hem kopyalama *hem de* yapıştırma sırasında o anda seçili yerleşim dikkate alınır.
+
+## Dinamik profil seçimi
+
+Auto Layout Selection etkinleştirildiğinde motor, en iyi eşleşen yerleşimi otomatik olarak seçer. Dinamik yerleşim eşleştirmesi, her ekran profili niteleyicisine aşağıdaki kurallara göre bir puan verir:
+
+1. Ayarlanmış bir cihaz modeli yoksa veya cihaz modeli eşleşiyorsa niteleyici için bir puan (S) hesaplanır.
+
+2. Puan (S); ekranın alanı (A), niteleyicideki alan (A_Q), ekranın en boy oranı (R) ve niteleyicinin en boy oranı (R_Q) kullanılarak hesaplanır:
+
+<img src="https://latex.codecogs.com/svg.latex?\inline&space;S=\left|1&space;-&space;\frac{A}{A_Q}\right|&space;&plus;&space;\left|1&space;-&space;\frac{R}{R_Q}\right|" title="S=\left|1 - \frac{A}{A_Q}\right| + \left|1 - \frac{R}{R_Q}\right|" />
+
+3. Niteleyicinin yönelimi (yatay veya dikey) ekranla eşleşiyorsa en düşük puanlı niteleyiciye sahip profil seçilir.
+
+4. Aynı yönelimde bir niteleyicisi olan profil bulunamazsa diğer yönelimdeki en iyi puanlı niteleyiciye sahip profil seçilir.
+
+5. Hiçbir profil seçilemezse yedek *Default* profili kullanılır.
+
+Daha iyi eşleşen bir yerleşim yoksa çalışma sırasında yedek olarak *Default* yerleşimi kullanılır. Bu nedenle bir "Landscape" yerleşimi eklerseniz bir "Portrait" yerleşimi de ekleyene kadar "Landscape", *tüm* yönelimler için en iyi eşleşme olur.
+
+## Yerleşim değişikliği iletileri
+
+Yerleşim değiştiğinde GUI bileşeninin (component) betiğine bir `layout_changed` iletisi gönderilir. Bu, motor yerleşimi otomatik olarak değiştirdiğinde (Auto Layout Selection ON) veya betiğiniz `gui.set_layout()` işlevini çağırıp yerleşim gerçekten değiştiğinde gerçekleşir. İleti, yerleşimin karma değeri alınmış tanımlayıcısını (hashed identifier) içerir; böylece betik, hangi yerleşimin seçildiğine bağlı olarak mantık çalıştırabilir:
+
+```lua
+function on_message(self, message_id, message, sender)
+  if message_id == hash("layout_changed") and message.id == hash("My Landscape") then
+    -- switching layout to landscape
+  elseif message_id == hash("layout_changed") and message.id == hash("My Portrait") then
+    -- switching layout to portrait
+  end
+end
+```
+
+Ayrıca görüntü oluşturma akışını yöneten geçerli işleme betiği (render script), pencere (oyun görünümü) her değiştiğinde bir ileti alır; buna yönelim değişiklikleri de dahildir.
+
+```lua
+function on_message(self, message_id, message)
+  if message_id == hash("window_resized") then
+    -- The window was resized. message.width and message.height contain the
+    -- new dimensions of the window.
+  end
+end
+```
+
+Yönelim değiştiğinde GUI yerleşim yöneticisi, GUI düğümlerini yerleşiminize ve düğüm özelliklerine göre otomatik olarak ölçekler ve yeniden konumlandırır. Oyun içi içerik ise (varsayılan olarak) ayrı bir geçişte, geçerli pencereye gerilerek sığdırılan bir izdüşümle işlenir. Bu davranışı değiştirmek için kendi değiştirilmiş işleme betiğinizi sağlayın veya bir kamera [kütüphanesi](/assets/) kullanın.
+
+## Elle yerleşim seçimi (Lua)
+
+Kullanılan Display Profiles için Auto Layout Selection OFF olduğunda motor yerleşimleri otomatik olarak değiştirmez. Yerleşimleri elle yönetmek için bir GUI betiğinden şu işlevleri kullanın:
+
+### gui.set_layout(layout)
+
+- Bir dize veya karma değeri (yerleşim tanımlayıcısı) kabul eder.
+- Mantıksal değer (boolean) döndürür: Yerleşim sahnede varsa ve uygulandıysa `true`; aksi durumda `false`.
+- Yerleşim Display Profiles içinde varsa sahne çözünürlüğünü profilin genişliği/yüksekliğiyle günceller.
+- Yerleşim gerçekten değiştiğinde `layout_changed` iletisini gönderir.
+
+Örnek:
+
+```lua
+function init(self)
+    -- Manually apply the "Portrait" layout
+    local ok = gui.set_layout("Portrait")
+    if not ok then
+        print("Portrait layout not found in this scene")
+    end
+end
+```
+
+### gui.get_layouts()
+
+- Her yerleşim tanımlayıcısının karma değerini `vmath.vector3(width, height, 0)` değerine eşleyen bir tablo döndürür.
+- Varsayılan yerleşim için geçerli sahne çözünürlüğünü döndürür.
+
+Örnek:
+
+```lua
+local layouts = gui.get_layouts()
+for id, size in pairs(layouts) do
+    print(id, size.x, size.y)
+end
+```
+
+Not: Bir GUI yerleşimi sahnede var ama Display Profiles içinde bulunmuyorsa `gui.set_layout()`, yerleşime özgü düğüm özelliklerinin geçersiz kılınmasını yine de uygular, ancak sahne çözünürlüğünü değiştirmez.

--- a/docs/tr/manuals/gui-particlefx.md
+++ b/docs/tr/manuals/gui-particlefx.md
@@ -1,0 +1,34 @@
+---
+title: Defold'da GUI parçacık efektleri
+brief: Bu kılavuz, parçacık efektlerinin Defold GUI içinde nasıl çalıştığını açıklar.
+---
+
+# GUI ParticleFX düğümleri
+
+Parçacık efekti düğümü (particle effect node), GUI ekran uzayında (screen space) parçacık efekti sistemlerini oynatmak için kullanılır.
+
+## Parçacık efekti düğümleri ekleme
+
+Yeni parçacık düğümleri eklemek için *Outline* görünümünde <kbd>sağ tıklayın</kbd> ve <kbd>Add ▸ ParticleFX</kbd> seçeneğini seçin ya da <kbd>A</kbd> tuşuna basıp <kbd>ParticleFX</kbd> seçeneğini seçin.
+
+GUI içine eklediğiniz parçacık efektlerini efektin kaynağı olarak kullanabilirsiniz. Parçacık efektleri eklemek için *Outline* görünümündeki *Particle FX* klasör simgesine <kbd>sağ tıklayın</kbd> ve <kbd>Add ▸ Particle FX...</kbd> seçeneğini seçin. Ardından düğümün *Particlefx* özelliğini ayarlayın:
+
+![Parçacık efekti](images/gui-particlefx/create.png)
+
+## Efekti denetleme {#controlling-the-effect}
+
+Düğümü bir betikten denetleyerek efekti başlatabilir ve durdurabilirsiniz:
+
+```lua
+-- start the particle effect
+local particles_node = gui.get_node("particlefx")
+gui.play_particlefx(particles_node)
+```
+
+```lua
+-- stop the particle effect
+local particles_node = gui.get_node("particlefx")
+gui.stop_particlefx(particles_node)
+```
+
+Parçacık efektlerinin nasıl çalıştığıyla ilgili ayrıntılar için [Parçacık efektleri kılavuzuna](/manuals/particlefx) bakın.

--- a/docs/tr/manuals/gui-pie.md
+++ b/docs/tr/manuals/gui-pie.md
@@ -1,0 +1,56 @@
+---
+title: Defold GUI daire dilimi düğümleri
+brief: Bu kılavuz, Defold GUI sahnelerinde daire dilimi düğümlerinin nasıl kullanılacağını açıklar.
+---
+
+# GUI daire dilimi düğümleri
+
+Daire dilimi düğümleri (pie nodes), basit dairelerden daire dilimlerine ve kare halka şekillerine kadar uzanan dairesel veya elipsoit biçimli nesneler oluşturmak için kullanılır.
+
+## Daire dilimi düğümü oluşturma
+
+*Outline* görünümündeki *Nodes* bölümüne <kbd>sağ tıklayın</kbd> ve <kbd>Add ▸ Pie</kbd> seçeneğini seçin. Yeni daire dilimi düğümü seçilir ve özelliklerini değiştirebilirsiniz.
+
+![Daire dilimi düğümü oluşturma](images/gui-pie/create.png)
+
+Aşağıdaki özellikler daire dilimi düğümlerine özgüdür:
+
+Inner Radius
+: Düğümün X ekseni boyunca belirtilen iç yarıçapı.
+
+Outer Bounds
+: Düğümün dış sınırlarının şekli.
+
+  - `Ellipse`, düğümü dış yarıçapa kadar uzatır.
+  - `Rectangle`, düğümü sınırlayıcı kutusuna (bounding box) kadar uzatır.
+
+Perimeter Vertices
+: Şekli oluşturmak için kullanılacak bölüm sayısı; düğümün 360 derecelik çevresini tamamen çevrelemek için gereken köşe (vertex) sayısı olarak belirtilir.
+
+Pie Fill Angle
+: Daire diliminin ne kadarının doldurulacağı. Sağdan başlayıp saat yönünün tersine ilerleyen bir açı olarak belirtilir.
+
+![Özellikler](images/gui-pie/properties.png)
+
+Düğüme bir doku (texture) atarsanız doku görüntüsü, dokunun köşeleri düğümün sınırlayıcı kutusunun köşelerine karşılık gelecek şekilde düz olarak uygulanır.
+
+## Çalışma sırasında daire dilimi düğümlerini değiştirme
+
+Daire dilimi düğümleri, boyut, dayanak noktası (pivot), renk ve benzeri ayarları değiştiren tüm genel düğüm işlevlerini destekler. Yalnızca daire dilimi düğümlerine özgü birkaç işlev ve özellik de bulunur:
+
+```lua
+local pienode = gui.get_node("my_pie_node")
+
+-- get the outer bounds
+local fill_angle = gui.get_fill_angle(pienode)
+
+-- increase perimeter vertices
+local vertices = gui.get_perimeter_vertices(pienode)
+gui.set_perimeter_vertices(pienode, vertices + 1)
+
+-- change outer bounds
+gui.set_outer_bounds(pienode, gui.PIEBOUNDS_RECTANGLE)
+
+-- animate the inner radius
+gui.animate(pienode, "inner_radius", 100, gui.EASING_INOUTSINE, 2, 0, nil, gui.PLAYBACK_LOOP_PINGPONG)
+```

--- a/docs/tr/manuals/gui-script.md
+++ b/docs/tr/manuals/gui-script.md
@@ -1,0 +1,149 @@
+---
+title: Defold'da GUI betikleri
+brief: Bu kılavuz, GUI betiklerinin kullanımını açıklar.
+---
+
+# GUI betikleri
+
+Grafik kullanıcı arayüzünüzün (GUI) mantığını denetlemek ve düğümleri (node) canlandırmak için Lua betikleri (script) kullanırsınız. GUI betikleri, normal oyun nesnesi (game object) betikleriyle aynı şekilde çalışır; ancak farklı bir dosya türünde kaydedilir ve farklı bir işlev kümesine, yani `gui` modülünün işlevlerine erişir.
+
+## GUI için betik ekleme
+
+Bir GUI'ye betik eklemek için önce *Assets* tarayıcısında bir konuma <kbd>sağ tıklayın</kbd> ve açılan bağlam menüsünden <kbd>New ▸ Gui Script</kbd> seçeneğini seçerek bir GUI betik dosyası oluşturun.
+
+Düzenleyici, yeni betik dosyasını otomatik olarak açar. Bu dosya bir şablona dayanır ve oyun nesnesi betikleri gibi boş yaşam döngüsü (lifecycle) işlevleri içerir:
+
+```lua
+function init(self)
+   -- Add initialization code here
+   -- Remove this function if not needed
+end
+
+function final(self)
+   -- Add finalization code here
+   -- Remove this function if not needed
+end
+
+function update(self, dt)
+   -- Add update code here
+   -- Remove this function if not needed
+end
+
+function on_message(self, message_id, message, sender)
+   -- Add message-handling code here
+   -- Remove this function if not needed
+end
+
+function on_input(self, action_id, action)
+   -- Add input-handling code here
+   -- Remove this function if not needed
+end
+
+function on_reload(self)
+   -- Add input-handling code here
+   -- Remove this function if not needed
+end
+```
+
+Betiği bir GUI bileşenine (component) bağlamak için GUI bileşeninin prototip dosyasını (diğer motorlarda "prefabs" veya "blueprints" olarak da bilinir) açın ve GUI *Properties* panelini görüntülemek için *Outline* görünümünde kökü seçin. *Script* özelliğini betik dosyasına ayarlayın
+
+![Betik](images/gui-script/set_script.png)
+
+GUI bileşeni oyununuzda bir oyun nesnesine eklenmişse betik artık çalışacaktır.
+
+## "gui" ad alanı
+
+GUI betikleri, `gui` ad alanına (namespace) ve [tüm `gui` işlevlerine](/ref/gui) erişebilir. `go` ad alanı kullanılamadığından oyun nesnesi mantığını betik bileşenlerine ayırmanız ve GUI betikleri ile oyun nesnesi betikleri arasında iletişim kurmanız gerekir. `go` işlevlerini kullanmaya yönelik her girişim hataya neden olur:
+
+```lua
+function init(self)
+   local id = go.get_id()
+end
+```
+
+```txt
+ERROR:SCRIPT: /main/my_gui.gui_script:2: You can only access go.* functions and values from a script instance (.script file)
+stack traceback:
+   [C]: in function 'get_id'
+   /main/my_gui.gui_script:2: in function </main/my_gui.gui_script:1>
+```
+
+## İleti aktarımı
+
+Bir betik bağlanmış her GUI bileşeni, ileti aktarımı (message passing) yoluyla oyununuzun çalışma zamanı ortamındaki diğer nesnelerle iletişim kurabilir; diğer betik bileşenleri gibi davranır.
+
+GUI bileşenini diğer betik bileşenleri gibi adreslersiniz:
+
+```lua
+local stats = { score = 4711, stars = 3, health = 6 }
+msg.post("hud#gui", "set_stats", stats)
+```
+
+![İleti aktarımı](images/gui-script/message_passing.png)
+
+## Düğümleri adresleme
+
+GUI düğümleri, bileşene bağlanmış bir GUI betiğiyle değiştirilebilir. Her düğümün, düzenleyicide ayarlanan benzersiz bir *Id* değeri olması gerekir:
+
+![İleti aktarımı](images/gui-script/node_id.png)
+
+*Id* değeri, bir betiğin düğüme başvuru edinmesini ve düğümü [`gui` ad alanı işlevleriyle](/ref/gui) değiştirmesini sağlar:
+
+```lua
+-- extend the health bar by 10 units
+local healthbar_node = gui.get_node("healthbar")
+local size = gui.get_size(healthbar_node)
+size.x = size.x + 10
+gui.set_size(healthbar_node, size)
+```
+
+## Dinamik olarak oluşturulan düğümler
+
+Çalışma sırasında betikle yeni bir düğüm oluşturmak için iki seçeneğiniz vardır. İlk seçenek, `gui.new_[type]_node()` işlevlerini çağırarak sıfırdan düğümler oluşturmaktır. Bu işlevler yeni düğüme ait bir başvuru döndürür; bu başvuruyu düğümü değiştirmek için kullanabilirsiniz:
+
+```lua
+-- Create a new box node
+local new_position = vmath.vector3(400, 300, 0)
+local new_size = vmath.vector3(450, 400, 0)
+local new_boxnode = gui.new_box_node(new_position, new_size)
+gui.set_color(new_boxnode, vmath.vector4(0.2, 0.26, 0.32, 1))
+
+-- Create a new text node
+local new_textnode = gui.new_text_node(new_position, "Hello!")
+gui.set_font(new_textnode, "sourcesans")
+gui.set_color(new_textnode, vmath.vector4(0.69, 0.6, 0.8, 1.0))
+```
+
+![Dinamik düğüm](images/gui-script/dynamic_nodes.png)
+
+Yeni düğümler oluşturmanın diğer yolu, `gui.clone()` işleviyle mevcut bir düğümü veya `gui.clone_tree()` işleviyle bir düğüm ağacını klonlamaktır:
+
+```lua
+-- clone the healthbar
+local healthbar_node = gui.get_node("healthbar")
+local healthbar_node_2 = gui.clone(healthbar_node)
+
+-- clone button node-tree
+local button = gui.get_node("my_button")
+local new_button_nodes = gui.clone_tree(button)
+
+-- get the new tree root
+local new_root = new_button_nodes["my_button"]
+
+-- move the root (and children) 300 to the right
+local root_position = gui.get_position(new_root)
+root_position.x = root_position.x + 300
+gui.set_position(new_root, root_position)
+```
+
+## Dinamik düğüm tanımlayıcıları
+
+Dinamik olarak oluşturulan düğümlere bir tanımlayıcı atanmaz. Bu, bilinçli bir tasarım tercihidir. Düğümlere erişmek için yalnızca `gui.new_[type]_node()`, `gui.clone()` ve `gui.clone_tree()` işlevlerinden döndürülen başvurular gerekir ve bu başvuruları saklamanız önerilir.
+
+```lua
+-- Add a text node
+local new_textnode = gui.new_text_node(vmath.vector3(100, 100, 0), "Hello!")
+-- "new_textnode" contains the reference to the node.
+-- The node has no id, and that is fine. There's no reason why we want
+-- to do gui.get_node() when we already have the reference.
+```

--- a/docs/tr/manuals/gui-spine.md
+++ b/docs/tr/manuals/gui-spine.md
@@ -1,0 +1,6 @@
+---
+title: Defold GUI Spine düğümleri
+brief: Bu kılavuz, Defold GUI sahnelerinde kemik animasyonu (bone animation) uygulanan Spine düğümlerinin (node) nasıl kullanılacağını açıklar.
+---
+
+[Bu kılavuz taşındı](/extension-spine).

--- a/docs/tr/manuals/gui-template.md
+++ b/docs/tr/manuals/gui-template.md
@@ -1,0 +1,56 @@
+---
+title: GUI şablonları kılavuzu
+brief: Bu kılavuz, ortak şablonları veya 'prefab' yapılarını temel alan, yeniden kullanılabilir görsel GUI bileşenleri oluşturmak için kullanılan Defold GUI şablon sistemini açıklar.
+---
+
+# GUI şablon düğümleri
+
+GUI şablon düğümleri (GUI template nodes), ortak şablonları veya "prefab" adı verilen hazır tanımları temel alan, yeniden kullanılabilir GUI bileşenleri (GUI components) oluşturmak için güçlü bir mekanizma sunar. Bu kılavuz, bu özelliği ve nasıl kullanılacağını açıklar.
+
+GUI şablonu (GUI template), başka bir GUI sahnesinde (GUI scene) her düğümünün bir örneği (instance) oluşturulan bir GUI sahnesidir. Özgün şablon düğümlerindeki tüm özellik değerleri daha sonra geçersiz kılınabilir.
+
+## Şablon oluşturma
+
+GUI şablonu sıradan bir GUI sahnesidir, bu nedenle diğer GUI sahneleri gibi oluşturulur. *Assets* bölmesindeki bir konuma <kbd>sağ tıklayın</kbd> ve <kbd>New... ▸ Gui</kbd> seçeneğini seçin.
+
+![Şablon oluşturma](images/gui-templates/create.png)
+
+Şablonu oluşturun ve kaydedin. Örneğin düğümlerinin başlangıç noktasına göre yerleştirileceğini unutmayın; bu nedenle şablonu 0, 0, 0 konumunda oluşturmanız iyi olur.
+
+## Şablondan örnekler oluşturma
+
+Örneği temel alarak istediğiniz sayıda örnek oluşturabilirsiniz. Şablonu yerleştirmek istediğiniz GUI sahnesini oluşturun veya açın, ardından *Outline* görünümündeki *Nodes* bölümüne <kbd>sağ tıklayın</kbd> ve <kbd>Add ▸ Template</kbd> seçeneğini seçin.
+
+![Örnek oluşturma](images/gui-templates/create_instance.png)
+
+*Template* özelliğini şablon GUI sahnesi dosyasına ayarlayın.
+
+İstediğiniz sayıda şablon örneği ekleyebilir ve her örnekteki her düğümün özelliklerini geçersiz kılarak örnek düğümünün konumunu, rengini, boyutunu, dokusunu ve benzer özelliklerini değiştirebilirsiniz.
+
+![Örnekler](images/gui-templates/instances.png)
+
+Değiştirdiğiniz her özellik düzenleyicide maviyle işaretlenir. Değerini şablondaki değere döndürmek için özelliğin yanındaki sıfırlama düğmesine basın:
+
+![Properties](images/gui-templates/properties.png)
+
+Özellikleri geçersiz kılınmış tüm düğümler de *Outline* görünümünde mavi renkte gösterilir:
+
+![Outline](images/gui-templates/outline.png)
+
+Şablon örneği, *Outline* görünümünde daraltılabilir bir öğe olarak listelenir. Ancak bu görünümdeki öğenin *bir düğüm olmadığını* unutmamak önemlidir. Şablon örneği çalışma sırasında da var olmaz, ancak örneğin parçası olan tüm düğümler var olur.
+
+Şablon örneğinin parçası olan düğümler, *Id* değerlerine bir önek ve eğik çizgi (`"/"`) eklenerek otomatik olarak adlandırılır. Önek, şablon örneğinde ayarlanan *Id* değeridir.
+
+## Şablonları çalışma sırasında değiştirme
+
+Şablon mekanizmasıyla eklenen düğümleri değiştiren veya sorgulayan betiklerin yalnızca örnek düğümlerinin adlandırılmasını dikkate alması ve şablon örneğinin *Id* değerini düğüm adı öneki olarak eklemesi gerekir:
+
+```lua
+if gui.pick_node(gui.get_node("button_1/button"), x, y) then
+    -- Do something...
+end
+```
+
+Şablon örneğinin kendisine karşılık gelen bir düğüm yoktur. Bir örnek için kök düğüme ihtiyacınız varsa bunu şablona ekleyin.
+
+Bir betik şablon GUI sahnesiyle ilişkilendirilmişse bu betik, örneğin düğüm ağacının parçası olmaz. Her GUI sahnesine yalnızca tek bir betik bağlayabilirsiniz; dolayısıyla betik mantığınızın, şablonlarınızın örneklerini oluşturduğunuz GUI sahnesinde bulunması gerekir.

--- a/docs/tr/manuals/gui-text.md
+++ b/docs/tr/manuals/gui-text.md
@@ -1,0 +1,59 @@
+---
+title: Defold GUI metin düğümleri
+brief: Bu kılavuz, GUI sahnelerine nasıl metin ekleneceğini açıklar.
+---
+
+# GUI metin düğümleri
+
+Defold, GUI sahnesinde metin işleme (rendering) için özel bir GUI düğümü (GUI node) türünü destekler. Projeye eklenen herhangi bir yazı tipi kaynağı, metin düğümlerini (text node) işlemek için kullanılabilir.
+
+Düzenleyici önizlemesi, motorun yazı tipi işleyicisini kullanarak metin şekillendirmeyi ve sağdan sola yerleşimi destekler. Gerekli yazı tipi ve App Manifest ayarları için [metin yerleşimi desteğine](/manuals/font/#text-layout-support-eg-right-to-left) bakın.
+
+## Metin düğümleri ekleme
+
+GUI metin düğümlerinde kullanmak istediğiniz yazı tiplerinin GUI bileşenine (GUI component) eklenmesi gerekir. Bunun için *Fonts* klasörüne sağ tıklayın, üstteki <kbd>GUI</kbd> menüsünü kullanın veya ilgili klavye kısayoluna basın.
+
+![Yazı tipleri](images/gui-text/fonts.png)
+
+Metin düğümlerinin bir dizi özel özelliği vardır:
+
+*Font*
+: Oluşturduğunuz her metin düğümünün *Font* özelliği ayarlanmalıdır.
+
+*Text*
+: Bu özellik, görüntülenen metni içerir.
+
+*Line Break*
+: Metin hizalaması, dayanak noktası (pivot) ayarını izler ve bu özelliğin ayarlanması, metnin birden çok satıra yayılmasını sağlar. Düğümün genişliği, metnin nerede alt satıra kaydırılacağını belirler.
+
+## Hizalama
+
+Düğümün dayanak noktasını ayarlayarak metnin hizalama modunu değiştirebilirsiniz.
+
+*Ortalanmış*
+: Dayanak noktası `Center`, `North` veya `South` olarak ayarlanırsa metin ortalanır.
+
+*Sola hizalı*
+: Dayanak noktası `West` modlarından herhangi birine ayarlanırsa metin sola hizalanır.
+
+*Sağa hizalı*
+: Dayanak noktası `East` modlarından herhangi birine ayarlanırsa metin sağa hizalanır.
+
+![Metin hizalaması](images/gui-text/align.png)
+
+## Çalışma sırasında metin düğümlerini değiştirme
+
+Metin düğümleri, boyut, dayanak noktası, renk ve benzerlerini ayarlayan tüm genel düğüm düzenleme işlevleriyle değiştirilebilir. Yalnızca metin düğümlerine özgü birkaç işlev de vardır:
+
+* Bir metin düğümünün yazı tipini değiştirmek için [`gui.set_font()`](/ref/gui/#gui.set_font) işlevini kullanın.
+* Bir metin düğümünün satır kaydırma davranışını değiştirmek için [`gui.set_line_break()`](/ref/gui/#gui.set_line_break) işlevini kullanın.
+* Bir metin düğümünün içeriğini değiştirmek için [`gui.set_text()`](/ref/gui/#gui.set_text) işlevini kullanın.
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("set_score") then
+        local s = gui.get_node("score")
+        gui.set_text(s, message.score)
+    end
+end
+```

--- a/docs/tr/manuals/gui.md
+++ b/docs/tr/manuals/gui.md
@@ -1,0 +1,421 @@
+---
+title: Defold'da GUI sahneleri
+brief: Bu kılavuz Defold GUI düzenleyicisini, çeşitli GUI düğümü türlerini ve GUI betiklerini ele alır.
+---
+
+# GUI
+
+Defold, kullanıcı arayüzlerini oluşturmak ve uygulamak için özel olarak tasarlanmış bir GUI düzenleyicisi ve güçlü betik olanakları sunar.
+
+Defold'da grafik kullanıcı arayüzü (GUI), oluşturup bir oyun nesnesine (game object) eklediğiniz ve bir koleksiyona (collection) yerleştirdiğiniz bir bileşendir (component). Bu bileşenin özellikleri şunlardır:
+
+* Kullanıcı arayüzünüzün çözünürlükten ve en boy oranından bağımsız olarak işlenmesini (rendering) sağlayan basit ama güçlü yerleşim özellikleri vardır.
+* Bir *GUI betiği (GUI script)* aracılığıyla mantıksal davranış eklenebilir.
+* (Varsayılan olarak) kamera görünümünden bağımsız biçimde diğer içeriklerin üzerinde işlenir. Böylece hareketli bir kameranız olsa bile GUI öğeleriniz ekranda sabit kalır. İşleme davranışı değiştirilebilir.
+
+GUI bileşenleri oyun görünümünden bağımsız olarak işlenir. Bu nedenle koleksiyon düzenleyicisinde belirli bir konuma yerleştirilmez ve görsel bir gösterimleri de bulunmaz. Ancak GUI bileşenlerinin, koleksiyon içinde bir konumu olan bir oyun nesnesinde bulunması gerekir. Bu konumu değiştirmenin GUI üzerinde bir etkisi yoktur.
+
+## GUI bileşeni oluşturma
+
+GUI bileşenleri bir GUI sahnesi prototip dosyasından oluşturulur (diğer motorlarda "prefabs" veya "blueprints" olarak da bilinir). Yeni bir GUI bileşeni oluşturmak için *Assets* tarayıcısında bir konuma <kbd>sağ tıklayın</kbd> ve <kbd>New ▸ Gui</kbd> seçeneğini seçin. Yeni GUI dosyası için bir ad yazın ve <kbd>Ok</kbd> düğmesine basın.
+
+![Yeni GUI dosyası](images/gui/new_gui_file.png)
+
+Defold şimdi dosyayı otomatik olarak GUI sahne düzenleyicisinde açar.
+
+![Yeni GUI](images/gui/new_gui.png)
+
+*Outline* görünümü GUI'nin tüm içeriğini listeler: düğüm (node) listesini ve tüm bağımlılıklarını (aşağıya bakın).
+
+Ortadaki düzenleme alanı GUI'yi gösterir. Düzenleme alanının sağ üst köşesindeki araç çubuğunda *Move*, *Rotate* ve *Scale* araçlarının yanı sıra bir [yerleşim](/manuals/gui-layouts) seçicisi bulunur.
+
+![Araç çubuğu](images/gui/toolbar.png)
+
+Beyaz bir dikdörtgen, proje ayarlarında belirlenen varsayılan ekran genişliği ve yüksekliğinde, o anda seçili yerleşimin sınırlarını gösterir.
+
+## GUI özellikleri
+
+*Outline* görünümünde "Gui" kök düğümünü seçtiğinizde GUI bileşeninin özellikleri *Properties* panelinde gösterilir:
+
+*Script*
+: Bu GUI bileşenine bağlı GUI betiği.
+
+*Material*
+: Bu GUI işlenirken kullanılan materyal (material). *Outline* panelinden bir GUI bileşenine birden fazla materyal ekleyip bunları tek tek düğümlere atamak da mümkündür.
+
+*Adjust Reference*
+: Her düğümün *Adjust Mode* değerinin nasıl hesaplanacağını belirler:
+
+  - `Per Node`, her düğümü üst düğümün uyarlanmış boyutuna veya yeniden boyutlandırılmış ekrana göre uyarlar.
+  - `Disable`, düğüm uyarlama modunu kapatır. Bu, tüm düğümlerin ayarlanmış boyutlarını korumasını zorunlu kılar.
+
+*Current Nodes*
+: Bu GUI'de şu anda kullanılan düğüm sayısı.
+
+*Max Nodes*
+: Bu GUI'de bulunabilecek en fazla düğüm sayısı.
+
+*Max Dynamic Textures*
+: Bu GUI bileşeninin izlediği en fazla dinamik doku sayısıdır; varsayılan değeri `128`'dir. Buna [`gui.new_texture()`](/ref/stable/gui/#gui.new_texture:texture_id-width-height-type-buffer-flip) ile oluşturulan dokular ve `go.set(..., "textures", ...)` veya `gui.set(msg.url(), "textures", ...)` ile GUI'ye atanan harici dokular dahildir. Çok sayıda harici dokuyu değiştiren projelerde bu sınırın artırılması gerekebilir.
+
+
+## Çalışma sırasında değiştirme
+
+GUI özelliklerini çalışma sırasında bir betik bileşeninden `go.get()` ve `go.set()` kullanarak değiştirebilirsiniz:
+
+Fonts
+: GUI'de kullanılan bir yazı tipini alın veya ayarlayın.
+
+![Yazı tipini alma ve ayarlama](images/gui/get_set_font.png)
+
+```lua
+go.property("mybigfont", resource.font("/assets/mybig.font"))
+
+function init(self)
+  -- get the font file currently assigned to the font with id 'default'
+  print(go.get("#gui", "fonts", { key = "default" })) -- /builtins/fonts/default.font
+
+  -- set the font with id 'default' to the font file assigned to the resource property 'mybigfont'
+  go.set("#gui", "fonts", self.mybigfont, { key = "default" })
+
+  -- get the new font file assigned to the font with id 'default'
+  print(go.get("#gui", "fonts", { key = "default" })) -- /assets/mybig.font
+end
+```
+
+Materials
+: GUI'de kullanılan bir materyali alın veya ayarlayın.
+
+![Materyali alma ve ayarlama](images/gui/get_set_material.png)
+
+```lua
+go.property("myeffect", resource.material("/assets/myeffect.material"))
+
+function init(self)
+  -- get the material file currently assigned to the material with id 'effect'
+  print(go.get("#gui", "materials", { key = "effect" })) -- /effect.material
+
+  -- set the material id 'effect' to the material file assigned to the resource property 'myeffect'
+  go.set("#gui", "materials", self.myeffect, { key = "effect" })
+
+  -- get the new material file assigned to the material with id 'effect'
+  print(go.get("#gui", "materials", { key = "effect" })) -- /assets/myeffect.material
+end
+```
+
+Textures
+: GUI'de kullanılan bir dokuyu (atlas) alın veya ayarlayın.
+
+![Dokuyu alma ve ayarlama](images/gui/get_set_texture.png)
+
+```lua
+go.property("mytheme", resource.atlas("/assets/mytheme.atlas"))
+
+function init(self)
+  -- get the texture file currently assigned to the texture with id 'theme'
+  print(go.get("#gui", "textures", { key = "theme" })) -- /theme.atlas
+
+  -- set the texture with id 'theme' to the texture file assigned to the resource property 'mytheme'
+  go.set("#gui", "textures", self.mytheme, { key = "theme" })
+
+  -- get the new texture file assigned to the texture with id 'theme'
+  print(go.get("#gui", "textures", { key = "theme" })) -- /assets/mytheme.atlas
+end
+```
+
+## Bağımlılıklar
+
+Defold oyunlarında kaynak ağacı sabittir; bu nedenle GUI düğümleri için gereken tüm bağımlılıkların bileşene eklenmesi gerekir. *Outline* görünümü tüm bağımlılıkları türlerine göre "klasörler" altında gruplar:
+
+![Bağımlılıklar](images/gui/dependencies.png)
+
+Yeni bir bağımlılık eklemek için bağımlılığı *Asset* bölmesinden düzenleyici görünümüne sürükleyip bırakın.
+
+Alternatif olarak *Outline* görünümündeki "Gui" köküne <kbd>sağ tıklayın</kbd> ve açılan bağlam menüsünden <kbd>Add ▸ [type]</kbd> seçeneğini seçin.
+
+Eklemek istediğiniz türün klasör simgesine <kbd>sağ tıklayıp</kbd> <kbd>Add ▸ [type]</kbd> seçeneğini de seçebilirsiniz.
+
+## Düğüm türleri {#node-types}
+
+GUI bileşeni bir düğüm kümesinden oluşur. Düğümler basit öğelerdir. Düzenleyicide ya da çalışma sırasında betiklerle dönüşümleri değiştirilebilir (taşınabilir, ölçeklenebilir ve döndürülebilir) ve üst-alt düğüm hiyerarşilerinde sıralanabilirler. Şu düğüm türleri bulunur:
+
+Kutu düğümü
+: ![Kutu düğümü](images/icons/gui-box-node.png){.left}
+  Kutu düğümü (box node), tek bir renk, doku veya kare dizisi animasyonu (flip-book animation) içeren dikdörtgen düğümdür. Ayrıntılar için [kutu düğümü belgelerine](/manuals/gui-box) bakın.
+
+<div style="clear: both;"></div>
+
+Metin düğümü
+: ![Metin düğümü](images/icons/gui-text-node.png){.left}
+  Metin düğümü (text node), metin gösterir. Ayrıntılar için [metin düğümü belgelerine](/manuals/gui-text) bakın.
+
+<div style="clear: both;"></div>
+
+Daire dilimi düğümü
+: ![Daire dilimi düğümü](images/icons/gui-pie-node.png){.left}
+  Daire dilimi düğümü (pie node), kısmen doldurulabilen veya ters çevrilebilen, daire ya da elipsoit biçiminde bir düğümdür. Ayrıntılar için [daire dilimi düğümü belgelerine](/manuals/gui-pie) bakın.
+
+<div style="clear: both;"></div>
+
+Şablon düğümü
+: ![Şablon düğümü](images/icons/gui.png){.left}
+  Şablon düğümleri (template node), başka GUI sahne dosyalarına dayalı örnekler (instance) oluşturmak için kullanılır. Ayrıntılar için [şablon düğümü belgelerine](/manuals/gui-template) bakın.
+
+<div style="clear: both;"></div>
+
+ParticleFX düğümü
+: ![ParticleFX düğümü](images/icons/particlefx.png){.left}
+  Bir parçacık efekti oynatır. Ayrıntılar için [ParticleFX düğümü belgelerine](/manuals/gui-particlefx) bakın.
+
+<div style="clear: both;"></div>
+
+Düğüm eklemek için *Nodes* klasörüne sağ tıklayın ve önce <kbd>Add ▸</kbd>, ardından <kbd>Box</kbd>, <kbd>Text</kbd>, <kbd>Pie</kbd>, <kbd>Template</kbd> veya <kbd>ParticleFx</kbd> seçeneğini seçin.
+
+![Düğüm ekleme](images/gui/add_node.png)
+
+<kbd>A</kbd> tuşuna basıp GUI'ye eklemek istediğiniz türü de seçebilirsiniz.
+
+## Düğüm özellikleri {#node-properties}
+
+Her düğümün, görünümünü belirleyen kapsamlı bir özellik kümesi vardır:
+
+Id
+: Düğümün kimliği. Bu ad, GUI sahnesi içinde benzersiz olmalıdır.
+
+Position, Rotation ve Scale
+: Düğümün konumunu, yönelimini ve esnemesini belirler. Bu değerleri değiştirmek için *Move*, *Rotate* ve *Scale* araçlarını kullanabilirsiniz. Değerlere betikle animasyon uygulanabilir ([daha fazla bilgi](/manuals/property-animation)).
+
+Size (kutu, metin ve daire dilimi düğümleri)
+: Düğümün boyutu varsayılan olarak otomatiktir, ancak *Size Mode* değerini `Manual` olarak ayarlayarak boyutu değiştirebilirsiniz. Boyut, düğümün sınırlarını tanımlar ve girdiyle düğüm seçerken kullanılır. Bu değere betikle animasyon uygulanabilir ([daha fazla bilgi](/manuals/property-animation)).
+
+Size Mode (kutu ve daire dilimi düğümleri)
+: `Automatic` olarak ayarlandığında düzenleyici düğümün boyutunu belirler. `Manual` olarak ayarlandığında boyutu kendiniz belirleyebilirsiniz.
+
+Enabled
+: İşaretli değilse düğüm işlenmez, düğüme animasyon uygulanmaz ve düğüm `gui.pick_node()` ile seçilemez. Bu özelliği program yoluyla değiştirmek ve kontrol etmek için `gui.set_enabled()` ve `gui.is_enabled()` kullanın.
+
+Visible
+: İşaretli değilse düğüm işlenmez; ancak düğüme animasyon uygulanabilir ve düğüm `gui.pick_node()` ile seçilebilir. Bu özelliği program yoluyla değiştirmek ve kontrol etmek için `gui.set_visible()` ve `gui.get_visible()` kullanın.
+
+Text (metin düğümleri)
+: Düğümde gösterilecek metin.
+
+Line Break (metin düğümleri)
+: Metnin düğüm genişliğine göre satırlara kaydırılması için işaretleyin.
+
+Font (metin düğümleri)
+: Metin işlenirken kullanılacak yazı tipi.
+
+Texture (kutu ve daire dilimi düğümleri)
+: Düğüm üzerine çizilecek doku. Bu, bir atlas veya karo kaynağındaki (tile source) görüntüye ya da animasyona başvurudur.
+
+Material (kutu, daire dilimi, metin ve particlefx düğümleri)
+: Düğüm çizilirken kullanılacak materyal. *Outline* görünümünün Materials bölümüne eklenmiş bir materyal seçilebilir veya GUI bileşenine atanmış varsayılan materyali kullanmak için boş bırakılabilir.
+
+Slice 9 (kutu düğümleri)
+: Düğüm yeniden boyutlandırıldığında, düğümün dokusunun kenarlarındaki piksel boyutunu korumak için ayarlayın. Ayrıntılar için [kutu düğümü belgelerine](/manuals/gui-box) bakın.
+
+Inner Radius (daire dilimi düğümleri)
+: Düğümün X ekseni boyunca ifade edilen iç yarıçapı. Ayrıntılar için [daire dilimi düğümü belgelerine](/manuals/gui-pie) bakın.
+
+Outer Bounds (daire dilimi düğümleri)
+: Dış sınırların davranışını belirler. Ayrıntılar için [daire dilimi düğümü belgelerine](/manuals/gui-pie) bakın.
+
+Perimeter Vertices (daire dilimi düğümleri)
+: Şekli oluşturmak için kullanılacak parça sayısı. Ayrıntılar için [daire dilimi düğümü belgelerine](/manuals/gui-pie) bakın.
+
+Pie Fill Angle (daire dilimi düğümleri)
+: Daire diliminin ne kadarının doldurulacağı. Ayrıntılar için [daire dilimi düğümü belgelerine](/manuals/gui-pie) bakın.
+
+Template (şablon düğümleri)
+: Düğüm için şablon olarak kullanılacak GUI sahne dosyası. Ayrıntılar için [şablon düğümü belgelerine](/manuals/gui-template) bakın.
+
+ParticleFX (particlefx düğümleri)
+: Bu düğümde kullanılacak parçacık efekti. Ayrıntılar için [ParticleFX düğümü belgelerine](/manuals/gui-particlefx) bakın.
+
+Color
+: Düğümün rengi. Düğüm dokuluysa renk, dokuya renk çarpanı olarak uygulanır. Renge betikle animasyon uygulanabilir ([daha fazla bilgi](/manuals/property-animation)).
+
+Alpha
+: Düğümün saydamlığı. Alfa değerine betikle animasyon uygulanabilir ([daha fazla bilgi](/manuals/property-animation)).
+
+Inherit Alpha
+: Bu onay kutusunu işaretlemek, düğümün üst düğümün alfa değerini devralmasını sağlar. Düğümün alfa değeri, üst düğümün alfa değeriyle çarpılır.
+
+Leading (metin düğümleri)
+: Satır aralığı için ölçekleme katsayısı. `0` değeri satır aralığı bırakmaz. `1` (varsayılan değer) normal satır aralığı sağlar.
+
+Tracking (metin düğümleri)
+: Harf aralığı için ölçekleme katsayısı. Varsayılan değeri 0'dır.
+
+Layer
+: Düğüme bir katman (layer) atandığında normal çizim sırasının yerine katman sırası kullanılır. Ayrıntılar için aşağıya bakın.
+
+Blend mode
+: Düğümün grafiklerinin arka plan grafikleriyle nasıl harmanlanacağını belirler:
+  - `Alpha`, düğümün piksel değerlerini arka planla alfa harmanlaması kullanarak birleştirir. Bu, grafik yazılımlarındaki "Normal" harmanlama moduna karşılık gelir.
+  - `Add`, düğümün piksel değerlerini arka plan değerlerine ekler. Bu, bazı grafik yazılımlarındaki "Linear dodge" moduna karşılık gelir.
+  - `Multiply`, düğümün piksel değerlerini arka plan değerleriyle çarpar.
+  - `Screen`, düğümün piksel değerlerini arka plan değerleriyle ters çarpar. Bu, grafik yazılımlarındaki "Screen" harmanlama moduna karşılık gelir.
+
+Pivot
+: Düğümün dayanak noktasını (pivot) belirler. Bu nokta, düğümün "merkez noktası" olarak düşünülebilir. Her türlü döndürme, ölçekleme veya boyut değişikliği bu noktanın çevresinde gerçekleşir.
+
+  Olası değerler `Center`, `North`, `South`, `East`, `West`, `North West`, `North East`, `South West` veya `South East` değerleridir.
+
+  ![Dayanak noktası](images/gui/pivot.png)
+
+  Düğümün dayanak noktasını değiştirirseniz düğüm, yeni dayanak noktası düğümün konumunda olacak şekilde taşınır. Metin düğümleri, `Center` metni ortaya, `West` sola ve `East` sağa hizalayacak şekilde hizalanır.
+
+X Anchor, Y Anchor
+: Sabitleme (anchoring), sahne sınırları veya üst düğümün sınırları fiziksel ekran boyutuna sığacak şekilde esnetildiğinde düğümün dikey ve yatay konumunun nasıl değişeceğini belirler.
+
+  ![Sabitleme uygulanmadan önce](images/gui/anchoring_unadjusted.png)
+
+  Şu sabitleme modları kullanılabilir:
+
+  - `None` (hem *X Anchor* hem de *Y Anchor* için), düğümün üst düğümün veya sahnenin merkezine göre konumunu, bunların *uyarlanmış* boyutuna oranla korur.
+  - `Left` veya `Right` (*X Anchor*), düğümün yatay konumunu ölçekleyerek üst düğümün veya sahnenin sol ve sağ kenarlarına göre konumunu aynı yüzdede tutar.
+  - `Top` veya `Bottom` (*Y Anchor*), düğümün dikey konumunu ölçekleyerek üst düğümün veya sahnenin üst ve alt kenarlarına göre konumunu aynı yüzdede tutar.
+
+  ![Sabitleme](images/gui/anchoring.png)
+
+Adjust Mode
+: Düğümün uyarlama modunu (adjust mode) belirler. Uyarlama modu ayarı, sahne sınırları veya üst düğümün sınırları fiziksel ekran boyutuna sığacak şekilde uyarlandığında düğüme ne olacağını belirler.
+
+  Mantıksal çözünürlüğün tipik bir yatay ekran çözünürlüğü olduğu sahnede oluşturulmuş bir düğüm:
+
+  ![Uyarlanmamış](images/gui/unadjusted.png)
+
+  Sahneyi dikey bir ekrana sığdırmak, sahnenin esnetilmesine neden olur. Her düğümün sınırlayıcı kutusu da benzer şekilde esnetilir. Ancak uyarlama modu ayarlanarak düğüm içeriğinin en boy oranı korunabilir. Şu modlar kullanılabilir:
+
+  - `Fit`, düğüm içeriğini esnetilmiş sınırlayıcı kutunun genişliği veya yüksekliğinden küçük olanına eşit olacak şekilde ölçekler. Başka bir deyişle içerik, düğümün esnetilmiş sınırlayıcı kutusunun içine sığar.
+  - `Zoom`, düğüm içeriğini esnetilmiş sınırlayıcı kutunun genişliği veya yüksekliğinden büyük olanına eşit olacak şekilde ölçekler. Başka bir deyişle içerik, düğümün esnetilmiş sınırlayıcı kutusunu tamamen kaplar.
+  - `Stretch`, düğüm içeriğini düğümün esnetilmiş sınırlayıcı kutusunu dolduracak şekilde esnetir.
+
+  ![Uyarlama modları](images/gui/adjusted.png)
+
+  GUI sahnesinin *Adjust Reference* özelliği `Disabled` olarak ayarlanmışsa bu ayar yok sayılır.
+
+Clipping Mode (kutu ve daire dilimi düğümleri)
+: Düğümün kırpma modunu belirler:
+
+  - `None`, düğümü her zamanki gibi işler.
+  - `Stencil`, düğümün sınırlarının, düğümün alt düğümlerini kırpmak için kullanılan bir şablon maskesi tanımlamasını sağlar.
+
+  Ayrıntılar için [GUI kırpma kılavuzuna](/manuals/gui-clipping) bakın.
+
+Clipping Visible (kutu ve daire dilimi düğümleri)
+: Düğümün içeriğini şablon alanında işlemek için işaretleyin. Ayrıntılar için [GUI kırpma kılavuzuna](/manuals/gui-clipping) bakın.
+
+Clipping Inverted (kutu ve daire dilimi düğümleri)
+: Şablon maskesini ters çevirir. Ayrıntılar için [GUI kırpma kılavuzuna](/manuals/gui-clipping) bakın.
+
+
+## Pivot, Anchors ve Adjust Mode
+
+Pivot, Anchors ve Adjust Mode özelliklerinin birleşimi, GUI tasarımında büyük esneklik sağlar; ancak somut bir örneğe bakmadan bunların birlikte nasıl çalıştığını anlamak biraz zor olabilir. 640x1136 boyutunda bir ekran için oluşturulmuş bu GUI taslağını örnek alalım:
+
+![](images/gui/adjustmode_example_original.png)
+
+Kullanıcı arayüzü, X ve Y Anchors değerleri None olarak ayarlanarak oluşturulmuştur ve her düğümün Adjust Mode ayarı, varsayılan Fit değerinde bırakılmıştır. Üst panelin Pivot noktası North, alt panelinki South, üst paneldeki çubukların dayanak noktaları ise West olarak ayarlanmıştır. Diğer düğümlerin dayanak noktaları Center olarak ayarlanmıştır. Pencereyi daha geniş olacak şekilde yeniden boyutlandırırsak şu sonuç ortaya çıkar:
+
+![](images/gui/adjustmode_example_resized.png)
+
+Peki, üst ve alt çubukların her zaman ekran kadar geniş olmasını istersek ne yapabiliriz? Üstteki ve alttaki gri arka plan panellerinin Adjust Mode değerini Stretch olarak değiştirebiliriz:
+
+![](images/gui/adjustmode_example_resized_stretch.png)
+
+Bu daha iyi oldu. Gri arka plan panelleri artık her zaman pencere genişliğine kadar esnetilir; ancak üst paneldeki çubuklar ve alttaki iki kutu doğru konumlandırılmamıştır. Üstteki çubukların solda kalmasını istiyorsak X Anchor değerini None yerine Left olarak değiştirmemiz gerekir:
+
+![](images/gui/adjustmode_example_top_anchor_left.png)
+
+Üst panel için tam olarak istediğimiz sonuç budur. Üst paneldeki çubukların Pivot noktaları zaten West olarak ayarlanmıştı. Bu nedenle çubuklar, sol/batı kenarları (Pivot) üst panelin sol kenarına (X Anchor) sabitlenmiş olarak düzgün biçimde konumlanır.
+
+Şimdi soldaki kutunun X Anchor değerini Left, sağdaki kutunun X Anchor değerini Right olarak ayarlarsak şu sonucu elde ederiz:
+
+![](images/gui/adjustmode_example_bottom_anchor_left_right.png)
+
+Bu, tam olarak beklenen sonuç değildir. İki kutunun, üst paneldeki iki çubuk gibi sol ve sağ kenarlara yakın kalması gerekir. Bunun nedeni Pivot noktasının yanlış olmasıdır:
+
+![](images/gui/adjustmode_example_bottom_pivot_center.png)
+
+Her iki kutunun Pivot noktası da Center olarak ayarlanmıştır. Bu, ekran genişlediğinde kutuların merkez noktasının (dayanak noktasının) kenarlardan aynı oransal uzaklıkta kalacağı anlamına gelir. Soldaki kutu, ilk 640x1136 boyutundaki pencerede sol kenardan %17 uzaklıktaydı:
+
+![](images/gui/adjustmode_example_original_ratio.png)
+
+Ekran yeniden boyutlandırıldığında soldaki kutunun merkez noktası sol kenardan yine %17 uzaklıkta kalır:
+
+![](images/gui/adjustmode_example_resized_stretch_ratio.png)
+
+Pivot noktasını soldaki kutu için Center yerine West, sağdaki kutu için de East olarak değiştirip kutuları yeniden konumlandırırsak ekran yeniden boyutlandırıldığında bile istediğimiz sonucu elde ederiz:
+
+![](images/gui/adjustmode_example_bottom_pivot_west_east.png)
+
+
+## Çizim sırası
+
+Tüm düğümler "Nodes" klasörü altında listelendikleri sırayla işlenir. Listenin en üstündeki düğüm önce çizilir ve bu nedenle diğer tüm düğümlerin arkasında görünür. Listedeki son düğüm en son çizilir; yani diğer tüm düğümlerin önünde görünür. Bir düğümün Z değerini değiştirmek, çizim sırasını belirlemez; ancak Z değerini işleme betiğinizin işleme aralığı dışında bir değere ayarlarsanız düğüm artık ekrana işlenmez. Düğümlerin indeks sıralamasını katmanlarla geçersiz kılabilirsiniz (aşağıya bakın).
+
+![Çizim sırası](images/gui/draw_order.png)
+
+Düğümü yukarı veya aşağı taşıyarak indeks sırasını değiştirmek için bir düğüm seçin ve <kbd>Alt + Up/Down</kbd> tuşlarına basın.
+
+Çizim sırası betikte değiştirilebilir:
+
+```lua
+local bean_node = gui.get_node("bean")
+local shield_node = gui.get_node("shield")
+
+if gui.get_index(shield_node) < gui.get_index(bean_node) then
+  gui.move_above(shield_node, bean_node)
+end
+```
+
+## Üst-alt düğüm hiyerarşileri
+
+Bir düğümü başka bir düğümün alt düğümü yapmak için onu, üst düğümü olmasını istediğiniz düğümün üzerine sürükleyin. Üst düğümü olan bir düğüm, üst düğümün dayanak noktasına göre üst düğüme uygulanan dönüşümü (konum, dönme ve ölçek) devralır.
+
+![Üst ve alt düğüm](images/gui/parent_child.png)
+
+Üst düğümler alt düğümlerinden önce çizilir. Üst ve alt düğümlerin çizim sırasını değiştirmek ve düğümlerin işlenmesini optimize etmek için katmanları kullanın (aşağıya bakın).
+
+
+## Katmanlar ve çizim çağrıları {#layers-and-draw-calls}
+
+Katmanlar, düğümlerin nasıl çizileceği üzerinde ayrıntılı denetim sağlar ve motorun bir GUI sahnesini çizmek için oluşturması gereken çizim çağrılarının (draw call) sayısını azaltmak için kullanılabilir. Motor, bir GUI sahnesinin düğümlerini çizerken bunları aşağıdaki koşullara göre çizim çağrısı gruplarında toplar:
+
+- Düğümler aynı türde olmalıdır.
+- Düğümler aynı atlası veya karo kaynağını kullanmalıdır.
+- Düğümler aynı harmanlama moduyla işlenmelidir.
+- Aynı yazı tipini kullanmalıdırlar.
+
+Bir düğüm bu noktalardan herhangi birinde önceki düğümden farklıysa grubu böler ve başka bir çizim çağrısı oluşturur. Kırpma düğümleri her zaman grubu böler; her şablon kapsamı da grubu böler.
+
+Düğümleri hiyerarşilerde düzenleyebilmek, düğümleri yönetilebilir birimler halinde gruplamayı kolaylaştırır. Ancak farklı düğüm türlerini karıştırırsanız hiyerarşiler toplu çizimi (batch rendering) bölebilir:
+
+![Toplu çizimi bölen hiyerarşi](images/gui/break_batch.png)
+
+İşleme hattı düğüm listesinde ilerlerken, türleri farklı olduğu için her düğüm için ayrı bir grup oluşturmak zorunda kalır. Sonuç olarak bu üç düğme toplam altı çizim çağrısı gerektirir.
+
+Düğümlere katmanlar atayarak düğümleri farklı bir sıraya koyabilirsiniz; böylece işleme hattı düğümleri daha az çizim çağrısında gruplayabilir. Önce gereken katmanları sahneye ekleyin. *Outline* görünümündeki "Layers" klasör simgesine <kbd>sağ tıklayın</kbd> ve <kbd>Add ▸ Layer</kbd> seçeneğini seçin. Yeni katmanı seçin ve *Properties* görünümünde *Name* özelliğine bir değer atayın.
+
+![Katmanlar](images/gui/layers.png)
+
+Ardından her düğümün *Layer* özelliğini ilgili katmana ayarlayın. Katman çizim sırası, normal indeksli düğüm sırasından önce gelir; bu nedenle düğme grafiklerini oluşturan kutu düğümlerini "graphics", düğme metin düğümlerini ise "text" katmanına ayarlamak şu çizim sırasını oluşturur:
+
+* Önce "graphics" katmanındaki tüm düğümler, en üstten başlayarak:
+
+  1. "button-1"
+  2. "button-2"
+  3. "button-3"
+
+* Ardından "text" katmanındaki tüm düğümler, en üstten başlayarak:
+
+  4. "button-text-1"
+  5. "button-text-2"
+  6. "button-text-3"
+
+Düğümler artık altı yerine iki çizim çağrısında gruplanabilir. Büyük bir performans kazanımı!
+
+Katmanı ayarlanmamış bir alt düğümün, üst düğümünün katman ayarını örtük olarak devraldığını unutmayın. Bir düğümün katmanını ayarlamamak, onu örtük olarak diğer tüm katmanlardan önce çizilen "null" katmanına ekler.

--- a/docs/tr/manuals/hot-reload.md
+++ b/docs/tr/manuals/hot-reload.md
@@ -1,0 +1,122 @@
+---
+title: Çalışma sırasında yeniden yükleme
+brief: Bu kılavuz, Defold'daki çalışma sırasında yeniden yükleme özelliğini açıklar.
+---
+
+# Kaynakları çalışma sırasında yeniden yükleme
+
+Defold, kaynakları (resource) çalışma sırasında yeniden yüklemenizi (hot reload) sağlar. Oyun geliştirirken bu özellik belirli görevleri büyük ölçüde hızlandırır. Oyunun kodunu ve içeriğini oyun çalışırken değiştirmenize olanak tanır. Yaygın kullanım alanları şunlardır:
+
+- Lua betiklerinde (script) oynanış parametrelerini ayarlamak.
+- Grafik öğelerini (parçacık efektleri veya GUI öğeleri gibi) düzenleyip ayarlamak ve sonuçları uygun bağlamda görmek.
+- Gölgelendirici (shader) kodunu düzenleyip ayarlamak ve sonuçları uygun bağlamda görmek.
+- Oyunu durdurmadan bölümleri yeniden başlatarak, durumu ayarlayarak ve benzeri işlemlerle oyun testlerini kolaylaştırmak.
+
+## Çalışma sırasında yeniden yükleme nasıl yapılır?
+
+Oyunu düzenleyiciden başlatın (<kbd>Project ▸ Build</kbd>).
+
+Ardından güncellenmiş bir kaynağı yeniden yüklemek için <kbd>File ▸ Hot Reload</kbd> menü öğesini seçmeniz veya klavyede ilgili kısayola basmanız yeterlidir:
+
+![Kaynakları yeniden yükleme](images/hot-reload/menu.png)
+
+## Cihazda çalışma sırasında yeniden yükleme
+
+Çalışma sırasında yeniden yükleme, masaüstünde olduğu gibi cihazda da çalışır. Bu özelliği cihazda kullanmak için mobil cihazınızda oyunun hata ayıklama derlemesini veya [geliştirme uygulamasını](/manuals/dev-app) çalıştırın, ardından düzenleyicide hedef olarak seçin:
+
+![Hedef cihaz](images/hot-reload/target.png)
+
+Artık projeyi derleyip çalıştırdığınızda düzenleyici tüm varlıkları (asset) cihazda çalışan uygulamaya yükler ve oyunu başlatır. Bundan sonra çalışma sırasında yeniden yüklediğiniz her dosya cihazda güncellenir.
+
+Örneğin, telefonunuzda çalışan bir oyunda gösterilen GUI'ye birkaç düğme eklemek için GUI dosyasını açmanız yeterlidir:
+
+![GUI'yi yeniden yükleme](images/hot-reload/gui.png)
+
+Yeni düğmeleri ekleyin, GUI dosyasını kaydedin ve çalışma sırasında yeniden yükleyin. Artık yeni düğmeleri telefon ekranında görebilirsiniz:
+
+![Yeniden yüklenmiş GUI](images/hot-reload/gui-reloaded.png)
+
+Bir dosyayı çalışma sırasında yeniden yüklediğinizde motor, yeniden yüklenen her kaynak dosyasını konsola yazdırır.
+
+## Betikleri yeniden yükleme
+
+Yeniden yüklenen her Lua betik dosyası, çalışan Lua ortamında yeniden yürütülür.
+
+```lua
+local my_value = 10
+
+function update(self, dt)
+    print(my_value)
+end
+```
+
+`my_value` değerini 11 olarak değiştirip dosyayı çalışma sırasında yeniden yüklediğinizde değişiklik hemen etkili olur:
+
+```text
+...
+DEBUG:SCRIPT: 10
+DEBUG:SCRIPT: 10
+DEBUG:SCRIPT: 10
+INFO:RESOURCE: /main/hunter.scriptc was successfully reloaded.
+DEBUG:SCRIPT: 11
+DEBUG:SCRIPT: 11
+DEBUG:SCRIPT: 11
+...
+```
+
+Çalışma sırasında yeniden yüklemenin yaşam döngüsü (lifecycle) işlevlerinin yürütülmesini değiştirmediğini unutmayın. Örneğin, çalışma sırasında yeniden yükleme yapıldığında `init()` çağrılmaz. Ancak yaşam döngüsü işlevlerini yeniden tanımlarsanız yeni sürümleri kullanılır.
+
+## Lua modüllerini yeniden yükleme
+
+Bir modül dosyasında değişkenleri genel kapsama (global scope) eklediğiniz sürece, dosyayı yeniden yüklemek bu genel değişkenleri değiştirir:
+
+```lua
+--- my_module.lua
+my_module = {}
+my_module.val = 10
+```
+
+```lua
+-- user.script
+require "my_module"
+
+function update(self, dt)
+    print(my_module.val) -- hot reload "my_module.lua" and the new value will print
+end
+```
+
+Lua modüllerinde yaygın bir yaklaşım, yerel bir tablo oluşturmak, tabloyu doldurmak ve ardından döndürmektir:
+
+```lua
+--- my_module.lua
+local M = {} -- a new table object is created here
+M.val = 10
+return M
+```
+
+```lua
+-- user.script
+local mm = require "my_module"
+
+function update(self, dt)
+    print(mm.val) -- will print 10 even if you change and hot reload "my_module.lua"
+end
+```
+
+`my_module.lua` dosyasını değiştirip yeniden yüklemek, `user.script` dosyasının davranışını _değiştirmez_. Bunun nedeni ve bu sorundan nasıl kaçınabileceğiniz hakkında daha fazla bilgi için [Modüller kılavuzuna](/manuals/modules) bakın.
+
+## on_reload() işlevi
+
+Her betik bileşeni (script component) bir `on_reload()` işlevi tanımlayabilir. Bu işlev varsa betik her yeniden yüklendiğinde çağrılır. Bu, verileri incelemek veya değiştirmek, ileti göndermek ve benzeri işlemler için kullanışlıdır:
+
+```lua
+function on_reload(self)
+    print(self.velocity)
+
+    msg.post("/level#controller", "setup")
+end
+```
+
+## Gölgelendirici kodunu yeniden yükleme
+
+Köşe gölgelendiricileri (vertex shader) ve parça gölgelendiricileri (fragment shader) yeniden yüklenirken GLSL kodu grafik sürücüsü tarafından yeniden derlenir ve GPU'ya yüklenir. Gölgelendirici kodu bir çökmeye yol açarsa motor da çöker; GLSL çok düşük düzeyde yazıldığı için buna yol açmak kolaydır.

--- a/docs/tr/manuals/html5.md
+++ b/docs/tr/manuals/html5.md
@@ -1,0 +1,386 @@
+---
+title: HTML5 platformu için Defold ile geliştirme
+brief: Bu kılavuz, HTML5 oyunu oluşturma sürecini, bilinen sorunları ve kısıtlamaları açıklar.
+---
+
+# HTML5 için geliştirme
+
+Defold, diğer platformlarda olduğu gibi HTML5 platformu için de standart paketleme (bundling) menüsü üzerinden oyun derlemeyi destekler. Ayrıca ortaya çıkan oyun, basit bir şablon sistemi aracılığıyla biçimlendirilebilen standart bir HTML sayfasına gömülür.
+
+*game.project* dosyası HTML5'e özgü ayarları içerir:
+
+![Proje ayarları](images/html5/html5_project_settings.png)
+
+## Öbek boyutu {#heap-size}
+
+Defold'un HTML5 desteği Emscripten ile sağlanır (bkz. http://en.wikipedia.org/wiki/Emscripten). Emscripten, uygulamanın çalıştığı öbek (heap) için yalıtılmış bir bellek alanı oluşturur. Motor varsayılan olarak oldukça büyük miktarda bellek (256 MB) ayırır. Bu miktarın tipik bir oyun için fazlasıyla yeterli olması beklenir. Optimizasyon sürecinizin bir parçası olarak daha küçük bir değer kullanmayı seçebilirsiniz. Bunu yapmak için şu adımları izleyin:
+
+1. *heap_size* ayarını tercih ettiğiniz değere ayarlayın. Değer megabayt cinsinden belirtilmelidir.
+2. HTML5 dağıtım paketinizi oluşturun (aşağıya bakın)
+
+## HTML5 derlemesini test etme
+
+HTML5 derlemesini test etmek için bir HTTP sunucusu gerekir. <kbd>Project ▸ Build HTML5</kbd> seçeneğini seçerseniz Defold sizin için bir sunucu oluşturur.
+
+![HTML5 derleme](images/html5/html5_build_launch.png)
+
+Dağıtım paketinizi test etmek için uzak HTTP sunucunuza yüklemeniz veya örneğin dağıtım paketi klasöründe Python kullanarak yerel bir sunucu oluşturmanız yeterlidir.
+Python 2:
+
+```sh
+python -m SimpleHTTPServer
+```
+
+Python 3:
+
+```sh
+python -m http.server
+```
+
+veya
+
+```sh
+python3 -m http.server
+```
+
+::: important
+HTML5 dağıtım paketini, `index.html` dosyasını tarayıcıda açarak test edemezsiniz. Bunun için bir HTTP sunucusu gerekir.
+:::
+
+::: important
+Konsolda `"wasm streaming compile failed: TypeError: Failed to execute ‘compile’ on ‘WebAssembly’: Incorrect response MIME type. Expected ‘application/wasm’."` hatasını görürseniz sunucunuzun `.wasm` dosyaları için `application/wasm` MIME türünü kullandığından emin olmalısınız.
+:::
+
+## HTML5 dağıtım paketi oluşturma {#creating-html5-bundle}
+
+Defold ile HTML5 içeriği oluşturmak basittir ve desteklenen diğer tüm platformlarla aynı yöntemi izler: menüden <kbd>Project ▸ Bundle... ▸ HTML5 Application...</kbd> seçeneğini seçin:
+
+![HTML5 dağıtım paketi oluşturma](images/html5/html5_bundle.png)
+
+HTML5 dağıtım paketleri iki WebAssembly mimarisini destekler:
+
+* `wasm-web` - iş parçacıklarını (thread) kullanmayan standart WebAssembly motoru.
+* `wasm_pthread-web` - iş parçacıklarını kullanabilen bir WebAssembly motoru.
+
+Mimarilerden birini veya her ikisini de pakete ekleyebilirsiniz. Her ikisi de eklendiğinde yükleyici, tarayıcı ve barındırma ortamı destekliyorsa `wasm_pthread-web` mimarisini seçer; aksi durumda `wasm-web` mimarisine geçer. Standart hedef adları için [Bob kılavuzuna](/manuals/bob/#usage) bakın.
+
+::: important
+İş parçacıklarını kullanan motor, güvenli ve [kökenler arasında yalıtılmış (cross-origin-isolated)](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated) bir sayfada `SharedArrayBuffer` gerektirir. Dağıtım paketini HTTPS (veya localhost) üzerinden sunun ve sunucuyu uyumlu kökenler arası yalıtım üstbilgileriyle yapılandırın. Yaygın olarak kullanılan üstbilgiler şunlardır:
+
+```txt
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+Sayfanın farklı kökenlerden yüklediği kaynaklar da uyumlu CORS veya Cross-Origin-Resource-Policy üstbilgileri kullanmalıdır. Yalnızca `wasm_pthread-web` içeren bir dağıtım paketi, bu gereksinimler karşılanmadığında çalışamaz; oyun kökenler arası yalıtımı desteklemeyen bir sitede barındırılabilecekse yedek seçenek olarak `wasm-web` mimarisini de ekleyin.
+:::
+
+Defold HTML5 dağıtım paketleri, WebAssembly destekleyen modern bir tarayıcı gerektirir. Internet Explorer 11 desteklenmez.
+
+<kbd>Create bundle</kbd> düğmesine tıkladığınızda uygulamanın oluşturulacağı klasörü seçmeniz istenir. Dışa aktarma işlemi tamamlandıktan sonra uygulamayı çalıştırmak için gereken tüm dosyaları bu klasörde bulabilirsiniz.
+
+## WebGL bağlam sürümü
+
+İstenen grafik bağlamını [`graphics.webgl_version_hint`](/manuals/project-settings/#webgl-version-hint) aracılığıyla seçin. Varsayılan değer WebGL 2'dir; her iki sürümü de destekleyen tarayıcılarda WebGL 1 bağlamını test etmek veya hedeflemek için WebGL 1'i isteyin.
+
+## İndirme doğrulaması {#download-verification}
+
+HTML5 yükleyicisi varsayılan olarak indirilen motor ve arşiv dosyalarının boyutlarını kontrol eder. Kontroller başarısız olursa yükleyici hata bildirmeden önce indirmeler yeniden denenir:
+
+* Motorun JavaScript veya WebAssembly dosyasını indirirken oluşan ağ hataları, başarısız HTTP durumları ve boyut uyuşmazlıkları için `html5.retry_count` ayarındaki yeniden deneme sınırı kullanılır.
+* Arşiv dosyası doğrulamasında boyut veya SHA-1 uyuşmazlıkları için ayrı bir yeniden deneme sınırı vardır. Her doğrulama yeniden denemesi, dosyanın parçalarını yeniden indirir ve her indirme için normal ağ yeniden denemeleri kullanılabilir.
+
+`html5.retry_time` ayarı, her iki durumda da yeniden denemeler arasındaki gecikmeyi kontrol eder.
+
+Sunucunuz, vekil sunucunuz veya CDN'niz sunulan dosyaları kasıtlı olarak yeniden yazıyor ve boyutlarını değiştiriyorsa *game.project* dosyasında boyut doğrulamasını devre dışı bırakın:
+
+```ini
+[html5]
+verify_downloaded_file_size = 0
+```
+
+**Verify Downloaded File Size** seçeneğinin devre dışı bırakılması, dağıtım paketine dahil edilen tüm SHA-1 doğrulamalarını etkin bırakır. [HTML5 proje ayarlarına](/manuals/project-settings/#verify-downloaded-file-size) bakın.
+
+## Bilinen sorunlar ve kısıtlamalar
+
+* Çalışma sırasında yeniden yükleme (Hot Reload) - Çalışma sırasında yeniden yükleme HTML5 derlemelerinde çalışmaz. Defold uygulamalarının düzenleyiciden güncellemeleri alabilmek için kendi küçük web sunucularını çalıştırmaları gerekir; bu, bir HTML5 derlemesinde mümkün değildir.
+* Chrome
+  * Yavaş hata ayıklama derlemeleri - HTML5 hata ayıklama derlemelerinde hataları saptamak için tüm WebGL grafik çağrılarını doğrularız. Ne yazık ki Chrome'da test yaparken bu işlem çok yavaştır. *game.project* dosyasındaki *Engine Arguments* alanını `--verify-graphics-calls=false` olarak ayarlayarak bunu devre dışı bırakabilirsiniz.
+* Oyun kumandası (gamepad) desteği - HTML5'te dikkate almanız gereken özel durumlar ve uygulamanız gerekebilecek adımlar için [oyun kumandası belgelerine bakın](/manuals/input-gamepads/#gamepads-in-html5).
+
+## HTML5 dağıtım paketini özelleştirme
+
+Oyununuzun HTML5 sürümünü oluştururken Defold varsayılan bir web sayfası sağlar. Bu sayfa, oyununuzun nasıl sunulacağını belirleyen stil ve betik kaynaklarına başvurur.
+
+Uygulama her dışa aktarıldığında bu içerik yeniden oluşturulur. Bu öğelerden herhangi birini özelleştirmek istiyorsanız proje ayarlarınızda değişiklik yapmanız gerekir. Bunun için Defold düzenleyicisinde *game.project* dosyasını açın ve *html5* bölümüne kaydırın:
+
+![HTML5 bölümü](images/html5/html5_section.png)
+
+Her seçenek hakkında daha fazla bilgi [proje ayarları kılavuzunda](/manuals/project-settings/#html5) bulunur.
+
+::: important
+`builtins` klasöründeki varsayılan html/css şablonunun dosyalarını değiştiremezsiniz. Değişikliklerinizi uygulamak için gereken dosyayı `builtins` klasöründen kopyalayıp yapıştırın ve bu dosyayı *game.project* içinde ayarlayın.
+:::
+
+::: important
+Tuvale (canvas) kenarlık veya iç boşluk uygulanmamalıdır. Uygularsanız fare girdisinin koordinatları yanlış olur.
+:::
+
+*game.project* dosyasında `Fullscreen` düğmesini ve `Made with Defold` bağlantısını kapatabilirsiniz.
+Defold, `index.html` için koyu ve açık tema sağlar. Varsayılan olarak açık tema seçilidir ancak `Custom CSS` dosyasını değiştirerek temayı değiştirebilirsiniz. Ayrıca `Scale Mode` alanında seçebileceğiniz dört ön tanımlı ölçek modu vardır.
+
+::: important
+*game.project* dosyasında (`Display` bölümü) `High Dpi` seçeneğini açarsanız tüm ölçek modlarının hesaplamaları geçerli ekran DPI değerini de içerir
+:::
+
+### Downscale Fit ve Fit
+
+`Fit` modunda tuvalin boyutu, oyun tuvalinin tamamını özgün oranlarıyla ekranda gösterecek şekilde değiştirilir. `Downscale Fit` modunun tek farkı, boyutu yalnızca web sayfasının iç boyutu oyunun özgün tuvalinden küçük olduğunda değiştirmesidir; web sayfası oyunun özgün tuvalinden büyük olduğunda tuvali büyütmez.
+
+![HTML5 bölümü](images/html5/html5_fit.png)
+
+### Stretch
+
+`Stretch` modunda tuvalin boyutu, web sayfasının iç alanını tamamen dolduracak şekilde değiştirilir.
+
+![HTML5 bölümü](images/html5/html5_stretch.png)
+
+### No Scale
+`No Scale` modunda tuvalin boyutu, *game.project* dosyasının `[display]` bölümünde önceden tanımladığınız boyutla tamamen aynıdır.
+
+![HTML5 bölümü](images/html5/html5_no_scale.png)
+
+## Şablon belirteçleri
+
+`index.html` dosyasını oluşturmak için [Mustache şablon dilini](https://mustache.github.io/mustache.5.html) kullanırız. Projeyi derlerken veya paketlerken HTML ve CSS dosyaları, belirli belirteçleri (token) proje ayarlarınıza bağlı değerlerle değiştirebilen bir derleyiciden geçirilir. Bu belirteçler, karakter dizilerine kaçış uygulanıp uygulanmayacağına bağlı olarak her zaman çift veya üçlü süslü parantez içine alınır (`{{TOKEN}}` veya `{{{TOKEN}}}`). Proje ayarlarınızı sık sık değiştiriyorsanız veya içeriği başka projelerde yeniden kullanmayı planlıyorsanız bu özellik yararlı olabilir.
+
+::: sidenote
+Mustache şablon dili hakkında daha fazla bilgi [kılavuzda](https://mustache.github.io/mustache.5.html) bulunur.
+:::
+
+*game.project* dosyasındaki her değer bir belirteç olabilir. Örneğin, `Display` bölümündeki `Width` değerini kullanmak istiyorsanız:
+
+![Display bölümü](images/html5/html5_display.png)
+
+*game.project* dosyasını metin olarak açın ve `[section_name]` değerini ve kullanmak istediğiniz alanın adını kontrol edin. Ardından bunu bir belirteç olarak kullanabilirsiniz: `{{section_name.field}}` veya `{{{section_name.field}}}`.
+
+![Display bölümü](images/html5/html5_game_project.png)
+
+Örneğin, HTML şablonunda JavaScript içinde:
+
+```javascript
+function doSomething() {
+    var x = {{display.width}};
+    // ...
+}
+```
+
+Ayrıca şu özel belirteçler de vardır:
+
+DEFOLD_SPLASH_IMAGE
+: Açılış görseli dosyasının adını veya *game.project* dosyasındaki `html5.splash_image` boşsa `false` yazar
+
+
+```css
+{{#DEFOLD_SPLASH_IMAGE}}
+		background-image: url("{{DEFOLD_SPLASH_IMAGE}}");
+{{/DEFOLD_SPLASH_IMAGE}}
+```
+
+exe-name
+: Geçersiz simgeler çıkarılmış proje adı
+
+DEFOLD_ARCHIVE_LOCATION_PREFIX
+: `html5.archive_location_prefix` temel alınarak çözümlenen ve yükleyici tarafından kullanılan arşiv yolu öneki.
+
+DEFOLD_ARCHIVE_LOCATION_SUFFIX
+: `html5.archive_location_suffix` temel alınarak çözümlenen ve arşiv URL'lerine eklenen sonek.
+
+DEFOLD_HAS_ARCHIVE_ORIGIN
+: Arşiv öneki, `//cdn.example.com/archive` gibi protokole göreli bir URL dahil olmak üzere bir HTTP veya HTTPS kökeni belirtiyorsa `true` olur. Göreli arşiv önekleri için `false` olur. Defold 1.13.2'den itibaren kullanılabilir.
+
+DEFOLD_ARCHIVE_ORIGIN
+: Şema, ana makine ve isteğe bağlı bağlantı noktası dahil arşiv kökeni; köken belirtilmemişse boş bir dize. Protokole göreli bir önek, protokole göreli bir köken üretir. Ön bağlantı ipucu için kullanılır ve Defold 1.13.2'den itibaren kullanılabilir.
+
+DEFOLD_HAS_WASM_ENGINE
+: Dağıtım paketi, `wasm-web` veya `wasm_pthread-web` olmak üzere bir WebAssembly motoru içeriyorsa `true` olur.
+
+DEFOLD_HAS_WASM_PTHREAD_ENGINE
+: Dağıtım paketi `wasm_pthread-web` içeriyorsa `true` olur. Yükleyici mimariyi çalışma sırasında seçtiğinde yanlış motor çeşidinin önceden yüklenmesini önlemek için bunu kullanın.
+
+
+DEFOLD_CUSTOM_CSS_INLINE
+: *game.project* ayarlarınızda belirtilen CSS dosyasının içeriğinin satır içi olarak eklendiği yerdir.
+
+
+```html
+<style>
+{{{DEFOLD_CUSTOM_CSS_INLINE}}}
+</style>
+```
+
+::: important
+Bu satır içi bloğun, ana uygulama betiği yüklenmeden önce yer alması önemlidir. HTML etiketleri içerdiği için bu makro, karakter dizilerine kaçış uygulanmasını önlemek üzere üçlü süslü parantez `{{{TOKEN}}}` içinde yer almalıdır.
+:::
+
+DEFOLD_SCALE_MODE_IS_DOWNSCALE_FIT
+: `html5.scale_mode` değeri `Downscale Fit` ise bu belirteç `true` olur.
+
+DEFOLD_SCALE_MODE_IS_FIT
+: `html5.scale_mode` değeri `Fit` ise bu belirteç `true` olur.
+
+DEFOLD_SCALE_MODE_IS_NO_SCALE
+: `html5.scale_mode` değeri `No Scale` ise bu belirteç `true` olur.
+
+DEFOLD_SCALE_MODE_IS_STRETCH
+: `html5.scale_mode` değeri `Stretch` ise bu belirteç `true` olur.
+
+DEFOLD_HEAP_SIZE
+: *game.project* dosyasındaki `html5.heap_size` ayarında belirtilen öbek boyutunun bayta dönüştürülmüş değeri.
+
+DEFOLD_ENGINE_ARGUMENTS
+: *game.project* dosyasındaki `html5.engine_arguments` ayarında belirtilen, `,` simgesiyle ayrılmış motor bağımsız değişkenleri.
+
+build-timestamp
+: Geçerli derlemenin saniye cinsinden zaman damgası.
+
+
+## Ek parametreler
+
+Özel bir şablon oluşturursanız genel `CUSTOM_PARAMETERS` nesnesinde değer atamaları yaparak motor yükleyicisinin parametrelerini değiştirebilirsiniz. Yerleşik şablon, bu özelleştirmeler için bilerek boş bırakılmış bir `<script id="engine-setup">` bloğu sağlar.
+::: important
+`engine-setup` bloğunu, `dmloader.js` dosyasını yükleyen betikten sonra ve `EngineLoader.load()` işlevini çağıran `engine-start` bloğundan önce tutun.
+:::
+Örneğin:
+
+```html
+    <script id="engine-setup" type="text/javascript">
+        CUSTOM_PARAMETERS.disable_context_menu = false;
+        CUSTOM_PARAMETERS.unsupported_webgl_callback = function() {
+            console.log("Oh-oh. WebGL not supported...");
+        };
+    </script>
+```
+
+`CUSTOM_PARAMETERS`, aşağıdakiler dahil çeşitli alanlar içerebilir:
+
+```
+'archive_location_filter':
+    Filter function that will run for each archive path.
+
+'unsupported_webgl_callback':
+    Function that is called if WebGL is not supported.
+
+'engine_arguments':
+    List of arguments (strings) that will be passed to the engine.
+
+'custom_heap_size':
+    Number of bytes specifying the memory heap size.
+
+'disable_context_menu':
+    Disables the right-click context menu on the canvas element if true.
+
+'retry_time':
+    Pause in seconds before retry file loading after error.
+
+'retry_count':
+    How many attempts we do when trying to download a file.
+
+'can_not_download_file_callback':
+    Function that is called if you can't download file after 'retry_count' attempts.
+
+'resize_window_callback':
+    Function that is called when resize/orientationchanges/focus events happened
+
+'start_success':
+    Function that is called just before main is called upon successful load.
+
+'update_progress':
+    Function that is called as progress is updated. Parameter progress is updated 0-100.
+```
+
+## HTML5'te dosya işlemleri
+
+HTML5 derlemeleri `sys.save()`, `sys.load()` ve `io.open()` gibi dosya işlemlerini destekler, ancak bu işlemlerin içeride nasıl ele alındığı diğer platformlardan farklıdır. JavaScript bir tarayıcıda çalıştırıldığında gerçek anlamda bir dosya sistemi kavramı yoktur ve güvenlik nedeniyle yerel dosya erişimi engellenir. Bunun yerine Emscripten (ve dolayısıyla Defold), tarayıcıda sanal bir dosya sistemi oluşturmak için verileri kalıcı olarak saklamakta kullanılan tarayıcı içi bir veritabanı olan [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) kullanır. Diğer platformlardaki dosya sistemi erişiminden önemli farkı, bir dosyaya yazılması ile değişikliğin veritabanına gerçekten kaydedilmesi arasında küçük bir gecikme olabilmesidir. Tarayıcının geliştirici konsolu genellikle IndexedDB içeriğini incelemenize olanak tanır.
+
+
+## HTML5 oyununa bağımsız değişken aktarma
+
+Bazen bir oyuna başlatılmadan önce veya başlatılırken ek bağımsız değişkenler sağlamak gerekir. Bu, örneğin bir kullanıcı kimliği, oturum belirteci veya oyun başladığında hangi seviyenin yükleneceği olabilir. Bunu gerçekleştirmenin farklı yolları vardır; bunlardan bazıları burada açıklanmıştır.
+
+### Motor bağımsız değişkenleri
+
+Motor yapılandırılıp yüklenirken ek motor bağımsız değişkenleri belirtmek mümkündür. Bu ek motor bağımsız değişkenleri, çalışma sırasında `sys.get_config_string()` kullanılarak alınabilir. Bağımsız değişkenleri `index.html` dosyasının `engine-setup` bloğunda doğrudan `CUSTOM_PARAMETERS.engine_arguments` alanına atayın:
+
+
+```html
+    <script id="engine-setup" type="text/javascript">
+        CUSTOM_PARAMETERS.engine_arguments = [
+            "--config=example.foo1=bar1",
+            "--config=example.foo2=bar2"
+        ];
+    </script>
+```
+
+Yeni bir dizi atamak, *game.project* dosyasında yapılandırılmış tüm motor bağımsız değişkenlerinin yerini alır. Bu bağımsız değişkenleri koruyup bir tane daha eklemek için bunun yerine `CUSTOM_PARAMETERS.engine_arguments.push("--config=example.foo3=bar3")` kullanın.
+
+Ayrıca *game.project* dosyasının HTML5 bölümündeki *Engine Arguments* alanına `--config=example.foo1=bar1, --config=example.foo2=bar2` ekleyebilirsiniz. Virgülle ayrılmış değerler, oluşturulan `dmloader.js` dosyasındaki `CUSTOM_PARAMETERS.engine_arguments` alanına eklenir.
+
+Çalışma sırasında değerleri şöyle alırsınız:
+
+```lua
+local foo1 = sys.get_config_string("example.foo1")
+local foo2 = sys.get_config_string("example.foo2")
+print(foo1) -- bar1
+print(foo2) -- bar2
+```
+
+
+### URL'deki sorgu bağımsız değişkenleri
+
+Bağımsız değişkenleri sayfa URL'sindeki sorgu parametrelerinin bir parçası olarak aktarabilir ve bunları çalışma sırasında okuyabilirsiniz:
+
+```
+https://www.mygame.com/index.html?foo1=bar1&foo2=bar2
+```
+
+```lua
+local url = html5.run("window.location")
+print(url)
+```
+
+Tüm sorgu parametrelerini bir Lua tablosu olarak alan eksiksiz bir yardımcı işlev:
+
+```lua
+local function get_query_parameters()
+    local url = html5.run("window.location")
+    -- get the query part of the url (the bit after ?)
+    local query = url:match(".*?(.*)")
+    if not query then
+        return {}
+    end
+
+    local params = {}
+    -- iterate over all key value pairs
+    for kvp in query:gmatch("([^&]+)") do
+        local key, value = kvp:match("(.+)=(.+)")
+        params[key] = value
+    end
+    return params
+end
+
+function init(self)
+    local params = get_query_parameters()
+    print(params.foo1) -- bar1
+end
+```
+
+## Optimizasyonlar
+HTML5 oyunlarında, düşük donanımlı cihazlarda ve yavaş internet bağlantılarında oyunların hızlı yüklenmesini ve iyi çalışmasını sağlamak için ilk indirme boyutu, başlatma süresi ve bellek kullanımı konusunda genellikle sıkı gereksinimler vardır. Bir HTML5 oyununu optimize etmek için şu alanlara odaklanmanız önerilir:
+
+* [Bellek kullanımı](/manuals/optimization-memory)
+* [Motor boyutu](/manuals/optimization-size)
+* [Oyun boyutu](/manuals/optimization-size)
+
+## Sık sorulan sorular
+:[HTML5 FAQ](../shared/html5-faq.md)

--- a/docs/tr/manuals/http-requests.md
+++ b/docs/tr/manuals/http-requests.md
@@ -1,0 +1,176 @@
+---
+title: HTTP istekleri
+brief: Bu kılavuz, HTTP isteklerinin nasıl gönderileceğini açıklar.
+---
+
+## HTTP istekleri
+
+Defold, `http.request()` işleviyle standart HTTP istekleri (HTTP requests) gönderebilir.
+
+### HTTP GET
+
+Sunucudan veri almak için kullanılan en temel istek türüdür. Örnek:
+
+```lua
+local function handle_response(self, id, response)
+	print(response.status, response.response)
+end
+
+http.request("https://www.defold.com", "GET", handle_response)
+```
+
+Bu kod, https://www.defold.com adresine bir HTTP GET isteği gönderir. İşlev eşzamansızdır (asynchronous) ve isteği gönderirken yürütmeyi engellemez. İstek gönderildikten ve sunucu bir yanıt verdikten sonra, belirtilen geri çağırım (callback) işlevini çağırır. Geri çağırım işlevi, durum kodu ve yanıt üstbilgileri dahil sunucu yanıtının tamamını alır. Yanıt tablosuyla nasıl çalışılacağı hakkında daha fazla bilgi için aşağıya bakın.
+
+::: sidenote
+Ağ performansını artırmak için HTTP istekleri istemcide otomatik olarak önbelleğe alınır. Önbelleğe alınan dosyalar, işletim sistemine özgü uygulama destek yolunda `defold/http-cache` adlı bir klasörde saklanır. Genellikle HTTP önbelleğiyle ilgilenmeniz gerekmez, ancak geliştirme sırasında önbelleği temizlemeniz gerekirse önbelleğe alınan dosyaları içeren klasörü elle silebilirsiniz. Bu klasör macOS'ta `%HOME%/Library/Application Support/Defold/http-cache/`, Windows'ta ise `%APP_DATA%/defold/http-cache` konumundadır.
+:::
+
+### HTTP POST
+
+Bir sunucuya puan veya kimlik doğrulama verileri gibi veriler gönderilirken genellikle POST isteği kullanılır:
+
+```lua
+local function handle_response(self, id, response)
+	print(response.status, response.response)
+end
+
+local body = "12345"
+http.request("https://www.myserver.com/score", "POST", handle_response, nil, body)
+```
+
+
+### Diğer HTTP yöntemleri
+
+Defold HTTP istekleri HEAD, DELETE ve PUT yöntemlerini de destekler. CONNECT yöntemi de desteklenir (aşağıdaki vekil sunucu bağlantıları bölümüne bakın).
+
+### HTTP yanıtıyla çalışma
+
+Geri çağırımda döndürülen `response` tablosu, yanıtı ayrıntılı olarak işlemek için gereken tüm bilgileri içerir. Temel alanlardan ikisi `status` ve `response` alanlarıdır:
+
+```lua
+
+local function handle_response(self, id, response)
+	-- check the response status code. Common response codes:
+	-- 200 OK - the request completed successfully
+	-- 301 Moved permanently - the requested data has moved, see redirect header
+	-- 307 Temporary redirect - same as above
+	-- 208 Permanent redirect - same as above
+	-- 400 Bad Request - the request was malformed
+	-- 401 Unauthorized - the client must authenticate itself
+	-- 404 Not Found - the server cannot find the information
+	-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
+	if response.status == 200 then
+		-- the response data
+		-- this can be anything from plain text, json encoded data or binary data
+		print(response.response)
+		json.decode(response.response)
+		sys.save(..., response.response)
+	end
+end
+```
+
+Yanıt, bir görüntü veya müzik parçası gibi büyük bir ikili veri bloğu içeriyorsa veriyi belleğe yüklemek yerine bir dosyaya yazmak mantıklı olabilir:
+
+```lua
+-- in this example we download myimage.png and write it directly to a file on disk
+
+local options = {
+	path = sys.get_save_file("mygame", "myimage.png")
+}
+
+local function handle_response(self, id, response)
+	if response.status == 200 then
+		print("File was successfully written to:", response.path)
+		print("File size:", response.document_size)
+		print("File path:", response.path)
+	else
+		print("File was not written to disk:", response.error)
+	end
+end
+
+http.request("https://www.foobar.com/myimage.png", "GET", handle_response, nil, nil, options)
+```
+
+Ağ üzerinden büyük miktarda veri yüklemenin bir başka kullanım alanı da akış yoluyla ses oynatmadır (sound streaming). Bu işlemde, ses verilerinin "parçaları" bir URL adresinden yüklenir ve bir ses kaynağına (sound resource) aktarılır. Eksiksiz bir örneği [Akış yoluyla ses oynatma kılavuzunda](/sound-streaming#sound-streaming) bulabilirsiniz.
+
+
+### İstek üstbilgileri
+
+İstek gönderirken ek üstbilgiler ayarlayabilirsiniz. Örneğin bu özellik, bir `Authorization` üstbilgisi ayarlamak veya sunucuya istek gövdesinin hangi biçimde olduğunu bildirmek için `Content-Type` üstbilgisini ayarlamak amacıyla kullanılabilir.
+
+```Lua
+local function handle_response(self, id, response)
+	print(response.status, response.response)
+end
+
+-- send some form data
+local headers = {
+	["Content-Type"] = "application/x-www-form-urlencoded"
+}
+local body = "key1=value1&key2=value2"
+http.request("https://www.myserver.com/post", "POST", handle_response, headers, body)
+
+-- send some json encoded data
+local headers = {
+	["Content-Type"] = "application/json"
+}
+local body = json.encode({ key1 = value1, key2 = value2 })
+http.request("https://www.myserver.com/post", "POST", handle_response, headers, body)
+
+-- request some data which requires authorization to access
+local token = ... -- generate an access token (JWT, OAuth etc)
+local headers = {
+	["Authorization"] = "Bearer " .. token
+}
+http.request("https://www.myserver.com/content", "GET", handle_response, headers)
+```
+
+Defold bazı istek üstbilgilerini otomatik olarak ayarlar:
+
+* `If-None-Match: <etag>`, daha önce önbelleğe alınmış bir yanıt varsa bu yanıtın ETag değeriyle ayarlanır.
+* İstek gövdesi 16384 bayttan büyükse `Transfer-Encoding: chunked` ayarlanır.
+* `Content-Length`, istek gövdesinin boyutuyla ayarlanır (istek parçalara bölünmüş değilse).
+* Örneğin [akış yoluyla ses oynatırken](/sound-streaming#sound-streaming) olduğu gibi kısmi bir yanıt isteniyorsa `Range: bytes=<from>-<to>` ayarlanır.
+
+
+### Yanıt üstbilgileri
+
+Sunucu yanıtı bir veya daha fazla yanıt üstbilgisi içerebilir. Bunlara `response` tablosundan erişebilirsiniz:
+
+```lua
+local function handle_response(self, id, response)
+	for header,value in pairs(response.headers) do
+		print(header, value)
+	end
+end
+
+http.request("https://www.defold.com", "GET", handle_response)
+```
+
+
+### HTTP vekil sunucusu
+
+Bazen bir isteği vekil sunucu (proxy server) üzerinden göndermek isteyebilirsiniz. Bunun için hedef sunucuya bağlanırken kullanılacak bir vekil sunucu belirtin. Vekil sunucu kullanıldığında, hedef sunucuya bağlantı vekil sunucu üzerinden geçen bir HTTP tüneliyle kurulur. HTTP tüneli, CONNECT HTTP yöntemiyle oluşturulur. Örnek:
+
+
+```lua
+-- connect to www.defold.com via localhost proxy on port 8888
+local url = "https://www.defold.com:443"
+local method = "GET"
+local headers = {}
+local post_data = nil
+local options = {
+	proxy = "https://127.0.0.1:8888"
+}
+http.request(url, method, function(self, id, response)
+	pprint(response)
+end, headers, post_data, options)
+```
+
+### API başvuru belgeleri
+
+Daha fazla bilgi edinmek için [API başvuru belgelerine](/ref/http/) bakın.
+
+### Eklentiler
+
+Alternatif bir HTTP isteği uygulamasını [TinyHTTP eklentisinde](https://defold.com/assets/tinyhttp/) bulabilirsiniz.

--- a/docs/tr/manuals/iac.md
+++ b/docs/tr/manuals/iac.md
@@ -1,0 +1,44 @@
+---
+title: Defold'da uygulamalar arası iletişim
+brief: Uygulamalar arası iletişim (inter-app communication), uygulamanız başlatılırken kullanılan başlatma bağımsız değişkenlerine erişmenizi sağlar. Bu kılavuz, Defold'un bu işlevsellik için sunduğu API'yi açıklar.
+---
+
+# Uygulamalar arası iletişim
+
+Çoğu işletim sisteminde uygulamalar çeşitli yollarla başlatılabilir:
+
+* Kurulu uygulamalar listesinden
+* Uygulamaya özgü bir bağlantıdan
+* Bir anlık bildirimden (push notification)
+* Kurulum sürecinin son adımı olarak.
+
+Uygulama bir bağlantıdan veya bildirimden ya da kurulum sırasında başlatıldığında ek bağımsız değişkenler iletilebilir. Örneğin, kurulum sırasında kurulum yönlendirme bilgisi (install referrer), uygulamaya özgü bir bağlantıdan veya bildirimden başlatılırken ise derin bağlantı (deep link) iletilebilir. Defold, bir yerel kod eklentisi (native extension) aracılığıyla uygulamanın nasıl çağrıldığına ilişkin bilgileri almak için ortak bir yöntem sunar.
+
+## Eklentiyi kurma
+
+Uygulamalar arası iletişim eklentisini kullanmaya başlamak için eklentiyi *game.project* dosyanıza bağımlılık olarak eklemeniz gerekir. En son kararlı sürüme şu bağımlılık URL adresinden ulaşabilirsiniz:
+```
+https://github.com/defold/extension-iac/archive/master.zip
+```
+
+[Belirli bir sürümün](https://github.com/defold/extension-iac/releases) zip dosyasına bağlantı kullanmanızı öneririz.
+
+## Eklentiyi kullanma
+
+API'nin kullanımı çok kolaydır. Eklentiye bir dinleyici işlevi (listener function) sağlarsınız ve dinleyicinin geri çağırımlarına (callback) tepki verirsiniz.
+
+```
+local function iac_listener(self, payload, type)
+     if type == iac.TYPE_INVOCATION then
+         -- This was an invocation
+         print(payload.origin) -- origin may be empty string if it could not be resolved
+         print(payload.url)
+     end
+end
+
+function init(self)
+     iac.set_listener(iac_listener)
+end
+```
+
+API belgelerinin tamamına [eklentinin GitHub sayfasından](https://defold.github.io/extension-iac/) ulaşabilirsiniz.

--- a/docs/tr/manuals/iap.md
+++ b/docs/tr/manuals/iap.md
@@ -1,0 +1,6 @@
+---
+title: Defold'da uygulama içi satın alma
+brief: Uygulama içi satın alma (in-app purchase), diğer adıyla uygulama içi faturalandırma, oyuncularınızdan veya uygulama kullanıcılarınızdan ek içerik ya da işlevler için ücret almanızı sağlar. Bu kılavuz, Defold'un bu amaçla sunduğu API'yi açıklar.
+---
+
+[Bu kılavuz taşındı](/extension-iap)

--- a/docs/tr/manuals/importing-assets.md
+++ b/docs/tr/manuals/importing-assets.md
@@ -1,0 +1,43 @@
+---
+title: Varlıkları içe aktarma ve düzenleme
+brief: Bu kılavuz, varlıkların nasıl içe aktarılacağını ve düzenleneceğini açıklar.
+---
+
+# Varlıkları içe aktarma ve düzenleme
+
+Bir oyun projesi genellikle grafik, 3B model, ses dosyası, animasyon vb. üretmeye yönelik çeşitli özel programlarda hazırlanmış çok sayıda harici varlıktan (asset) oluşur. Defold, harici araçlarınızda çalışıp varlıklar tamamlandıkça bunları Defold'a içe aktardığınız bir iş akışı için tasarlanmıştır.
+
+
+## Varlıkları içe aktarma
+
+Defold, projenizde kullanılan tüm varlıkların proje hiyerarşisi içinde bir yerde bulunmasını gerektirir. Bu nedenle tüm varlıkları kullanmadan önce içe aktarmanız gerekir. Varlıkları içe aktarmak için dosyaları bilgisayarınızın dosya sisteminden sürükleyip Defold düzenleyicisinin *Assets bölmesinde* uygun bir yere bırakmanız yeterlidir.
+
+![Dosyaları içe aktarma](images/graphics/import.png)
+
+::: sidenote
+Defold, PNG ve JPEG görüntü biçimlerindeki görüntüleri destekler. PNG görüntülerinin 32 bit RGBA biçiminde olması gerekir. Diğer görüntü biçimlerinin kullanılmadan önce dönüştürülmesi gerekir.
+:::
+
+
+## Varlıkları kullanma
+
+Varlıklar Defold'a içe aktarıldıktan sonra Defold'un desteklediği çeşitli bileşen (component) türleri tarafından kullanılabilir:
+
+* Görüntüler, 2B oyunlarda sık kullanılan birçok görsel bileşen türünü oluşturmak için kullanılabilir. [2B grafiklerin nasıl içe aktarılacağı ve kullanılacağı hakkında daha fazla bilgiyi burada bulabilirsiniz](/manuals/importing-graphics).
+* Sesler, ses çalmak için [ses bileşeni (Sound)](/manuals/sound) tarafından kullanılabilir.
+* Yazı tipleri, [etiket bileşeni (Label)](/manuals/label) ve GUI içindeki [metin düğümleri](/manuals/gui-text) tarafından kullanılır.
+* glTF modelleri (*.gltf* ve *.glb*), animasyonlu 3B modelleri göstermek için [model bileşeni (Model)](/manuals/model) tarafından kullanılabilir. Modelin kullandığı tüm doku görüntülerini ayrı varlıklar olarak içe aktarın ve bunları model bileşeninin materyal doku özelliklerine atayın. [3B modellerin nasıl içe aktarılacağı ve kullanılacağı hakkında daha fazla bilgiyi burada bulabilirsiniz](/manuals/importing-models).
+
+
+## Harici varlıkları düzenleme
+
+Defold; görüntüler, ses dosyaları, modeller veya animasyonlar için düzenleme araçları sunmaz. Bu tür varlıkların Defold dışında, özel araçlarla oluşturulması ve Defold'a içe aktarılması gerekir. Defold, proje dosyalarınız arasındaki herhangi bir varlıkta yapılan değişiklikleri otomatik olarak algılar ve düzenleyici görünümünü buna göre günceller.
+
+
+## Defold varlıklarını düzenleme
+
+Düzenleyici, tüm Defold varlıklarını birleştirmeye uygun metin tabanlı dosyalara kaydeder. Bu dosyaları basit betiklerle oluşturmak ve değiştirmek de kolaydır. Daha fazla bilgi için [bu forum konusuna](https://forum.defold.com/t/deftree-a-python-module-for-editing-defold-files/15210) bakın. Ancak zaman zaman değiştiği için dosya biçimimizin ayrıntılarını yayımlamadığımızı unutmayın. Ayrıca varlık oluşturmak veya değiştirmek için betikler çalıştırmak üzere düzenleyicideki belirli yaşam döngüsü olaylarına [düzenleyici betikleri (Editor Scripts)](/manuals/editor-scripts/) aracılığıyla bağlanabilirsiniz.
+
+Defold varlık dosyalarıyla bir metin düzenleyicisi veya harici araç üzerinden çalışırken daha dikkatli olmanız önerilir. Oluşturduğunuz hatalar, dosyanın Defold düzenleyicisinde açılmasını engelleyebilir.
+
+[Tiled](/assets/tiled/) ve [Tilesetter](https://www.tilesetter.org/beta) gibi bazı harici araçlar, Defold varlıklarını otomatik olarak oluşturmak için kullanılabilir.

--- a/docs/tr/manuals/importing-graphics.md
+++ b/docs/tr/manuals/importing-graphics.md
@@ -1,0 +1,73 @@
+---
+title: 2B grafikleri içe aktarma ve kullanma
+brief: Bu kılavuz, 2B grafiklerin nasıl içe aktarılacağını ve kullanılacağını açıklar.
+---
+
+# 2B grafikleri içe aktarma
+
+Defold, 2B oyunlarda sık kullanılan birçok görsel bileşen (component) türünü destekler. Defold ile durağan ve animasyonlu sprite bileşenleri, kullanıcı arayüzü (UI) bileşenleri, parçacık efektleri, karo haritaları ve bit eşlem yazı tipleri oluşturabilirsiniz. Bu görsel bileşenlerden herhangi birini oluşturabilmek için önce kullanmak istediğiniz grafikleri içeren görüntü dosyalarını içe aktarmanız gerekir. Görüntü dosyalarını içe aktarmak için dosyaları bilgisayarınızdaki dosya sisteminden sürükleyip Defold düzenleyicisindeki *Assets panelinde* uygun bir yere bırakmanız yeterlidir.
+
+![Dosyaları içe aktarma](images/graphics/import.png)
+
+::: sidenote
+Defold, PNG ve JPEG görüntü biçimlerindeki görüntüleri destekler. Diğer görüntü biçimlerinin kullanılmadan önce dönüştürülmesi gerekir.
+:::
+
+
+## Defold varlıkları oluşturma
+
+Görüntüler Defold'a içe aktarıldıktan sonra Defold'a özgü varlıklar (asset) oluşturmak için kullanılabilir:
+
+![atlas](images/icons/atlas.png){.icon} Atlas
+: Atlas, daha büyük bir doku (texture) görüntüsünde otomatik olarak birleştirilen ayrı görüntü dosyalarının bir listesini içerir. Atlaslar durağan görüntüler ve birlikte bir kare dizisi animasyonu (flipbook animation) oluşturan görüntü kümeleri olan animasyon grupları (*Animation Groups*) içerebilir.
+
+  ![atlas](images/graphics/atlas.png)
+
+Atlas kaynağı hakkında daha fazla bilgi için [Atlas kılavuzuna](/manuals/atlas) bakın.
+
+![karo kaynağı](images/icons/tilesource.png){.icon} Karo kaynağı
+: Karo kaynağı (tile source), eşit aralıklı bir ızgara üzerinde sıralanmış daha küçük alt görüntülerden oluşacak şekilde önceden hazırlanmış bir görüntü dosyasına başvurur. Bu tür birleşik görüntüler için yaygın olarak kullanılan başka bir terim de _sprite sayfası_ (sprite sheet) ifadesidir. Karo kaynakları, animasyonun ilk ve son karosuyla tanımlanan kare dizisi animasyonları içerebilir. Karolara otomatik olarak çarpışma şekilleri eklemek için bir görüntü kullanmak da mümkündür.
+
+  ![karo kaynağı](images/graphics/tilesource.png)
+
+Karo kaynağı hakkında daha fazla bilgi için [Karo kaynağı kılavuzuna](/manuals/tilesource) bakın.
+
+![bit eşlem yazı tipi](images/icons/font.png){.icon} Bit eşlem yazı tipi
+: Bit eşlem yazı tipinin (bitmap font) glifleri (glyph), PNG biçimindeki bir yazı tipi sayfasında bulunur. Bu tür yazı tipleri, TrueType veya OpenType yazı tipi dosyalarından oluşturulan yazı tiplerine göre performans artışı sağlamaz; ancak doğrudan görüntü içinde istenilen grafikleri, renklendirmeleri ve gölgeleri içerebilir.
+
+Bit eşlem yazı tipleri hakkında daha fazla bilgi için [Yazı tipleri kılavuzuna](/manuals/font/#bitmap-bmfonts) bakın.
+
+  ![BMfont](images/font/bm_font.png)
+
+
+## Defold varlıklarını kullanma
+
+Görüntüleri Atlas ve Tile Source dosyalarına dönüştürdükten sonra bunları çeşitli görsel bileşen türleri oluşturmak için kullanabilirsiniz:
+
+![sprite](images/icons/sprite.png){.icon}
+: Sprite bileşeni, ekranda gösterilen durağan bir görüntü veya kare dizisi animasyonudur.
+
+  ![sprite](images/graphics/sprite.png)
+
+Sprite bileşenleri hakkında daha fazla bilgi için [Sprite kılavuzuna](/manuals/sprite) bakın.
+
+![karo haritası](images/icons/tilemap.png){.icon} Karo haritası
+: Karo haritası (tilemap) bileşeni, bir karo kaynağından gelen karoları (görüntü ve çarpışma şekilleri) bir araya getirerek bir harita oluşturur. Karo haritaları atlas kaynaklarını kullanamaz.
+
+  ![karo haritası](images/graphics/tilemap.png)
+
+Karo haritaları hakkında daha fazla bilgi için [Karo haritası kılavuzuna](/manuals/tilemap) bakın.
+
+![parçacık efekti](images/icons/particlefx.png){.icon} Parçacık efekti
+: Bir parçacık yayıcısından (emitter) oluşturulan parçacıklar, bir atlas veya karo kaynağındaki durağan bir görüntüden ya da kare dizisi animasyonundan oluşur.
+
+  ![parçacıklar](images/graphics/particles.png)
+
+Parçacık efektleri hakkında daha fazla bilgi için [Parçacık efekti kılavuzuna](/manuals/particlefx) bakın.
+
+![GUI](images/icons/gui.png){.icon} GUI
+: GUI kutu düğümleri ve daire dilimi düğümleri, atlaslardaki ve karo kaynaklarındaki durağan görüntüleri ve kare dizisi animasyonlarını kullanabilir.
+
+  ![GUI](images/graphics/gui.png)
+
+GUI hakkında daha fazla bilgi için [GUI kılavuzuna](/manuals/gui) bakın.

--- a/docs/tr/manuals/importing-models.md
+++ b/docs/tr/manuals/importing-models.md
@@ -1,0 +1,94 @@
+---
+title: Modelleri içe aktarma
+brief: Bu kılavuz, model bileşeninin kullandığı 3B modellerin nasıl içe aktarılacağını açıklar.
+---
+
+# 3B modelleri içe aktarma
+Defold, glTF 2.0 (GL Transmission Format) biçimindeki modelleri, iskeletleri (skeleton) ve animasyonları destekler. 3B modeller için *.gltf* veya *.glb* dosyalarını kullanın. glTF, oyun motorlarında ve gerçek zamanlı uygulamalarda 3B verilerin aktarılması ve yüklenmesi için tasarlanmış modern bir biçimdir.
+
+3B modeller oluşturmak veya bunları glTF biçimine dönüştürmek için Maya, 3ds Max, SketchUp ve Blender gibi araçlar kullanabilirsiniz.
+
+Blender, güçlü ve popüler bir 3B modelleme, animasyon ve işleme (rendering, görüntü oluşturma) programıdır. Windows, macOS ve Linux üzerinde çalışır ve [https://www.blender.org](https://www.blender.org) adresinden ücretsiz olarak edinilebilir.
+
+![Blender'da model](images/model/blender_gltf.png)
+
+## Defold'a içe aktarma
+Bir modeli içe aktarmak için *.gltf* veya *.glb* dosyasını Defold düzenleyicisinin *Assets bölmesine* sürükleyip bırakın.
+
+glTF yaygın olarak iki şekilde saklanabilir:
+
+* *.glb* tek bir ikili dosyadır. Model verilerini içerir ve paketlenmiş doku (texture) görüntülerini de içerebilir. Modeli tek bir dosya olarak taşımak veya saklamak istediğinizde bu kullanışlıdır.
+* *.gltf* metin tabanlı bir JSON dosyasıdır. Genellikle örgü (mesh) verileri için ayrı bir *.bin* dosyasına ve *.png* veya *.jpg* gibi ayrı doku görüntülerine başvurur. Bu çeşidi kullanırken başvurulan tüm dosyaları projeye ekleyin ve göreli yollarını koruyun.
+
+Modelin Defold'da bir doku kullanması gerekiyorsa doku görüntüsünü ayrı bir varlık (asset) olarak içe aktarın. Kaynak glTF/GLB dosyası gömülü görüntüler içerse bile dokular, bileşen materyalinin (material) doku özellikleri aracılığıyla model bileşenine (model component) atanmalıdır.
+
+![İçe aktarılan model varlıkları](images/model/assets_gltf.png)
+
+::: sidenote
+Defold 1.13.0 sürümünden itibaren Defold, içe aktarılan glTF dosyasındaki konumları ve dönüşümleri (transform) korur ve içe aktarma sırasında modeli otomatik olarak yeniden merkezlemez. Düzenleyici önizlemesi ve çalışma zamanı, içe aktarılan dönüşümleri tutarlı biçimde kullanır: iskelete bağlanmış (skinned) veya bir kemiğe alt nesne olarak bağlanmış örgüler, iskelete göre yerel dönüşümlerini korurken rijit örgüler, hiyerarşisi düzleştirilmiş dünya yerleşimlerini korur.
+
+Defold 1.13.2 sürümünden itibaren bir [model bileşeni](/manuals/model/#model-properties), içe aktarılan sahneden tek bir adlandırılmış örgü seçebilir. *Mesh* alanını boş bırakmak tüm sahneyi kullanır ve yukarıda açıklanan dönüşümleri korur. Bir örgü seçmek, glTF düğüm dönüşümleri olmadan örgünün yerel geometrisini kullanır; bu nedenle örgüyü model bileşeninin veya oyun nesnesinin (game object) dönüşümünü kullanarak yerleştirin.
+
+Defold'un eski bir sürümüyle oluşturulmuş bir modelin konumu veya yönelimi yeniden içe aktarıldıktan sonra değişirse Blender'da veya başka bir içerik oluşturma aracında dönüşümü düzeltin ve *.gltf* veya *.glb* dosyasını yeniden dışa aktarın.
+:::
+
+## Model kullanma
+Modeli içe aktardıktan sonra bir [model bileşeninde](/manuals/model) kullanın:
+
+1. *Assets* bölmesinde <kbd>New... ▸ Model</kbd> ile bir Model dosyası oluşturun veya <kbd>Add Component ▸ Model</kbd> ile doğrudan bir oyun nesnesine model bileşeni ekleyin.
+2. *Scene* özelliğini içe aktarılan *.gltf* veya *.glb* dosyasına ayarlayın. Tüm sahneyi kullanmak için *Mesh* alanını boş bırakın veya yalnızca yerel geometrisini kullanmak için adlandırılmış bir örgü seçin.
+3. Animasyonlu bir model için *Skeleton* özelliğini iskeleti içeren *.gltf* veya *.glb* dosyasına ayarlayın. Örgü, iskelet ve animasyonlar birlikte dışa aktarıldığında bu genellikle *Scene* için kullanılan dosyayla aynıdır.
+4. Animasyonlar için bir *Animation Set* dosyası oluşturun ve bunu *Animations* özelliğine atayın. Bir animasyonun otomatik olarak başlamasını istiyorsanız *Default Animation* özelliğini ayarlayın.
+5. *Material* özelliğini modele uygun bir materyale ayarlayın. Yerleşik *model.material*, *model_instanced.material*, *model_skinned.material* ve *model_skinned_instanced.material* dosyaları yararlı başlangıç noktalarıdır. İskelete bağlı modellerin materyalleri, iskelete bağlama (skinning) işleminin GPU üzerinde çalışabilmesi için yerel köşe uzayını kullanır; GPU üzerinde iskelete bağlanan veya örnekler hâlinde çizilen (instanced) modeller için özel materyaller de yerel köşe uzayını kullanmalıdır. Grafik bağdaştırıcısı gereksinimi için [model kılavuzuna](/manuals/model/#material) bakın.
+6. *Texture* gibi materyal doku özelliklerini içe aktarılan doku görüntüsü dosyalarına ayarlayın. Materyal birden çok doku kullanıyorsa her dokuyu ilgili materyal doku alanına atayın.
+
+
+## glTF biçimine dışa aktarma
+Dışa aktarılan *.gltf* veya *.glb* dosyası, modeli oluşturan tüm köşeleri, kenarları ve yüzleri, tanımladıysanız _UV koordinatlarını_ (doku görüntüsünün hangi bölümünün örgünün belirli bir bölümüne eşlendiğini), iskeletteki kemikleri ve animasyon verilerini içerir.
+
+* Çokgen örgülerle ilgili ayrıntılı bir açıklamayı http://en.wikipedia.org/wiki/Polygon_mesh adresinde bulabilirsiniz.
+
+* UV koordinatları ve UV eşleme http://en.wikipedia.org/wiki/UV_mapping adresinde açıklanır.
+
+Defold, dışa aktarılan animasyon verilerine bazı kısıtlamalar getirir:
+
+* Defold şu anda yalnızca önceden hesaplanmış (baked) animasyonları destekler. Animasyonlarda her anahtar karede animasyon uygulanan her kemik için matrisler bulunmalıdır; konum, dönme ve ölçek ayrı anahtarlar olarak bulunmamalıdır.
+
+* Animasyonlara doğrusal ara değerleme (interpolation) de uygulanır. Daha gelişmiş eğri ara değerlemesi yapıyorsanız animasyonların dışa aktarma aracı tarafından önceden hesaplanması gerekir.
+
+### Gereksinimler
+Bir modeli dışa aktarırken glTF desteğinin araçlar ve motorlar arasında farklılık gösterebileceğini unutmayın. glTF 2.0 kullanın, model doku kullanıyorsa doğru UV koordinatlarına sahip olduğundan emin olun ve bir model bileşenine atanacak doku görüntülerini ayrı olarak içe aktarın.
+
+Amacımız glTF biçimini tam olarak desteklemek olsa da henüz bu noktaya ulaşamadık.
+Eksik bir özellik varsa lütfen [depomuzda](https://github.com/defold/defold/issues) bu özellik için istekte bulunun
+
+### Bir dokuyu dışa aktarma
+Modeliniz için henüz bir dokunuz yoksa Blender ile doku oluşturabilirsiniz. Bunu, modelden fazladan materyalleri kaldırmadan önce yapmanız önerilir. Örgüyü ve tüm köşelerini seçerek başlayın:
+
+![Tümünü seçme](images/model/blender_select_all_vertices.png)
+
+Tüm köşeler seçildiğinde UV yerleşimini elde etmek için örgünün UV açılımını yapın:
+
+![Örgünün UV açılımını yapma](images/model/blender_unwrap_mesh.png)
+
+Ardından UV yerleşimini doku olarak kullanılabilecek bir görüntüye dışa aktarabilirsiniz:
+
+![UV yerleşimini dışa aktarma](images/model/blender_export_uv_layout.png)
+
+![UV yerleşimini dışa aktarmanın sonucu](images/model/blender_export_uv_layout_result.png)
+
+### Blender ile dışa aktarma
+Modelinizi Blender'dan <kbd>File ▸ Export ▸ glTF 2.0 (.glb/.gltf)</kbd> ile dışa aktarın.
+
+![Blender ile dışa aktarma](images/model/export_gltf.png)
+
+Dışa aktarmadan önce nesneyi veya nesneleri seçin ve yalnızca seçimi dışa aktarmak istiyorsanız *Selected Objects* seçeneğini etkinleştirin.
+
+*Format* seçeneklerinden birini seçin:
+
+* *glTF Binary (.glb)* tek bir dosya oluşturur. Modelin tek bir varlık olarak kolayca taşınabilmesini veya saklanabilmesini istediğinizde bunu kullanın.
+* *glTF Separate (.gltf + .bin + textures)* model açıklaması, ikili veriler ve dokular için ayrı dosyalar oluşturur. Doku görüntülerini düzenlemek veya Defold'da ayrı olarak atamak istediğinizde bunu kullanın.
+
+Model animasyonlar içeriyorsa animasyon dışa aktarmayı etkinleştirin ve animasyonların önceden hesaplandığından emin olun. Model doku kullanıyorsa örgünün UV açılımının yapıldığından ve doku görüntülerinin PNG veya JPEG gibi Defold'un içe aktarabileceği bir biçimde dışa aktarıldığından emin olun.
+
+![Blender ile dışa aktarma](images/model/export_settings.png)

--- a/docs/tr/manuals/input-gamepads.md
+++ b/docs/tr/manuals/input-gamepads.md
@@ -1,0 +1,229 @@
+---
+title: Defold'da oyun kumandası girdisi
+brief: Bu kılavuz, oyun kumandası girdisinin nasıl çalıştığını açıklar.
+---
+
+::: sidenote
+Defold'da girdinin genel olarak nasıl çalıştığını, girdinin nasıl alındığını ve betik dosyalarınızda hangi sırayla alındığını öğrenmeniz önerilir. Girdi sistemi hakkında daha fazla bilgi için [Girdiye genel bakış kılavuzuna](/manuals/input) bakın.
+:::
+
+# Oyun kumandaları
+Oyun kumandası (gamepad) tetikleyicileri, standart oyun kumandası girdisini oyun işlevlerine bağlamanızı sağlar. Oyun kumandası girdisi şu öğeler için girdi eşlemeleri (input binding) sunar:
+
+- Sol ve sağ çubuklar (yön ve tıklamalar)
+- Sol ve sağ dijital düğme grupları (digital pads). Sağ düğme grubu genellikle Xbox oyun kumandasında "A", "B", "X" ve "Y" düğmelerine, Playstation oyun kumandasında ise "square", "circle", "triangle" ve "cross" düğmelerine karşılık gelir.
+- Sol ve sağ tetikler
+- Sol ve sağ omuz düğmeleri
+- Start, Back ve Guide düğmeleri
+
+![](images/input/gamepad_bindings.png)
+
+::: important
+Aşağıdaki örneklerde, yukarıdaki görüntüde gösterilen eylemler kullanılır. Tüm girdilerde olduğu gibi, girdi eylemlerinizi istediğiniz şekilde adlandırabilirsiniz.
+:::
+
+## Dijital düğmeler
+Dijital düğmeler `pressed`, `released` ve `repeated` olayları üretir. Aşağıdaki örnek, bir dijital düğmenin girdisinin (basılma veya bırakılma) nasıl algılandığını gösterir:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_lpad_left") then
+        if action.pressed then
+            -- start moving left
+        elseif action.released then
+            -- stop moving left
+        end
+    end
+end
+```
+
+## Analog çubuklar
+Analog çubuklar (analog stick), oyun kumandası ayar dosyasında tanımlanan ölü bölgenin (dead zone) dışına hareket ettirildiğinde sürekli girdi olayları üretir (aşağıya bakın). Aşağıdaki örnek, bir analog çubuğun girdisinin nasıl algılandığını gösterir:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_lstick_down") then
+        -- left stick was moved down
+        print(action.value) -- a value between 0.0 an -1.0
+    end
+end
+```
+
+Analog çubuklar, ana yönlerde belirli bir eşik değerinin ötesine hareket ettirildiğinde `pressed` ve `released` olayları da üretir. Böylece bir analog çubuğu dijital yön girdisi olarak da kullanmak kolaylaşır:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_lstick_down") and action.pressed then
+        -- left stick was moved to its extreme down position
+    end
+end
+```
+
+## Birden fazla oyun kumandası
+Defold, üzerinde çalıştığı işletim sistemi aracılığıyla birden fazla oyun kumandasını destekler. Eylemler, `action` tablosunun `gamepad` alanını girdinin geldiği oyun kumandasının numarasına ayarlar:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_start") then
+        if action.gamepad == 0 then
+          -- gamepad 0 wants to join the game
+        end
+    end
+end
+```
+
+## Bağlanma ve bağlantının kesilmesi
+Oyun kumandası girdi eşlemeleri, bir oyun kumandasının bağlandığını (başlangıçtan itibaren bağlı olanlar dahil) veya bağlantısının kesildiğini algılamak için `Connected` ve `Disconnected` adlı iki ayrı eşleme de sağlar.
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("gamepad_connected") then
+        if action.gamepad == 0 then
+          -- gamepad 0 was connected
+        end
+    elseif action_id == hash("gamepad_disconnected") then
+        if action.gamepad == 0 then
+          -- gamepad 0 was disconnected
+        end
+    end
+end
+```
+
+## Ham oyun kumandası girdileri
+
+Oyun kumandası girdi eşlemeleri, bağlı herhangi bir oyun kumandasının filtrelenmemiş (ölü bölge uygulanmamış) düğme, eksen ve yön anahtarı (hat) girdisini sağlamak için `Raw` adlı ayrı bir eşleme de sunar.
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("raw") then
+        pprint(action.gamepad_buttons)
+        pprint(action.gamepad_axis)
+        pprint(action.gamepad_hats)
+    end
+end
+```
+
+## Oyun kumandası ayar dosyası {#gamepads-settings-file}
+Oyun kumandası girdi yapılandırması, her donanımsal oyun kumandası türü için ayrı bir eşleme dosyası kullanır. Belirli donanımsal oyun kumandalarının eşlemeleri bir *gamepads* dosyasında ayarlanır. Defold, yaygın oyun kumandalarının ayarlarını içeren yerleşik bir gamepads dosyasıyla gelir:
+
+![Oyun kumandası ayarları](images/input/gamepads.png)
+
+Yeni bir oyun kumandası ayar dosyası oluşturmanız gerekiyorsa, bunun için basit bir aracımız var:
+
+[gdc.zip dosyasını indirmek için tıklayın](https://forum.defold.com/t/big-thread-of-gamepad-testing/56032).
+
+Windows, Linux ve macOS için ikili dosyalar içerir. Komut satırından çalıştırın:
+
+```sh
+./gdc
+```
+
+Araç, bağlı oyun kumandanızdaki farklı düğmelere basmanızı ister. Ardından kumandanız için doğru eşlemeleri içeren yeni bir gamepads dosyası oluşturur. Yeni dosyayı kaydedin veya mevcut gamepads dosyanızla birleştirin, ardından *game.project* dosyasındaki ayarı güncelleyin:
+
+![Oyun kumandası ayarları](images/input/gamepad_setting.png)
+
+### Tanımlanamayan oyun kumandaları
+
+Bir oyun kumandası bağlandığında bu kumanda için bir eşleme yoksa, kumanda yalnızca `connected`, `disconnected` ve `raw` eylemlerini üretir. Bu durumda ham oyun kumandası verilerini oyununuzdaki eylemlerle elle eşleştirmeniz gerekir.
+
+`action` içindeki `gamepad_unknown` değerini okuyarak bir oyun kumandası girdi eyleminin bilinmeyen bir oyun kumandasından gelip gelmediğini kontrol edebilirsiniz:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("connected") then
+        if action.gamepad_unknown then
+            print("The connected gamepad is unidentified and will only generate raw input")
+        else
+            print("The connected gamepad is known and will generate input actions for buttons and sticks")
+        end
+    end
+end
+``` 
+
+## HTML5'te oyun kumandaları {#gamepads-in-html5}
+Oyun kumandaları HTML5 derlemelerinde desteklenir ve diğer platformlarla aynı girdi olaylarını üretir. Oyun kumandası desteği, çoğu tarayıcı tarafından desteklenen [Gamepad API](https://www.w3.org/TR/gamepad/) üzerine kuruludur ([bu destek tablosuna bakın](https://caniuse.com/?search=gamepad)). Tarayıcı Gamepad API desteği sunmuyorsa Defold, projenizdeki tüm oyun kumandası tetikleyicilerini herhangi bir bildirim vermeden yok sayar. `navigator` nesnesinde `getGamepads` işlevinin bulunup bulunmadığını kontrol ederek tarayıcının Gamepad API desteği sunup sunmadığını öğrenebilirsiniz:
+
+```lua
+local function supports_gamepads()
+    return not html5 or (html5.run('typeof navigator.getGamepads === "function"') == "true")
+end
+
+if supports_gamepads() then
+    print("Platform supports gamepads")
+end
+```
+
+Oyununuz bir `iframe` içinde çalışıyorsa, `iframe` öğesine `gamepad` izninin de eklendiğinden emin olmanız gerekir:
+
+```html
+<iframe allow="gamepad"></iframe>
+```
+
+### Standart oyun kumandası
+
+Bağlı bir oyun kumandası tarayıcı tarafından standart oyun kumandası olarak tanımlanırsa, [oyun kumandası ayar dosyasındaki](/manuals/input-gamepads/#gamepads-settings-file) `Standard Gamepad` eşlemesini kullanır (`/builtins` içindeki `default.gamepads` dosyasında bir `Standard Gamepad` eşlemesi bulunur). Standart oyun kumandası, PlayStation veya Xbox oyun kumandasına benzer bir düğme düzeninde 16 düğme ve 2 analog çubuğa sahip kumanda olarak tanımlanır (daha fazla bilgi için [W3C tanımına ve düğme düzenine](https://w3c.github.io/gamepad/#dfn-standard-gamepad) bakın). Bağlı oyun kumandası standart oyun kumandası olarak tanımlanmazsa Defold, oyun kumandası ayar dosyasında donanımsal oyun kumandası türüne uyan bir eşleme arar.
+
+## Windows'ta oyun kumandaları
+Windows'ta şu anda yalnızca XBox 360 oyun kumandaları desteklenir. 360 oyun kumandanızı Windows bilgisayarınıza bağlamak için [doğru yapılandırıldığından emin olun](http://www.wikihow.com/Use-Your-Xbox-360-Controller-for-Windows).
+
+## Android'de oyun kumandaları
+
+Oyun kumandaları Android derlemelerinde desteklenir ve diğer platformlarla aynı girdi olaylarını üretir. Oyun kumandası desteği, [tuş ve hareket olayları için Android girdi sistemine](https://developer.android.com/training/game-controllers/controller-input) dayanır. Android girdi olayları, yukarıda açıklanan aynı *gamepad* dosyası kullanılarak Defold oyun kumandası olaylarına dönüştürülür.
+
+Android'de ek oyun kumandası eşlemeleri oluştururken Android girdi olaylarını *gamepad* dosyası değerlerine dönüştürmek için aşağıdaki başvuru tablolarını kullanabilirsiniz:
+
+| Tuş olayından düğme indeksine   | İndeks |
+|-----------------------------|-------|
+| `AKEYCODE_BUTTON_A`           | 0     |
+| `AKEYCODE_BUTTON_B`           | 1     |
+| `AKEYCODE_BUTTON_C`           | 2     |
+| `AKEYCODE_BUTTON_X`           | 3     |
+| `AKEYCODE_BUTTON_L1`          | 4     |
+| `AKEYCODE_BUTTON_R1`          | 5     |
+| `AKEYCODE_BUTTON_Y`           | 6     |
+| `AKEYCODE_BUTTON_Z`           | 7     |
+| `AKEYCODE_BUTTON_L2`          | 8     |
+| `AKEYCODE_BUTTON_R2`          | 9     |
+| `AKEYCODE_DPAD_CENTER`        | 10    |
+| `AKEYCODE_DPAD_DOWN`          | 11    |
+| `AKEYCODE_DPAD_LEFT`          | 12    |
+| `AKEYCODE_DPAD_RIGHT`         | 13    |
+| `AKEYCODE_DPAD_UP`            | 14    |
+| `AKEYCODE_BUTTON_START`       | 15    |
+| `AKEYCODE_BUTTON_SELECT`      | 16    |
+| `AKEYCODE_BUTTON_THUMBL`      | 17    |
+| `AKEYCODE_BUTTON_THUMBR`      | 18    |
+| `AKEYCODE_BUTTON_MODE`        | 19    |
+| `AKEYCODE_BUTTON_1`           | 20    |
+| `AKEYCODE_BUTTON_2`           | 21    |
+| `AKEYCODE_BUTTON_3`           | 22    |
+| `AKEYCODE_BUTTON_4`           | 23    |
+| `AKEYCODE_BUTTON_5`           | 24    |
+| `AKEYCODE_BUTTON_6`           | 25    |
+| `AKEYCODE_BUTTON_7`           | 26    |
+| `AKEYCODE_BUTTON_8`           | 27    |
+| `AKEYCODE_BUTTON_9`           | 28    |
+| `AKEYCODE_BUTTON_10`          | 29    |
+| `AKEYCODE_BUTTON_11`          | 30    |
+| `AKEYCODE_BUTTON_12`          | 31    |
+| `AKEYCODE_BUTTON_13`          | 32    |
+| `AKEYCODE_BUTTON_14`          | 33    |
+| `AKEYCODE_BUTTON_15`          | 34    |
+| `AKEYCODE_BUTTON_16`          | 35    |
+
+([Android `KeyEvent` tanımları](https://developer.android.com/ndk/reference/group/input#group___input_1gafccd240f973cf154952fb917c9209719))
+
+| Hareket olayından eksen indeksine  | İndeks |
+|-----------------------------|-------|
+| `AMOTION_EVENT_AXIS_X`        | 0     |
+| `AMOTION_EVENT_AXIS_Y`        | 1     |
+| `AMOTION_EVENT_AXIS_Z`        | 2     |
+| `AMOTION_EVENT_AXIS_RZ`       | 3     |
+| `AMOTION_EVENT_AXIS_LTRIGGER` | 4     |
+| `AMOTION_EVENT_AXIS_RTRIGGER` | 5     |
+| `AMOTION_EVENT_AXIS_HAT_X`    | 6     |
+| `AMOTION_EVENT_AXIS_HAT_Y`    | 7     |
+
+([Android `MotionEvent` tanımları](https://developer.android.com/ndk/reference/group/input#group___input_1ga157d5577a5b2f5986037d0d09c7dc77d))
+
+Oyun kumandanızdaki her düğmenin hangi tuş olayına eşlendiğini belirlemek için bu başvuru tablosunu Google Play Store'dan edineceğiniz bir oyun kumandası test uygulamasıyla birlikte kullanın.

--- a/docs/tr/manuals/input-key-and-text.md
+++ b/docs/tr/manuals/input-key-and-text.md
@@ -1,0 +1,53 @@
+---
+title: Defold'da tuş ve metin girdisi
+brief: Bu kılavuz, tuş ve metin girdisinin nasıl çalıştığını açıklar.
+---
+
+::: sidenote
+Defold'da girdinin genel olarak nasıl çalıştığını, girdiyi nasıl alacağınızı ve betik dosyalarınızın girdiyi hangi sırayla aldığını öğrenmeniz önerilir. Girdi sistemi hakkında daha fazla bilgi için [Girdiye genel bakış kılavuzuna](/manuals/input) bakın.
+:::
+
+# Tuş tetikleyicileri
+Tuş tetikleyicileri (key triggers), klavyedeki tek bir tuştan gelen girdiyi oyun eylemlerine bağlamanızı sağlar. Her tuş, karşılık gelen eylemle ayrı ayrı eşlenir. Tuş tetikleyicileri, yön veya WASD tuşlarıyla karakter hareketi gibi belirli işlevleri belirli tuşlara bağlamak için kullanılır. Serbest klavye girdisini okumanız gerekiyorsa metin tetikleyicilerini kullanın (aşağıya bakın).
+
+![](images/input/key_bindings.png)
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("left") then
+        if action.pressed then
+            -- start moving left
+        elseif action.released then
+            -- stop moving left
+        end
+    end
+end
+```
+
+# Metin tetikleyicileri
+Metin tetikleyicileri (text triggers), serbest metin girdisini okumak için kullanılır. İki tür metin tetikleyicisi vardır: `text` ve `marked-text`.
+
+![](images/input/text_bindings.png)
+
+## Metin
+`text` tetikleyicisi normal metin girdisini yakalar. Eylem tablosunun `text` alanını, yazılan karakteri içeren bir dizeye ayarlar. Eylem yalnızca tuşa basıldığında tetiklenir; `release` veya `repeated` eylemi gönderilmez.
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("text") then
+        -- Concatenate the typed character to the "user" node...
+        local node = gui.get_node("user")
+        local name = gui.get_text(node)
+        name = name .. action.text
+        gui.set_text(node, name)
+    end
+end
+```
+
+## İşaretli metin
+İşaretli metin (marked text) tetikleyicisi `marked-text`, esas olarak birden fazla tuşa basmanın tek bir girdiye karşılık gelebildiği Asya dillerine ait klavyelerde kullanılır. Örneğin, iOS "Japanese-Kana" klavyesinde kullanıcı tuş birleşimleri yazabilir; klavyenin üst kısmında girilebilecek simgeler veya simge dizileri görüntülenir.
+
+![İşaretli metin girdisi](images/input/marked_text.png)
+
+- Bir tuşa her basıldığında ayrı bir eylem oluşturulur ve eylemin `text` alanı o ana kadar girilen simge dizisine ("işaretli metin") ayarlanır.
+- Kullanıcı bir simge veya simge birleşimi seçtiğinde, girdi eşlemesi (input binding) listesinde tanımlanmış olması koşuluyla ayrı bir `text` türü tetikleyici eylemi gönderilir. Bu ayrı eylemde `text` alanı kesinleşen simge dizisine ayarlanır.

--- a/docs/tr/manuals/input-mouse-and-touch.md
+++ b/docs/tr/manuals/input-mouse-and-touch.md
@@ -1,0 +1,121 @@
+---
+title: Defold'da fare ve dokunma girdisi
+brief: Bu kılavuz fare ve dokunma girdisinin nasıl çalıştığını açıklar.
+---
+
+::: sidenote
+Defold'da girdinin (input) genel olarak nasıl çalıştığını, girdinin nasıl alındığını ve betik dosyalarınızın girdiyi hangi sırayla aldığını öğrenmeniz önerilir. Girdi sistemi hakkında daha fazla bilgi için [Girdiye genel bakış kılavuzuna](/manuals/input) bakın.
+:::
+
+# Fare tetikleyicileri
+Fare tetikleyicileri (mouse triggers), fare düğmelerinden ve tekerleklerinden gelen girdiyi oyun eylemlerine bağlamanızı sağlar.
+
+![](images/input/mouse_bindings.png)
+
+::: sidenote
+`MOUSE_BUTTON_LEFT`, `MOUSE_BUTTON_RIGHT` ve `MOUSE_BUTTON_MIDDLE` fare düğmesi girdileri, sırasıyla `MOUSE_BUTTON_1`, `MOUSE_BUTTON_2` ve `MOUSE_BUTTON_3` ile eşdeğerdir.
+:::
+
+::: important
+Aşağıdaki örnekler, yukarıdaki görüntüde gösterilen eylemleri kullanır. Tüm girdilerde olduğu gibi, girdi eylemlerinize (input action) istediğiniz adı verebilirsiniz.
+:::
+
+## Fare düğmeleri
+Fare düğmeleri `pressed`, `released` ve `repeated` olayları üretir. Aşağıdaki örnek, sol fare düğmesinin girdisinin (basılma veya bırakılma) nasıl algılandığını gösterir:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("mouse_button_left") then
+        if action.pressed then
+            -- left mouse button pressed
+        elseif action.released then
+            -- left mouse button released
+        end
+    end
+end
+```
+
+::: important
+`MOUSE_BUTTON_LEFT` (veya `MOUSE_BUTTON_1`) girdi eylemleri, tekli dokunma girdileri için de gönderilir.
+:::
+
+## Fare tekerleği
+Fare tekerleği girdileri kaydırma eylemlerini algılar. Tekerlek döndürüldüğünde `action.value` alanı `1`, aksi durumda `0` olur. (Kaydırma eylemleri, düğmeye basma gibi işlenir. Defold şu anda dokunmatik yüzeylerde hassas kaydırma girdisini desteklemez.)
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("mouse_wheel_up") then
+        if action.value == 1 then
+            -- mouse wheel is scrolled up
+        end
+    end
+end
+```
+
+## Fare hareketi
+Fare hareketi ayrı olarak işlenir. Girdi eşlemelerinizde (input binding) en az bir fare tetikleyicisi ayarlanmadıkça fare hareketi olayları alınmaz.
+
+Fare hareketi girdi eşlemelerinde bir eyleme bağlanmaz; bunun yerine `action_id` değeri `nil` olarak ayarlanır ve `action` tablosu farenin konumu ve konumundaki değişimle doldurulur.
+
+```lua
+function on_input(self, action_id, action)
+    if action.x and action.y then
+        -- let game object follow mouse/touch movement
+        local pos = vmath.vector3(action.x, action.y, 0)
+        go.set_position(pos)
+    end
+end
+```
+
+# Dokunma tetikleyicileri
+Tekli dokunma (single-touch) ve çoklu dokunma (multi-touch) türündeki tetikleyiciler, iOS ve Android cihazlarda hem yerel uygulamalarda hem de HTML5 dağıtım paketlerinde kullanılabilir.
+
+![](images/input/touch_bindings.png)
+
+## Tekli dokunma
+Tekli dokunma türündeki tetikleyiciler, girdi eşlemelerinin Touch Triggers bölümünden ayarlanmaz. Bunun yerine **`MOUSE_BUTTON_LEFT` veya `MOUSE_BUTTON_1` için fare düğmesi girdisini ayarladığınızda tekli dokunma tetikleyicileri otomatik olarak ayarlanır**.
+
+## Çoklu dokunma
+Çoklu dokunma türündeki tetikleyiciler, eylem tablosunun içindeki `touch` adlı tabloyu doldurur. Tablonun elemanları `1`--`N` aralığındaki tam sayılarla indekslenir; burada `N`, dokunma noktalarının sayısıdır. Tablodaki her eleman girdi verileri içeren alanlar barındırır:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("touch_multi") then
+        -- Spawn at each touch point
+        for i, touchdata in ipairs(action.touch) do
+            local pos = vmath.vector3(touchdata.x, touchdata.y, 0)
+            factory.create("#factory", pos)
+        end
+    end
+end
+```
+
+::: important
+Çoklu dokunmaya, `MOUSE_BUTTON_LEFT` veya `MOUSE_BUTTON_1` fare düğmesi girdisiyle aynı eylem atanmamalıdır. Aynı eylemi atamak, tekli dokunmanın yerini alır ve herhangi bir tekli dokunma olayı almanızı engeller.
+:::
+
+::: sidenote
+[Defold-Input varlığı](https://defold.com/assets/defoldinput/), çoklu dokunma desteğine sahip düğmeler ve analog çubuklar gibi sanal ekran kontrollerini kolayca oluşturmak için kullanılabilir.
+:::
+
+
+## Nesnelere tıklamayı veya dokunmayı algılama
+Kullanıcının görsel bir bileşene (component) ne zaman tıkladığını veya dokunduğunu algılamak, birçok oyunda ihtiyaç duyulan çok yaygın bir işlemdir. Bu, kullanıcının bir düğmeyle veya başka bir kullanıcı arayüzü (UI) öğesiyle etkileşimi olabilir. Strateji oyununda oyuncunun yönettiği bir birim, zindan keşif oyununda bir bölümdeki hazine veya rol yapma oyununda (RPG) görev veren bir karakter gibi bir oyun nesnesiyle (game object) etkileşim de olabilir. Kullanılacak yaklaşım, görsel bileşenin türüne göre değişir.
+
+### GUI düğümleriyle etkileşimi algılama
+Kullanıcı arayüzü öğeleri için `gui.pick_node(node, x, y)` işlevi bulunur. Bu işlev, belirtilen koordinatın bir GUI düğümünün (GUI node) sınırları içinde olup olmamasına göre `true` veya `false` döndürür. Daha fazla bilgi için [API belgelerine](/ref/gui/#gui.pick_node:node-x-y), [işaretçinin öğe üzerinde olmasını algılama örneğine](/examples/gui/pointer_over/) veya [düğme örneğine](/examples/gui/button/) bakın.
+
+### Oyun nesneleriyle etkileşimi algılama
+Kamera ötelemesi ve işleme betiğinin (render script) izdüşümü gibi etkenler gerekli hesaplamaları etkilediğinden, oyun nesneleriyle etkileşimi algılamak daha karmaşıktır. Oyun nesneleriyle etkileşimi algılamak için iki genel yaklaşım vardır:
+
+  1. Kullanıcının etkileşim kurabileceği oyun nesnelerinin konumunu ve boyutunu takip edin ve fare ya da dokunma koordinatının bu nesnelerden herhangi birinin sınırları içinde olup olmadığını kontrol edin.
+  2. Kullanıcının etkileşim kurabileceği oyun nesnelerine çarpışma nesneleri (collision object) ekleyin. Fareyi veya parmağı takip eden bir çarpışma nesnesi de ekleyin ve aralarında çarpışma olup olmadığını kontrol edin.
+
+::: sidenote
+Çarpışma nesneleriyle kullanıcı girdisini algılamak için sürükleme ve tıklama desteğine sahip, kullanıma hazır bir çözümü [Defold-Input varlığında](https://defold.com/assets/defoldinput/) bulabilirsiniz.
+:::
+
+Her iki durumda da fare veya dokunma olayının ekran uzayı (screen space) koordinatları ile oyun nesnelerinin dünya uzayı (world space) koordinatları arasında dönüşüm yapmak gerekir. Bunu birkaç farklı yolla yapabilirsiniz:
+
+  * İşleme betiğinin kullandığı görünümü ve izdüşümü elle takip edin ve bunları dünya uzayına ve dünya uzayından dönüşüm yapmak için kullanın. [Kamera kılavuzunda bunun bir örneğini bulabilirsiniz](/manuals/camera/#converting-mouse-to-world-coordinates).
+  * [Üçüncü taraf bir kamera çözümü](/manuals/camera/#third-party-camera-solutions) kullanın ve sunduğu ekran uzayından dünya uzayına dönüşüm işlevlerinden yararlanın.

--- a/docs/tr/manuals/input.md
+++ b/docs/tr/manuals/input.md
@@ -1,0 +1,221 @@
+---
+title: Defold'da cihaz girdisi
+brief: Bu kılavuz, girdinin nasıl çalıştığını, girdi eylemlerini yakalamayı ve bu eylemlere tepki veren betikler oluşturmayı açıklar.
+---
+
+# Girdi
+
+Motor, tüm kullanıcı girdilerini yakalar ve girdi odağı (input focus) edinmiş oyun nesnelerinde (game object) bulunan, `on_input()` işlevini uygulayan betik ve GUI betiği bileşenlerine (component) eylemler olarak dağıtır. Bu kılavuz, girdiyi yakalamak için girdi eşlemelerini (input binding) nasıl ayarlayacağınızı ve girdiye tepki veren kodu nasıl oluşturacağınızı açıklar.
+
+Girdi sistemi, girdiyi oyununuza uygun gördüğünüz şekilde yönetmenizi sağlayan basit ve güçlü kavramlar kullanır.
+
+![Girdi eşlemeleri](images/input/overview.png)
+
+Cihazlar
+: Bilgisayarınızın veya mobil cihazınızın parçası olan ya da bunlara bağlanan girdi cihazları, Defold çalışma zamanı ortamına sistem düzeyinde ham girdi sağlar. Aşağıdaki cihaz türleri desteklenir:
+
+  1. Klavye (tek tuş girdisi ve metin girdisi)
+  2. Fare (konum, düğme tıklamaları ve fare tekerleği eylemleri)
+  3. Tekli ve çoklu dokunma (iOS ve Android cihazlarda ve mobil cihazlardaki HTML5 uygulamalarında)
+  4. Oyun kumandaları (işletim sistemi tarafından desteklendiği ve [gamepads](/manuals/input-gamepads/#gamepads-settings-file) dosyasında eşlendiği şekilde)
+
+Girdi eşlemeleri
+: Girdi bir betiğe gönderilmeden önce, cihazdan gelen ham girdi, girdi eşlemeleri tablosu aracılığıyla anlamlı *eylemlere* dönüştürülür.
+
+Eylemler
+: Eylemler, girdi eşlemeleri dosyasında listelediğiniz adlarla (bu adların karma değerleriyle) tanımlanır. Her eylem ayrıca girdiyle ilgili veriler içerir: bir düğmeye basılıp basılmadığı veya düğmenin bırakılıp bırakılmadığı, fare ve dokunma koordinatları vb.
+
+Girdi dinleyicileri
+: Herhangi bir betik bileşeni veya GUI betiği, *girdi odağı edinerek* girdi eylemleri (input action) alabilir. Aynı anda birden fazla dinleyici etkin olabilir.
+
+Girdi yığını
+: Girdi yığını (input stack), odağı ilk edinen dinleyicinin en altta, son edinen dinleyicinin en üstte olduğu girdi dinleyicileri listesidir.
+
+Girdiyi tüketme
+: Bir betik, aldığı girdiyi tüketmeyi seçerek yığının daha aşağısındaki dinleyicilerin bu girdiyi almasını engelleyebilir.
+
+## Girdi eşlemelerini ayarlama
+
+Girdi eşlemeleri, cihaz girdileri betik bileşenlerinize ve GUI betiklerinize dağıtılmadan önce bunların adlandırılmış *eylemlere* nasıl dönüştürüleceğini belirtmenizi sağlayan, proje genelinde geçerli bir tablodur. Yeni bir girdi eşlemesi dosyası oluşturmak için *Assets* görünümünde bir konuma <kbd>sağ tıklayın</kbd> ve <kbd>New... ▸ Input Binding</kbd> seçeneğini seçin. Motorun yeni dosyayı kullanması için *game.project* dosyasındaki *Game Binding* alanını değiştirin.
+
+![Girdi eşlemesi ayarı](images/input/setting.png)
+
+Tüm yeni proje şablonlarıyla birlikte varsayılan bir girdi eşlemesi dosyası otomatik olarak oluşturulur; bu nedenle genellikle yeni bir eşleme dosyası oluşturmanız gerekmez. Varsayılan dosyanın adı `game.input_binding` şeklindedir ve projenin kök dizinindeki `input` klasöründe bulunur. Dosyayı düzenleyicide açmak için dosyaya <kbd>çift tıklayın</kbd>:
+
+![Girdi eşlemelerini ayarlama](images/input/input_binding.png)
+
+Yeni bir eşleme oluşturmak için ilgili tetikleyici türü bölümünün altındaki <kbd>+</kbd> düğmesine tıklayın. Her kayıt iki alan içerir:
+
+*Input*
+: Kullanılabilir girdilerin kaydırılabilir listesinden seçilen, dinlenecek ham girdi.
+
+*Action*
+: Girdi eylemleri oluşturulup betiklerinize dağıtılırken onlara verilen eylem adı. Aynı eylem adı birden fazla girdiye atanabilir. Örneğin, <kbd>Space</kbd> tuşunu ve oyun kumandasının `A` düğmesini `jump` eylemine bağlayabilirsiniz. Ne yazık ki dokunma girdilerinin diğer girdilerle aynı eylem adlarını kullanmasını engelleyen bilinen bir hata olduğunu unutmayın.
+
+## Tetikleyici türleri
+
+Cihaza özgü beş tür tetikleyici oluşturabilirsiniz:
+
+Key Triggers
+: Tek tuşluk klavye girdisi. Her tuş, karşılık gelen bir eyleme ayrı ayrı eşlenir. Daha fazla bilgi için [tuş ve metin girdisi kılavuzuna](/manuals/input-key-and-text) bakın.
+
+Text Triggers
+: Metin tetikleyicileri, serbest metin girdisini okumak için kullanılır. Daha fazla bilgi için [tuş ve metin girdisi kılavuzuna](/manuals/input-key-and-text) bakın
+
+Mouse Triggers
+: Fare düğmelerinden ve kaydırma tekerleklerinden gelen girdi. Daha fazla bilgi için [fare ve dokunma girdisi kılavuzuna](/manuals/input-mouse-and-touch) bakın.
+
+Touch Triggers
+: Tekli dokunma ve çoklu dokunma türündeki tetikleyiciler, iOS ve Android cihazlarda yerel uygulamalarda ve HTML5 dağıtım paketlerinde kullanılabilir. Daha fazla bilgi için [fare ve dokunma kılavuzuna](/manuals/input-mouse-and-touch) bakın.
+
+Gamepad Triggers
+: Oyun kumandası tetikleyicileri, standart oyun kumandası girdisini oyun işlevlerine bağlamanızı sağlar. Daha fazla bilgi için [oyun kumandaları kılavuzuna](/manuals/input-gamepads) bakın.
+
+### İvmeölçer girdisi
+
+Defold, yukarıda listelenen beş farklı tetikleyici türüne ek olarak yerel Android ve iOS uygulamalarında ivmeölçer girdisini de destekler. *game.project* dosyanızın *Input* bölümündeki *Use Accelerometer* kutusunu işaretleyin.
+
+```lua
+function on_input(self, action_id, action)
+    if action.acc_x and action.acc_y and action.acc_z then
+        -- react to accelerometer data
+    end
+end
+```
+
+## Girdi odağı {#input-focus}
+
+Bir betik bileşeninde veya GUI betiğinde girdi eylemlerini dinlemek için, bileşeni barındıran oyun nesnesine `acquire_input_focus` iletisi gönderilmelidir:
+
+```lua
+-- tell the current game object (".") to acquire input focus
+msg.post(".", "acquire_input_focus")
+```
+
+Bu ileti, motora oyun nesnelerindeki girdi alabilen bileşenleri (betik bileşenleri, GUI bileşenleri ve koleksiyon vekilleri) *girdi yığınına* ekleme talimatı verir. Oyun nesnesinin bileşenleri girdi yığınının en üstüne yerleştirilir; son eklenen bileşen yığının en üstünde olur. Oyun nesnesinde girdi alabilen birden fazla bileşen varsa tüm bileşenlerin yığına ekleneceğini unutmayın:
+
+![Girdi yığını](images/input/input_stack.png)
+
+Daha önce girdi odağı edinmiş bir oyun nesnesi bunu yeniden yaparsa bileşenleri yığının en üstüne taşınır.
+
+
+## Girdi dağıtımı ve on_input() {#input-dispatch-and-on_input}
+
+Girdi eylemleri, girdi yığınına göre yukarıdan aşağıya doğru dağıtılır.
+
+![Eylem dağıtımı](images/input/actions.png)
+
+Yığında bulunan ve `on_input()` işlevini içeren her bileşende bu işlev, kare boyunca her girdi eylemi için bir kez, aşağıdaki bağımsız değişkenlerle çağrılır:
+
+`self`
+: Geçerli betik örneği.
+
+`action_id`
+: Eylemin, girdi eşlemelerinde ayarlanan adının karma değeri.
+
+`action`
+: Girdinin değeri, konumu (mutlak konum ve konum farkı), düğme girdisinin `pressed` olup olmadığı gibi eylemle ilgili yararlı verileri içeren bir tablo. Kullanılabilir eylem alanlarıyla ilgili ayrıntılar için [on_input()](/ref/go#on_input) işlevine bakın.
+
+```lua
+function on_input(self, action_id, action)
+  if action_id == hash("left") and action.pressed then
+    -- move left
+    local pos = go.get_position()
+    pos.x = pos.x - 100
+    go.set_position(pos)
+  elseif action_id == hash("right") and action.pressed then
+    -- move right
+    local pos = go.get_position()
+    pos.x = pos.x + 100
+    go.set_position(pos)
+  end
+end
+```
+
+
+### Girdi odağı ve koleksiyon vekili bileşenleri
+
+Bir koleksiyon vekili (collection proxy) aracılığıyla dinamik olarak yüklenen her oyun dünyasının kendi girdi yığını vardır. Eylem dağıtımının yüklenen dünyanın girdi yığınına ulaşması için vekil bileşenin ana dünyanın girdi yığınında bulunması gerekir. Dağıtım ana yığında aşağıya doğru devam etmeden önce, yüklenen dünyanın yığınındaki tüm bileşenler ele alınır:
+
+![Eylemlerin vekillere dağıtımı](images/input/proxy.png)
+
+::: important
+Koleksiyon vekili bileşenini barındıran oyun nesnesine `acquire_input_focus` göndermeyi unutmak yaygın bir hatadır. Bu adımın atlanması, girdinin yüklenen dünyanın girdi yığınındaki herhangi bir bileşene ulaşmasını engeller.
+:::
+
+
+### Girdiyi bırakma
+
+Girdi eylemlerini dinlemeyi durdurmak için oyun nesnesine bir `release_input_focus` iletisi gönderin. Bu ileti, oyun nesnesinin girdi yığınında bulunan tüm bileşenlerini yığından çıkarır:
+
+```lua
+-- tell the current game object (".") to release input focus.
+msg.post(".", "release_input_focus")
+```
+
+
+## Girdiyi tüketme
+
+Bir bileşenin `on_input()` işlevi, eylemlerin yığında daha aşağıya aktarılıp aktarılmayacağını etkin olarak denetleyebilir:
+
+- `on_input()` işlevi `false` döndürürse veya bir dönüş değeri belirtilmezse (bu durumda Lua'da yanlış olarak değerlendirilen `nil` değeri döndürülür) girdi eylemleri, girdi yığınındaki bir sonraki bileşene aktarılır.
+- `on_input()` işlevi `true` döndürürse girdi tüketilir. Girdi yığınının daha aşağısındaki hiçbir bileşen bu girdiyi almaz. Bunun *tüm* girdi yığınları için geçerli olduğunu unutmayın. Bir vekil aracılığıyla yüklenen dünyanın yığınındaki bir bileşen, girdiyi tüketerek ana yığındaki bileşenlerin girdi almasını engelleyebilir:
+
+![Girdiyi tüketme](images/input/consuming.png)
+
+Girdiyi tüketmenin, girdiyi oyunun farklı bölümleri arasında yönlendirmek için basit ve güçlü bir yol sunduğu birçok kullanım durumu vardır. Örneğin, geçici olarak oyunun girdi dinleyen tek bölümü olacak bir açılır menüye ihtiyacınız olduğunu düşünün:
+
+![Girdiyi tüketme](images/input/game.png)
+
+Duraklatma menüsü başlangıçta gizlidir (devre dışıdır) ve oyuncu oyun içi bilgi göstergesindeki (HUD) `PAUSE` öğesine dokunduğunda etkinleştirilir:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("mouse_press") and action.pressed then
+        -- Did the player press PAUSE?
+        local pausenode = gui.get_node("pause")
+        if gui.pick_node(pausenode, action.x, action.y) then
+            -- Tell the pause menu to take over.
+            msg.post("pause_menu", "show")
+        end
+    end
+end
+```
+
+![Duraklatma menüsü](images/input/game_paused.png)
+
+Duraklatma menüsünün GUI bileşeni girdi odağı edinir ve girdiyi tüketerek açılır menüyle ilgili girdiler dışındaki tüm girdileri engeller:
+
+```lua
+function on_message(self, message_id, message, sender)
+  if message_id == hash("show") then
+    -- Show the pause menu.
+    local node = gui.get_node("pause_menu")
+    gui.set_enabled(node, true)
+
+    -- Acquire input.
+    msg.post(".", "acquire_input_focus")
+  end
+end
+
+function on_input(self, action_id, action)
+  if action_id == hash("mouse_press") and action.pressed then
+
+    -- do things...
+
+    local resumenode = gui.get_node("resume")
+    if gui.pick_node(resumenode, action.x, action.y) then
+        -- Hide the pause menu
+        local node = gui.get_node("pause_menu")
+        gui.set_enabled(node, false)
+
+        -- Release input.
+        msg.post(".", "release_input_focus")
+    end
+  end
+
+  -- Consume all input. Anything below us on the input stack
+  -- will never see input until we release input focus.
+  return true
+end
+```

--- a/docs/tr/manuals/install.md
+++ b/docs/tr/manuals/install.md
@@ -1,0 +1,10 @@
+---
+title: Defold kurulumu
+brief: Bu kılavuz, işletim sisteminiz için Defold düzenleyicisini nasıl indirip kuracağınızı açıklar.
+---
+
+# Defold kurulumu
+
+Defold düzenleyicisinin kurulumu oldukça basittir. İşletim sisteminiz için derlenmiş sürümü indirin, arşivden çıkarın ve yazılımı uygun bir konuma kopyalayın.
+
+:[install](../shared/install.md)

--- a/docs/tr/manuals/instant-games.md
+++ b/docs/tr/manuals/instant-games.md
@@ -1,0 +1,6 @@
+---
+title: Facebook Instant Games
+brief: Bu kılavuz, Defold ile Facebook Instant Games oyunlarının nasıl oluşturulacağını açıklar.
+---
+
+[Bu kılavuz taşındı](/extension-fbinstant)

--- a/docs/tr/manuals/introduction.md
+++ b/docs/tr/manuals/introduction.md
@@ -1,0 +1,74 @@
+---
+brief: Defold'a kısa bir giriş. Oyun geliştirme ve Defold maceranıza başlamak için harika bir yer.
+github: https://github.com/defold/doc
+layout: manual
+locale: tr
+title: Defold'a giriş
+toc:
+- Defold'a hoş geldiniz
+- Nereden başlamalı?
+---
+
+## Defold'a hoş geldiniz
+
+Defold, 2B ve 3B oyun geliştirmek için ücretsiz, hafif ve yüksek performanslı, kullanıma hazır bir çözümdür. Oyun motorunu, düzenleyiciyi ve derleme ekosistemini tek pakette sunarak tasarlamak, geliştirmek ve yayımlamak için ihtiyacınız olan her şeyi sağlar. Desteklenen özelliklerin tam listesini [Ürüne genel bakış](/product) sayfamızda bulabilirsiniz.
+
+Oyun geliştirme sürecinin bazı temel unsurlarını olabildiğince sorunsuz ve zahmetsiz hâle getirmek için çok zaman ve emek harcadık. Bunun Defold'u diğerlerinden ayırdığına inanıyoruz. [Defold'u neden kullanmanız gerektiğini düşündüğümüzü](/why) öğrenin.
+
+## Nereden başlamalı?
+
+[**Öğrenme merkezimiz**](/learn), Defold'a yönelik tüm öğrenme kaynakları için başlangıç noktasıdır. Burada şunları bulabilirsiniz:
+
+- [**Kılavuzlar**](/manuals) (bu kılavuz gibi) - belirli bir konuyu derinlemesine anlamak ve bilginizi genişletmek için
+- [**Öğreticiler**](/tutorials) - adım adım yönlendirmeleri izleyerek bir şeyler oluşturmak için
+- [**Örnekler**](/examples) - kısa kod parçaları ile basit, küçük, kendi içinde bütünlük taşıyan işlevler ve örnekler
+- [**Kurslar**](/courses) - Zenva ve Udemy'deki derslerin yanı sıra topluluğun hazırladığı, daha uzun, kapsamlı ve yapılandırılmış dersler
+- [**Videolar**](/videos) - izlemeyi tercih ediyorsanız aralarından seçebileceğiniz çok sayıda video öğretici ve genel bakış videosu
+- [**API**](/ref/stable/overview_defoldlua) - güncel ve eksiksiz belgelerimizle sunulan tüm işlevleri ve sabitleri anlamak için
+- [**Sık sorulan sorular**](/faq/faq) - en sık sorulan soruların yanıtları; sorununuzun daha önce çözülüp çözülmediğini görmek için arama yapın
+
+Denemeler yapmanızı, öğreticileri izlemenizi, kılavuzlarımızı ve API belgelerimizi okumanızı, soru sormak, diğer kullanıcılardan öğrenmek ve Defold'un gelişimini takip etmek için [topluluk kanallarımıza](/community) katılmanızı öneririz.
+
+Oyun geliştirmeye başlarken veya Defold'u öğrenirken bilmenizde yarar olan bazı noktalar şunlardır:
+
+### Defold düzenleyicisi
+
+[![Düzenleyiciye genel bakış](images/editor/editor_overview.png)](/manuals/editor)
+
+[Düzenleyiciye genel bakış](/manuals/editor/) kılavuzu, düzenleyiciye iyi bir giriş sağlar; arayüzde yolunuzu bulmanıza, görsel araçları kullanmanıza ve kod yazmanıza yardımcı olur. Diğer oyun motorlarının düzenleyicilerine, 3B modelleme programlarına ve programlama için kullanılan tümleşik geliştirme ortamlarına (IDE) aşinaysanız pek fazla sürprizle karşılaşmazsınız. Yine de en sevdiğiniz yazılımdan farklı olan noktalar her zaman olacaktır.
+
+### Defold'un yapı taşları
+
+[![Yapı taşları](images/building_blocks/building_blocks.png)](/manuals/building-blocks)
+
+[Defold'un yapı taşları](/manuals/building-blocks/) kılavuzu, Defold'da oyun geliştirmenin temel kavramlarına harika bir giriş sunar. Defold, oyun geliştirmek için farklı türlerde birden çok bileşen (component) içeren oyun nesneleri (game object) kullanır; bu oyun nesneleri daha sonra koleksiyonlar (collection) hâlinde gruplanır. Daha önce başka motorlar kullandıysanız bunlar size tanıdık gelebilir. Defold'un yapı taşlarını özel kılan bazı mimari tasarım kararları vardır ve bunlarla rahatça çalışmaya alışmak biraz zaman alır. Bu nedenle yapı taşları kılavuzumuz, özellikle sistemin nasıl çalıştığını anlamaya ihtiyaç duyuyorsanız iyi bir başlangıçtır.
+
+### Örnekler
+
+[![Örnekler](images/introduction/examples.png)](/examples)
+
+[Örnekler](/examples/) derlemesi, parçaları bir araya getirerek çalışan bir şey oluşturmayı öğrenmek için iyi bir başlangıçtır. Burada, Defold'da sık karşılaşılan pek çok farklı işlemin nasıl yapılacağını gösteren en küçük örnekleri, kullanabileceğiniz kod parçalarını, yaygın işlevlerin örneklerini ve belirli özellikleri gösteren uygulamaları bulabilirsiniz.
+
+### Öğreticiler
+
+[![Öğreticiler](images/introduction/tutorials.png)](/tutorials)
+
+[Öğreticiler](/tutorials), oyun geliştirmeye başlamak için harikadır. En iyi yaparak öğrendiğinize inanıyoruz. Bu nedenle, çeşitli beceri ve karmaşıklık düzeylerinde bir dizi öğreticiyi doğrudan [düzenleyicide](/manuals/editor/) ve öğrenme merkezimizde sunuyoruz. Düzenleyiciyi başlatın; bir şeyler oluşturmayı ve Defold'un nasıl çalıştığını öğrenmek için adım adım yönergeleri izleyin.
+
+### Lua dili
+
+[![Lua'ya genel bakış](images/introduction/lua.png)](/manuals/lua)
+
+[Lua](/manuals/lua/), Defold'daki tüm mantık denetimi için kullanılan dildir. Motorun iç yapısı C++ ile yazılmış hızlı bir sistemdir, ancak üst düzeyde Lua betikleriyle kontrol edilir. Python, GDScript, GML, JavaScript veya başka bir yüksek düzeyli dilde programlama yaptıysanız Lua'yı oldukça kolay kavrar ve muhtemelen bir öğreticiyi rahatça takip edebilirsiniz. Aksi hâlde Lua kılavuzumuzu okuyarak başlayın ve oradan devam edin.
+
+### Defold forumu
+
+[![Forum](images/introduction/forum.png)](//forum.defold.com/)
+
+[Defold forumu](//forum.defold.com/), çoğu zaman öğrenmenin en iyi yoludur. Başkalarından öğrenebilir, sorunuzun daha önce yanıtlanıp yanıtlanmadığını bulmak için forumda arama yapabilir veya doğrudan sorabilirsiniz. Topluluğumuz çok sıcakkanlı ve yardımseverdir; genel olarak oyun geliştirme, özel olarak da Defold hakkında çok şey bilir. Bir yerde takılırsanız tereddüt etmeyin, yardım almak için foruma gidin!
+
+### Öğrenme merkezi
+
+Defold'u öğrenmek için hangi yolu seçerseniz seçin, başka öğrenme kaynakları bulmak ve Defold'un sunduğu çeşitli özellikler ile kavramlar hakkında derinlemesine açıklamalar içeren kılavuzları okumak için [**Öğrenme merkezimize**](/learn) her zaman dönebileceğinizi unutmayın. Anlamadığınız veya yanlış olduğunu düşündüğünüz noktaları belirtmekten de çekinmeyin. Bu sayfalar sizin için hazırlanıyor ve onları olabildiğince iyi hâle getirmek istiyoruz. Bu nedenle kullanıcıların geri bildirimlerini dikkate alıyor ve öğrenme sürecini mümkün olduğunca sorunsuz kılmak için kaynakları geliştirmeye çalışıyoruz!
+
+Bir sonraki harika oyununuzu Defold'da oluştururken keyif almanızı umuyoruz!

--- a/docs/tr/manuals/ios.md
+++ b/docs/tr/manuals/ios.md
@@ -1,0 +1,273 @@
+---
+title: Defold ile iOS platformu için geliştirme
+brief: Bu kılavuz, Defold'da iOS cihazları için oyun ve uygulama derlemeyi ve çalıştırmayı açıklar.
+---
+
+# iOS için geliştirme
+
+::: sidenote
+iOS için oyun paketleme yalnızca Defold düzenleyicisinin Mac sürümünde kullanılabilir.
+:::
+
+iOS, derlediğiniz ve telefonunuzda veya tabletinizde çalıştırmak istediğiniz _her_ uygulamanın Apple tarafından verilmiş bir sertifika ve sağlama profiliyle (provisioning profile) imzalanmasını _zorunlu kılar_. Bu kılavuz, oyununuzu iOS için paketlerken izlemeniz gereken adımları açıklar. Geliştirme sırasında oyununuzu [geliştirme uygulaması](/manuals/dev-app) üzerinden çalıştırmak genellikle tercih edilir; çünkü bu yöntem, içeriği ve kodu doğrudan cihazınızda çalışma sırasında yeniden yüklemenize (hot reload) olanak tanır.
+
+## Apple'ın kod imzalama süreci
+
+iOS uygulamalarının güvenliği birkaç bileşenden oluşur. [Apple'ın iOS Developer Program](https://developer.apple.com/programs/) programına kaydolarak gerekli araçlara erişebilirsiniz. Kaydolduktan sonra [Apple Developer Member Center](https://developer.apple.com/membercenter/index.action) sayfasına gidin.
+
+![Apple Member Center](images/ios/apple_member_center.png)
+
+*Certificates, Identifiers & Profiles* bölümü, ihtiyacınız olan tüm araçları içerir. Buradan aşağıdakileri oluşturabilir, silebilir ve düzenleyebilirsiniz:
+
+Certificates
+: Sizi geliştirici olarak tanımlayan, Apple tarafından verilmiş kriptografik sertifikalardır. Geliştirme veya üretim sertifikaları oluşturabilirsiniz. Geliştirici sertifikaları, uygulama içi satın alma mekanizması gibi belirli özellikleri yalıtılmış bir test ortamında denemenize olanak tanır. Üretim sertifikaları, App Store'a yüklenecek son uygulamayı imzalamak için kullanılır. Uygulamaları test amacıyla cihazınıza koymadan önce imzalamak için bir sertifikaya ihtiyacınız vardır.
+
+Identifiers
+: Çeşitli amaçlarla kullanılan tanımlayıcılardır. Birden çok uygulamayla kullanılabilen joker karakterli tanımlayıcılar (ör. `some.prefix.*`) kaydedebilirsiniz. App ID'ler, uygulamanın Passbook entegrasyonunu, Game Center'ı vb. etkinleştirip etkinleştirmediği gibi Application Service bilgilerini içerebilir. Bu tür App ID'ler joker karakterli tanımlayıcılar olamaz. Application Services işlevlerinin çalışması için uygulamanızın *paket tanımlayıcısı* (bundle identifier), App ID tanımlayıcısıyla eşleşmelidir.
+
+Devices
+: Her geliştirme cihazının kendi UDID değeriyle (Unique Device IDentifier, aşağıya bakın) kaydedilmesi gerekir.
+
+Provisioning Profiles
+: Sağlama profilleri, sertifikaları App ID'ler ve bir cihaz listesiyle ilişkilendirir. Hangi geliştiricinin hangi uygulamasının hangi cihazlarda bulunmasına izin verildiğini belirtir.
+
+Defold'da oyunlarınızı ve uygulamalarınızı imzalarken geçerli bir sertifikaya ve geçerli bir sağlama profiline ihtiyacınız vardır.
+
+::: sidenote
+Member Center ana sayfasında yapabileceğiniz işlemlerin bazılarını, kuruluysa Xcode geliştirme ortamından da yapabilirsiniz.
+:::
+
+Cihaz tanımlayıcısı (UDID)
+: Bir iOS cihazının UDID değerini bulmak için cihazı Wi-Fi veya kabloyla bir bilgisayara bağlayın. Xcode'u açın ve <kbd>Window ▸ Devices and Simulators</kbd> seçeneğini seçin. Cihazınızı seçtiğinizde seri numarası ve tanımlayıcısı görüntülenir.
+
+  ![Xcode cihazları](images/ios/xcode_devices.png)
+
+  Xcode kurulu değilse tanımlayıcıyı iTunes'da bulabilirsiniz. Cihazlar simgesine tıklayın ve cihazınızı seçin.
+
+  ![iTunes cihazları](images/ios/itunes_devices.png)
+
+  1. *Summary* sayfasında *Serial Number* alanını bulun.
+  2. Alanın *UDID* olarak değişmesi için *Serial Number* alanına bir kez tıklayın. Art arda tıklarsanız cihazla ilgili çeşitli bilgiler gösterilir. *UDID* görünene kadar tıklamaya devam edin.
+  3. Uzun UDID dizesine sağ tıklayın ve tanımlayıcıyı panoya kopyalamak için <kbd>Copy</kbd> seçeneğini seçin. Böylece cihazı Apple Developer Member Center'da kaydederken UDID alanına kolayca yapıştırabilirsiniz.
+
+## Ücretsiz Apple geliştirici hesabıyla geliştirme
+
+Xcode 7'den itibaren herkes Xcode'u kurup ücretsiz olarak cihaz üzerinde geliştirme yapabilir. iOS Developer Program programına kaydolmanız gerekmez. Bunun yerine Xcode, geliştirici olarak sizin için otomatik olarak bir sertifika (1 yıl geçerli) ve belirli cihazınızdaki uygulamanız için bir sağlama profili (bir hafta geçerli) oluşturur.
+
+1. Cihazınızı bağlayın.
+2. Xcode'u kurun.
+3. Xcode'a yeni bir hesap ekleyin ve Apple ID'nizle giriş yapın.
+4. Yeni bir proje oluşturun. En basit `Single View App` yeterlidir.
+5. `Team` seçeneğini (sizin için otomatik oluşturulur) seçin ve uygulamaya bir paket tanımlayıcısı verin.
+
+::: important
+Defold projenizde aynı paket tanımlayıcısını kullanmanız gerektiğinden bu tanımlayıcıyı not edin.
+:::
+
+6. Xcode'un uygulama için bir *Provisioning Profile* ve *Signing Certificate* oluşturduğundan emin olun.
+
+   ![](images/ios/xcode_certificates.png)
+
+7. Uygulamayı cihazınızda derleyin. İlk seferde Xcode, Developer mode seçeneğini etkinleştirmenizi ister ve cihazı hata ayıklayıcı desteğiyle hazırlar. Bu işlem biraz zaman alabilir.
+8. Uygulamanın çalıştığını doğruladıktan sonra uygulamayı diskinizde bulun. Derleme konumunu `Report Navigator` içindeki derleme raporunda görebilirsiniz.
+
+   ![](images/ios/app_location.png)
+
+9. Uygulamayı bulun, sağ tıklayın ve <kbd>Show Package Contents</kbd> seçeneğini seçin.
+
+   ![](images/ios/app_contents.png)
+
+10. `embedded.mobileprovision` dosyasını diskinizde daha sonra bulabileceğiniz bir yere kopyalayın.
+
+   ![](images/ios/free_provisioning.png)
+
+Bu sağlama dosyası, kod imzalama kimliğinizle birlikte Defold'da uygulamaları bir hafta boyunca imzalamak için kullanılabilir.
+
+Sağlama dosyasının süresi dolduğunda uygulamayı Xcode'da yeniden derlemeniz ve yukarıda açıklandığı gibi yeni bir geçici sağlama dosyası almanız gerekir.
+
+## iOS uygulama dağıtım paketi oluşturma {#creating-an-ios-application-bundle}
+
+Kod imzalama kimliğini ve sağlama profilini edindikten sonra, düzenleyiciden oyununuz için bağımsız bir uygulama dağıtım paketi (bundle) oluşturmaya hazırsınız. Menüden <kbd>Project ▸ Bundle... ▸ iOS Application...</kbd> seçeneğini seçin.
+
+![iOS dağıtım paketini imzalama](images/ios/sign_bundle.png)
+
+Kod imzalama kimliğinizi seçin, mobil sağlama dosyanızı bulup seçin ve derleme çeşidini (Debug veya Release) belirleyin. İsterseniz `Sign application` onay kutusunun işaretini kaldırarak imzalama işlemini atlayabilir ve daha sonraki bir aşamada elle imzalayabilirsiniz. Cihaz dağıtım paketi yerine iOS Simulator için bir `arm64_sim-ios` dağıtım paketi oluşturmak üzere `Simulator` seçeneğini işaretleyin.
+
+::: important
+Simülatör dağıtım paketleri yalnızca Apple Silicon Mac'lerdeki iOS Simulator üzerinde çalışır. İmzalama kimliği veya sağlama profili kullanmadıklarından, `Simulator` işaretlendiğinde imzalama, kurma ve başlatma seçenekleri devre dışı bırakılır. Dağıtım paketini aşağıda açıklandığı gibi `xcrun simctl` ile kurun.
+:::
+
+*Create Bundle* düğmesine basın; ardından dağıtım paketinin bilgisayarınızda nerede oluşturulacağını belirtmeniz istenir.
+
+![ipa iOS uygulama dağıtım paketi](images/ios/ipa_file.png){.left}
+
+Uygulamada kullanılacak simgeyi, açılış ekranının arayüz taslağını (storyboard) ve benzeri ayarları *game.project* proje ayarları dosyasının [iOS bölümünde](/manuals/project-settings/#ios) belirtirsiniz.
+
+### Özel Info.plist ve yerel hedef keşfi
+
+Yerleşik iOS `Info.plist` dosyası, yayıma yönelik olmayan derlemelerde düzenleyicinin hedefleri otomatik keşfetmesi için gereken Bonjour hizmetini ve yerel ağ kullanım açıklamasını içerir. Özel bir `Info.plist`, bu yerleşik temel bildirimin yerini alır. Bir hata ayıklama derlemesinde özel bildirim kullanıyorsanız ve yerel ağ üzerinden hedef keşfine, profil çıkarmaya, çalışma sırasında yeniden yüklemeye veya günlük akışına ihtiyacınız varsa şu girdileri ekleyin:
+
+```xml
+{{^variant_release}}
+<key>NSBonjourServices</key>
+<array>
+    <string>_defold._tcp</string>
+</array>
+<key>NSLocalNetworkUsageDescription</key>
+<string>Discover Defold targets on the local network.</string>
+{{/variant_release}}
+```
+
+Mustache koşulu, keşif girdilerinin yayıma yönelik dağıtım paketlerine dahil edilmesini önler. Kullanım açıklaması dizesi iOS tarafından kullanıcıya gösterilir ve düzenlenebilir veya yerelleştirilebilir. Koşulu yalnızca yayıma yönelik uygulamanın kendisi aynı Bonjour hizmetini ve yerel ağ işlevlerini kullanıyorsa kaldırın.
+
+:[Build Variants](../shared/build-variants.md)
+
+## Bağlı bir iPhone'a dağıtım paketi kurma ve başlatma
+
+Derlenen dağıtım paketini, düzenleyicinin Bundle iletişim kutusundaki `Install on connected device` ve `Launch installed app` onay kutularını kullanarak kurabilir ve başlatabilirsiniz:
+
+![iOS dağıtım paketini kurma ve başlatma](images/ios/install_and_launch.png)
+
+Bu özelliğin çalışması için [ios-deploy](https://github.com/ios-control/ios-deploy) komut satırı aracının kurulu olması gerekir. Kurmanın en basit yolu Homebrew kullanmaktır:
+```
+$ brew install ios-deploy
+```
+
+Düzenleyici ios-deploy aracının kurulum konumunu algılayamazsa bu konumu [Preferences](/manuals/editor-preferences/#tools) bölümünde belirtmeniz gerekir. 
+
+### Arayüz taslağı oluşturma {#creating-a-storyboard}
+
+Arayüz taslağı dosyasını Xcode kullanarak oluşturursunuz. Xcode'u başlatın ve yeni bir proje oluşturun. iOS ve Single View App seçeneklerini seçin:
+
+![Proje oluşturma](images/ios/xcode_create_project.png)
+
+Next düğmesine tıklayıp projenizi yapılandırmaya devam edin. Product Name alanına bir ad girin:
+
+![Proje ayarları](images/ios/xcode_storyboard_create_project_settings.png)
+
+İşlemi tamamlamak için Create düğmesine tıklayın. Projeniz artık oluşturuldu; arayüz taslağını oluşturmaya geçebiliriz:
+
+![Proje görünümü](images/ios/xcode_storyboard_project_view.png)
+
+Bir görüntüyü projeye içe aktarmak için sürükleyip bırakın. Ardından `Assets.xcassets` öğesini seçin ve görüntüyü `Assets.xcassets` içine bırakın:
+
+![Görüntü ekleme](images/ios/xcode_storyboard_add_image.png)
+
+`LaunchScreen.storyboard` dosyasını açın ve artı düğmesine (<kbd>+</kbd>) tıklayın. ImageView bileşenini bulmak için iletişim kutusuna `imageview` yazın.
+
+![Görüntü görünümü ekleme](images/ios/xcode_storyboard_add_imageview.png)
+
+Image View bileşenini arayüz taslağına sürükleyin:
+
+![Arayüz taslağına ekleme](images/ios/xcode_storyboard_add_imageview_to_storyboard.png)
+
+Daha önce `Assets.xcassets` içine eklediğiniz görüntüyü Image açılır listesinden seçin:
+
+![](images/ios/xcode_storyboard_select_image.png)
+
+Görüntüyü konumlandırın ve ihtiyaç duyduğunuz diğer ayarlamaları yapın; örneğin bir Label veya başka bir arayüz öğesi ekleyebilirsiniz. Bitirdiğinizde etkin şemayı **Any iOS Device (arm64)** (veya **Generic iOS Device**) olarak ayarlayın ve **Product ▸ Build** seçeneğini seçin. Defold, 64 bit cihazlarda iOS 15.0 ve sonraki sürümleri destekler; bu nedenle dağıtıma alma hedefini 15.0 veya daha yeni bir sürümde tutun. Derleme işleminin tamamlanmasını bekleyin.
+
+Arayüz taslağında görüntü kullanırsanız bunlar `LaunchScreen.storyboardc` dosyanıza otomatik olarak dahil edilmez. Kaynakları dahil etmek için *game.project* dosyasındaki `Bundle Resources` alanını kullanın.
+Örneğin, Defold projesinde `LaunchScreen` klasörünü ve bunun içinde `ios` klasörünü oluşturun (`ios` klasörü, bu dosyaların yalnızca iOS dağıtım paketlerine dahil edilmesi için gereklidir), ardından dosyalarınızı `LaunchScreen/ios/` içine koyun. Bu yolu `Bundle Resources` alanına ekleyin.
+
+![](images/ios/bundle_res.png)
+
+Son adım, derlenmiş `LaunchScreen.storyboardc` dosyasını Defold projenize kopyalamaktır. Finder'da aşağıdaki konumu açın ve `LaunchScreen.storyboardc` dosyasını Defold projenize kopyalayın:
+
+    /Library/Developer/Xcode/DerivedData/YOUR-PRODUCT-NAME-cbqnwzfisotwygbybxohrhambkjy/Build/Intermediates.noindex/YOUR-PRODUCT-NAME.build/Debug-iphonesimulator/YOUR-PRODUCT-NAME.build/Base.lproj/LaunchScreen.storyboardc
+
+::: sidenote
+Forum kullanıcısı Sergey Lerg, [bu süreci gösteren bir video öğretici](https://www.youtube.com/watch?v=6jU8wGp3OwA&feature=emb_logo) hazırladı.
+:::
+
+Arayüz taslağı dosyasını edindikten sonra *game.project* dosyasından ona başvurabilirsiniz.
+
+
+### Simge varlık kataloğu oluşturma
+
+Varlık kataloğu (asset catalog) kullanmak, uygulamanızın simgelerini yönetmek için Apple'ın tercih ettiği yöntemdir. Hatta App Store listelemesinde kullanılan simgeyi sağlamanın tek yolu budur. Varlık kataloğunu, arayüz taslağıyla aynı şekilde Xcode kullanarak oluşturursunuz. Xcode'u başlatın ve yeni bir proje oluşturun. iOS ve Single View App seçeneklerini seçin:
+
+![Proje oluşturma](images/ios/xcode_create_project.png)
+
+Next düğmesine tıklayıp projenizi yapılandırmaya devam edin. Product Name alanına bir ad girin:
+
+![Proje ayarları](images/ios/xcode_icons_create_project_settings.png)
+
+İşlemi tamamlamak için Create düğmesine tıklayın. Projeniz artık oluşturuldu; varlık kataloğunu oluşturmaya geçebiliriz:
+
+![Proje görünümü](images/ios/xcode_icons_project_view.png)
+
+Görüntüleri, desteklenen farklı simge boyutlarını temsil eden boş kutulara sürükleyip bırakın:
+
+![Simge ekleme](images/ios/xcode_icons_add_icons.png)
+
+::: sidenote
+Notifications, Settings veya Spotlight için simge eklemeyin.
+:::
+
+Bitirdiğinizde etkin şemayı `Build -> Any iOS Device (arm64)`(veya `Generic iOS Device`) olarak ayarlayın ve <kbd>Product</kbd> -> <kbd>Build</kbd> seçeneğini seçin. Derleme işleminin tamamlanmasını bekleyin.
+
+::: sidenote
+`Any iOS Device (arm64)` veya `Generic iOS Device` için derlediğinizden emin olun; aksi halde derleme çıktınızı yüklerken `ERROR ITMS-90704` hatasını alırsınız.
+:::
+
+![Projeyi derleme](images/ios/xcode_icons_build.png)
+
+Son adım, derlenmiş `Assets.car` dosyasını Defold projenize kopyalamaktır. Finder'da aşağıdaki konumu açın ve `Assets.car` dosyasını Defold projenize kopyalayın:
+
+    /Library/Developer/Xcode/DerivedData/YOUR-PRODUCT-NAME-cbqnwzfisotwygbybxohrhambkjy/Build/Products/Debug-iphoneos/Icons.app/Assets.car
+
+Varlık kataloğu dosyasını edindikten sonra *game.project* dosyasından kataloğa ve simgelere başvurabilirsiniz:
+
+![game.project dosyasına simge ve varlık kataloğu ekleme](images/ios/defold_icons_game_project.png)
+
+::: sidenote
+App Store simgesine *game.project* dosyasından başvurmanız gerekmez. Simge, iTunes Connect'e yükleme sırasında `Assets.car` dosyasından otomatik olarak çıkarılır.
+:::
+
+
+## iOS uygulama dağıtım paketi kurma
+
+Düzenleyici, iOS uygulama dağıtım paketi olan bir *.ipa* dosyası yazar. Dosyayı cihazınıza kurmak için aşağıdaki araçlardan birini kullanabilirsiniz:
+
+* `Devices and Simulators` penceresi üzerinden Xcode
+* [`ios-deploy`](https://github.com/ios-control/ios-deploy) komut satırı aracı
+* macOS App Store'dan [`Apple Configurator 2`](https://apps.apple.com/us/app/apple-configurator-2/)
+* iTunes
+
+Xcode üzerinden kullanılabilen iOS simülatörleriyle çalışmak için `xcrun simctl` komut satırı aracını da kullanabilirsiniz:
+
+```
+# show a list of available devices
+xcrun simctl list
+
+# boot an iPhone X simulator
+xcrun simctl boot "iPhone X"
+
+# install your.app to a booted simulator
+xcrun simctl install booted your.app
+
+# launch the simulator
+open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
+```
+
+:[Apple Privacy Manifest](../shared/apple-privacy-manifest.md)
+
+
+## İhracat uygunluğu bilgileri
+
+Oyununuzu App Store'a gönderirken oyununuzdaki şifreleme kullanımıyla ilgili ihracat uygunluğu bilgileri sağlamanız istenir. [Apple bunun neden gerekli olduğunu açıklıyor](https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations):
+
+"Uygulamanızı TestFlight'a veya App Store'a gönderdiğinizde uygulamanızı Amerika Birleşik Devletleri'ndeki bir sunucuya yüklersiniz. Uygulamanızı ABD veya Kanada dışında dağıtıyorsanız tüzel kişiliğinizin merkezinin nerede olduğuna bakılmaksızın uygulamanız ABD ihracat yasalarına tabidir. Uygulamanız şifreleme kullanıyor, şifrelemeye erişiyor, şifreleme içeriyor, uyguluyor veya bünyesine dahil ediyorsa bu, şifreleme yazılımı ihracatı olarak kabul edilir. Bu da uygulamanızın, dağıtımını yaptığınız ülkelerin ithalat uygunluğu gerekliliklerinin yanı sıra ABD ihracat uygunluğu gerekliliklerine de tabi olduğu anlamına gelir."
+
+Defold oyun motoru, şifrelemeyi aşağıdaki amaçlarla kullanır:
+
+* Güvenli kanallar üzerinden çağrı yapmak (ör. HTTPS ve SSL)
+* Lua kodunun telif hakkını korumak (çoğaltılmasını önlemek için)
+
+Defold motorundaki bu şifreleme kullanımları, Amerika Birleşik Devletleri ve Avrupa Birliği yasaları kapsamında ihracat uygunluğu belgesi gerekliliklerinden muaftır. Çoğu Defold projesi muaf kalır; ancak başka kriptografik yöntemlerin eklenmesi bu durumu değiştirebilir. Projenizin bu yasaların gerekliliklerini ve App Store kurallarını karşıladığından emin olmak sizin sorumluluğunuzdadır. Daha fazla bilgi için Apple'ın [İhracat uygunluğuna genel bakış](https://help.apple.com/app-store-connect/#/dev88f5c7bf9) belgesine bakın.
+
+Projenizin muaf olduğunu düşünüyorsanız projenin `Info.plist` dosyasında [`ITSAppUsesNonExemptEncryption`](https://developer.apple.com/documentation/bundleresources/information-property-list/itsappusesnonexemptencryption) anahtarını `False` olarak ayarlayın. Daha fazla ayrıntı için [Uygulama bildirimleri](/manuals/extensions-manifest-merge-tool) kılavuzuna bakın.
+
+## Sık sorulan sorular
+:[iOS FAQ](../shared/ios-faq.md)

--- a/docs/tr/manuals/label.md
+++ b/docs/tr/manuals/label.md
@@ -1,0 +1,140 @@
+---
+title: Defold'da etiket metin bileşenleri
+brief: Bu kılavuz, oyun dünyasındaki oyun nesnelerinde metin kullanmak için etiket bileşenlerinin nasıl kullanılacağını açıklar.
+---
+
+# Etiket
+
+Bir *etiket* (Label) bileşeni (component), bir metin parçasını oyun uzayında ekranda görüntüler. Varsayılan olarak tüm sprite ve karo grafikleriyle birlikte sıralanır ve çizilir. Bileşenin, metnin nasıl işleneceğini (rendering) belirleyen bir dizi özelliği vardır. Defold'un GUI sistemi metni destekler ancak GUI öğelerini oyun dünyasına yerleştirmek zor olabilir. Etiketler bunu kolaylaştırır.
+
+## Etiket oluşturma
+
+Bir etiket bileşeni oluşturmak için oyun nesnesine (game object) <kbd>sağ tıklayın</kbd> ve <kbd>Add Component ▸ Label</kbd> seçeneğini seçin.
+
+![Etiket ekleme](images/label/add_label.png)
+
+(Aynı şablondan birden fazla etiket örneği oluşturmak isterseniz alternatif olarak yeni bir etiket bileşeni dosyası oluşturabilirsiniz: *Assets* tarayıcısındaki bir klasöre <kbd>sağ tıklayın</kbd> ve <kbd>New... ▸ Label</kbd> seçeneğini seçin, ardından dosyayı istediğiniz oyun nesnelerine bileşen olarak ekleyin)
+
+![Yeni etiket](images/label/label.png)
+
+*Font* özelliğini kullanmak istediğiniz yazı tipine ayarlayın ve *Material* özelliğini yazı tipi türüyle eşleşen bir materyale ayarladığınızdan emin olun:
+
+![Yazı tipi ve materyal](images/label/font_material.png)
+
+## Etiket özellikleri
+
+*Id*, *Position*, *Rotation* ve *Scale* özelliklerinin yanı sıra bileşene özgü aşağıdaki özellikler de bulunur:
+
+*Text*
+: Etiketin metin içeriği.
+
+*Size*
+: Metnin sınırlayıcı kutusunun boyutu. *Line Break* etkinleştirilmişse genişlik, metnin hangi noktada alt satıra kaydırılacağını belirtir.
+
+*Color*
+: Metnin rengi.
+
+*Outline*
+: Dış çizginin rengi.
+
+*Shadow*
+: Gölgenin rengi.
+
+::: sidenote
+Varsayılan materyalde performans nedeniyle gölge işlemenin devre dışı bırakıldığını unutmayın.
+:::
+
+*Leading*
+: Satır aralığı için bir ölçekleme katsayısı. 0 değeri satır aralığını kaldırır. Varsayılan değer 1'dir.
+
+*Tracking*
+: Harf aralığı için bir ölçekleme katsayısı. Varsayılan değer 0'dır.
+
+*Pivot*
+: Metnin dayanak noktası (pivot). Metin hizalamasını değiştirmek için bunu kullanın (aşağıya bakın).
+
+*Blend Mode*
+: Etiketi işlerken kullanılacak harmanlama modu (blend mode).
+
+*Line Break*
+: Metin hizalaması dayanak noktası ayarını izler ve bu özelliği etkinleştirmek metnin birden fazla satıra yayılmasını sağlar. Bileşenin genişliği, metnin nerede alt satıra kaydırılacağını belirler. Metnin alt satıra kaydırılabilmesi için içinde bir boşluk bulunması gerektiğini unutmayın.
+
+*Font*
+: Bu etiket için kullanılacak yazı tipi kaynağı.
+
+*Material*
+: Bu etiketi işlemek için kullanılacak materyal. Kullandığınız yazı tipi türü (bit eşlem, uzaklık alanı veya BMFont) için oluşturulmuş bir materyal seçtiğinizden emin olun.
+
+### Harmanlama modları
+:[blend-modes](../shared/blend-modes.md)
+
+### Dayanak noktası ve hizalama
+
+*Pivot* özelliğini ayarlayarak metnin hizalama modunu değiştirebilirsiniz.
+
+*Ortalanmış*
+: Dayanak noktası `Center`, `North` veya `South` olarak ayarlanırsa metin ortalanır.
+
+*Sola hizalı*
+: Dayanak noktası `West` modlarından herhangi birine ayarlanırsa metin sola hizalanır.
+
+*Sağa hizalı*
+: Dayanak noktası `East` modlarından herhangi birine ayarlanırsa metin sağa hizalanır.
+
+![Metin hizalama](images/label/align.png)
+
+## Çalışma sırasında değiştirme
+
+Etiket metnini ve çeşitli diğer özellikleri alıp ayarlayarak çalışma sırasında etiketleri değiştirebilirsiniz.
+
+`text`
+: Etiketin metin içeriği (`string`). Defold 1.13.2 sürümünden itibaren `go.get()` ve `go.set()` aracılığıyla kullanılabilir.
+
+`color`
+: Etiket rengi (`vector4`)
+
+`outline`
+: Etiketin dış çizgi rengi (`vector4`)
+
+`shadow`
+: Etiketin gölge rengi (`vector4`)
+
+`scale`
+: Etiketin ölçeği; tüm eksenlerde eşit ölçekleme için bir `number` veya her eksende ayrı ölçekleme için bir `vector3`.
+
+`size`
+: Etiketin boyutu (`vector3`)
+
+```lua
+function init(self)
+    -- Set the text of the "my_label" component in the same game object
+    -- as this script.
+    go.set("#my_label", "text", "New text")
+    local text = go.get("#my_label", "text")
+    print(text) -- New text
+end
+```
+
+::: sidenote
+Defold 1.13.2 sürümünden itibaren `label.set_text()` ve `label.get_text()` işlevlerinin kullanımı artık önerilmez; bunların yerine `text` özelliği önerilir. Eski işlevler uyumluluk için kullanılabilir durumdadır. Eski ayarlama işlevi bir iletiyi kuyruğa eklerken `go.set()` metni hemen günceller.
+:::
+
+```lua
+function init(self)
+    -- Set the color of the "my_label" component in the same game object
+    -- as this script. Color is a RGBA value stored in a vector4.
+    local grey = vmath.vector4(0.5, 0.5, 0.5, 1.0)
+    go.set("#my_label", "color", grey)
+
+    -- ...and remove the outline, by setting its alpha to 0...
+    go.set("#my_label", "outline.w", 0)
+
+    -- ...and scale it x2 along x axis.
+    local scale_x = go.get("#my_label", "scale.x")
+    go.set("#my_label", "scale.x", scale_x * 2)
+end
+```
+
+## Proje yapılandırması
+
+*game.project* dosyasında etiketlerle ilgili birkaç [proje ayarı](/manuals/project-settings#label) bulunur.

--- a/docs/tr/manuals/libraries.md
+++ b/docs/tr/manuals/libraries.md
@@ -1,0 +1,128 @@
+---
+title: Defold'da kütüphane projeleriyle çalışma
+brief: Kütüphaneler özelliği, projeler arasında varlık paylaşmanızı sağlar. Bu kılavuz, özelliğin nasıl çalıştığını açıklar.
+---
+
+# Kütüphaneler
+
+Kütüphaneler (Libraries) özelliği, projeler arasında varlık (asset) paylaşmanızı sağlar. İş akışınızda çeşitli biçimlerde kullanabileceğiniz, basit ama çok güçlü bir mekanizmadır.
+
+Kütüphaneler aşağıdaki amaçlar için kullanışlıdır:
+
+* Tamamlanmış bir projedeki varlıkları yeni bir projeye kopyalamak. Önceki bir oyunun devamını yapıyorsanız bu, işe başlamanın kolay bir yoludur.
+* Projelerinize kopyalayıp ardından özelleştirebileceğiniz veya belirli bir amaca uyarlayabileceğiniz bir şablon kütüphanesi oluşturmak.
+* Doğrudan başvurabileceğiniz hazır nesneler veya betikler içeren bir ya da daha fazla kütüphane oluşturmak. Bu, ortak betik modüllerini saklamak veya grafik, ses ve animasyon varlıklarından oluşan ortak bir kütüphane oluşturmak için çok kullanışlıdır.
+
+## Kütüphane paylaşımını ayarlama {#setting-up-library-sharing}
+
+Paylaşılan sprite bileşenleri ve karo kaynakları (tile source) içeren bir kütüphane oluşturmak istediğinizi varsayalım. Önce [yeni bir proje oluşturun](/manuals/project-setup/). Projeden hangi klasörleri paylaşmak istediğinize karar verin ve bu klasörlerin adlarını proje ayarlarındaki *`include_dirs`* özelliğine ekleyin. Birden fazla klasör listelemek istiyorsanız adları boşluklarla ayırın:
+
+![Dahil edilecek dizinler](images/libraries/libraries_include_dirs.png)
+
+Bu kütüphaneyi başka bir projeye eklemeden önce kütüphanenin konumunu belirlemenin bir yoluna ihtiyacımız var.
+
+## Kütüphane URL adresi
+
+Kütüphanelere standart bir URL aracılığıyla başvurulur. GitHub'da barındırılan bir proje için bu, projenin yayımlanan bir sürümünün URL adresidir:
+
+![GitHub kütüphane URL adresi](images/libraries/libraries_library_url_github.png)
+
+::: important
+Bir kütüphane projesinin `master` dalı yerine her zaman belirli bir sürümüne bağımlı olmanız önerilir. Böylece kütüphane projesinin `master` dalından her zaman en son (ve mevcut işleyişi bozabilecek) değişiklikleri almak yerine, kütüphane projesindeki değişiklikleri ne zaman dahil edeceğinize geliştirici olarak siz karar verirsiniz.
+:::
+
+::: important
+Üçüncü taraf kütüphaneleri kullanmadan önce her zaman incelemeniz önerilir. [Üçüncü taraf yazılımları güvenli kullanma](https://defold.com/manuals/application-security/#securing-your-use-of-third-party-software) hakkında daha fazla bilgi edinin.
+:::
+
+### Temel erişim kimlik doğrulaması
+
+Herkese açık olmayan kütüphaneleri kullanırken temel erişim kimlik doğrulaması yapmak için kütüphane URL adresine kullanıcı adı ve parola/belirteç ekleyebilirsiniz:
+
+```
+https://username:password@github.com/defold/private/archive/main.zip
+```
+
+`username` ve `password` alanları çıkarılıp `Authorization` istek üstbilgisi olarak eklenir. Bu, temel erişim yetkilendirmesini destekleyen her sunucuda çalışır.
+
+::: important
+Oluşturduğunuz kişisel erişim belirtecini veya parolayı paylaşmadığınızdan ya da yanlışlıkla sızdırmadığınızdan emin olun; bunların yanlış ellere geçmesi ciddi sonuçlar doğurabilir!
+:::
+
+Kimlik bilgilerinin kütüphane URL adresinde açık metin olarak bulunması nedeniyle yanlışlıkla sızmasını önlemek için bir dize değiştirme kalıbı kullanabilir ve kimlik bilgilerini ortam değişkenlerinde saklayabilirsiniz:
+
+```
+https://__PRIVATE_USERNAME__:__PRIVATE_TOKEN__@github.com/defold/private/archive/main.zip
+```
+
+Yukarıdaki örnekte kullanıcı adı ve belirteç, sistemin `PRIVATE_USERNAME` ve `PRIVATE_TOKEN` ortam değişkenlerinden okunur.
+
+#### GitHub kimlik doğrulaması
+
+GitHub'daki özel bir depodan veri almak için [kişisel erişim belirteci oluşturmanız](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) ve bunu parola olarak kullanmanız gerekir.
+
+```
+https://github-username:personal-access-token@github.com/defold/private/archive/main.zip
+```
+
+#### GitLab kimlik doğrulaması
+
+GitLab'daki özel bir depodan veri almak için [kişisel erişim belirteci oluşturmanız](https://docs.gitlab.com/ee/security/token_overview.html) ve bunu URL parametresi olarak göndermeniz gerekir.
+
+```
+https://gitlab.com/defold/private/-/archive/main/test-main.zip?private_token=personal-access-token
+```
+
+### Gelişmiş erişim kimlik doğrulaması
+
+Temel erişim kimlik doğrulaması kullanıldığında, bir kullanıcının erişim belirteci ve kullanıcı adı projede kullanılan her depoda paylaşılır. Birden fazla kişiden oluşan bir ekipte bu sorun olabilir. Bu sorunu çözmek için kütüphanenin bulunduğu depoya erişimde "salt okunur" bir kullanıcı kullanılmalıdır. GitHub'da bunun için bir kuruluş, bir ekip ve depoyu düzenlemesi gerekmeyen (bu nedenle salt okunur olan) bir kullanıcı gerekir.
+
+GitHub adımları:
+* [Bir kuruluş oluşturun](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/creating-a-new-organization-from-scratch)
+* [Kuruluş içinde bir ekip oluşturun](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/creating-a-team)
+* [İstediğiniz özel depoyu kuruluşunuza aktarın](https://docs.github.com/en/github/administering-a-repository/transferring-a-repository)
+* [Ekibe depoya "salt okunur" erişim verin](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/managing-team-access-to-an-organization-repository)
+* [Bu ekibin üyesi olacak bir kullanıcı oluşturun veya seçin](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/organizing-members-into-teams)
+* Bu kullanıcı için kişisel erişim belirteci oluşturmak üzere yukarıdaki "temel erişim kimlik doğrulaması" bölümünü kullanın
+
+Bu aşamada yeni kullanıcının kimlik doğrulama bilgileri sürüm kontrolüne kaydedilip depoya gönderilebilir. Bu, özel deponuzla çalışan herkesin, kütüphanenin kendisini düzenleme izni olmadan depoyu kütüphane olarak almasını sağlar.
+
+::: important
+Salt okunur kullanıcının belirtecine, kütüphaneyi kullanan oyun depolarına erişebilen herkes tamamen erişebilir.
+:::
+
+Bu çözüm Defold forumunda önerilmiş ve [bu başlıkta tartışılmıştır](https://forum.defold.com/t/private-github-for-library-solved/67240).
+
+## Kütüphane bağımlılıklarını ayarlama {#setting-up-library-dependencies}
+
+Kütüphaneye erişmesini istediğiniz projeyi açın. Proje ayarlarında kütüphane URL adresini *dependencies* özelliğine ekleyin. İsterseniz birden fazla bağımlı proje belirtebilirsiniz. Bunları `+` düğmesini kullanarak birer birer ekleyin ve `-` düğmesini kullanarak kaldırın:
+
+![Bağımlılıklar](images/libraries/libraries_dependencies.png)
+
+Şimdi kütüphane bağımlılıklarını güncellemek için <kbd>Project ▸ Fetch Libraries</kbd> seçeneğini seçin. Bu işlem, bir projeyi her açtığınızda otomatik olarak gerçekleşir. Bu nedenle yalnızca projeyi yeniden açmadan bağımlılıklar değişirse bu işlemi yapmanız gerekir. Bağımlılık olarak kullanılan kütüphaneleri eklediğinizde veya kaldırdığınızda ya da bu kütüphane projelerinden biri başka biri tarafından değiştirilip eşitlendiğinde bu durum oluşur.
+
+![Kütüphaneleri alma](images/libraries/libraries_fetch_libraries.png)
+
+Paylaştığınız klasörler artık *Assets bölmesinde* görünür ve paylaştığınız her şeyi kullanabilirsiniz. Kütüphane projesinde yapılan ve eşitlenen tüm değişiklikler projenizde kullanılabilir hale gelir.
+
+![Kütüphane kurulumu tamamlandı](images/libraries/libraries_done.png)
+
+## Kütüphane bağımlılıklarındaki dosyaları düzenleme
+
+Kütüphanelerdeki dosyalar kaydedilemez. Değişiklik yapabilirsiniz ve düzenleyici bu değişikliklerle projeyi derleyebilir; bu, test için kullanışlıdır. Ancak dosyanın kendisi değişmeden kalır ve dosya kapatıldığında tüm değişiklikler atılır.
+
+Kütüphane dosyalarında değişiklik yapmak istiyorsanız kütüphanenin size ait bir çatallanmasını (fork) oluşturun ve değişiklikleri orada yapın. Bir diğer seçenek, kütüphane klasörünün tamamını proje dizininize kopyalayıp yapıştırmak ve yerel kopyayı kullanmaktır. Bu durumda yerel klasörünüz özgün bağımlılığın önüne geçer ve bağımlılık bağlantısının `game.project` dosyasından kaldırılması önerilir (ardından <kbd>Project ▸ Fetch Libraries</kbd> seçeneğini seçmeyi unutmayın).
+
+`builtins` de motor tarafından sağlanan bir kütüphanedir. Oradaki dosyaları düzenlemek istiyorsanız dosyaları projenize kopyalayın ve özgün `builtins` dosyaları yerine bunları kullanın. Örneğin, `default.render_script` dosyasını değiştirmek için hem `/builtins/render/default.render` hem de `/builtins/render/default.render_script` dosyasını proje klasörünüze `my_custom.render` ve `my_custom.render_script` adlarıyla kopyalayın. Ardından yerel `my_custom.render` dosyanızı, yerleşik betik yerine `my_custom.render_script` dosyasına başvuracak şekilde güncelleyin ve özel `my_custom.render` dosyanızı `game.project` içindeki Render ayarında belirtin.
+
+Bir materyali kopyalayıp yapıştırdıysanız ve belirli bir türün tüm bileşenlerinde (component) kullanmak istiyorsanız [projeye özel şablonları](/manuals/editor/#creating-new-project-files) kullanmak yararlı olabilir.
+
+## Bozuk başvurular
+
+Kütüphane paylaşımı yalnızca paylaşılan klasörlerin altında bulunan dosyaları içerir. Paylaşılan hiyerarşinin dışındaki varlıklara başvuran bir şey oluşturursanız başvuru yolları bozulur.
+
+## Ad çakışmaları
+
+*dependencies* proje ayarında birden fazla proje URL adresi listeleyebildiğiniz için ad çakışmasıyla karşılaşabilirsiniz. Bu, bağımlı projelerden iki veya daha fazlasının *`include_dirs`* proje ayarında aynı adlı bir klasörü paylaşması durumunda gerçekleşir.
+
+Defold, aynı adlı klasörlere yapılan başvurulardan *dependencies* listesindeki proje URL sırasına göre sonuncusu dışındaki tümünü yok sayarak ad çakışmalarını çözer. Örneğin, bağımlılıklarda 3 kütüphane projesinin URL adresini listelerseniz ve hepsi *items* adlı bir klasör paylaşıyorsa yalnızca bir *items* klasörü görünür---URL listesinin sonundaki projeye ait olan klasör.

--- a/docs/tr/manuals/light.md
+++ b/docs/tr/manuals/light.md
@@ -1,0 +1,248 @@
+---
+title: Defold'da ışık bileşeni
+brief: Bu kılavuz, ortam ışığının, yönlü, noktasal ve spot ışıklarının nasıl kullanılacağını ve gölgelendiricilerde ışık verilerine nasıl erişileceğini açıklar.
+---
+
+# Işık bileşeni
+
+Işık bileşeni (Light component), bir koleksiyondaki (collection) ışık kaynağını temsil eder. Defold şu anda dört ışık kaynağı türünü destekler:
+
+- Ortam ışığı (ambient light) (`.ambient_light`)
+- Yönlü ışık (directional light) (`.directional_light`)
+- Noktasal ışık (point light) (`.point_light`)
+- Spot ışığı (spot light) (`.spot_light`)
+
+Işık kaynakları, diğer bileşen kaynakları gibi oyun nesnelerine (game object) eklenir. Işık bileşenlerini doğrudan bir oyun nesnesinin altında oluşturabilir veya *Assets* tarayıcısında bir ışık kaynağı oluşturup ardından bunu *Outline* görünümünde bir oyun nesnesine bileşen olarak ekleyebilirsiniz.
+
+Defold, her materyale (material) otomatik olarak aydınlatma uygulamaz. Işıklar motor tarafından toplanır ve yerleşik ışık arabelleği (light buffer) aracılığıyla gölgelendiricilerin (shader) kullanımına sunulur. Işık verilerinin nasıl kullanılacağına materyalin gölgelendiricisi karar verir.
+
+Aşağıdaki örneklerde, farklı ışık türlerinin nihai sonucu nasıl etkilediğini göstermek için aynı sahne kullanılır:
+
+![Işıksız sahne](images/light/no_light.png)
+
+## Işık özellikleri
+
+Tüm ışık renkleri RGB değerleridir. Işık kaynaklarında alfa kanalı kullanılmaz.
+
+### Ortam ışığı
+
+Ortam ışıkları sahneye sabit ışık ekler. Oyun nesnesinin konumundan, dönmesinden veya ölçeğinden etkilenmezler. Örneğin genel bir arka plan aydınlatması için veya nesnelerin aydınlatma uygulanmamış gibi görünmesini sağlamak için kullanılabilirler.
+
+Ortam ışığı bileşeni, düzenleyicide okları merkeze doğru dönük bir simgeyle gösterilir. Simgenin rengi, bileşenin `color` özelliğiyle aynıdır. 
+
+![Daha düşük şiddetli ortam ışığı](images/light/ambient_light_less_intensity.png)
+
+Özellikler:
+
+`color`
+: Ortam ışığının RGB rengi.
+
+`intensity`
+: Ortam ışığının rengini çarpar.
+
+![Daha yüksek şiddetli ortam ışığı](images/light/ambient_light_full_intensity.png)
+
+Ortam ışıkları, gölgelendiricinin ışık arabelleğinde tek bir ortam rengi olan `light_info.xyz` değerinde biriktirilir. `lights[]` dizisinde yer kaplamazlar. Sahnedeki birden fazla ortam ışığı bileşeni, hepsinin harmanından oluşan yalnızca tek bir çıktı rengi üretir.
+
+### Yönlü ışık
+
+Yönlü ışıklar, güneş ışığı gibi tek bir yönden gelen ışığı temsil eder. Oyun nesnesinin konumunu veya ölçeğini kullanmazlar; ışığın yönü, oyun nesnesinin dünya uzayındaki dönmesinin yerel ileri yön olan `(0, 0, -1)` yönüne uygulanmasıyla elde edilir.
+
+Yönlü ışık bileşeni, düzenleyicide yönünü belirten bir 3B ok içeren renkli bir güneş simgesiyle gösterilir.
+
+![Yönlü ışık](images/light/directional_light.png)
+
+Özellikler:
+
+`color`
+: Yönlü ışığın RGB rengi.
+
+`intensity`
+: Yönlü ışığın rengini çarpar.
+
+
+Yönlü ışığın tersine bakan yüzeylerin tamamen kararmasını önlemek için yönlü ışıklar genellikle ortam ışığıyla birlikte kullanılır.
+
+![Yönlü ışık ve ortam ışığı](images/light/directional_and_ambient_light.png)
+
+### Noktasal ışık
+
+Noktasal ışıklar, oyun nesnesinin dünya uzayındaki konumundan dışarıya doğru ışık yayar. Noktasal ışığın konumu, oyun nesnesinin dünya uzayındaki konumundan alınır.
+
+Noktasal ışık bileşeni, düzenleyicide etrafına ışınlar yayılan bir noktayla gösterilir. Noktanın rengi `color` özelliğini, çember ise `range` değerini temsil eder.
+
+![Noktasal ışık](images/light/point_light.png)
+
+Özellikler:
+
+`color`
+: Noktasal ışığın RGB rengi.
+
+`intensity`
+: Noktasal ışığın rengini çarpar.
+
+`range`
+: Dünya birimleri cinsinden ışığın yarıçapı.
+
+Etkin menzil, oyun nesnesinin dünya uzayındaki ölçeğinin eksen bileşenleri arasındaki en küçük mutlak değerle çarpılır.
+
+![Noktasal ışığın menzili](images/light/point_light_range.png)
+
+Işığın rengini değiştirmek, noktasal ışığın aydınlatmaya katkısını renklendirir; menzil ise ışığın kaynaktan ne kadar uzağa ulaşacağını belirler.
+
+![Yeşil renkli noktasal ışığın menzili](images/light/point_ight_range_green_color.png)
+
+### Spot ışığı
+
+Spot ışıkları, oyun nesnesinin dünya uzayındaki konumundan koni biçiminde ışık yayar. Yön, oyun nesnesinin dünya uzayındaki dönmesinin `(0, 0, -1)` yönüne uygulanmasıyla elde edilir.
+
+Spot ışığı bileşeni, düzenleyicide renkli bir lamba simgesi ve dış ve iç konileri gösteren kılavuz çizgileriyle gösterilir.
+
+![Spot ışığı](images/light/spot_light.png)
+
+Özellikler:
+
+`color`
+: Spot ışığının RGB rengi.
+
+`intensity`
+: Spot ışığının rengini çarpar.
+
+`range`
+: Dünya birimleri cinsinden ışığın yarıçapı.
+
+`inner_cone_angle`
+: Düzenleyicide derece cinsinden iç koni açısı. Bu koninin içindeki pikseller, spot ışığının katkısını tam olarak alır.
+
+`outer_cone_angle`
+: Düzenleyicide derece cinsinden dış koni açısı. Işık, iç koni ile dış koni arasında giderek azalır.
+
+Etkin menzil, oyun nesnesinin dünya uzayındaki ölçeğinin eksen bileşenleri arasındaki en küçük mutlak değerle çarpılır. Koni açıları derece cinsinden düzenlenir ve derlenmiş ışık kaynağında radyana dönüştürülür.
+
+![Spot ışığının düzenleme araçları](images/light/spot_light_gizmos.png)
+
+## Doğrulama
+
+Proje derleme hattı, ışık kaynağı verilerini doğrular ve normalleştirir:
+
+- `color` tam olarak üç sayı içermelidir.
+- `intensity`, en az `0` olacak şekilde sınırlandırılır.
+- Noktasal ve spot ışıklarında `range`, en az `0` olacak şekilde sınırlandırılır.
+- Spot koni açıları `0..180` derece aralığıyla sınırlandırılır.
+- `inner_cone_angle`, hiçbir zaman `outer_cone_angle` değerini aşmayacak şekilde sınırlandırılır.
+
+## Proje sınırı
+
+En fazla kaç ışık bileşeni olabileceği, `light.max_count` proje ayarıyla belirlenir. Varsayılan değer `64` olur.
+
+Ortam ışıkları, gölgelendiricinin `lights[]` dizisinde yer kaplamaz; ancak yine de ışık bileşeni oldukları için `light.max_count` sınırına dahil edilirler. Yönlü, noktasal ve spot ışıkları, etkin oldukları sürece `lights[]` dizisinde yer kaplar.
+
+Işık bileşenlerinin sayısı `light.max_count` değerini aşarsa motor, bileşen arabelleğinin dolu olduğunu bildiren bir hata verir.
+
+## Gölgelendiricilerde ışık arabelleği
+
+Bir gölgelendirici, yerleşik düzene sahip ve `LightBuffer` adını taşıyan bir uniform bloğu bildirerek etkin ışıklara erişebilir. Motor bu bloğu algılar ve onu kullanan materyaller ile hesaplama programları için ışık verilerini otomatik olarak bağlar.
+
+![Işık arabelleğini kullanan gölgelendirici](images/light/light-buffer-shader.png)
+
+```glsl
+#version 140
+
+#define MAX_LIGHT_COUNT 32
+
+struct Light
+{
+    vec4 position;        // xyz: world position, w: unused
+    vec4 color;           // rgb: color, a: unused
+    vec4 direction_range; // xyz: normalized world direction, w: range
+    vec4 params;          // x: type, y: intensity, z: inner cone, w: outer cone
+};
+
+uniform LightBuffer
+{
+    // xyz: accumulated ambient color, w: active non-ambient light count
+    vec4 light_info;
+    Light lights[MAX_LIGHT_COUNT];
+};
+```
+
+Işık türü, `lights[i].params.x` alanında saklanır:
+
+| Tür | Değer |
+|------|-------|
+| Yönlü | `0` |
+| Noktasal | `1` |
+| Spot | `2` |
+
+Gölgelendirici, `lights[]` dizisini `light.max_count` değerinden daha küçük bir boyutla bildirebilir, ancak daha büyük bir boyutla bildiremez. Işık döngülerini her zaman bildirilen dizi boyutuyla sınırlandırın:
+
+```glsl
+vec3 apply_lights(vec3 normal)
+{
+    vec3 result = light_info.xyz;
+    int active_light_count = int(light_info.w);
+
+    for (int i = 0; i < MAX_LIGHT_COUNT; ++i)
+    {
+        if (i >= active_light_count)
+        {
+            break;
+        }
+
+        int type = int(lights[i].params.x);
+        vec3 light_color = lights[i].color.rgb * lights[i].params.y;
+
+        if (type == 0) // Directional
+        {
+            vec3 light_dir = normalize(-lights[i].direction_range.xyz);
+            result += light_color * max(dot(normal, light_dir), 0.0);
+        }
+        else if (type == 1) // Point
+        {
+            result += light_color;
+        }
+        else if (type == 2) // Spot
+        {
+            result += light_color;
+        }
+    }
+
+    return result;
+}
+```
+
+Yukarıdaki örnek, arabelleğe erişim biçimini gösterir. Gerçek bir noktasal veya spot ışığı gölgelendiricisinin, gölgelendirilen noktadan `lights[i].position.xyz` konumuna uzanan vektörü de hesaplaması, `lights[i].direction_range.w` değerini kullanarak uzaklığa bağlı zayıflamayı uygulaması ve spot ışıklarında `lights[i].params.z` ile `lights[i].params.w` değerlerini radyan cinsinden koni açıları olarak kullanması önerilir.
+
+## Yerleşik aydınlatma yardımcısı
+
+Defold, `/builtins/materials/lighting.glsl` yolunda bir gölgelendirici yardımcısı içerir. `MAX_LIGHT_COUNT` değerini tanımlayın, yardımcının beklediği değişkenleri (varyings) sağlayın ve ardından yardımcıyı parça gölgelendiricinizden dahil edin:
+
+```glsl
+#version 140
+
+#define MAX_LIGHT_COUNT 32
+
+in vec3 var_normal;
+in vec4 var_position;
+in mat4 var_view;
+
+out vec4 color_out;
+
+#include "/builtins/materials/lighting.glsl"
+
+void main()
+{
+    vec3 normal = normalize(var_normal);
+    vec3 ambient = ambient_light();
+    vec3 diffuse = diffuse_lambert(normal, var_position.xyz);
+    color_out = vec4(ambient + diffuse, 1.0);
+}
+```
+
+Yardımcı, `LIGHT_DIRECTIONAL`, `LIGHT_POINT` ve `LIGHT_SPOT` sabitlerini tanımlar, `ambient_light()` işlevini kullanıma sunar ve arabellekteki ışıklar için Lambert dağınık yansıma işlevleri sağlar.
+
+## Ayrıca bakınız
+
+- [Gölgelendirici kılavuzu](/manuals/shader)
+- [Materyal kılavuzu](/manuals/material)
+- [İşleme kılavuzu](/manuals/render)

--- a/docs/tr/manuals/linux.md
+++ b/docs/tr/manuals/linux.md
@@ -1,0 +1,11 @@
+---
+title: Linux platformu için Defold ile geliştirme
+brief: Bu kılavuz, Linux'ta Defold uygulamalarının nasıl derleneceğini ve çalıştırılacağını açıklar
+---
+
+# Linux için geliştirme
+
+Linux platformu için Defold uygulamaları geliştirmek basit bir süreçtir ve dikkate almanız gereken çok az nokta vardır.
+
+## Sık sorulan sorular
+:[Linux FAQ](../shared/linux-faq.md)

--- a/docs/tr/manuals/live-update-aws.md
+++ b/docs/tr/manuals/live-update-aws.md
@@ -1,0 +1,127 @@
+---
+title: Live Update içeriğini AWS'ye yükleme
+brief: Bu bölümde, oyununuzu paketlerken Live Update kaynaklarını otomatik olarak yüklemek için Defold düzenleyicisiyle birlikte kullanabileceğiniz, Amazon Web Services üzerinde sınırlı erişime sahip yeni bir kullanıcının nasıl oluşturulacağı açıklanır.
+---
+
+# Amazon Web Service kurulumu
+
+Defold'un Live Update özelliğini Amazon hizmetleriyle birlikte kullanmak için bir Amazon Web Services hesabınızın olması gerekir. Henüz bir hesabınız yoksa buradan oluşturabilirsiniz: https://aws.amazon.com/.
+
+Bu bölümde, oyununuzu paketlerken Live Update kaynaklarını (resources) otomatik olarak yüklemek için Defold düzenleyicisiyle birlikte kullanabileceğiniz, Amazon Web Services üzerinde sınırlı erişime sahip yeni bir kullanıcının nasıl oluşturulacağı ve oyun istemcilerinin kaynakları alabilmesi için Amazon S3'ün nasıl yapılandırılacağı açıklanır. Amazon S3'ü nasıl yapılandırabileceğiniz hakkında daha fazla bilgi için [Amazon S3 belgelerine](http://docs.aws.amazon.com/AmazonS3/latest/dev/Welcome.html) bakın.
+
+1. Live Update kaynakları için bir kova oluşturun
+
+    `Services` menüsünü açın ve `S3` seçeneğini seçin; bu seçenek _Storage_ kategorisinde bulunur ([Amazon S3 Konsolu](https://console.aws.amazon.com/s3)). Mevcut tüm kovalarınızı (bucket) ve yeni bir kova oluşturma seçeneğini göreceksiniz. Mevcut bir kovayı kullanmak mümkün olsa da erişimi kolayca kısıtlayabilmeniz için Live Update kaynaklarına yönelik yeni bir kova oluşturmanızı öneririz.
+
+    ![Kova oluşturma](images/live-update/01-create-bucket.png)
+
+2. Kovanıza bir kova politikası ekleyin
+
+    Kullanmak istediğiniz kovayı seçin, *Properties* panelini açın ve paneldeki *Permissions* seçeneğini genişletin. *Add bucket policy* düğmesine tıklayarak kova politikasını (bucket policy) açın. Bu örnekteki kova politikası, anonim bir kullanıcının kovadan dosya almasına izin verir; böylece oyun istemcisi, oyunun gerektirdiği Live Update kaynaklarını indirebilir. Kova politikaları hakkında daha fazla bilgi için [Amazon belgelerine](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html) bakın.
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AddPerm",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::defold-liveupdate-example/*"
+            }
+        ]
+    }
+    ```
+
+    ![Kova politikası](images/live-update/02-bucket-policy.png)
+
+3. Kovanıza bir CORS yapılandırması ekleyin (İsteğe bağlı)
+
+    [Kökenler arası kaynak paylaşımı (Cross-Origin Resource Sharing, CORS)](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing), bir web sitesinin JavaScript kullanarak farklı bir etki alanından kaynak almasını sağlayan bir mekanizmadır. Oyununuzu bir HTML5 istemcisi olarak yayımlamayı planlıyorsanız kovanıza bir CORS yapılandırması eklemeniz gerekir.
+
+    Kullanmak istediğiniz kovayı seçin, *Properties* panelini açın ve paneldeki *Permissions* seçeneğini genişletin. *Add CORS Configuration* düğmesine tıklayarak kova politikasını açın. Bu örnekteki yapılandırma, etki alanı için joker karakter belirterek herhangi bir web sitesinden erişime izin verir; ancak oyununuzu hangi etki alanlarında sunacağınızı biliyorsanız bu erişimi daha fazla kısıtlayabilirsiniz. Amazon CORS yapılandırması hakkında daha fazla bilgi için [Amazon belgelerine](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) bakın.
+
+    ```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <CORSRule>
+            <AllowedOrigin>*</AllowedOrigin>
+            <AllowedMethod>GET</AllowedMethod>
+        </CORSRule>
+    </CORSConfiguration>
+    ```
+
+    ![CORS yapılandırması](images/live-update/03-cors-configuration.png)
+
+4. IAM politikası oluşturun
+
+    *Services* menüsünü açın ve *IAM* seçeneğini seçin; bu seçenek _Security, Identity & Compliance_ kategorisinde bulunur ([Amazon IAM Konsolu](https://console.aws.amazon.com/iam)). Soldaki menüden *Policies* seçeneğini seçtiğinizde mevcut tüm politikalarınızı ve yeni bir politika oluşturma seçeneğini göreceksiniz.
+
+    *Create Policy* düğmesine tıklayın ve ardından _Create Your Own Policy_ seçeneğini seçin. Bu örnekteki politika, kullanıcının tüm kovaları listelemesine izin verir; bu yalnızca bir Defold projesini Live Update için yapılandırırken gereklidir. Ayrıca kullanıcının erişim denetim listesini (Access Control List, ACL) almasına ve Live Update kaynakları için kullanılan belirli kovaya kaynak yüklemesine izin verir. Amazon Identity and Access Management (IAM) hakkında daha fazla bilgi için [Amazon belgelerine](http://docs.aws.amazon.com/IAM/latest/UserGuide/access.html) bakın.
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListAllMyBuckets"
+                ],
+                "Resource": "arn:aws:s3:::*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetBucketAcl"
+                ],
+                "Resource": "arn:aws:s3:::defold-liveupdate-example"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:PutObject"
+                ],
+                "Resource": "arn:aws:s3:::defold-liveupdate-example/*"
+            }
+        ]
+    }
+    ```
+
+    ![IAM politikası](images/live-update/04-create-policy.png)
+
+5. Program aracılığıyla erişim için bir kullanıcı oluşturun
+
+    *Services* menüsünü açın ve *IAM* seçeneğini seçin; bu seçenek _Security, Identity & Compliance_ kategorisinde bulunur ([Amazon IAM Konsolu](https://console.aws.amazon.com/iam)). Soldaki menüden *Users* seçeneğini seçtiğinizde mevcut tüm kullanıcılarınızı ve yeni bir kullanıcı ekleme seçeneğini göreceksiniz. Mevcut bir kullanıcıyı kullanmak mümkün olsa da erişimi kolayca kısıtlayabilmeniz için Live Update kaynaklarına yönelik yeni bir kullanıcı eklemenizi öneririz.
+
+    *Add User* düğmesine tıklayın, bir kullanıcı adı girin ve *Programmatic access* seçeneğini *Access type* olarak seçin, ardından *Next: Permissions* düğmesine basın. *Attach existing policies directly* seçeneğini seçin ve 4. adımda oluşturduğunuz politikayı seçin.
+
+    İşlemi tamamladığınızda size bir *Access key ID* ve bir *Secret access key* verilecektir.
+
+    ::: important
+    Bu anahtarları saklamanız *çok önemlidir*, çünkü sayfadan ayrıldıktan sonra bunları Amazon'dan tekrar alamazsınız.
+    :::
+
+6. Kimlik bilgileri profil dosyası oluşturun
+
+    Bu aşamada bir kova oluşturmuş, bir kova politikası yapılandırmış, bir CORS yapılandırması eklemiş, bir kullanıcı politikası oluşturmuş ve yeni bir kullanıcı oluşturmuş olmalısınız. Geriye yalnızca, Defold düzenleyicisinin sizin adınıza kovaya erişebilmesi için bir [kimlik bilgileri profil dosyası](https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks) oluşturmak kalır.
+
+    Ana klasörünüzde *.aws* adlı yeni bir dizin oluşturun ve bu yeni dizinde *credentials* adlı bir dosya oluşturun.
+
+    ```bash
+    $ mkdir ~/.aws
+    $ touch ~/.aws/credentials
+    ```
+
+    *~/.aws/credentials* dosyası, Amazon Web Services hizmetlerine program aracılığıyla erişmek için kullanacağınız kimlik bilgilerinizi içerir ve AWS kimlik bilgilerini yönetmenin standartlaştırılmış bir yoludur. Dosyayı bir metin düzenleyicisinde açın ve *Access key ID* ile *Secret access key* değerlerinizi aşağıda gösterilen biçimde girin.
+
+    ```ini
+    [defold-liveupdate-example]
+    aws_access_key_id = <Access key ID>
+    aws_secret_access_key = <Secret access key>
+    ```
+
+    Köşeli parantezler içinde belirtilen tanımlayıcı, bu örnekte _defold-liveupdate-example_, Defold düzenleyicisinde projenizin Live Update ayarlarını yapılandırırken girmeniz gereken tanımlayıcının aynısıdır.
+
+    ![Live Update ayarları](images/live-update/05-liveupdate-settings.png)

--- a/docs/tr/manuals/live-update-scripting.md
+++ b/docs/tr/manuals/live-update-scripting.md
@@ -1,0 +1,188 @@
+---
+title: Live Update içeriğini betiklerle kullanma
+brief: Live Update içeriğini kullanmak için verileri indirip oyununuza bağlamanız gerekir. Bu kılavuzda Live Update'i betiklerle nasıl kullanacağınızı öğrenin.
+---
+
+# Live Update'i betiklerle kullanma
+
+Temel bağlama (mount) iş akışında `liveupdate.add_mount()`, `liveupdate.remove_mount()` ve `liveupdate.get_mounts()` kullanılır. Kullanılabilir tüm işlevler için [`liveupdate` API başvuru belgelerinin tamamına](/ref/liveupdate/) bakın.
+
+Kodun, derleme bildirimi (build manifest) dışarıda bırakılmış Live Update içeriği bekleyen bir dağıtım paketini ayırt etmesi gerektiğinde `liveupdate.is_built_with_excluded_files()` kullanın:
+
+```lua
+if liveupdate.is_built_with_excluded_files() then
+    print("The bundle expects excluded Live Update content")
+end
+```
+
+Bu işlev yalnızca derleme bildiriminin üst verilerini bildirir. Bir arşivin şu anda bağlı olduğu veya belirli bir kaynağın (resource) kullanılabilir olduğu anlamına gelmez. Etkin bağlama kayıtlarını incelemek için `liveupdate.get_mounts()`, bir koleksiyon vekilinin (collection proxy) bildirimde kayıtlı kaynak karma değerlerini (hash) incelemek için [`collectionproxy.get_resources()`](/ref/collectionproxy/#collectionproxy.get_resources) kullanın.
+
+Önerilen iş akışı, eksiksiz bir Zip arşivini indirip bir `zip:` URI değeri kullanarak bağlamaktır.
+
+## Bağlama kayıtlarını alma
+
+`liveupdate.get_mounts()`, geçerli oturumda etkin olan bağlama kayıtlarını döndürür. Her kayıtta bir `uri` dizesi, sayısal bir `priority` değeri ve bir `name` karma değeri bulunur. Liste ayrıca motorun öncelikleri sıfırın altında olan ve kaldırılamayan temel bağlama kayıtlarını da içerir.
+
+Motor, yeniden başlatıldıktan sonra bağlamaları geri yüklemez. Uygulamanın daha sonraki bir oturumda önceden indirilmiş içeriğe ihtiyacı varsa paketin URI değerini, adını ve önceliğini kendi kayıt verilerinde kalıcı olarak saklaması ve başlangıçta `liveupdate.add_mount()` işlevini yeniden çağırması gerekir.
+
+Birden fazla paket bağlandığında, bunların uygulama tarafından tanımlanan üst verilerini doğrulamak yararlıdır. `mount.name` bir karma değeri olduğundan onu tablo anahtarı olarak kullanın veya `hash("mount-name")` ile karşılaştırın; bir kaynak yolu oluşturmak için dizelere eklemeyin. Aşağıdaki örnek, her adın karma değerini benzersiz bir üst veri kaynağı yoluna eşler:
+
+```lua
+local function remove_old_mounts()
+	local mounts = liveupdate.get_mounts() -- table with mounts
+	local version_resources = {
+		[hash("level-pack")] = "/version_level_pack.json",
+		[hash("season-pack")] = "/version_season_pack.json",
+	}
+
+	for _, mount in ipairs(mounts) do
+		local version_resource = version_resources[mount.name]
+		local version_data = version_resource and sys.load_resource(version_resource)
+
+		if version_data then
+			version_data = json.decode(version_data)
+		elseif mount.priority >= 0 then
+			version_data = {version = 0} -- if it has no version file, it's likely an old/invalid archive
+		end
+
+		-- Ignore the engine's base mounts, which have negative priorities.
+		if version_data and version_data.version < sys.get_config_int("game.minimum_lu_version") then
+			liveupdate.remove_mount(mount.name)
+		end
+	end
+end
+```
+
+Farklı paketler için benzersiz üst veri yolları kullanın. Kaynak arama işlemi bağlama önceliğine göre yapıldığından, aynı yolun birden fazla pakette kullanılması en yüksek öncelikli bağlamadaki kopyanın okunmasına neden olur.
+
+## Dışarıda bırakılan koleksiyon vekillerini betiklerle kullanma
+
+Paketleme dışında bırakılmış bir koleksiyon vekili, önemli bir farkla normal bir koleksiyon vekili gibi çalışır. Dağıtım paketinin depolama alanında bulunmayan kaynakları varken ona `load` iletisi göndermek, yüklemenin başarısız olmasına neden olur.
+
+Arşiv tabanlı iş akışında, genellikle bir vekilin hangi arşive veya arşivlere ihtiyaç duyduğunu önceden belirler ve bunları vekili yüklemeden önce bağlarsınız. Dışarıda bırakıldığını bildiğiniz bir vekilin bildirimde kayıtlı kaynak karma değerlerini incelemek için `collectionproxy.get_resources()` kullanın.
+
+Bir paket bağlandıktan sonra, dışarıda bırakılmış ve yüklü olmayan bir vekil `collectionproxy.set_collection()` ile derlenmiş farklı bir koleksiyona (collection) da yönlendirilebilir. Kısıtlamalar ve yükleme sırası için [Dışarıda bırakılan bir vekilin koleksiyonunu değiştirme](/manuals/collection-proxy/#changing-an-excluded-proxys-collection) bölümüne bakın.
+
+Live Update içeriği yayımlayan bir arşiv derlemesinde, dağıtım paketine dahil edilen ana bildirim dışarıda bırakılan Live Update kayıtlarını içermez; yayımlanan paketin bildirimi ise bunları korur. `collectionproxy.get_resources()`, bildirimdeki bağımlılık üst verilerini okur; başvurulan her veri bloğunun kullanılabilir olduğunu doğrulamaz:
+
+* Vekilin dışarıda bırakılan kayıtlarını içeren bir paket bildirimi bağlanmadan önce, `collectionproxy.get_resources("#proxy")` boş bir `{}` tablosu döndürür.
+* İlgili paket bağlandıktan sonra, o vekilin kaynak karma değerlerini içeren boş olmayan bir tablo döndürür. Örneğin:
+
+```lua
+{
+    "a1b2c3...",
+    "d4e5f6...",
+    "7890ab...",
+    ...
+}
+```
+
+ Aşağıdaki örnek kod, kaynakların `game.http_url` ayarında belirtilen URL üzerinden erişilebilir olduğunu varsayar.
+
+```lua
+
+-- You'll need to track which archive contains which content
+-- In this example, we only use a single liveupdate archive, containing all missing resource.
+-- If you are using multiple archive, you need to structure the downloads accordingly
+local lu_infos = {
+    liveupdate = {
+        name = "liveupdate",
+        priority = 10,
+    }
+}
+
+local function get_lu_info_for_level(level_name)
+    if level_name == "level1" then
+        return lu_infos['liveupdate']
+    end
+end
+
+local function mount_zip(self, name, priority, path, callback)
+    liveupdate.add_mount(name, "zip:" .. path, priority, function(_self, _name, _uri, _result) -- <1>
+        callback(_name, _uri, _result)
+    end)
+end
+
+local function has_mount(name)
+    local name_hash = hash(name)
+    for _, mount in ipairs(liveupdate.get_mounts()) do
+        if mount.name == name_hash then
+            return true
+        end
+    end
+    return false
+end
+
+function init(self)
+    self.http_url = sys.get_config_string("game.http_url", nil) -- <2>
+
+    local level_name = "level1"
+
+    local info = get_lu_info_for_level(level_name) -- <3>
+
+    msg.post("#", "load_level", {level = "level1", info = info }) -- <4>
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("load_level") then
+        local proxy_resources = collectionproxy.get_resources("#" .. message.level) -- <5>
+
+        -- A build that publishes Live Update content omits excluded entries from the
+        -- bundled manifest, so this table is empty until the relevant package manifest
+        -- is mounted. After mounting, it contains the resource hashes for the proxy.
+        if message.info and #proxy_resources == 0 and not has_mount(message.info.name) then
+            msg.post("#", "download_archive", message) -- <6>
+        else
+            msg.post("#" .. message.level, "load")
+        end
+
+    elseif message_id == hash("download_archive") then
+        local zip_filename = message.info.name .. ".zip"
+        local download_path = sys.get_save_file("mygame", zip_filename)
+        local url = self.http_url .. "/" .. zip_filename
+
+        -- Check if the archive already exists. If it does, try to mount it!
+        if sys.exists(download_path) then
+            mount_zip(self, message.info.name, message.info.priority, download_path, function(name, uri, result) -- <8>
+                if result == liveupdate.LIVEUPDATE_OK then
+                    msg.post("#", "load_level", message) -- try to load the level again
+                else
+                    os.remove(download_path)             -- remove and try to
+                    msg.post("#", "load_level", message) -- download again
+                end
+            end)
+        else
+            -- Make the request. You can use credentials
+            http.request(url, "GET", function(self, id, response) -- <7>
+                if response.status == 200 or response.status == 304 then
+                    mount_zip(self, message.info.name, message.info.priority, download_path, function(name, uri, result) -- <8>
+                        if result == liveupdate.LIVEUPDATE_OK then
+                            msg.post("#", "load_level", message) -- try to load the level again
+                        else
+                            print("Failed to mount archive", download_path, ":", result)
+                        end
+                    end)
+                else
+                    print("Failed to download archive", download_path, "from", url, ":", response.status)
+                end
+            end, nil, nil, {path=download_path})
+        end
+
+    elseif message_id == hash("proxy_loaded") then -- the level is loaded, and we can enable it
+        msg.post(sender, "init")
+        msg.post(sender, "enable")
+    end
+end
+```
+
+1. `liveupdate.add_mount()`, belirtilen bir ad, öncelik ve zip dosyası kullanarak tek bir arşivi bağlar. Veriler hemen yüklenebilir duruma gelir (motoru yeniden başlatmak gerekmez). Bağlama yalnızca geçerli oturum boyunca etkindir. İndirilen paketin yolunu ve istediğiniz bağlama ayarlarını kendi kayıt verilerinizde kalıcı olarak saklayın ve her yeniden başlatmadan sonra `liveupdate.add_mount()` işlevini tekrar çağırın.
+2. Arşivi, indirebileceğiniz çevrimiçi bir konumda (örneğin S3 üzerinde) saklamanız gerekir.
+3. Bir koleksiyon vekilinin adına göre hangi arşivi veya arşivleri indireceğinizi ve bunları nasıl bağlayacağınızı belirlemeniz gerekir
+4. Başlangıçta bölümü yüklemeyi deneriz.
+5. Bu arşiv yayımlama iş akışında, vekilin dışarıda bırakılan içeriğine ait üst verileri incelemek için `collectionproxy.get_resources()` kullanın. İlgili paket bildirimi bağlanana kadar `{}`, bağlandıktan sonra ise kaynak karma değerlerini içeren boş olmayan bir tablo döndürür. Bu karma değerleri bağımlılıkları tanımlar; sonuç tek başına her veri bloğunun kullanılabilir olduğunu doğrulamaz.
+6. Vekil Live Update içeriği kullanıyorsa ve ilgili arşiv henüz bağlanmamışsa, vekili yüklemeden önce arşivi indirip bağlarız.
+7. Bir HTTP isteği yapın ve arşivi `download_path` konumuna indirin
+8. Veriler indirildi; artık bunları çalışan motora bağlama zamanı.
+
+
+Yükleme kodu hazır olduğuna göre uygulamayı test edebiliriz. Ancak uygulamayı düzenleyiciden çalıştırmak hiçbir şey indirmez. Bunun nedeni Live Update'in bir dağıtım paketi özelliği olmasıdır. Düzenleyici ortamında çalıştırılırken hiçbir kaynak dışarıda bırakılmaz. Her şeyin düzgün çalıştığından emin olmak için bir dağıtım paketi oluşturmamız gerekir.

--- a/docs/tr/manuals/live-update.md
+++ b/docs/tr/manuals/live-update.md
@@ -1,0 +1,152 @@
+---
+title: Defold'da Live Update içeriği
+brief: Live Update özelliği, derleme sırasında bilinçli olarak paket dışında bırakılan kaynakların çalışma zamanı ortamı tarafından getirilip uygulamanın dağıtım paketinde saklanmasını sağlayan bir mekanizma sunar. Bu kılavuz, bu mekanizmanın nasıl çalıştığını açıklar.
+---
+
+# Live Update
+
+Bir oyunun dağıtım paketi (bundle) oluşturulurken Defold, oyunun tüm kaynaklarını (resource) hedef platforma özgü pakete ekler. Çalışan motor tüm kaynaklara anında erişebildiği ve bunları depolama alanından hızla yükleyebildiği için çoğu durumda bu tercih edilir. Ancak bazı durumlarda kaynakların yüklenmesini daha sonraki bir aşamaya ertelemek isteyebilirsiniz. Örneğin:
+
+- Oyununuz bir dizi bölümden oluşuyor ve oyuncuların oyunun geri kalanına devam edip etmeyeceklerine karar vermeden önce denemeleri için pakete yalnızca ilk bölümü eklemek istiyorsunuz.
+- Oyununuz HTML5 platformunu hedefliyor. Tarayıcıda bir uygulamayı depolama alanından yüklemek, uygulama başlatılmadan önce uygulama paketinin tamamının indirilmesini gerektirir. Böyle bir platformda, oyun kaynaklarının geri kalanını indirmeden önce asgari boyutta bir başlangıç paketi gönderip uygulamayı hızla çalışır duruma getirmek isteyebilirsiniz.
+- Oyununuz, indirilmelerini oyunda görüntülenmelerinden hemen öncesine kadar ertelemek istediğiniz çok büyük kaynaklar (görüntüler, videolar vb.) içeriyor. Bunun amacı kurulum boyutunu düşük tutmaktır.
+
+Live Update özelliği, koleksiyon vekili (collection proxy) kavramını genişletir; derleme sırasında bilinçli olarak paket dışında bırakılan kaynakların çalışma zamanı ortamı tarafından getirilip uygulamanın dağıtım paketinde saklanmasını sağlayan bir mekanizma ekler.
+
+Bu sayede içeriğinizi birden fazla arşive ayırabilirsiniz:
+
+* _Temel arşiv_
+* Seviyelerin ortak dosyaları
+* Seviye paketi 1
+* Seviye paketi 2
+* ...
+
+## İçeriği Live Update için hazırlama
+
+Büyük ve yüksek çözünürlüklü görüntü kaynakları içeren bir oyun yaptığımızı varsayalım. Oyun, bu görüntüleri bir oyun nesnesi (game object) ve görüntüyü içeren bir sprite bileşeni (sprite component) bulunan koleksiyonlarda (collection) tutar:
+
+![Mona Lisa koleksiyonu](images/live-update/mona-lisa.png)
+
+Motorun böyle bir koleksiyonu dinamik olarak yüklemesi için bir koleksiyon vekili bileşeni (component) ekleyip onu *`monalisa.collection`* dosyasına yönlendirmemiz yeterlidir. Artık oyun, koleksiyon vekiline bir `load` iletisi göndererek koleksiyondaki içeriğin depolama alanından belleğe ne zaman yükleneceğini seçebilir. Ancak biz daha ileri gidip koleksiyonda bulunan kaynakların yüklenmesini kendimiz kontrol etmek istiyoruz.
+
+Bunun için koleksiyon vekilinin özelliklerindeki *Exclude* onay kutusunu işaretlemek yeterlidir. Bu, Defold'a uygulamanın dağıtım paketini oluştururken *`monalisa.collection`* içindeki tüm içeriği paket dışında bırakmasını söyler.
+
+::: important
+Temel oyun paketinin başvurduğu hiçbir kaynak paket dışında bırakılmaz.
+:::
+
+![Paket dışında bırakılan koleksiyon vekili](images/live-update/proxy-excluded.png)
+
+## Live Update ayarları
+
+Defold, uygulamanın dağıtım paketini oluştururken paket dışında bırakılan kaynakları bir yerde saklamalıdır. Live Update için proje ayarları bu kaynakların konumunu belirler. Ayarlara <kbd>Project ▸ Live update Settings...</kbd> seçeneğinden erişilir. Henüz bir ayar dosyası yoksa bu işlem bir tane oluşturur. *game.project* içinde, paketleme sırasında hangi Live Update ayar dosyasının kullanılacağını seçin. Böylece canlı ortam, kalite güvencesi (QA), geliştirme gibi farklı ortamlar için farklı Live Update ayarları kullanabilirsiniz.
+
+![Live Update ayarları](images/live-update/05-liveupdate-settings-zip.png)
+
+Defold şu anda kaynakları üç farklı yöntemle saklayabilir. Ayarlar penceresindeki *Mode* açılır listesinden yöntemi seçin:
+
+`Zip`
+: Bu seçenek, Defold'a paket dışında bırakılan kaynakları içeren bir Zip arşiv dosyası oluşturmasını söyler. Arşiv, *Export path* ayarında belirtilen konuma kaydedilir ve çalışma sırasında bir `zip:` URI'si ve `liveupdate.add_mount()` kullanılarak bağlanabilir (mount).
+
+`Folder`  
+: Bu seçenek, Defold'a paket dışında bırakılan tüm kaynakları içeren bir klasör oluşturmasını söyler. Dosyaları yüklemeden veya paketlemeden önce üzerlerinde sonradan işlem yapmanız gerektiğinde yararlıdır. Tek tek derlenmiş dosyaların beklenen kaynak yollarına yerleştirildiği bir klasör, çalışma sırasında bir `file:` URI'si kullanılarak bağlanabilir.
+
+`Amazon`
+: Bu seçenek, Defold'a paket dışında bırakılan kaynakları otomatik olarak bir Amazon Web Service (AWS) S3 kovasına yüklemesini söyler. AWS *Credential profile* adınızı girin, uygun *Bucket* seçeneğini seçin ve bir *Prefix* adı belirtin. AWS hesabının nasıl kurulacağı hakkında daha fazla bilgiyi bu [AWS kılavuzunda](/manuals/live-update-aws) bulabilirsiniz
+
+## Live Update ile paketleme
+
+::: important
+Düzenleyiciden derleyip çalıştırma (<kbd>Project ▸ Build</kbd>) Live Update özelliğini desteklemez. Live Update özelliğini test etmek için projenin dağıtım paketini oluşturmanız gerekir.
+:::
+
+Live Update ile dağıtım paketi oluşturmak kolaydır. <kbd>Project ▸ Bundle ▸ ...</kbd> seçeneğini, ardından uygulamanın dağıtım paketini oluşturmak istediğiniz platformu seçin. Bu, paketleme iletişim kutusunu açar:
+
+![Live Update uygulamasının dağıtım paketini oluşturma](images/live-update/bundle-app.png)
+
+Paketleme sırasında, hariç tutulan tüm kaynaklar uygulamanın dağıtım paketinin dışında bırakılır. *Publish Live update content* onay kutusunu işaretlediğinizde, Defold'a Live Update ayarlarınızın yapılandırmasına göre (yukarıya bakın) paket dışında bırakılan kaynakları Amazon'a yüklemesini veya bir Zip arşivi oluşturmasını söylersiniz. Yayımlanan Live Update içeriği, uzaktan dağıtım için gereken tam kaynak listesini içeren `liveupdate.game.dmanifest` dosyasını içermeye devam eder.
+
+Live Update içeriği yayımlanırken Defold, dağıtım paketindeki `game.dmanifest` dosyasından yalnızca Live Update için kullanılan kayıtları otomatik olarak kaldırır; yayımlanan `liveupdate.game.dmanifest` dosyası ise kaynak listesinin tamamını korur. Bu, dağıtım paketinin boyutunu ve çalışma sırasındaki bellek kullanımını azaltır. Eski `liveupdate.exclude_entries_from_main_manifest` ayarı kaldırılmıştır; projede bu ayara ait bir kayıt kaldıysa yok sayılır.
+
+Arşiv tabanlı iş akışında `collectionproxy.get_resources()`, ilgili arşiv bağlanana kadar `{}` döndürür. Bağlama işleminden sonra, söz konusu vekilin kaynak karma değerlerini döndürür.
+
+*Package* seçeneğine tıklayın ve uygulamanın dağıtım paketi için bir konum seçin. Artık uygulamayı başlatıp her şeyin beklendiği gibi çalıştığını kontrol edebilirsiniz.
+
+## .zip arşivleri
+
+Bir Live Update .zip dosyası, temel oyun paketinin dışında bırakılan dosyaları içerir.
+
+Mevcut işlem hattımız yalnızca tek bir .zip dosyası oluşturmayı desteklese de bu zip dosyasını daha küçük .zip dosyalarına bölmek mümkündür. Böylece seviye paketleri, sezonluk içerikler vb. oyun içerikleri daha küçük parçalar halinde indirilebilir. Her .zip dosyası, içindeki her kaynağın üst verilerini (metadata) açıklayan bir bildirim dosyası (manifest) da içerir.
+
+## .zip arşivlerini bölme
+
+Kaynak kullanımı üzerinde daha ayrıntılı kontrol sağlamak için paket dışında bırakılan içeriği birkaç küçük arşive bölmek çoğu zaman tercih edilir. Seviyelerden oluşan bir oyunu birden fazla seviye paketine bölmek buna bir örnektir. Bir başka örnek de farklı bayram ve tatil temalı arayüz süslemelerini ayrı arşivlere koyup yalnızca takvimde o anda geçerli olan temayı yüklemek ve bağlamaktır.
+
+Kaynak grafı (resource graph), `build/default/game.graph.json` dosyasında saklanır ve projenin dağıtım paketi her oluşturulduğunda otomatik olarak üretilir. Oluşturulan dosya, projedeki tüm kaynakların listesini ve her kaynağın bağımlılıklarını içerir. Örnek kayıt:
+
+```json
+{
+  "path" : "/game/player.goc",
+  "hexDigest" : "caa342ec99794de45b63735b203e83ba60d7e5a1",
+  "children" : [ "/game/ship.spritec", "/game/player.scriptc" ]
+}
+```
+
+Her kaydın, kaynağın proje içindeki benzersiz yolunu temsil eden bir `path` alanı vardır. `hexDigest`, kaynağın kriptografik parmak izini temsil eder ve Live Update .zip arşivinde kullanılan dosya adı olur. Son olarak `children` alanı, bu kaynağın bağlı olduğu diğer bağımlılıkların listesidir. Yukarıdaki örnekte `/game/player.goc`, bir sprite bileşenine ve bir betik bileşenine bağımlıdır.
+
+`game.graph.json` dosyasını ayrıştırıp bu bilgileri kullanarak kaynak grafındaki kayıt gruplarını belirleyebilir ve bunlara karşılık gelen kaynakları özgün bildirim dosyasıyla birlikte ayrı arşivlerde saklayabilirsiniz (bildirim dosyası, çalışma sırasında yalnızca arşivdeki dosyaları içerecek şekilde budanır).
+
+## Android'de Live Update
+
+Live Update içeriğini indirmek ve bağlamak için Play Asset Delivery kullanabilirsiniz. Daha fazla bilgiyi [resmî kılavuzda](https://defold.com/extension-pad/) bulabilirsiniz.
+
+## İçerik doğrulama
+
+Live Update sisteminin başlıca özelliklerinden biri, artık birçok farklı Defold sürümünden gelebilen çok sayıda içerik arşivini kullanabilmenizdir.
+
+`liveupdate.add_mount()` işlevinin varsayılan davranışı, bir bağlama eklerken motor sürümünü kontrol etmektir.
+Bu, hem oyunun temel arşivinin hem de Live Update arşivlerinin paketleme seçeneği kullanılarak aynı anda, aynı motor sürümüyle oluşturulması gerektiği anlamına gelir. Bu işlem, istemcinin daha önce indirdiği tüm arşivleri geçersiz kılar ve istemcinin içeriği yeniden indirmesini gerektirir.
+
+Bu davranış bir seçenek bayrağıyla kapatılabilir.
+Kapatıldığında, her Live Update arşivinin kullanılmakta olan motorla çalışacağını garanti etmek için içeriği doğrulama sorumluluğu tamamen geliştiriciye aittir.
+
+Uygulamanın paketin bağlı kalıp kalmayacağına karar verebilmesi için her bağlamaya ait üst verileri saklamanızı öneririz. Uygulamanın başlangıç sırasında gereken bağlamaları yeniden eklediği durumlar da dahil olmak üzere, bağlamayı ekledikten sonra bu verileri doğrulayın.
+Bunu yapmanın bir yolu, oyunun dağıtım paketi oluşturulduktan sonra zip arşivine ek bir dosya koymaktır. Örneğin, oyunun ihtiyaç duyduğu bilgileri içeren bir `metadata.json` dosyası ekleyin ve ardından bağlama işleminden sonra `sys.load_resource("/metadata.json")` ile bu dosyayı alın. _Her bağlamanın özel verileri için benzersiz bir kaynak yolu kullanın; aksi takdirde kaynak araması en yüksek önceliğe sahip bağlamadaki dosyayı döndürür._
+
+Bunu yapmazsanız içeriğin motorla hiç uyumlu olmadığı ve motorun kapanmak zorunda kaldığı bir durumla karşılaşabilirsiniz.
+
+## Bağlamalar
+
+Live Update sistemi aynı anda birden fazla içerik arşivini kullanabilir.
+Her arşiv, bir ad ve öncelik değeriyle motorun kaynak sistemine "bağlanır".
+
+İki arşivde de aynı `sprite.texturec` dosyası varsa motor, dosyayı en yüksek önceliğe sahip bağlamadan yükler.
+
+Motor, bir bağlamadaki herhangi bir kaynağa başvuru tutmaz. Bir kaynak belleğe yüklendikten sonra arşivin bağlaması kaldırılabilir. Kaynak, bellekten kaldırılana kadar bellekte kalır.
+
+Bağlamalar yalnızca geçerli motor oturumu boyunca etkindir. Uygulama, yeniden başlatıldıktan sonra ihtiyaç duyduğu her paket için `liveupdate.add_mount()` işlevini yeniden çağırmalıdır. Bu seçimlerin oturumlar arasında korunması gerekiyorsa paket konumunu, bağlama adını ve önceliğini uygulamanın yönettiği kalıcı verilerde saklayın.
+
+::: sidenote
+Bir Zip arşivini veya klasörü bağlamak onu kopyalamaz ya da taşımaz. Bağlanan içerik, bağlama kullanımda olduğu sürece belirtilen konumda kalmalıdır.
+:::
+
+## Live Update ile betik yazma
+
+Live Update içeriğini kullanabilmek için verileri indirip oyununuza bağlamanız gerekir.
+[Live Update ile nasıl betik yazılacağı hakkında daha fazla bilgiyi burada bulabilirsiniz](/manuals/live-update-scripting).
+
+## Geliştirme sırasında dikkat edilmesi gerekenler
+
+Hata ayıklama
+: Oyununuzun dağıtım paketi oluşturulmuş bir sürümünü çalıştırırken bir konsola doğrudan erişiminiz olmaz. Bu durum, hata ayıklamada sorunlara yol açar. Ancak uygulamayı komut satırından veya dağıtım paketindeki yürütülebilir dosyaya doğrudan çift tıklayarak çalıştırabilirsiniz:
+
+  ![Dağıtım paketindeki uygulamayı çalıştırma](images/live-update/run-bundle.png)
+
+  Artık oyun, tüm `print()` ifadelerinin çıktısını gösterecek bir kabuk penceresiyle başlar:
+
+  ![Konsol çıktısı](images/live-update/run-bundle-console.png)
+
+Kaynakların yeniden indirilmesini zorunlu kılma
+: Geliştirici, içeriği istediği dosyaya veya klasöre indirebilir; ancak içerik genellikle uygulama yolunun altında bulunur. Uygulama destek klasörünün konumu işletim sistemine bağlıdır. Bu konum `print(sys.get_save_file("", ""))` ile bulunabilir. Yeniden indirmeyi zorunlu kılmak için indirilen paketi ve uygulamanın yönettiği durum verilerindeki ilgili kaydı kaldırın. Silinecek, motor tarafından yönetilen bir bağlama listesi yoktur; bağlamalar yeniden başlatmalar arasında korunmaz.
+
+  ![Yerel depolama](images/live-update/local-storage.png)

--- a/docs/tr/manuals/lua.md
+++ b/docs/tr/manuals/lua.md
@@ -1,0 +1,670 @@
+---
+title: Defold'da Lua programlama
+brief: Bu kılavuz, genel olarak Lua programlamanın temellerine ve Defold'da Lua ile çalışırken dikkat etmeniz gerekenlere kısa bir giriş sunar.
+---
+
+# Defold'da Lua
+
+Defold motoru, betik (script) yazımı için gömülü Lua dilini kullanır. Lua güçlü, hızlı ve başka yazılımlara gömülmesi kolay, hafif bir dinamik dildir. Video oyunlarında betik dili olarak yaygın biçimde kullanılır. Lua programları basit bir yordamsal sözdizimiyle yazılır. Dil dinamik türlendirmelidir ve bir bayt kodu (bytecode) yorumlayıcısı tarafından çalıştırılır. Artımlı çöp toplama (incremental garbage collection) ile otomatik bellek yönetimi sunar.
+
+Bu kılavuz, genel olarak Lua programlamanın temellerine ve Defold'da Lua ile çalışırken dikkat etmeniz gerekenlere kısa bir giriş sunar. Python, Perl, Ruby, JavaScript veya benzer bir dinamik dil konusunda biraz deneyiminiz varsa oldukça hızlı ilerleyebilirsiniz. Programlamaya yeni başlıyorsanız başlangıç düzeyine yönelik bir Lua kitabıyla başlamak isteyebilirsiniz. Aralarından seçim yapabileceğiniz pek çok kitap vardır.
+
+## Lua sürümleri
+
+Defold, Lua'nın oyunlarda ve performansın kritik olduğu diğer yazılımlarda kullanıma uygun, yüksek ölçüde optimize edilmiş bir sürümü olan [LuaJIT](https://luajit.org/) kullanır. Lua 5.1'den geçişte tam uyumluluk sağlar ve tüm standart Lua kütüphanesi işlevleriyle Lua/C API işlevlerinin tamamını destekler.
+
+LuaJIT ayrıca çeşitli [dil uzantıları](https://luajit.org/extensions.html) ile bazı Lua 5.2 ve 5.3 özellikleri ekler.
+
+Defold'un tüm platformlarda aynı şekilde çalışmasını hedefliyoruz, ancak şu anda platformlar arasında Lua dili sürümü açısından birkaç küçük farklılık bulunuyor:
+* iOS, JIT kod derlemesine izin vermez.
+* Nintendo Switch, JIT kod derlemesine izin vermez.
+* HTML5, LuaJIT yerine Lua 5.1.4 kullanır.
+
+::: important
+Oyununuzun desteklenen tüm platformlarda çalışmasını garantilemek için YALNIZCA Lua 5.1 dil özelliklerini kullanmanızı önemle öneririz.
+:::
+
+### Standart kütüphaneler ve uzantılar
+Defold, [Lua 5.1 standart kütüphanelerinin](http://www.lua.org/manual/5.1/manual.html#5) tamamının yanı sıra bir soket ve bir bit işlemleri kütüphanesi içerir:
+
+  - base (`assert()`, `error()`, `print()`, `ipairs()`, `require()` vb.)
+  - coroutine
+  - package
+  - string
+  - table
+  - math
+  - io
+  - os
+  - debug
+  - socket ([LuaSocket](https://github.com/diegonehab/luasocket) kaynaklı)
+  - bitop ([BitOp](http://bitop.luajit.org/api.html) kaynaklı)
+
+Tüm kütüphaneler [API başvuru belgelerinde](/ref/go) açıklanmıştır.
+
+## Lua kitapları ve kaynakları
+
+### Çevrimiçi kaynaklar
+* [Lua ile programlama (ilk baskı)](http://www.lua.org/pil/contents.html) Sonraki baskılar basılı olarak bulunabilir.
+* [Lua 5.1 başvuru kılavuzu](http://www.lua.org/manual/5.1/)
+* [15 dakikada Lua öğrenin](http://tylerneylon.com/a/learn-lua/)
+* [Awesome Lua - öğreticiler bölümü](https://github.com/LewisJEllis/awesome-lua#tutorials)
+
+### Kitaplar
+* [Lua ile programlama](https://www.amazon.com/gp/product/8590379868/ref=dbs_a_def_rwt_hsch_vapi_taft_p1_i0) - Programming in Lua, dilin resmî kitabıdır ve Lua kullanmak isteyen her programcıya sağlam bir temel sunar. Dilin baş mimarı Roberto Ierusalimschy tarafından yazılmıştır.
+* [Lua programlamanın incileri](https://www.amazon.com/Programming-Gems-Luiz-Henrique-Figueiredo/dp/8590379841) - Bu makale derlemesi, Lua'da iyi programlama konusunda birikmiş bilgi ve uygulamaların bir bölümünü bir araya getirir.
+* [Lua 5.1 başvuru kılavuzu](https://www.amazon.com/gp/product/8590379833/ref=dbs_a_def_rwt_hsch_vapi_taft_p1_i4) - Çevrimiçi olarak da bulunabilir (yukarıya bakın)
+* [Lua programlamaya başlangıç](https://www.amazon.com/Beginning-Lua-Programming-Kurt-Jung/dp/0470069171)
+
+### Videolar
+* [Tek videoda Lua öğrenin](https://www.youtube.com/watch?v=iMacxZQMPXs)
+
+## Sözdizimi
+
+Programların basit, okunması kolay bir sözdizimi vardır. Her deyim ayrı bir satıra yazılır ve deyimin sonunu işaretlemek gerekmez. İsterseniz deyimleri ayırmak için noktalı virgül `;` kullanabilirsiniz. Kod bloklarının sınırları anahtar sözcüklerle belirlenir ve bloklar `end` anahtar sözcüğüyle biter. Yorumlar bir blok halinde veya satır sonuna kadar yazılabilir:
+
+```lua
+--[[
+Here is a block of comments that can run
+over several lines in the source file.
+--]]
+
+a = 10
+b = 20 ; c = 30 -- two statements on one line
+
+if my_variable == 3 then
+    call_some_function(true) -- Here is a line comment
+else
+    call_another_function(false)
+end
+```
+
+## Değişkenler ve veri türleri
+
+Lua dinamik türlendirmelidir; yani değişkenlerin türü yoktur, ancak değerlerin vardır. 
+Statik türlendirmeli dillerden farklı olarak, istediğiniz herhangi bir değeri herhangi bir değişkene atayabilirsiniz. 
+
+Lua'da sekiz temel tür vardır:
+
+`nil`
+: Bu türün yalnızca `nil` değeri vardır. Genellikle yararlı bir değerin bulunmadığını ifade eder; örneğin değer atanmamış değişkenlerde kullanılır.
+
+  ```lua
+  print(my_var) -- will print 'nil' since 'my_var' is not yet assigned a value
+  ```
+
+boolean
+: `true` veya `false` değerini alır. `false` veya `nil` olan koşullar yanlış olarak değerlendirilir. Diğer tüm değerler doğru olarak değerlendirilir.
+
+  ```lua
+  flag = true
+  if flag then
+      print("flag is true")
+  else
+      print("flag is false")
+  end
+
+  if my_var then
+      print("my_var is not nil nor false!")
+  end
+
+  if not my_var then
+      print("my_var is either nil or false!")
+  end
+  ```
+
+number
+: Sayılar dahili olarak 64 bit _tam sayılar_ veya 64 bit _kayan noktalı_ sayılar biçiminde temsil edilir. Lua gerektiğinde bu gösterimler arasında otomatik dönüşüm yapar, dolayısıyla genellikle bununla ilgilenmeniz gerekmez.
+
+  ```lua
+  print(10) --> prints '10'
+  print(10.0) --> '10'
+  print(10.000000000001) --> '10.000000000001'
+
+  a = 5 -- integer
+  b = 7/3 -- float
+  print(a - b) --> '2.6666666666667'
+  ```
+
+string
+: Dizeler, gömülü sıfırlar (`\0`) dahil herhangi bir 8 bitlik değeri içerebilen, değişmez bayt dizileridir. Lua bir dizenin içeriği hakkında varsayımda bulunmaz; bu nedenle dizelerde istediğiniz veriyi saklayabilirsiniz. Dize sabitleri tek veya çift tırnak içinde yazılır. Lua, çalışma sırasında sayılarla dizeler arasında dönüşüm yapar. Dizeler `..` işleciyle birleştirilebilir.
+
+  Dizeler, aşağıdaki C tarzı kaçış dizilerini içerebilir:
+
+  | Dizi | Karakter |
+  | -------- | --------- |
+  | `\a`     | zil       |
+  | `\b`     | geri silme |
+  | `\f`     | sayfa ilerletme  |
+  | `\n`     | yeni satır    |
+  | `\r`     | satır başı |
+  | `\t`     | yatay sekme |
+  | `\v`     | dikey sekme   |
+  | `\\`     | ters eğik çizgi      |
+  | `\"`     | çift tırnak   |
+  | `\'`     | tek tırnak   |
+  | `\[`     | sol köşeli ayraç    |
+  | `\]`     | sağ köşeli ayraç   |
+  | `\ddd`   | sayısal değeriyle belirtilen karakter; burada `ddd`, en fazla üç _ondalık_ rakamdan oluşan bir dizidir |
+
+  ```lua
+  my_string = "hello"
+  another_string = 'world'
+  print(my_string .. another_string) --> "helloworld"
+
+  print("10.2" + 1) --> 11.2
+  print(my_string + 1) -- error, can't convert "hello"
+  print(my_string .. 1) --> "hello1"
+
+  print("one\nstring") --> one
+                       --> string
+
+  print("\097bc") --> "abc"
+
+  multi_line_string = [[
+  Here is a chunk of text that runs over several lines. This is all
+  put into the string and is sometimes very handy.
+  ]]
+  ```
+
+function
+: Lua'da işlevler birinci sınıf değerlerdir (first-class values); yani onları işlevlere parametre olarak aktarabilir ve değer olarak döndürebilirsiniz. Bir işlevin atandığı değişkenler, o işleve bir başvuru içerir. Değişkenlere anonim işlevler atayabilirsiniz, ancak Lua kolaylık sağlamak için bir sözdizimi kısayolu (`function name(param1, param2) ... end`) sunar.
+
+  ```lua
+  -- Assign 'my_plus' to function
+  my_plus = function(p, q)
+      return p + q
+  end
+
+  print(my_plus(4, 5)) --> 9
+
+  -- Convenient syntax to assign function to variable 'my_mult'
+  function my_mult(p, q)
+      return p * q
+  end
+
+  print(my_mult(4, 5)) --> 20
+
+  -- Takes a function as parameter 'func'
+  function operate(func, p, q)
+      return func(p, q) -- Calls the provided function with parameters 'p' and 'q'
+  end
+
+  print(operate(my_plus, 4, 5)) --> 9
+  print(operate(my_mult, 4, 5)) --> 20
+
+  -- Create an adder function and return it
+  function create_adder(n)
+      return function(a)
+          return a + n
+      end
+  end
+
+  adder = create_adder(2)
+  print(adder(3)) --> 5
+  print(adder(10)) --> 12
+  ```
+
+table
+: Tablolar, Lua'daki tek veri yapılandırma türüdür. Listeleri, dizileri, sıralı dizileri (sequence), simge tablolarını, kümeleri, kayıtları, grafları, ağaçları vb. temsil etmek için kullanılan ilişkisel dizi _nesneleridir_. Tablolar her zaman anonimdir ve bir tabloyu atadığınız değişkenler tablonun kendisini değil, ona bir başvuruyu içerir. Bir tabloyu sıralı dizi olarak başlatırken ilk indeks `0` değil, `1` olur.
+
+  ```lua
+  -- Initialize a table as a sequence
+  weekdays = {"Sunday", "Monday", "Tuesday", "Wednesday",
+              "Thursday", "Friday", "Saturday"}
+  print(weekdays[1]) --> "Sunday"
+  print(weekdays[5]) --> "Thursday"
+
+  -- Initialize a table as a record with sequence values
+  moons = { Earth = { "Moon" },
+            Uranus = { "Puck", "Miranda", "Ariel", "Umbriel", "Titania", "Oberon" } }
+  print(moons.Uranus[3]) --> "Ariel"
+
+  -- Build a table from an empty constructor {}
+  a = 1
+  t = {}
+  t[1] = "first"
+  t[a + 1] = "second"
+  t.x = 1 -- same as t["x"] = 1
+
+  -- Iterate over the table key, value pairs
+  for key, value in pairs(t) do
+      print(key, value)
+  end
+  --> 1   first
+  --> 2   second
+  --> x   1
+
+  u = t -- u now refers to the same table as t
+  u[1] = "changed"
+
+  for key, value in pairs(t) do -- still iterating over t!
+      print(key, value)
+  end
+  --> 1   changed
+  --> 2   second
+  --> x   1
+  ```
+
+userdata
+: `userdata`, herhangi bir C verisinin Lua değişkenlerinde saklanabilmesini sağlar. Defold, karma değerlerini (hash), URL nesnelerini (url), matematik nesnelerini (vector3, vector4, matrix4, quaternion), oyun nesnelerini (game object), GUI düğümlerini (node), işleme yüklemlerini (predicate), işleme hedeflerini (render_target) ve işleme sabiti arabelleklerini (constant_buffer) saklamak için Lua `userdata` nesnelerini kullanır
+
+thread
+: İş parçacıkları (thread), birbirinden bağımsız yürütme akışlarını temsil eder ve eş yordamları (coroutine) uygulamak için kullanılır. Ayrıntılar için aşağıya bakın.
+
+## İşleçler
+
+Aritmetik işleçler
+: Matematiksel işleçler `+`, `-`, `*`, `/`, tekli `-` (işaret değiştirme) ve üs alma işleci `^`.
+
+  ```lua
+  a = -1
+  print(a * 2 + 3 / 4^5) --> -1.9970703125
+  ```
+
+  Lua, çalışma sırasında sayılarla dizeler arasında otomatik dönüşüm sağlar. Bir dizeye uygulanan her sayısal işlem, dizeyi sayıya dönüştürmeyi dener:
+
+  ```lua
+  print("10" + 1) --> 11
+  ```
+
+İlişkisel/karşılaştırma işleçleri
+: `<` (küçüktür), `>` (büyüktür), `<=` (küçüktür veya eşittir), `>=` (büyüktür veya eşittir), `==` (eşittir), `~=` (eşit değildir). Bu işleçler her zaman `true` veya `false` döndürür. Farklı türlerdeki değerler farklı kabul edilir. Türler aynıysa değerlerine göre karşılaştırılırlar. Lua; tabloları, `userdata` değerlerini ve işlevleri başvurularına göre karşılaştırır. Bu türden iki değer, yalnızca aynı nesneye başvuruyorlarsa eşit kabul edilir.
+
+  ```lua
+  a = 5
+  b = 6
+
+  if a <= b then
+      print("a is less than or equal to b")
+  end
+
+  print("A" < "a") --> true
+  print("aa" < "ab") --> true
+  print(10 == "10") --> false
+  print(tostring(10) == "10") --> true
+  ```
+
+Mantıksal işleçler
+: `and`, `or` ve `not`. `and`, ilk bağımsız değişkeni `false` ise onu, aksi halde ikinci bağımsız değişkeni döndürür. `or`, ilk bağımsız değişkeni `false` değilse onu, aksi halde ikinci bağımsız değişkeni döndürür.
+
+  ```lua
+  print(true or false) --> true
+  print(true and false) --> false
+  print(not false) --> true
+
+  if a == 5 and b == 6 then
+      print("a is 5 and b is 6")
+  end
+  ```
+
+Birleştirme
+: Dizeler `..` işleciyle birleştirilebilir. Sayılar birleştirme sırasında dizeye dönüştürülür.
+
+  ```lua
+  print("donkey" .. "kong") --> "donkeykong"
+  print(1 .. 2) --> "12"
+  ```
+
+Uzunluk
+: Tekli uzunluk işleci `#`. Bir dizenin uzunluğu, içerdiği bayt sayısıdır. Bir tablonun uzunluğu, sıralı dizisinin uzunluğudur; yani `1`'den başlayarak yukarı doğru numaralandırılmış ve değeri `nil` olmayan indekslerin sayısıdır. Not: Sıralı dizide `nil` değerli "boşluklar" varsa uzunluk, bir `nil` değerinden önce gelen herhangi bir indeks olabilir.
+
+  ```lua
+  s = "donkey"
+  print(#s) --> 6
+
+  t = { "a", "b", "c", "d" }
+  print(#t) --> 4
+
+  u = { a = 1, b = 2, c = 3 }
+  print(#u) --> 0
+
+  v = { "a", "b", nil }
+  print(#v) --> 2
+  ```
+
+## Akış denetimi
+
+Lua, yaygın akış denetimi yapılarını sunar.
+
+if---then---else
+: Bir koşulu sınar; koşul doğruysa `then` bölümünü, aksi halde isteğe bağlı `else` bölümünü yürütür. `if` deyimlerini iç içe yazmak yerine `elseif` kullanabilirsiniz. Bu, Lua'da bulunmayan switch deyiminin yerini alır.
+
+  ```lua
+  a = 5
+  b = 4
+
+  if a < b then
+      print("a is smaller than b")
+  end
+
+  if a == '1' then
+      print("a is 1")
+  elseif a == '2' then
+      print("a is 2")
+  elseif a == '3' then
+      print("a is 3")
+  else
+      print("I have no idea what a is...")
+  end
+  ```
+
+while
+: Bir koşulu sınar ve koşul doğru olduğu sürece bloğu yürütür.
+
+  ```lua
+  weekdays = {"Sunday", "Monday", "Tuesday", "Wednesday",
+              "Thursday", "Friday", "Saturday"}
+
+  -- Print each weekday
+  i = 1
+  while weekdays[i] do
+      print(weekdays[i])
+      i = i + 1
+  end
+  ```
+
+repeat---until
+: Bir koşul doğru olana kadar bloğu tekrarlar. Koşul gövdeden sonra sınandığı için blok en az bir kez yürütülür.
+
+  ```lua
+  weekdays = {"Sunday", "Monday", "Tuesday", "Wednesday",
+              "Thursday", "Friday", "Saturday"}
+
+  -- Print each weekday
+  i = 0
+  repeat
+      i = i + 1
+      print(weekdays[i])
+  until weekdays[i] == "Saturday"
+  ```
+
+for
+: Lua'da iki tür `for` döngüsü vardır: sayısal ve genel. Sayısal `for`, 2 veya 3 sayısal değer alırken genel `for`, bir _yineleyici_ (iterator) işlevinin döndürdüğü tüm değerleri dolaşır.
+
+  ```lua
+  -- Print the numbers 1 to 10
+  for i = 1, 10 do
+      print(i)
+  end
+
+  -- Print the numbers 1 to 10 and increment with 2 each time
+  for i = 1, 10, 2 do
+      print(i)
+  end
+
+  -- Print the numbers 10 to 1
+  for i=10, 1, -1 do
+      print(i)
+  end
+
+  t = { "a", "b", "c", "d" }
+  -- Iterate over the sequence and print the values
+  for i, v in ipairs(t) do
+      print(v)
+  end
+  ```
+
+break ve return
+: Bir `for`, `while` veya `repeat` döngüsünün iç bloğundan çıkmak için `break` deyimini kullanın. Bir işlevden değer döndürmek ya da işlevin yürütülmesini bitirip çağırana dönmek için `return` kullanın. `break` veya `return`, yalnızca bir bloğun son deyimi olarak yer alabilir.
+
+  ```lua
+  a = 1
+  while true do
+      a = a + 1
+      if a >= 100 then
+          break
+      end
+  end
+
+  function my_add(a, b)
+      return a + b
+  end
+
+  print(my_add(10, 12)) --> 22
+  ```
+
+## Yerel değişkenler, genel değişkenler ve sözcüksel kapsam
+
+Bildirdiğiniz tüm değişkenler varsayılan olarak geneldir (global); yani Lua çalışma zamanı bağlamının her yerinden kullanılabilirler. Değişkenleri açıkça `local` olarak bildirebilirsiniz; bu durumda değişken yalnızca geçerli kapsam içinde var olur.
+
+Her Lua kaynak dosyası ayrı bir kapsam tanımlar. Bir dosyanın en üst düzeyindeki `local` bildirimleri, değişkenin o Lua betik dosyasına yerel olduğu anlamına gelir. Her işlev yeni bir iç kapsam oluşturur ve her denetim yapısı bloğu ek kapsamlar oluşturur. `do` ve `end` anahtar sözcükleriyle açıkça bir kapsam oluşturabilirsiniz. Lua sözcüksel kapsam (lexical scoping) kullanır; yani bir kapsam, kendisini çevreleyen kapsamdaki _yerel_ değişkenlere tam erişim sağlar. Yerel değişkenlerin kullanılmadan önce bildirilmesi gerektiğine dikkat edin.
+
+```lua
+function my_func(a, b)
+    -- 'a' and 'b' are local to this function and available through its scope
+
+    do
+        local x = 1
+    end
+
+    print(x) --> nil. 'x' is not available outside the do-end scope
+    print(foo) --> nil. 'foo' is declared after 'my_func'
+    print(foo_global) --> "value 2"
+end
+
+local foo = "value 1"
+foo_global = "value 2"
+
+print(foo) --> "value 1". 'foo' is available in the topmost scope after declaration.
+```
+
+Bir betik dosyasında işlevleri `local` olarak bildirirseniz (ki bu genellikle iyi bir fikirdir) kodun sıralamasına dikkat etmeniz gerekir. Birbirini çağıran işlevleriniz varsa ileri bildirimler kullanabilirsiniz.
+
+```lua
+local func2 -- Forward declare 'func2'
+
+local function func1(a)
+    print("func1")
+    func2(a)
+end
+
+function func2(a) -- or func2 = function(a)
+    print("func2")
+    if a < 10 then
+        func1(a + 1)
+    end
+end
+
+function init(self)
+    func1(1)
+end
+```
+
+Başka bir işlevin içinde bir işlev yazarsanız bu işlev de kendisini çevreleyen işlevin yerel değişkenlerine tam erişim sağlar. Bu çok güçlü bir yapıdır.
+
+```lua
+function create_counter(x)
+    -- 'x' is a local variable in 'create_counter'
+    return function()
+        x = x + 1
+        return x
+    end
+end
+
+count1 = create_counter(10)
+count2 = create_counter(20)
+print(count1()) --> 11
+print(count2()) --> 21
+print(count1()) --> 12
+```
+
+## Değişken gölgeleme
+
+Bir blokta bildirilen yerel değişkenler, çevreleyen bloktaki aynı adlı değişkenleri gölgeler.
+
+```lua
+my_global = "global"
+print(my_global) -->"global"
+
+local v = "local"
+print(v) --> "local"
+
+local function test(v)
+    print(v)
+end
+
+function init(self)
+    v = "apple"
+    print(v) --> "apple"
+    test("banana") --> "banana"
+end
+```
+
+## Eş yordamlar
+
+İşlevler baştan sona yürütülür ve onları yarıda durdurmanın bir yolu yoktur. Eş yordamlar bunu yapmanıza olanak tanır ve bu bazı durumlarda çok kullanışlı olabilir. Bir oyun nesnesini 1. kareden 5. kareye kadar, y konumu `0`'dan belirli y konumlarına taşıdığımız, kare kare ilerleyen çok özel bir animasyon oluşturmak istediğimizi varsayalım. Bunu `update()` işlevinde (aşağıya bakın) bir sayaç ve konum listesiyle çözebiliriz. Ancak eş yordam kullanarak genişletmesi ve üzerinde çalışması kolay, çok temiz bir uygulama elde ederiz. Durumun tamamı eş yordamın kendi içinde tutulur.
+
+Bir eş yordam yürütmeye ara verdiğinde denetimi çağırana geri verir, ancak yürütmenin hangi noktasında olduğunu hatırlar; böylece daha sonra o noktadan devam edebilir.
+
+```lua
+-- This is our coroutine
+local function sequence(self)
+    coroutine.yield(120)
+    coroutine.yield(320)
+    coroutine.yield(510)
+    coroutine.yield(240)
+    return 440 -- return the final value
+end
+
+function init(self)
+    self.co = coroutine.create(sequence) -- Create the coroutine. 'self.co' is a thread object
+    go.set_position(vmath.vector3(100, 0, 0)) -- Set initial position
+end
+
+function update(self, dt)
+    local status, y_pos = coroutine.resume(self.co, self) -- Continue execution of coroutine.
+    if status then
+        -- If the coroutine is still not terminated/dead, use its yielded return value as a new position
+        go.set_position(vmath.vector3(100, y_pos, 0))
+    end
+end
+```
+
+
+## Defold'da Lua bağlamları
+
+Bildirdiğiniz tüm değişkenler varsayılan olarak geneldir; yani Lua çalışma zamanı bağlamının her yerinden kullanılabilirler. Defold'un *game.project* dosyasında bu bağlamı denetleyen bir *shared_state* ayarı vardır. Seçenek etkinse tüm betikler, GUI betikleri ve işleme betiği (render script) aynı Lua bağlamında değerlendirilir ve genel değişkenler her yerden görünür. Seçenek etkin değilse motor; betikleri, GUI betiklerini ve işleme betiğini ayrı bağlamlarda yürütür.
+
+![Bağlamlar](images/lua/lua_contexts.png)
+
+Defold, aynı betik dosyasını birkaç ayrı oyun nesnesi bileşeninde (component) kullanmanıza izin verir. Yerel olarak bildirilen tüm değişkenler, aynı betik dosyasını çalıştıran bileşenler arasında paylaşılır.
+
+```lua
+-- 'my_global_value' will be available from all scripts, gui_scripts, render script and modules (Lua files)
+my_global_value = "global scope"
+
+-- this value will be shared through all component instances that use this particular script file
+local script_value = "script scope"
+
+function init(self, dt)
+    -- This value will be available on this script component instance
+    self.foo = "self scope"
+
+    -- this value will be available inside init() and after it's declaration
+    local local_foo = "local scope"
+    print(local_foo)
+end
+
+function update(self, dt)
+    print(self.foo)
+    print(my_global_value)
+    print(script_value)
+    print(local_foo) -- will print nil, since local_foo is only visible in init()
+end
+```
+
+## Performansla ilgili dikkat edilecek noktalar
+
+Akıcı bir şekilde 60 FPS hızında çalışması hedeflenen yüksek performanslı bir oyunda, küçük performans hataları deneyimi büyük ölçüde etkileyebilir. Dikkat edilmesi gereken bazı basit genel noktalar ve ilk bakışta sorunlu görünmeyebilecek bazı durumlar vardır.
+
+Basit noktalardan başlayalım. Gereksiz döngüler içermeyen, doğrudan anlaşılır kod yazmak genellikle iyi bir fikirdir. Bazen öğe listelerini dolaşmanız gerekir, ancak liste yeterince büyükse dikkatli olun. Bu örnek, oldukça iyi bir dizüstü bilgisayarda 1 milisaniyeden biraz daha uzun sürede çalışır. Her karenin yalnızca 16 milisaniye sürdüğü (60 FPS hızında) ve motorun, işleme betiğinin, fizik benzetiminin vb. bu sürenin bir kısmını kullandığı düşünüldüğünde, bu süre belirleyici olabilir.
+
+```lua
+local t = socket.gettime()
+local table = {}
+for i=1,2000 do
+    table[i] = vmath.vector3(i, i, i)
+end
+print((socket.gettime() - t) * 1000)
+
+-- DEBUG:SCRIPT: 0.40388
+```
+
+Şüphelendiğiniz kodun performansını ölçmek için `socket.gettime()` işlevinin döndürdüğü değeri (sistemin zaman başlangıcından beri geçen saniye sayısı) kullanın.
+
+## Bellek ve çöp toplama
+
+Lua'nın çöp toplama işlemi varsayılan olarak arka planda otomatik çalışır ve Lua çalışma zamanı ortamının ayırdığı belleği geri kazanır. Çok miktarda çöp toplamak zaman alabileceğinden, çöp toplama gerektiren nesnelerin sayısını düşük tutmak yararlıdır:
+
+* Yerel değişkenler kendi başlarına maliyetsizdir ve çöp oluşturmaz. (ör. `local v = 42`)
+* Her _yeni ve benzersiz_ dize yeni bir nesne oluşturur. `local s = "some_string"` yazmak yeni bir nesne oluşturur ve bu nesneyi `s` değişkenine atar. Yerel `s` değişkeninin kendisi çöp oluşturmaz, ancak dize nesnesi çöp oluşturur. Aynı dizeyi birden fazla kez kullanmanın ek bellek maliyeti yoktur.
+* Bir tablo oluşturucusu her yürütüldüğünde (`{ ... }`) yeni bir tablo oluşturulur.
+* Bir _işlev deyiminin_ yürütülmesi bir kapanış (closure) nesnesi oluşturur. (yani tanımlı bir işlevi çağırmak değil, `function () ... end` deyimini yürütmek)
+* Değişken sayıda bağımsız değişken alan işlevler (vararg) (`function(v, ...) end`), işlev her _çağrıldığında_ üç nokta için bir tablo oluşturur (Lua'nın 5.2 öncesi sürümlerinde veya LuaJIT kullanılmıyorsa).
+* `dofile()` ve `dostring()`
+* Userdata nesneleri
+
+Yeni nesneler oluşturmak yerine elinizdekileri yeniden kullanabileceğiniz pek çok durum vardır. Örneğin, her `update()` işlevinin sonunda aşağıdaki kullanım yaygındır:
+
+```lua
+-- Reset velocity
+self.velocity = vmath.vector3()
+```
+
+Her `vmath.vector3()` çağrısının yeni bir nesne oluşturduğunu unutmak kolaydır. Bir `vector3` nesnesinin ne kadar bellek kullandığını bulalım:
+
+```lua
+print(collectgarbage("count") * 1024)       -- 88634
+local v = vmath.vector3()
+print(collectgarbage("count") * 1024)       -- 88704. 70 bytes in total has been allocated
+```
+
+`collectgarbage()` çağrıları arasında 70 bayt eklenmiştir, ancak buna `vector3` nesnesi dışındaki bellek ayırmaları da dahildir. `collectgarbage()` sonucunun her yazdırılışında, kendi başına 22 bayt çöp ekleyen bir dize oluşturulur:
+
+```lua
+print(collectgarbage("count") * 1024)       -- 88611
+print(collectgarbage("count") * 1024)       -- 88633. 22 bytes allocated
+```
+
+Yani bir `vector3` nesnesi 70-22=48 bayt yer kaplar. Bu fazla değildir, ancak 60 FPS hızındaki bir oyunda her karede _bir tane_ oluşturursanız bir anda saniyede 2,8 kB çöp ortaya çıkar. Her biri her karede bir `vector3` oluşturan 360 betik bileşeniyle, saniyede 1 MB çöp üretilir. Miktarlar çok hızlı birikebilir. Lua çalışma zamanı ortamı çöp toplarken, özellikle mobil platformlarda, değerli milisaniyelerinizin çoğunu tüketebilir.
+
+Bellek ayırmalarından kaçınmanın bir yolu, bir `vector3` oluşturup aynı nesneyle çalışmaya devam etmektir. Örneğin, bir `vector3` nesnesini sıfırlamak için aşağıdaki yapıyı kullanabiliriz:
+
+```lua
+-- Instead of doing self.velocity = vmath.vector3() which creates a new object
+-- we zero an existing velocity vector object's components
+self.velocity.x = 0
+self.velocity.y = 0
+self.velocity.z = 0
+```
+
+Varsayılan çöp toplama düzeni, zamanlamanın kritik olduğu bazı uygulamalar için en uygun seçenek olmayabilir. Oyununuzda veya uygulamanızda takılmalar görüyorsanız [`collectgarbage()`](/ref/base/#collectgarbage) Lua işleviyle Lua'nın çöp toplama biçimini ayarlamak isteyebilirsiniz. Örneğin, düşük bir `step` değeriyle toplayıcıyı her karede kısa bir süre çalıştırabilirsiniz. Oyununuzun veya uygulamanızın ne kadar bellek tükettiği hakkında fikir edinmek için geçerli çöp miktarını bayt cinsinden şöyle yazdırabilirsiniz:
+
+```lua
+print(collectgarbage("count") * 1024)
+```
+
+## İyi uygulamalar
+
+Yaygın bir uygulama tasarımı konusu, ortak davranışlar için kodun nasıl yapılandırılacağıdır. Birkaç yaklaşım mümkündür.
+
+Modül içindeki davranışlar
+: Bir davranışı bir modül içinde kapsüllemek, farklı oyun nesnelerinin betik bileşenleri (ve GUI betikleri) arasında kodu kolayca paylaşmanızı sağlar. Modül işlevleri yazarken genellikle tamamen işlevsel programlamaya dayalı kod yazmak en iyisidir. Durum saklamanın veya yan etkilerin gerekli olduğu (ya da daha temiz bir tasarım sağladığı) durumlar vardır. Dahili durumu modülde saklamanız gerekiyorsa bileşenlerin Lua bağlamlarını paylaştığını unutmayın. Ayrıntılar için [Modüller belgelerine](/manuals/modules) bakın.
+
+  ![Modül](images/lua/lua_module.png)
+
+  Ayrıca modül kodunun bir oyun nesnesinin iç yapısını doğrudan değiştirmesi mümkün olsa da (bir modül işlevine `self` aktararak), çok sıkı bir bağımlılık oluşturacağınız için bunu yapmaktan kesinlikle kaçınmanızı öneririz.
+
+Davranışı kapsülleyen yardımcı bir oyun nesnesi
+: Betik kodunu bir Lua modülünde barındırabildiğiniz gibi, betik bileşeni olan bir oyun nesnesinde de barındırabilirsiniz. Aradaki fark, kodu bir oyun nesnesinde barındırdığınızda onunla yalnızca ileti aktarımı (message passing) yoluyla iletişim kurabilmenizdir.
+
+  ![Yardımcı](images/lua/lua_helper.png)
+
+Oyun nesnesini yardımcı davranış nesnesiyle bir koleksiyon içinde gruplama
+: Bu tasarımda, başka bir hedef oyun nesnesi üzerinde otomatik olarak işlem yapan bir davranış oyun nesnesi oluşturabilirsiniz. Bunun için önceden tanımlanmış bir ad (kullanıcının hedef oyun nesnesinin adını buna uyacak şekilde değiştirmesi gerekir) veya hedef oyun nesnesini gösteren bir `go.property()` URL değeri kullanılabilir.
+
+  ![Koleksiyon](images/lua/lua_collection.png)
+
+  Bu düzenin yararı, hedef nesneyi içeren bir koleksiyona (collection) bir davranış oyun nesnesi bırakabilmenizdir. Hiçbir ek kod gerekmez.
+
+  Çok sayıda oyun nesnesini yönetmeniz gereken durumlarda bu tasarım tercih edilmez; çünkü davranış nesnesi her örnek (instance) için çoğaltılır ve her nesnenin bellek maliyeti vardır.

--- a/docs/tr/manuals/macos.md
+++ b/docs/tr/manuals/macos.md
@@ -1,0 +1,124 @@
+---
+title: macOS platformu için Defold geliştirme
+brief: Bu kılavuz, macOS üzerinde Defold uygulamalarının nasıl derlenip çalıştırılacağını açıklar
+---
+
+# macOS için geliştirme
+
+macOS platformu için Defold uygulamaları geliştirmek, dikkate alınması gereken çok az nokta içeren basit bir süreçtir.
+
+## Proje ayarları
+
+macOS'a özgü uygulama yapılandırması, *game.project* ayar dosyasının [macOS bölümünden](/manuals/project-settings/#macos) yapılır.
+
+## Uygulama simgesi
+
+Bir macOS oyununda kullanılan uygulama simgesi .`icns` biçiminde olmalıdır. Bir `.iconset` içinde toplanan `.png` dosyalarından kolayca bir `.icns` dosyası oluşturabilirsiniz. [`.icns` dosyası oluşturmaya yönelik resmî yönergeleri](https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html) izleyin. Gerekli adımların kısa özeti şöyledir:
+
+* Simgeler için bir klasör oluşturun, örneğin `game.iconset`
+* Simge dosyalarını oluşturduğunuz klasöre kopyalayın:
+
+    * `icon_16x16.png`
+    * `icon_16x16@2x.png`
+    * `icon_32x32.png`
+    * `icon_32x32@2x.png`
+    * `icon_128x128.png`
+    * `icon_128x128@2x.png`
+    * `icon_256x256.png`
+    * `icon_256x256@2x.png`
+    * `icon_512x512.png`
+    * `icon_512x512@2x.png`
+
+* `iconutil` komut satırı aracını kullanarak `.iconset` klasörünü bir `.icns` dosyasına dönüştürün:
+
+```
+iconutil -c icns -o game.icns game.iconset
+```
+
+## Uygulamanızı yayımlama
+Uygulamanızı Mac App Store'da, Steam veya itch.io gibi üçüncü taraf bir mağaza ya da portalda veya kendi web siteniz üzerinden yayımlayabilirsiniz. Uygulamanızı yayımlamadan önce gönderime hazırlamanız gerekir. Uygulamayı nasıl dağıtmayı planladığınızdan bağımsız olarak aşağıdaki adımlar gereklidir:
+
+1. Çalıştırma izinlerini ekleyerek herkesin oyununuzu çalıştırabilmesini sağlayın (varsayılan olarak yalnızca dosya sahibinin çalıştırma izni vardır):
+
+```
+$ chmod +x Game.app/Contents/MacOS/Game
+```
+
+2. Oyununuzun gerektirdiği izinleri belirten bir yetki (entitlement) dosyası oluşturun. Çoğu oyun için aşağıdaki izinler yeterlidir:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>
+```
+
+  * `com.apple.security.cs.allow-jit` - Uygulamanın MAP_JIT bayrağını kullanarak yazılabilir ve yürütülebilir bellek oluşturmasına izin verilip verilmediğini belirtir
+  * `com.apple.security.cs.allow-unsigned-executable-memory` - Uygulamanın MAP_JIT bayrağının kullanımından kaynaklanan kısıtlamalar olmadan yazılabilir ve yürütülebilir bellek oluşturmasına izin verilip verilmediğini belirtir
+  * `com.apple.security.cs.allow-dyld-environment-variables` - Uygulamanın, uygulama sürecine kod eklemek için kullanabileceğiniz dinamik bağlayıcı ortam değişkenlerinden etkilenmesine izin verilip verilmediğini belirtir
+
+Bazı uygulamalar ek yetkilere de ihtiyaç duyabilir. Steamworks eklentisi şu ek yetkiyi gerektirir:
+
+```
+<key>com.apple.security.cs.disable-library-validation</key>
+<true/>
+```
+
+  * `com.apple.security.cs.disable-library-validation` - Uygulamanın kod imzalama gerektirmeden herhangi bir eklenti veya yazılım çatısı yüklemesine izin verilip verilmediğini belirtir.
+
+Bir uygulamaya verilebilecek tüm yetkiler, resmî [Apple geliştirici belgelerinde](https://developer.apple.com/documentation/bundleresources/entitlements) listelenmiştir.
+
+3. Oyununuzu `codesign` kullanarak imzalayın:
+
+```
+$ codesign --force --sign "Developer ID Application: Company Name" --options runtime --deep --timestamp --entitlements entitlement.plist Game.app
+```
+
+## Mac App Store dışında yayımlama
+Apple, Mac App Store dışında dağıtılan tüm yazılımların macOS Catalina'da varsayılan olarak çalışabilmesi için Apple tarafından onaylanmasını (notarization) zorunlu tutar. Xcode dışında, betiklerle yürütülen bir derleme ortamına onay sürecini nasıl ekleyeceğinizi öğrenmek için [resmî belgelere](https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow) bakın. Gerekli adımların kısa özeti şöyledir:
+
+1. İzinleri eklemek ve uygulamayı imzalamak için yukarıdaki adımları izleyin.
+
+2. Oyununuzu ZIP arşivine sıkıştırın ve `altool` kullanarak onay için yükleyin.
+
+```
+$ xcrun altool --notarize-app
+               --primary-bundle-id "com.acme.foobar"
+               --username "AC_USERNAME"
+               --password "@keychain:AC_PASSWORD"
+               --asc-provider <ProviderShortname>
+               --file Game.zip
+
+altool[16765:378423] No errors uploading 'Game.zip'.
+RequestUUID = 2EFE2717-52EF-43A5-96DC-0797E4CA1041
+```
+
+3. `altool --notarize-app` çağrısının döndürdüğü istek UUID değerini kullanarak gönderiminizin durumunu kontrol edin:
+
+```
+$ xcrun altool --notarization-info 2EFE2717-52EF-43A5-96DC-0797E4CA1041
+               -u "AC_USERNAME"
+```
+
+4. Durum `success` olana kadar bekleyin ve onay biletini oyuna iliştirin:
+
+```
+$ xcrun stapler staple "Game.app"
+```
+
+5. Oyununuz artık dağıtıma hazırdır.
+
+## Mac App Store'da yayımlama
+Mac App Store'da yayımlama süreci [Apple geliştirici belgelerinde](https://developer.apple.com/macos/submit/) ayrıntılı olarak açıklanmıştır. Göndermeden önce yukarıda açıklandığı gibi izinleri eklediğinizden ve uygulamayı `codesign` ile imzaladığınızdan emin olun.
+
+Not: Mac App Store'da yayımlarken oyunun Apple'ın onay (notarization) sürecinden geçmesi gerekmez.
+
+:[Apple Privacy Manifest](../shared/apple-privacy-manifest.md)

--- a/docs/tr/manuals/material.md
+++ b/docs/tr/manuals/material.md
@@ -1,0 +1,440 @@
+---
+title: Defold materyal kılavuzu
+brief: Bu kılavuz, materyaller, gölgelendirici sabitleri ve örnekleyicilerle nasıl çalışılacağını açıklar.
+---
+
+# Materyaller
+
+Materyaller (material), bir grafik bileşeninin (component) görüntüsü oluşturulurken kullanılacak işleme (rendering) biçimini tanımlar; bu bileşen bir sprite bileşeni, karo haritası, yazı tipi, GUI düğümü, model vb. olabilir.
+
+Bir materyal, işleme hattında işlenecek nesneleri seçmeye yarayan bilgileri _etiketler_ olarak tutar. Ayrıca, kullanılabilir grafik sürücüsü aracılığıyla derlenip grafik donanımına yüklenen ve bileşen her karede işlenirken çalıştırılan _gölgelendirici programlarına_ (shader programs) başvurular da tutar.
+
+* İşleme hattı hakkında daha fazla bilgi için [İşleme belgelerine](/manuals/render) bakın.
+* Gölgelendirici programlarının ayrıntılı açıklaması için [Gölgelendirici belgelerine](/manuals/shader) bakın.
+
+## Materyal oluşturma
+
+Materyal oluşturmak için *Assets* tarayıcısındaki hedef klasöre <kbd>sağ tıklayın</kbd> ve <kbd>New... ▸ Material</kbd> seçeneğini seçin. (Menüden <kbd>File ▸ New...</kbd> seçeneğini, ardından <kbd>Material</kbd> seçeneğini de seçebilirsiniz). Yeni materyal dosyasına bir ad verin ve <kbd>Ok</kbd> düğmesine basın.
+
+![Materyal dosyası](images/materials/material_file.png)
+
+Yeni materyal *Material Editor* içinde açılır.
+
+![Materyal düzenleyicisi](images/materials/material.png)
+
+Materyal dosyası aşağıdaki bilgileri içerir:
+
+Name
+: Materyalin kimliği. Bu ad, materyali derlemeye dahil etmek üzere *Render* kaynağında listelemek için kullanılır. Ad ayrıca `render.enable_material()` işleme API'si işlevinde de kullanılır. Adın benzersiz olması önerilir.
+
+Vertex Program
+: Materyalle işleme yaparken kullanılacak köşe gölgelendiricisi (vertex shader) program dosyası (*`.vp`*). Köşe gölgelendiricisi programı, bileşenin geometrik temel öğelerini (primitive) oluşturan her köşe için GPU üzerinde çalıştırılır. Her köşenin ekran konumunu hesaplar ve isteğe bağlı olarak ara değerleme (interpolation) uygulanıp parça programına girdi olarak verilen "varying" değişkenleri üretir.
+
+Fragment Program
+: Materyalle işleme yaparken kullanılacak parça gölgelendiricisi (fragment shader) program dosyası (*`.fp`*). Program, bir geometrik temel öğenin her parçası (pikseli) için GPU üzerinde çalışır ve amacı her parçanın rengini belirlemektir. Bu genellikle doku sorgulamaları ve girdi değişkenlerine (varying değişkenleri veya sabitler) dayalı hesaplamalarla yapılır.
+
+Vertex Constants
+: Köşe gölgelendiricisi programına iletilecek uniform değerleri. Kullanılabilir sabitlerin listesi için aşağıya bakın.
+
+Fragment Constants
+: Parça gölgelendiricisi programına iletilecek uniform değerleri. Kullanılabilir sabitlerin listesi için aşağıya bakın.
+
+Samplers
+: Materyal dosyasında isteğe bağlı olarak belirli örnekleyicileri (sampler) yapılandırabilirsiniz. Bir örnekleyici ekleyin, gölgelendirici programında kullanılan ada göre adlandırın ve sarma ile filtreleme ayarlarını istediğiniz gibi belirleyin.
+
+Tags
+: Materyalle ilişkili etiketler. Etiketler motorda, birlikte çizilmesi gereken bileşenleri toplamak üzere [`render.predicate()`](/ref/render#render.predicate) tarafından kullanılan bir _bit maskesi_ olarak temsil edilir. Bunun nasıl yapıldığını öğrenmek için [İşleme belgelerine](/manuals/render) bakın. Bir projede kullanabileceğiniz en fazla etiket sayısı 32'dir.
+
+## Öznitelikler {#attributes}
+
+Gölgelendirici öznitelikleri (shader attributes; köşe akışları veya köşe öznitelikleri olarak da adlandırılır), GPU biriminin geometriyi işlemek için köşeleri bellekten nasıl aldığını belirleyen bir mekanizmadır. Köşe gölgelendiricisi, `attribute` anahtar sözcüğünü kullanarak bir akış kümesi belirtir ve çoğu durumda Defold, akışların adlarına göre verileri arka planda otomatik olarak üretip bağlar. Ancak bazı durumlarda, motorun üretmediği belirli bir efekti elde etmek için köşe başına daha fazla veri iletmek isteyebilirsiniz. Bir köşe özniteliği aşağıdaki alanlarla yapılandırılabilir:
+
+Name
+: Özniteliğin adı. Gölgelendirici sabitlerine benzer şekilde, öznitelik yapılandırması yalnızca köşe programında belirtilen bir öznitelikle eşleşiyorsa kullanılır.
+
+Semantic type
+: Anlamsal tür (semantic type), özniteliğin *ne* olduğunu ve/veya düzenleyicide *nasıl* gösterilmesi gerektiğini belirtir. Örneğin, bir özniteliği `SEMANTIC_TYPE_COLOR` ile tanımlamak düzenleyicide bir renk seçici gösterir; veriler ise motordan gölgelendiriciye yine olduğu gibi iletilir.
+
+  - `SEMANTIC_TYPE_NONE` Varsayılan anlamsal tür. Özniteliğe ait materyal verilerini doğrudan köşe arabelleğine iletmek dışında öznitelik üzerinde başka bir etkisi yoktur (varsayılan)
+  - `SEMANTIC_TYPE_POSITION` Öznitelik için köşe başına konum verisi üretir. Motora konumların nasıl hesaplanacağını belirtmek için koordinat uzayıyla birlikte kullanılabilir
+  - `SEMANTIC_TYPE_TEXCOORD` Öznitelik için köşe başına doku koordinatları üretir
+  - `SEMANTIC_TYPE_PAGE_INDEX` Öznitelik için köşe başına sayfa indisleri üretir
+  - `SEMANTIC_TYPE_COLOR` Düzenleyicinin özniteliği nasıl yorumladığını etkiler. Bir öznitelik renk anlamıyla yapılandırılırsa özellik denetleyicisinde bir renk seçici aracı gösterilir
+  - `SEMANTIC_TYPE_NORMAL` Öznitelik için köşe başına normal verisi üretir
+  - `SEMANTIC_TYPE_TANGENT` Öznitelik için köşe başına teğet verisi üretir
+  - `SEMANTIC_TYPE_WORLD_MATRIX` Öznitelik için köşe başına dünya matrisi verisi üretir
+  - `SEMANTIC_TYPE_NORMAL_MATRIX` Öznitelik için köşe başına normal matrisi verisi üretir
+  - `SEMANTIC_TYPE_TEXTURE_TRANSFORM_2D` Öznitelik için köşe başına 3x3 doku dönüşüm matrisi üretir. Parçacık bileşenleri için motor, bileşendeki görüntü özelliğine ait koordinatları atlas uzayına dönüştüren bir matris sağlar. Sprite bileşenleri için motor, bileşenin kullandığı her görüntüye ait bir matris sağlar (çoklu doku kullanılırken). Model bileşenleri için birim matris sağlanır.
+
+Data type
+: Özniteliğin dayandığı verilerin veri türü.
+
+  - `TYPE_BYTE` İşaretli 8 bitlik bayt değerleri
+  - `TYPE_UNSIGNED_BYTE` İşaretsiz 8 bitlik bayt değerleri
+  - `TYPE_SHORT` İşaretli 16 bitlik short değerleri
+  - `TYPE_UNSIGNED_SHORT` İşaretsiz 16 bitlik short değerleri
+  - `TYPE_INT` İşaretli tamsayı değerleri
+  - `TYPE_UNSIGNED_INT` İşaretsiz tamsayı değerleri
+  - `TYPE_FLOAT` Kayan noktalı değerler (varsayılan)
+
+Normalize
+: true ise öznitelik değerleri GPU sürücüsü tarafından normalleştirilir. Tam hassasiyete ihtiyaç duymadığınız ancak belirli sınırları bilmeden hesaplama yapmak istediğiniz durumlarda bu yararlı olabilir. Örneğin, bir renk vektörü genellikle yalnızca 0..255 aralığındaki bayt değerlerine ihtiyaç duyar, ancak gölgelendiricide yine de 0..1 aralığındaki bir değer olarak ele alınır.
+
+Coordinate space
+: Bazı anlamsal türler, verilerin farklı koordinat uzaylarında sağlanmasını destekler. Sprite bileşenleriyle kameraya dönük durma (billboarding) efekti uygularken, en etkili toplu çizim (batching) için genellikle yerel uzayda bir konum özniteliğinin yanı sıra dünya uzayına tamamen dönüştürülmüş bir konum da gerekir.
+
+Vector type
+: Özniteliğin vektör türü.
+
+  - `VECTOR_TYPE_SCALAR` Tek skaler değer
+  - `VECTOR_TYPE_VEC2` 2B vektör
+  - `VECTOR_TYPE_VEC3` 3B vektör
+  - `VECTOR_TYPE_VEC4` 4B vektör (varsayılan)
+  - `VECTOR_TYPE_MAT2` 2B matris
+  - `VECTOR_TYPE_MAT3` 3B matris
+  - `VECTOR_TYPE_MAT4` 4B matris
+
+Step function
+: Öznitelik verilerinin köşe işlevine nasıl sunulacağını belirtir. Bu yalnızca örneklerle çizim (instancing) için geçerlidir.
+
+  - `Vertex` Her köşe için bir kez; örneğin, bir konum özniteliği genellikle örgüdeki (mesh) her köşe için köşe işlevine verilir (varsayılan)
+  - `Instance` Her örnek için bir kez; örneğin, bir dünya matrisi özniteliği genellikle her örnek için köşe işlevine bir kez verilir
+
+Value
+: Özniteliğin değeri. Öznitelik değerleri bileşen başına geçersiz kılınabilir; bunun dışında bu değer, köşe özniteliğinin varsayılan değeri olarak kullanılır. Not: *varsayılan* öznitelikler (konum, doku koordinatları ve sayfa indisleri) için bu değer yok sayılır.
+
+::: sidenote
+Özel öznitelikler, akışları daha küçük bir veri türü veya farklı sayıda öğe kullanacak şekilde yeniden yapılandırarak hem CPU hem de GPU üzerindeki bellek kullanımını azaltmak için de kullanılabilir.
+:::
+
+### Varsayılan öznitelik anlamları
+
+Materyal sistemi, belirli bir ad kümesi için çalışma sırasında özniteliğin adına göre otomatik olarak varsayılan bir anlamsal tür atar:
+
+  - `position` - anlamsal tür: `SEMANTIC_TYPE_POSITION`
+  - `texcoord0` - anlamsal tür: `SEMANTIC_TYPE_TEXCOORD`
+  - `texcoord1` - anlamsal tür: `SEMANTIC_TYPE_TEXCOORD`
+  - `page_index` - anlamsal tür: `SEMANTIC_TYPE_PAGE_INDEX`
+  - `color` - anlamsal tür: `SEMANTIC_TYPE_COLOR`
+  - `normal` - anlamsal tür: `SEMANTIC_TYPE_NORMAL`
+  - `tangent` - anlamsal tür: `SEMANTIC_TYPE_TANGENT`
+  - `mtx_world` - anlamsal tür: `SEMANTIC_TYPE_WORLD_MATRIX`
+  - `mtx_normal` - anlamsal tür: `SEMANTIC_TYPE_NORMAL_MATRIX`
+  - `mtx_texture_transform_2d` - anlamsal tür: `SEMANTIC_TYPE_TEXTURE_TRANSFORM_2D`
+
+Materyalde bu özniteliklere ait girdiler varsa varsayılan anlamsal türün yerine materyal düzenleyicisinde yapılandırdığınız tür kullanılır.
+
+### Özel köşe özniteliği verilerini ayarlama
+
+Kullanıcı tanımlı gölgelendirici sabitlerine benzer şekilde, `go.get`, `go.set` ve `go.animate` çağrılarıyla köşe özniteliklerini de çalışma sırasında güncelleyebilirsiniz:
+
+![Özel materyal özniteliği](images/materials/set_custom_attribute.png)
+
+```lua
+go.set("#sprite", "tint", vmath.vector4(1,0,0,1))
+
+go.animate("#sprite", "tint", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,0,0,1), go.EASING_LINEAR, 2)
+```
+
+Ancak köşe özniteliklerini güncellerken dikkat edilmesi gereken bazı noktalar vardır; bir bileşenin değeri kullanıp kullanamayacağı özniteliğin anlamsal türüne bağlıdır. Örneğin, sprite bileşeni `SEMANTIC_TYPE_POSITION` türünü destekler. Bu anlamsal türe sahip bir özniteliği güncellerseniz bileşen, üzerine yazılan değeri yok sayar; çünkü anlamsal tür, verilerin her zaman sprite bileşeninin konumundan üretilmesini gerektirir.
+
+Model bileşenleri de özel materyal özniteliklerine `go.get()`, `go.set()` ve `go.animate()` aracılığıyla erişim sağlar. Örneğin, model materyalinde `my_attribute` adlı bir öznitelik tanımladıktan sonra:
+
+```lua
+go.set("#model", "my_attribute", vmath.vector4(1, 0, 0, 1))
+go.animate("#model", "my_attribute", go.PLAYBACK_LOOP_PINGPONG,
+    vmath.vector4(0, 1, 0, 1), go.EASING_LINEAR, 2)
+```
+
+Birden çok örgü içeren bir modelde şu anda yalnızca ilk örgüye bu şekilde erişilebilir. Örneklerle çizimde kullanılmayan ve köşe başına tanımlı bir özniteliği güncellemek, örgü boyutuyla orantılı miktarda köşe verisinin yeniden oluşturulup yüklenmesine de yol açabilir. Bu nedenle sık güncellemeler büyük örgüler için maliyetli olabilir.
+
+Bir köşe özniteliğinin skaler veya `Vec4` dışında bir vektör türü olduğu durumlarda da verileri `go.set` kullanarak ayarlayabilirsiniz:
+
+```lua
+-- The last two components in the vec4 will not be used!
+go.set("#sprite", "sprite_position_2d", vmath.vector4(my_x,my_y,0,0))
+go.animate("#sprite", "sprite_position_2d", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,2,0,0), go.EASING_LINEAR, 2)
+```
+
+Aynı durum matris öznitelikleri için de geçerlidir; öznitelik `Mat4` dışında bir matris türündeyse de verileri `go.set` kullanarak ayarlayabilirsiniz.
+
+### Özel köşe özniteliklerini kullanma örnekleri
+
+UV koordinatlarını atlas uzayına dönüştürmek için doku dönüşüm özniteliğini kullanma:
+
+```glsl
+#version 140
+
+in vec3 position;
+in vec4 texcoord0;
+in mat3 texture_transform_2d;
+
+out vec2 var_texcoord0;
+
+void main()
+{
+  // Extract position from the transform
+  vec2 atlas_pos = texture_transform_2d[2].xy;
+  // Extract the scale from the transform
+  vec2 atlas_size = vec2(
+      length(texture_transform_2d[0].xy),
+      length(texture_transform_2d[1].xy)
+  );
+  // convert to local UV (0..1)
+  vec2 localUV = (texcoord0 - atlas_pos) / atlas_size;
+
+  // Alternatively, if the UV coordinates already are in the 0..1 range,
+  // you can transform into atlas space directly by multiplying the transform:
+  vec2 transformedUv = texture_transform_2d * texcoord0;
+
+  // Pass the value into the fragment shader
+  var_texcoord0 = localUV;
+
+  // ... rest of vertex shader
+}
+```
+
+### Örneklerle çizim
+
+Örneklerle çizim, bir sahnede aynı nesnenin birden çok kopyasını verimli biçimde çizmek için kullanılan bir tekniktir. Nesne her kullanıldığında ayrı bir kopyasını oluşturmak yerine, grafik motorunun tek bir nesne oluşturup bunu birden çok kez yeniden kullanmasını sağlar. Örneğin, büyük bir orman içeren bir oyunda her ağaç için ayrı bir ağaç modeli oluşturmak yerine, örneklerle çizim sayesinde tek bir ağaç modeli oluşturup bunu farklı konum ve ölçeklerle yüzlerce veya binlerce kez yerleştirebilirsiniz. Böylece orman, her ağaç için ayrı çizim çağrıları yerine tek bir çizim çağrısıyla işlenebilir.
+
+::: sidenote
+Örneklerle çizim şu anda yalnızca model bileşenlerinde kullanılabilir.
+:::
+
+Örneklerle çizim, mümkün olduğunda otomatik olarak etkinleştirilir. Defold, çizim durumlarını mümkün olduğunca toplu çizim için birleştirmeye büyük ölçüde dayanır. Örneklerle çizimin çalışması için bazı gereksinimlerin karşılanması gerekir:
+
+- Tüm örneklerde aynı materyal kullanılmalıdır. `render.enable_material` ile özel bir materyal ayarlanmışsa da örneklerle çizim çalışır)
+- Materyal, 'local' köşe uzayını kullanacak şekilde yapılandırılmalıdır
+- Materyalde örnek başına tekrarlanan en az bir köşe özniteliği bulunmalıdır
+- Sabit değerleri tüm örneklerde aynı olmalıdır. Sabit değerleri bunun yerine özel köşe özniteliklerine konabilir veya başka bir veri saklama yöntemi kullanılabilir (örneğin bir doku)
+- Dokular veya depolama arabellekleri gibi gölgelendirici kaynakları tüm örneklerde aynı olmalıdır
+
+Bir köşe özniteliğini örnek başına tekrarlanacak şekilde yapılandırmak için `Step function` değerinin `Instance` olarak ayarlanması gerekir. Bu, belirli anlamsal türlerde ada göre otomatik olarak yapılır (yukarıdaki `Varsayılan öznitelik anlamları` tablosuna bakın), ancak materyal düzenleyicisinde `Step function` değeri `Instance` olarak ayarlanarak elle de yapılabilir.
+
+Basit bir örnek olarak, aşağıdaki sahnede her biri bir model bileşeni içeren dört oyun nesnesi (game object) vardır:
+
+![Örneklerle çizim kurulumu](images/materials/instancing-setup.png)
+
+Materyal, örnek başına tekrarlanan tek bir özel köşe özniteliğiyle şu şekilde yapılandırılmıştır:
+
+![Örneklerle çizim materyali](images/materials/instancing-material.png)
+
+Köşe gölgelendiricisinde örnek başına kullanılan birden çok öznitelik belirtilmiştir:
+
+```glsl
+// Per vertex attributes
+attribute highp vec4 position;
+attribute mediump vec2 texcoord0;
+attribute mediump vec3 normal;
+
+// Per instance attributes
+attribute mediump mat4 mtx_world;
+attribute mediump mat4 mtx_normal;
+attribute mediump vec4 instance_color;
+```
+
+`mtx_world` ve `mtx_normal` özniteliklerinin varsayılan olarak `Instance` adım işlevini kullanacak şekilde yapılandırıldığını unutmayın. Materyal düzenleyicisinde bunlar için birer girdi ekleyip `Step function` değerini `Vertex` olarak ayarlayarak bunu değiştirebilirsiniz. Böylece öznitelik, örnek başına değil köşe başına tekrarlanır.
+
+Bu durumda örneklerle çizimin çalıştığını doğrulamak için web profil çıkarıcısına bakabilirsiniz. Kutunun örnekleri arasında değişen tek şey örnek başına öznitelikler olduğundan, bu durumda tek bir çizim çağrısıyla işlenebilir:
+
+![Örneklerle çizimde çizim çağrıları](images/materials/instancing-draw-calls.png)
+
+#### Geriye dönük uyumluluk
+
+Masaüstünde OpenGL 3.1 ve mobilde OpenGL ES 3.0, örneklerle çizimi temel bir özellik olarak sağlar. Daha eski OpenGL ES ve WebGL bağlamları bunu `ANGLE_instanced_arrays` gibi bir uzantıyla destekleyebilir; diğer eski bağdaştırıcılar ise desteklemez. Örneklerle çizim kullanılamadığında işleme varsayılan olarak yine çalışır, ancak performansı daha düşük olabilir.
+
+Desteği saptamak ve gerektiğinde daha az maliyetli bir materyal seçmek veya çok sayıda örnek içeren içeriği çıkarmak için `graphics.get_adapter_info()` kullanın. `features` alanı, desteklenen özellik sabitlerinin dizisidir; bu sabitlerin anahtar olarak kullanıldığı bir tablo değildir:
+
+```lua
+local function has_context_feature(feature)
+    local adapter_info = graphics.get_adapter_info()
+    for _, supported_feature in ipairs(adapter_info.features) do
+        if supported_feature == feature then
+            return true
+        end
+    end
+    return false
+end
+
+local instancing_supported = has_context_feature(
+    graphics.CONTEXT_FEATURE_INSTANCING
+)
+```
+
+## Köşe ve parça sabitleri {#vertex-and-fragment-constants}
+
+Gölgelendirici sabitleri (shader constants) veya "uniform" değerleri, motordan köşe ve parça gölgelendiricisi programlarına iletilen değerlerdir. Bir sabiti kullanmak için materyal dosyasında onu *Vertex Constant* veya *Fragment Constant* özelliği olarak tanımlayın. Karşılık gelen `uniform` değişkenlerinin gölgelendirici programında tanımlanması gerekir. Bir materyalde aşağıdaki sabitler ayarlanabilir:
+
+`CONSTANT_TYPE_WORLD`
+: Dünya matrisi. Köşeleri dünya uzayına dönüştürmek için kullanın. Bazı bileşen türlerinde köşeler, köşe programına ulaştıklarında (toplu çizim nedeniyle) zaten dünya uzayındadır. Bu durumlarda gölgelendiricide dünya matrisiyle çarpmak yanlış sonuçlar verir.
+
+`CONSTANT_TYPE_VIEW`
+: Görünüm matrisi. Köşeleri görünüm (kamera) uzayına dönüştürmek için kullanın.
+
+`CONSTANT_TYPE_PROJECTION`
+: İzdüşüm matrisi. Köşeleri ekran uzayına dönüştürmek için kullanın.
+
+`CONSTANT_TYPE_VIEWPROJ`
+: Görünüm ve izdüşüm matrislerinin önceden çarpıldığı matris.
+
+`CONSTANT_TYPE_WORLDVIEW`
+: Dünya ve görünüm matrislerinin önceden çarpıldığı matris.
+
+`CONSTANT_TYPE_WORLDVIEWPROJ`
+: Dünya, görünüm ve izdüşüm matrislerinin önceden çarpıldığı matris.
+
+`CONSTANT_TYPE_WORLD_INVERSE`
+: Dünya matrisinin tersi. Dünya uzayından nesnenin yerel uzayına geri dönüştürmek için kullanın.
+
+`CONSTANT_TYPE_VIEW_INVERSE`
+: Görünüm matrisinin tersi. Kamera uzayından dünya uzayına geri dönüştürmek için kullanın.
+
+`CONSTANT_TYPE_PROJECTION_INVERSE`
+: İzdüşüm matrisinin tersi. Kırpma uzayından kamera uzayına geri dönüştürmek için kullanın.
+
+`CONSTANT_TYPE_VIEWPROJ_INVERSE`
+: Birleştirilmiş görünüm ve izdüşüm matrislerinin tersi. Kırpma uzayından dünya uzayına geri dönüştürmek için kullanın.
+
+`CONSTANT_TYPE_WORLDVIEW_INVERSE`
+: Birleştirilmiş dünya ve görünüm matrislerinin tersi. Kamera uzayından nesnenin yerel uzayına geri dönüştürmek için kullanın.
+
+`CONSTANT_TYPE_WORLDVIEWPROJ_INVERSE`
+: Birleştirilmiş dünya, görünüm ve izdüşüm matrislerinin tersi. Kırpma uzayından nesnenin yerel uzayına geri dönüştürmek için kullanın. Bu ters matris sabitleri, gölgelendiricide matris tersi hesaplama gereksinimini ortadan kaldırır.
+
+`CONSTANT_TYPE_NORMAL`
+: Normal yönelimini hesaplamak için kullanılan matris. Dünya dönüşümü, birleşik dünya-görünüm dönüşümünün dikliğini bozan eşit olmayan ölçekleme içerebilir. Normal matrisi, normalleri dönüştürürken yönle ilgili sorunları önlemek için kullanılır. (Normal matrisi, dünya-görünüm matrisinin tersinin devriğidir).
+
+`CONSTANT_TYPE_TIME`
+: Motorun sağladığı bir `vector4` değeridir; `.x` motorun başlatılmasından bu yana geçen süreyi, `.y` önceki kareden bu yana geçen süreyi içerir. `.z` ve `.w` şu anda sıfırdır. Motor bu değeri otomatik olarak günceller; `go.set()` ile güncellenmesi gerekmez. Bir örnek için [Shadertoy öğreticisine](/tutorials/shadertoy/#animation) bakın.
+
+  Modern bir GLSL uniform bloğunda `time` adlı bir Time sabiti tanımlayın:
+
+  ```glsl
+  uniform fragment_inputs
+  {
+      vec4 time;
+  };
+  ```
+
+`CONSTANT_TYPE_USER`
+: Gölgelendirici programlarınıza iletmek istediğiniz herhangi bir özel veri için kullanabileceğiniz vector4 sabiti. Sabitin başlangıç değerini sabit tanımında ayarlayabilirsiniz, ancak bu değer [go.set()](/ref/stable/go/#go.set) / [go.animate()](/ref/stable/go/#go.animate) işlevleriyle değiştirilebilir. Değeri [go.get()](/ref/stable/go/#go.get) ile de alabilirsiniz. Tek bir bileşen örneğinin materyal sabitini değiştirmek [toplu çizimi bozar ve ek çizim çağrılarına yol açar](/manuals/render/#draw-calls-and-batching).
+
+Örnek:
+
+```lua
+go.set("#sprite", "tint", vmath.vector4(1,0,0,1))
+
+go.animate("#sprite", "tint", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,0,0,1), go.EASING_LINEAR, 2)
+```
+
+`CONSTANT_TYPE_USER_MATRIX4`
+: Gölgelendirici programlarınıza iletmek istediğiniz herhangi bir özel veri için kullanabileceğiniz matrix4 sabiti. Sabitin başlangıç değerini sabit tanımında ayarlayabilirsiniz, ancak bu değer [go.set()](/ref/stable/go/#go.set) / [go.animate()](/ref/stable/go/#go.animate) işlevleriyle değiştirilebilir. Değeri [go.get()](/ref/stable/go/#go.get) ile de alabilirsiniz. Tek bir bileşen örneğinin materyal sabitini değiştirmek [toplu çizimi bozar ve ek çizim çağrılarına yol açar](/manuals/render/#draw-calls-and-batching).
+
+Örnek:
+
+```lua
+go.set("#sprite", "m", vmath.matrix4())
+```
+
+### GUI düğümü materyal sabitleri
+
+Bir GUI betiğinde, düğümün materyal sabitlerini okumak ve yazmak için `go` işlevleri yerine `gui.get()` ve `gui.set()` kullanın. Vektör bileşenleri, matris sabitleri ve sabit dizileri desteklenir. Seçenekler tablosundaki dizi indisleri 1'den başlar:
+
+```lua
+local node = gui.get_node("button")
+
+local tint = gui.get(node, "tint")
+gui.set(node, "tint.x", 0.5)
+gui.set(node, "light_matrix", vmath.matrix4())
+gui.set(node, "tint_array", vmath.vector4(1, 0, 0, 1), { index = 1 })
+```
+
+::: sidenote
+`CONSTANT_TYPE_USER` veya `CONSTANT_TYPE_USER_MATRIX4` türündeki bir materyal sabitinin `go.get()` ve `go.set()` ya da `gui.get()` ve `gui.set()` ile kullanılabilmesi için gölgelendirici programında kullanılması gerekir. Sabit materyalde tanımlanmış ancak programda kullanılmamışsa materyalden kaldırılır ve çalışma sırasında kullanılamaz.
+:::
+
+## Örnekleyiciler
+
+Örnekleyiciler, bir dokudan (karo kaynağı veya atlas) renk bilgisi örneklemek için kullanılır. Renk bilgisi daha sonra gölgelendirici programındaki hesaplamalarda kullanılabilir.
+
+Sprite, karo haritası, GUI ve parçacık efekti bileşenleri, görüntü dokularını ilk tanımlanan `sampler2D` değerine otomatik olarak bağlar. Sprite bileşenleri birden çok dokuyu da destekler: materyalde tanımlanan her örnekleyici, sprite bileşeninde adlandırılmış bir görüntü yuvasına dönüşür. İlk doku, sprite bileşeninin animasyon verilerini sağlar ve kare dizisini yönetir. Her karede, görüntü kimliği her ek dokuda karşılık gelen görüntüyü bulmak için kullanılır; ek dokular kendi UV koordinatlarını sağlar. Bu nedenle atanan atlasların veya karo kaynaklarının eşleşen kare kimlikleri ve benzer şekilli görüntüler içermesi önerilir; çokgen biçiminde paketlenen şekillerin farklı olması doku taşmasına yol açabilir. Ayrıntılar için [Çok dokulu sprite bileşenleri](/manuals/sprite/#multi-textured-sprites) bölümüne bakın.
+
+Ek bir doku yuvası sunmayan bir bileşen veya işleme iş akışı için, işleme betiğinden ek doku örnekleyicileri bağlamak üzere [`render.enable_texture()`](/ref/render/#render.enable_texture) kullanın.
+
+![Sprite örnekleyicisi](images/materials/sprite_sampler.png)
+
+```glsl
+-- mysprite.fp
+varying mediump vec2 var_texcoord0;
+uniform lowp sampler2D MY_SAMPLER;
+void main()
+{
+    gl_FragColor = texture2D(MY_SAMPLER, var_texcoord0.xy);
+}
+```
+
+Bir bileşenin örnekleyici ayarlarını, materyal dosyasına örnekleyiciyi adıyla ekleyerek belirtebilirsiniz. Örnekleyicinizi materyal dosyasında yapılandırmazsanız genel *graphics* proje ayarları kullanılır.
+
+![Örnekleyici ayarları](images/materials/my_sampler.png)
+
+Model bileşenleri için örnekleyicilerinizi materyal dosyasında istediğiniz ayarlarla belirtmeniz gerekir. Düzenleyici daha sonra bu materyali kullanan herhangi bir model bileşeni için dokuları ayarlamanıza izin verir:
+
+![Model örnekleyicileri](images/materials/model_samplers.png)
+
+```glsl
+-- mymodel.fp
+varying mediump vec2 var_texcoord0;
+uniform lowp sampler2D TEXTURE_1;
+uniform lowp sampler2D TEXTURE_2;
+void main()
+{
+    lowp vec4 color1 = texture2D(TEXTURE_1, var_texcoord0.xy);
+    lowp vec4 color2 = texture2D(TEXTURE_2, var_texcoord0.xy);
+    gl_FragColor = color1 * color2;
+}
+```
+
+![Model](images/materials/model.png)
+
+## Örnekleyici ayarları
+
+Name
+: Örnekleyicinin adı. Bu adın, parça gölgelendiricisinde tanımlanan `sampler2D` adıyla eşleşmesi önerilir.
+
+Wrap U/W
+: U ve V eksenleri için sarma modu:
+
+  - `WRAP_MODE_REPEAT`, [0,1] aralığının dışındaki doku verilerini tekrarlar.
+  - `WRAP_MODE_MIRRORED_REPEAT`, [0,1] aralığının dışındaki doku verilerini tekrarlar, ancak her ikinci tekrar aynalanır.
+  - `WRAP_MODE_CLAMP_TO_EDGE`, 1.0'dan büyük değerlerin doku verisini 1.0'a, 0.0'dan küçük değerlerinkini ise 0.0'a ayarlar---yani kenar pikselleri sınıra kadar tekrarlanır.
+
+Filter Min/Mag
+: Büyütme ve küçültme filtrelemesi. En yakın komşu filtreleme, doğrusal ara değerlemeden daha az hesaplama gerektirir, ancak örnekleme kaynaklı görüntü kusurlarına (aliasing) yol açabilir. Doğrusal ara değerleme genellikle daha pürüzsüz sonuçlar sağlar:
+
+  - `Default`, `game.project` dosyasında `Graphics` altında `Default Texture Min Filter` ve `Default Texture Mag Filter` olarak belirtilen varsayılan filtre seçeneğini kullanır.
+  - `FILTER_MODE_NEAREST`, koordinatları pikselin merkezine en yakın olan tekseli kullanır.
+  - `FILTER_MODE_LINEAR`, pikselin merkezine en yakın 2x2 teksel dizisinin ağırlıklı doğrusal ortalamasını ayarlar.
+  - `FILTER_MODE_NEAREST_MIPMAP_NEAREST`, tek bir mipmap içindeki en yakın teksel değerini seçer.
+  - `FILTER_MODE_NEAREST_MIPMAP_LINEAR`, en uygun iki yakın mipmap içindeki en yakın tekseli seçer ve ardından bu iki değer arasında doğrusal ara değerleme yapar.
+  - `FILTER_MODE_LINEAR_MIPMAP_NEAREST`, tek bir mipmap içinde doğrusal ara değerleme yapar.
+  - `FILTER_MODE_LINEAR_MIPMAP_LINEAR`, iki haritanın her birindeki değeri hesaplamak için doğrusal ara değerleme kullanır ve ardından bu iki değer arasında doğrusal ara değerleme yapar.
+
+Max Anisotropy
+: Anizotropik filtreleme, birden çok örnek alıp sonuçları harmanlayan gelişmiş bir filtreleme tekniğidir. Bu ayar, doku örnekleyicilerinin anizotropi düzeyini kontrol eder. GPU anizotropik filtrelemeyi desteklemiyorsa parametrenin hiçbir etkisi olmaz ve varsayılan olarak 1'e ayarlanır.
+
+## Sabit arabellekleri
+
+İşleme hattı çizim yaparken sabit değerlerini varsayılan sistem sabit arabelleğinden alır. Varsayılan sabitleri geçersiz kılmak ve gölgelendirici programının uniform değerlerini bunun yerine işleme betiğinde kodla ayarlamak için özel bir sabit arabelleği oluşturabilirsiniz:
+
+```lua
+self.constants = render.constant_buffer() -- <1>
+self.constants.tint = vmath.vector4(1, 0, 0, 1) -- <2>
+...
+render.draw(self.my_pred, {constants = self.constants}) -- <3>
+```
+1. Yeni bir sabit arabelleği oluşturun
+2. `tint` sabitini parlak kırmızıya ayarlayın
+3. Özel sabitlerimizi kullanarak işleme yükleminin (render predicate) seçtiği bileşenleri çizin
+
+Arabelleğin sabit öğelerine normal bir Lua tablosundaki gibi başvurulduğunu, ancak arabellek üzerinde `pairs()` veya `ipairs()` ile yineleme yapılamadığını unutmayın.

--- a/docs/tr/manuals/mesh.md
+++ b/docs/tr/manuals/mesh.md
@@ -1,0 +1,107 @@
+---
+title: Defold'da 3B örgüler
+brief: Bu kılavuz, oyununuzda çalışma sırasında 3B örgülerin nasıl oluşturulacağını açıklar.
+---
+
+# Örgü bileşeni
+
+Defold özünde bir 3B motordur. Yalnızca 2B içerikle çalışsanız bile görüntü oluşturmak için yapılan tüm işleme (rendering) 3B olarak gerçekleştirilir ve ekrana ortografik izdüşümle yansıtılır. Defold, koleksiyonlarınıza (collection) çalışma sırasında 3B örgüler (mesh) ekleyip oluşturarak 3B içerikten tam olarak yararlanmanıza olanak tanır. Yalnızca 3B varlıklarla tamamen 3B oyunlar oluşturabilir veya 3B ve 2B içeriği dilediğiniz gibi bir arada kullanabilirsiniz.
+
+## Örgü bileşeni oluşturma
+
+Örgü bileşenleri, diğer oyun nesnesi (game object) bileşenleri (component) gibi oluşturulur. Bunu iki şekilde yapabilirsiniz:
+
+- *Assets* tarayıcısında bir konuma <kbd>sağ tıklayıp</kbd> <kbd>New... ▸ Mesh</kbd> seçeneğini seçerek bir *örgü dosyası* oluşturun.
+- *Outline* görünümünde bir oyun nesnesine <kbd>sağ tıklayıp</kbd> <kbd>Add Component ▸ Mesh</kbd> seçeneğini seçerek bileşeni doğrudan oyun nesnesine gömülü olarak oluşturun.
+
+![Oyun nesnesindeki örgü](images/mesh/mesh.png)
+
+Örgüyü oluşturduktan sonra bazı özellikleri belirtmeniz gerekir:
+
+### Örgü özellikleri
+
+*Id*, *Position* ve *Rotation* özelliklerine ek olarak bileşene özgü şu özellikler bulunur:
+
+*Material*
+: Örgüyü işlemek için kullanılacak materyal (material).
+
+*Vertices*
+: Örgü verilerini akış (stream) başına tanımlayan bir arabellek (buffer) dosyası.
+
+*Primitive Type*
+: Lines, Triangles veya Triangle Strip.
+
+*Position Stream*
+: Bu özelliğin değeri, *position* akışının adı olmalıdır. Akış, köşe gölgelendiricisine (vertex shader) otomatik biçimde girdi olarak sağlanır.
+
+*Normal Stream*
+: Bu özelliğin değeri, *normal* akışının adı olmalıdır. Akış, köşe gölgelendiricisine otomatik biçimde girdi olarak sağlanır.
+
+*tex0*
+: Bunu örgü için kullanılacak dokuya (texture) ayarlayın.
+
+## Düzenleyicide değiştirme
+
+Örgü bileşenini ekledikten sonra, standart *Scene Editor* araçlarıyla bileşeni ve/veya onu içeren oyun nesnesini düzenleyip değiştirerek örgüyü istediğiniz gibi taşıyabilir, döndürebilir ve ölçekleyebilirsiniz.
+
+## Çalışma sırasında değiştirme
+
+Defold arabelleklerini kullanarak çalışma sırasında örgüleri değiştirebilirsiniz. Üçgen şeritlerinden (triangle strips) bir küp oluşturma örneği:
+
+```Lua
+
+-- cube
+local vertices = {
+	0, 0, 0,
+	0, 1, 0,
+	1, 0, 0,
+	1, 1, 0,
+	1, 1, 1,
+	0, 1, 0,
+	0, 1, 1,
+	0, 0, 1,
+	1, 1, 1,
+	1, 0, 1,
+	1, 0, 0,
+	0, 0, 1,
+	0, 0, 0,
+	0, 1, 0
+}
+
+-- create a buffer with a position stream
+local buf = buffer.create(#vertices / 3, {
+	{ name = hash("position"), type=buffer.VALUE_TYPE_FLOAT32, count = 3 }
+})
+
+-- get the position stream and write the vertices
+local positions = buffer.get_stream(buf, "position")
+for i, value in ipairs(vertices) do
+	positions[i] = vertices[i]
+end
+
+-- set the buffer with the vertices on the mesh
+local res = go.get("#mesh", "vertices")
+resource.set_buffer(res, buf)
+```
+
+Örgü bileşeninin nasıl kullanılacağı hakkında örnek projeler ve kod parçaları içeren [daha fazla bilgi için forumdaki duyuru yazısına bakın](https://forum.defold.com/t/mesh-component-in-defold-1-2-169-beta/65137).
+
+## Görüş hacmi dışında kalanları eleme {#frustum-culling}
+
+Örgü bileşenlerine, dinamik yapıları ve konum verilerinin nasıl kodlandığının kesin olarak bilinememesi nedeniyle görünmeyenleri eleme (culling) işlemi otomatik uygulanmaz. Bir örgünün elenebilmesi için eksenlere hizalı sınırlayıcı kutusunun (axis-aligned bounding box) 6 kayan noktalı sayı kullanılarak arabelleğe üst veri olarak ayarlanması gerekir (AABB min/max):
+
+```lua
+buffer.set_metadata(buf, hash("AABB"), { 0, 0, 0, 1, 1, 1 }, buffer.VALUE_TYPE_FLOAT32)
+```
+
+## Materyal sabitleri
+
+{% include shared/material-constants.md component='mesh' variable='tint' %}
+
+`tint`
+: Örgünün renk çarpanı (`vector4`). Renk çarpanını temsil etmek için `vector4` kullanılır; x, y, z ve w sırasıyla kırmızı, yeşil, mavi ve alfa renk çarpanlarına karşılık gelir.
+
+## Köşelerin yerel uzayı ve dünya uzayı
+Örgü materyalinin Vertex Space ayarı Local Space olarak ayarlanmışsa veriler gölgelendiricinize olduğu gibi sağlanır ve köşeleri/normalleri her zamanki gibi GPU üzerinde dönüştürmeniz gerekir.
+
+Örgü materyalinin Vertex Space ayarı World Space olarak ayarlanmışsa varsayılan bir `position` ve `normal` akışı sağlamanız gerekir veya örgüyü düzenlerken akışı açılır listeden seçebilirsiniz. Böylece motor, diğer nesnelerle toplu çizim (batching) yapmak için verileri dünya uzayına (world space) dönüştürebilir.

--- a/docs/tr/manuals/message-passing.md
+++ b/docs/tr/manuals/message-passing.md
@@ -1,0 +1,254 @@
+---
+title: Defold'da ileti aktarımı
+brief: İleti aktarımı, Defold'un gevşek bağlı nesnelerin iletişim kurmasını sağlamak için kullandığı mekanizmadır. Bu kılavuz, bu mekanizmayı ayrıntılı olarak açıklar.
+---
+
+# İleti aktarımı
+
+İleti aktarımı (message passing), Defold oyun nesnelerinin (game object) birbirleriyle iletişim kurmasını sağlayan bir mekanizmadır. Bu kılavuz, Defold'un [adresleme mekanizması](/manuals/addressing) ve [temel yapı taşları](/manuals/building-blocks) hakkında temel bilgiye sahip olduğunuzu varsayar.
+
+Defold'daki nesne yönelimi, uygulamanızı (Java, C++ veya C#'ta olduğu gibi) kalıtım içeren sınıf hiyerarşileri kurarak ve nesnelerinizde üye işlevler tanımlayarak oluşturmanız anlamına gelmez. Bunun yerine Defold, Lua'yı nesne durumunun betik bileşenlerinde (script component) tutulduğu ve `self` başvurusu üzerinden erişilebildiği basit ve güçlü bir nesne yönelimli tasarımla genişletir. Ayrıca nesneler arasında iletişim için eşzamansız ileti aktarımı kullanılarak nesneler birbirinden tamamen bağımsız tutulabilir.
+
+
+## Kullanım örnekleri
+
+Önce birkaç basit kullanım örneğine bakalım. Şu öğelerden oluşan bir oyun geliştirdiğinizi varsayalım:
+
+1. GUI bileşeni (GUI component) içeren bir oyun nesnesini barındıran ana başlangıç koleksiyonu (bootstrap collection); GUI, bir mini harita ve bir puan sayacından oluşur. Ayrıca "level" tanımlayıcısına sahip bir koleksiyon (collection) vardır.
+2. "level" adlı koleksiyon iki oyun nesnesi içerir: oyuncunun yönettiği bir kahraman karakter ve bir düşman.
+
+![İleti aktarımı yapısı](images/message_passing/message_passing_structure.png)
+
+::: sidenote
+Bu örneğin içeriği iki ayrı dosyada bulunur. Ana başlangıç koleksiyonu için bir dosya, "level" tanımlayıcısına sahip koleksiyon için de bir dosya vardır. Ancak Defold'da dosya adları _önemli değildir_. Önemli olan, örneklere (instance) atadığınız kimliktir.
+:::
+
+Oyunda, nesneler arasında iletişim gerektiren birkaç basit mekanik vardır:
+
+![İleti aktarımı](images/message_passing/message_passing.png)
+
+① Kahraman düşmana yumruk atar
+: Bu mekaniğin bir parçası olarak "hero" betik bileşeninden "enemy" betik bileşenine bir `"punch"` iletisi gönderilir. Her iki nesne de koleksiyon hiyerarşisinde aynı yerde bulunduğundan göreli adresleme tercih edilir:
+
+  ```lua
+  -- Send "punch" from the "hero" script to "enemy" script
+  msg.post("enemy#controller", "punch")
+  ```
+
+  Oyunda yalnızca tek bir güç düzeyine sahip yumruk hareketi bulunduğundan, iletinin adı olan "punch" dışında herhangi bir bilgi içermesi gerekmez.
+
+  Düşmanın betik bileşeninde, iletiyi almak için bir işlev oluşturursunuz:
+
+  ```lua
+  function on_message(self, message_id, message, sender)
+    if message_id == hash("punch") then
+      self.health = self.health - 100
+    end
+  end
+  ```
+
+  Bu durumda kod yalnızca iletinin adına bakar (ad, `message_id` parametresinde karma değeri alınmış bir dize olarak gönderilir). Kod, ileti verisiyle veya gönderenle ilgilenmez---"punch" iletisini gönderen *herkes* zavallı düşmana hasar verir.
+
+② Kahramanın puan kazanması
+: Oyuncu bir düşmanı her yendiğinde puanı artar. Ayrıca "hero" oyun nesnesinin betik bileşeninden "interface" oyun nesnesinin "gui" bileşenine bir `"update_score"` iletisi gönderilir.
+
+  ```lua
+  -- Enemy defeated. Increase score counter by 100.
+  self.score = self.score + 100
+  msg.post("/interface#gui", "update_score", { score = self.score })
+  ```
+
+  Bu durumda göreli bir adres yazmak mümkün değildir; çünkü "interface" adlandırma hiyerarşisinin kökündeyken "hero" kökte değildir. İleti, kendisine bir betik eklenmiş olan GUI bileşenine gönderilir; böylece bileşen iletiye uygun şekilde tepki verebilir. Betikler, GUI betikleri ve işleme betikleri (render script) arasında serbestçe ileti gönderilebilir.
+
+  `"update_score"` iletisi, puan verisiyle birlikte gönderilir. Veri, `message` parametresinde bir Lua tablosu olarak aktarılır:
+
+  ```lua
+  function on_message(self, message_id, message, sender)
+    if message_id == hash("update_score") then
+      -- set the score counter to new score
+      local score_node = gui.get_node("score")
+      gui.set_text(score_node, "SCORE: " .. message.score)
+    end
+  end
+  ```
+
+③ Düşmanın mini haritadaki konumu
+: Oyuncunun ekranında, düşmanların yerini bulmayı ve onları izlemeyi kolaylaştıran bir mini harita vardır. Her düşman, "interface" oyun nesnesindeki "gui" bileşenine bir `"update_minimap"` iletisi göndererek kendi konumunu bildirmekten sorumludur:
+
+  ```lua
+  -- Send the current position to update the interface minimap
+  local pos = go.get_position()
+  msg.post("/interface#gui", "update_minimap", { position = pos })
+  ```
+
+  GUI betiğinin kodu her düşmanın konumunu izlemelidir; aynı düşman yeni bir konum gönderirse eski konum değiştirilmelidir. İletiyi gönderen (`sender` parametresinde aktarılır), konumları içeren bir Lua tablosunda anahtar olarak kullanılabilir:
+
+  ```lua
+  function init(self)
+    self.minimap_positions = {}
+  end
+
+  local function update_minimap(self)
+    for url, pos in pairs(self.minimap_positions) do
+      -- update position on map
+      ...
+    end
+  end
+
+  function on_message(self, message_id, message, sender)
+    if message_id == hash("update_score") then
+      -- set the score counter to new score
+      local score_node = gui.get_node("score")
+      gui.set_text(score_node, "SCORE: " .. message.score)
+    elseif message_id == hash("update_minimap") then
+      -- update the minimap with new positions
+      self.minimap_positions[sender] = message.position
+      update_minimap(self)
+    end
+  end
+  ```
+
+## İleti gönderme
+
+Yukarıda gördüğümüz gibi, ileti gönderme mekanizması oldukça basittir. İletinizi ileti kuyruğuna ekleyen `msg.post()` işlevini çağırırsınız. Ardından motor, her karede kuyruğu tarar ve her iletiyi hedef adresine teslim eder. Bazı sistem iletilerini (`"enable"`, `"disable"`, `"set_parent"` vb.) motor kodu işler. Motor ayrıca nesnelerinize teslim edilen bazı sistem iletileri de üretir (fizik çarpışmalarında `"collision_response"` gibi). Betik bileşenlerine gönderilen kullanıcı tanımlı iletiler için motor yalnızca `on_message()` adlı özel bir Defold Lua işlevini çağırır.
+
+Var olan herhangi bir nesneye veya bileşene istediğiniz iletileri gönderebilirsiniz; iletiye yanıt vermek alıcı taraftaki koda bağlıdır. Bir betik bileşenine ileti gönderirseniz ve betik kodu iletiyi yok sayarsa bu bir sorun oluşturmaz. İletileri işleme sorumluluğu tamamen alıcı taraftadır.
+
+Motor, iletinin hedef adresini kontrol eder. Bilinmeyen bir alıcıya ileti göndermeye çalışırsanız Defold konsolda bir hata bildirir:
+
+```lua
+-- Try to post to a non existing object
+msg.post("dont_exist#script", "hello")
+```
+
+```txt
+ERROR:GAMEOBJECT: Instance '/dont_exists' could not be found when dispatching message 'hello' sent from main:/my_object#script
+```
+
+`msg.post()` çağrısının tam imzası şöyledir:
+
+`msg.post(receiver, message_id, [message])`
+
+receiver
+: Hedef bileşenin veya oyun nesnesinin tanımlayıcısı. Bir oyun nesnesini hedeflerseniz iletinin bu oyun nesnesindeki tüm bileşenlere gönderileceğini unutmayın.
+
+message_id
+: İletinin adını içeren bir dize veya karma değeri alınmış dize.
+
+[message]
+: İleti verisinin anahtar-değer çiftlerini içeren isteğe bağlı bir Lua tablosu. İletinin Lua tablosuna neredeyse her tür veri eklenebilir. Sayılar, dizeler, mantıksal değerler, URL değerleri, karma değerleri ve iç içe tablolar aktarabilirsiniz. İşlevleri aktaramazsınız.
+
+  ```lua
+  -- Send table data containing a nested table
+  local inventory_table = { sword = true, shield = true, bow = true, arrows = 9 }
+  local stats = { score = 100, stars = 2, health = 4, inventory = inventory_table }
+  msg.post("other_object#script", "set_stats", stats)
+  ```
+
+::: sidenote
+`message` parametresindeki tablonun boyutu için kesin bir sınır vardır. Bu sınır 2 kilobayt olarak belirlenmiştir. Bir tablonun bellekte kapladığı tam boyutu belirlemenin şu anda basit bir yolu yoktur; ancak bellek kullanımını izlemek için tabloyu eklemeden önce ve sonra `collectgarbage("count")` kullanabilirsiniz.
+:::
+
+### Kısa gösterimler
+
+Defold, tam bir URL belirtmeden ileti göndermek için kullanabileceğiniz iki kullanışlı kısa gösterim sunar:
+
+:[Shorthands](../shared/url-shorthands.md)
+
+
+## İleti alma
+
+İleti almak için hedef betik bileşeninin `on_message()` adlı bir işlev içerdiğinden emin olmanız yeterlidir. İşlev dört parametre kabul eder:
+
+`function on_message(self, message_id, message, sender)`
+
+`self`
+: Betik bileşeninin kendisine bir başvuru.
+
+`message_id`
+: İletinin adını içerir. Adın _karma değeri alınmıştır_.
+
+`message`
+: İleti verisini içerir. Bu bir Lua tablosudur. Veri yoksa tablo boştur.
+
+`sender`
+: Gönderenin tam URL adresini içerir.
+
+```lua
+function on_message(self, message_id, message, sender)
+    print(message_id) --> hash: [my_message_name]
+
+    pprint(message) --> {
+                    -->   score = 100,
+                    -->   value = "some string"
+                    --> }
+
+    print(sender) --> url: [main:/my_object#script]
+end
+```
+
+## Oyun dünyaları arasında ileti aktarımı
+
+Çalışma zamanı ortamına yeni bir oyun dünyası yüklemek için koleksiyon vekili (collection proxy) bileşeni kullanıyorsanız oyun dünyaları arasında ileti aktarmak isteyeceksiniz. Bir koleksiyonu vekil aracılığıyla yüklediğinizi ve koleksiyonun *Name* özelliğinin "level" olarak ayarlandığını varsayalım:
+
+![Koleksiyon adı](images/message_passing/collection_name.png)
+
+Koleksiyon yüklenip başlangıç işlemleri tamamlandıktan ve etkinleştirildikten hemen sonra, alıcı adresinin "socket" alanında oyun dünyasının adını belirterek yeni dünyadaki herhangi bir bileşene veya nesneye ileti gönderebilirsiniz:
+
+```lua
+-- Send a message to the player in the new game world
+msg.post("level:/player#controller", "wake_up")
+```
+Vekillerin nasıl çalıştığına ilişkin daha ayrıntılı bir açıklamayı [Koleksiyon vekilleri](/manuals/collection-proxy) belgesinde bulabilirsiniz.
+
+## İleti zincirleri
+
+Gönderilmiş bir ileti sonunda dağıtıldığında alıcıların `on_message()` işlevi çağrılır. Tepki veren kodun, ileti kuyruğuna eklenen yeni iletiler göndermesi oldukça yaygındır.
+
+Motor dağıtıma başladığında ileti kuyruğunu işler, her iletinin alıcısının `on_message()` işlevini çağırır ve ileti kuyruğu boşalana kadar devam eder. Dağıtım turu sırasında kuyruğa yeni iletiler eklenirse bir tur daha gerçekleştirir. Ancak motorun kuyruğu boşaltmayı kaç kez deneyeceğine ilişkin kesin bir sınır vardır; bu da bir kare içinde tamamen dağıtılmasını bekleyebileceğiniz ileti zincirlerinin uzunluğunu sınırlar. Motorun her `update()` çağrısı arasında kaç ileti dağıtım turu gerçekleştirdiğini aşağıdaki betikle kolayca test edebilirsiniz:
+
+```lua
+function init(self)
+    -- We’re starting a long message chain during object init
+    -- and keeps it running through a number of update() steps.
+    print("INIT")
+    msg.post("#", "msg")
+    self.updates = 0
+    self.count = 0
+end
+
+function update(self, dt)
+    if self.updates < 5 then
+        self.updates = self.updates + 1
+        print("UPDATE " .. self.updates)
+        print(self.count .. " dispatch passes before this update.")
+        self.count = 0
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("msg") then
+        self.count = self.count + 1
+        msg.post("#", "msg")
+    end
+end
+```
+
+Bu betiği çalıştırmak aşağıdakine benzer bir çıktı verir:
+
+```txt
+DEBUG:SCRIPT: INIT
+INFO:ENGINE: Defold Engine 1.2.36 (5b5af21)
+DEBUG:SCRIPT: UPDATE 1
+DEBUG:SCRIPT: 10 dispatch passes before this update.
+DEBUG:SCRIPT: UPDATE 2
+DEBUG:SCRIPT: 75 dispatch passes before this update.
+DEBUG:SCRIPT: UPDATE 3
+DEBUG:SCRIPT: 75 dispatch passes before this update.
+DEBUG:SCRIPT: UPDATE 4
+DEBUG:SCRIPT: 75 dispatch passes before this update.
+DEBUG:SCRIPT: UPDATE 5
+DEBUG:SCRIPT: 75 dispatch passes before this update.
+```
+
+Defold motorunun bu belirli sürümünün, `init()` ile ilk `update()` çağrısı arasında ileti kuyruğunda 10 ileti dağıtım turu gerçekleştirdiğini görüyoruz. Ardından sonraki her güncelleme döngüsünde 75 tur gerçekleştirir.

--- a/docs/tr/manuals/microsoft-xbox.md
+++ b/docs/tr/manuals/microsoft-xbox.md
@@ -1,0 +1,8 @@
+---
+title: Microsoft Xbox için Defold ile geliştirme
+brief: Bu kılavuz, Microsoft Xbox erişiminin nasıl alınacağını açıklar
+---
+
+# Xbox desteği
+
+Defold henüz Microsoft Xbox'ı desteklemiyor. Defold Foundation, Xbox Middleware sağlayıcısı olmak için aktif olarak çalışıyor. Onaylı Xbox geliştiricilerini, Xbox geliştirici temsilcileriyle iletişime geçerek Microsoft Xbox için Defold desteği talep etmeye teşvik ediyoruz.

--- a/docs/tr/manuals/model-animation.md
+++ b/docs/tr/manuals/model-animation.md
@@ -1,0 +1,222 @@
+---
+title: Defold'da 3B model animasyonu kılavuzu
+brief: Bu kılavuz, Defold'da 3B model animasyonlarının nasıl kullanılacağını açıklar.
+---
+
+# 3B model animasyonu
+
+Model bileşenleri (model components), glTF dosyalarından içe aktarılan iskelet animasyonlarını (skeletal animations) ve biçim hedefi animasyonlarını (morph target animations) oynatabilir. İskelet animasyonu, modelin köşelerini deforme etmek için modelin kemiklerini kullanır. Şekil harmanlama animasyonu (blend shape animation) olarak da bilinen biçim hedefi animasyonu, alternatif köşe konumlarının ağırlıklarına animasyon uygulayarak modelin şeklini değiştirir.
+
+Animasyon için 3B verilerin bir modele nasıl içe aktarılacağı hakkında ayrıntılı bilgi için [Model belgelerine](/manuals/model) bakın.
+
+  ![Blender animasyonu](images/animation/blender_animation.png)
+  ![Sallanma döngüsü](images/animation/suzanne.gif)
+
+
+## Animasyonları oynatma
+
+Modellere [`model.play_anim()`](/ref/model#model.play_anim) işleviyle animasyon uygulanır:
+
+```lua
+function init(self)
+    -- Start the "wiggle" animation back and forth on #model
+    model.play_anim("#model", "wiggle", go.PLAYBACK_LOOP_PINGPONG)
+end
+```
+
+::: important
+Defold şu anda yalnızca önceden hesaplanıp kaydedilmiş (baked) iskelet animasyonlarını destekler. İskelet animasyonlarında konum, dönme ve ölçek için ayrı anahtarlar yerine, her anahtar karede animasyon uygulanan her kemik için bir matris bulunması gerekir.
+
+Animasyonlarda ayrıca doğrusal ara değerleme (interpolation) uygulanır. Daha gelişmiş eğri ara değerlemesi kullanıyorsanız animasyonların dışa aktarma aracı tarafından önceden hesaplanıp kaydedilmesi gerekir.
+:::
+
+### Biçim hedefleri {#morph-targets}
+
+Biçim hedefleri (morph targets), aynı örgünün (mesh) alternatif şekilleridir. Her hedef konum, normal ve teğet farklarını saklar ve her hedefin, o şeklin ne ölçüde uygulanacağını denetleyen bir harmanlama ağırlığı vardır. Ağırlığın `0` olması hedefin hiçbir etkisinin olmadığı anlamına gelirken, `1` olması hedef şeklin tamamını uygular. Gölgelendirici ve varlık buna uygun hazırlanmışsa bu aralığın dışındaki değerler de abartılı efektler için yararlı olabilir.
+
+Defold, biçim hedeflerini ve başlangıçtaki biçim hedefi ağırlıklarını glTF model verilerinden içe aktarır. Biçim hedefi ağırlıklarına animasyon uygulayan glTF animasyonları, modelin animasyon kümesine içe aktarılır ve tıpkı iskelet animasyonları gibi [`model.play_anim()`](/ref/model#model.play_anim) ile oynatılabilir:
+
+```lua
+function init(self)
+    model.play_anim("#model", "smile", go.PLAYBACK_LOOP_FORWARD)
+end
+```
+
+Biçim hedefi verileri tek başına veya iskelet animasyonuyla birlikte kullanılabilir, ancak bir model bileşeni aynı anda yalnızca bir model animasyonu oynatabilir. Bu, `model.play_anim()` kullanarak bir iskelet animasyonunu ve ayrı bir biçim hedefi animasyonunu aynı anda oynatamayacağınız anlamına gelir. Modelin animasyon verileri varsa ancak iskeleti yoksa yalnızca biçim hedefi animasyon verileri kullanılır.
+
+Yine de iskelet animasyonu oynatmayı başka kaynaklardan gelen biçim hedefi değişiklikleriyle birleştirebilirsiniz; örneğin `model.set_blend_weights()` ile betikten biçim hedefi ağırlıklarını ayarlayabilirsiniz.
+
+Biçim hedefi ağırlıklarını betikten okuyabilir ve geçersiz kılabilirsiniz. [`model.get_blend_weights()`](/ref/model#model.get_blend_weights), modelde biçim hedefleri bulunan ilk örgünün o anki ağırlıklarını döndürür. [`model.set_blend_weights()`](/ref/model#model.set_blend_weights), modelde biçimi değiştirilen her örgüye betikten geçersiz kılma uygular:
+
+```lua
+function init(self)
+    local weights = model.get_blend_weights("#model")
+    weights[1] = 0.75
+    weights[2] = 0.25
+    model.set_blend_weights("#model", weights)
+end
+```
+
+Ağırlık tablosu, örgüdeki biçim hedefleriyle aynı sırada, birden başlayan Lua indekslerini kullanır. Fazladan değerler yok sayılır; tablonun içerdiğinden daha fazla biçim hedefi olan örgülerde eksik değerler sıfır kabul edilir. Betikle geçersiz kılma işlemi, kaldırılana kadar her karede animasyondan sonra uygulanır:
+
+```lua
+model.set_blend_weights("#model")     -- clear the override
+model.set_blend_weights("#model", nil) -- also clears the override
+```
+
+### Gölgelendirici desteği
+
+Biçim hedeflerini işleyerek (rendering) görüntü oluşturmak için model materyalinin köşe gölgelendiricisinin (vertex shader), oluşturulan `morph_targets` dokusundan örnekleme yapması ve ağırlıklandırılmış farkları köşe verilerine uygulaması gerekir. Biçim hedefi dokusu, her biçim hedefinin üç dizi katmanı kullandığı bir 2B dizi dokusudur: konum farkı, normal farkı ve teğet farkı.
+
+Motor, o anki biçim hedefi ağırlıklarını köşe gölgelendiricisine `morph_targets_weights` adlı bir uniform aracılığıyla sağlar. Her `vec4` dört ağırlık saklar, dolayısıyla `morph_targets_weights[2]` sekiz biçim hedefi için yer içerir.
+
+Aşağıdaki örnek, örnekli çizim kullanılmayan (non-instanced) bir model materyali için köşe gölgelendiricisinin ilgili bölümlerini gösterir:
+
+```glsl
+#version 140
+
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec3 normal;
+in mediump vec4 tangent;
+
+out mediump vec2 var_texcoord0;
+out mediump vec3 var_normal;
+out mediump vec4 var_tangent;
+
+uniform vs_uniforms
+{
+    mediump mat4 mtx_worldview;
+    mediump mat4 mtx_proj;
+    mediump mat4 mtx_normal;
+    // Each vec4 stores four blend weights. Use morph_targets_weights[1]
+    // for up to 4 morph targets, [2] for up to 8, [3] for up to 12, etc.
+    mediump vec4 morph_targets_weights[2];
+};
+
+uniform sampler2DArray morph_targets;
+
+vec2 get_morph_uv(int vertex_index, int width, int height)
+{
+    int x = vertex_index % width;
+    int y = vertex_index / width;
+    return vec2(
+        (float(x) + 0.5) / float(width),
+        (float(y) + 0.5) / float(height)
+    );
+}
+
+void apply_morph_target(vec2 uv, float weight, int target,
+    inout vec3 position_delta, inout vec3 normal_delta, inout vec3 tangent_delta)
+{
+    if (weight == 0.0) {
+        return;
+    }
+
+    int position_layer = target * 3 + 0;
+    int normal_layer = target * 3 + 1;
+    int tangent_layer = target * 3 + 2;
+
+    position_delta += weight * texture(morph_targets, vec3(uv, position_layer)).xyz;
+    normal_delta += weight * texture(morph_targets, vec3(uv, normal_layer)).xyz;
+    tangent_delta += weight * texture(morph_targets, vec3(uv, tangent_layer)).xyz;
+}
+
+void get_morph_target_data(int vertex_index,
+    out vec3 position_delta, out vec3 normal_delta, out vec3 tangent_delta)
+{
+    position_delta = vec3(0.0);
+    normal_delta = vec3(0.0);
+    tangent_delta = vec3(0.0);
+
+#ifndef EDITOR
+    ivec3 texture_size = textureSize(morph_targets, 0);
+    vec2 uv = get_morph_uv(vertex_index, texture_size.x, texture_size.y);
+
+    apply_morph_target(uv, morph_targets_weights[0].x, 0, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[0].y, 1, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[0].z, 2, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[0].w, 3, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[1].x, 4, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[1].y, 5, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[1].z, 6, position_delta, normal_delta, tangent_delta);
+    apply_morph_target(uv, morph_targets_weights[1].w, 7, position_delta, normal_delta, tangent_delta);
+#endif
+}
+
+void main()
+{
+    vec3 position_delta;
+    vec3 normal_delta;
+    vec3 tangent_delta;
+    get_morph_target_data(gl_VertexIndex, position_delta, normal_delta, tangent_delta);
+
+    vec3 morphed_position = position.xyz + position_delta;
+    vec3 morphed_normal = normalize(normal + normal_delta);
+    vec3 morphed_tangent = normalize(tangent.xyz + tangent_delta);
+
+    var_texcoord0 = texcoord0;
+    var_normal = normalize((mtx_normal * vec4(morphed_normal, 0.0)).xyz);
+    var_tangent = vec4(normalize((mtx_normal * vec4(morphed_tangent, 0.0)).xyz), tangent.w);
+
+    gl_Position = mtx_proj * mtx_worldview * vec4(morphed_position, 1.0);
+}
+```
+
+Düzenleyicide model animasyonu önizlemesi henüz bulunmadığından, oluşturulan biçim hedefi dokusu verileri yalnızca çalışma sırasında kullanılabilir; bu nedenle `#ifndef EDITOR` sarmalayıcısı gereklidir. Örgüde daha fazla biçim hedefi varsa `morph_targets_weights` dizisinin boyutunu artırın ve daha fazla `apply_morph_target()` çağrısı ekleyin.
+
+::: important
+Yukarıdaki gölgelendirici örneği `textureSize()` kullanır ve OpenGL ES 2.0 üzerinde çalışmaz.
+:::
+
+### Kemik hiyerarşisi
+
+Model iskeletindeki kemikler, motor içinde oyun nesneleri (game objects) olarak temsil edilir.
+
+Kemiğe ait oyun nesnesi örneğinin kimliğini çalışma sırasında alabilirsiniz. [`model.get_go()`](/ref/model#model.get_go) işlevi, belirtilen kemiğin oyun nesnesinin kimliğini döndürür.
+
+```lua
+-- Get the middle bone go of our wiggler model
+local bone_go = model.get_go("#wiggler", "Bone_002")
+
+-- Now do something useful with the game object...
+```
+
+### İmleç animasyonu
+
+Bir model animasyonunu ilerletmek için `model.play_anim()` kullanmanın yanı sıra, *Model* bileşenlerinin sunduğu `cursor` özelliğini `go.animate()` ile değiştirebilirsiniz ([özellik animasyonları](/manuals/property-animation) hakkında daha fazla bilgi):
+
+```lua
+-- Set the animation on #model but don't start it
+model.play_anim("#model", "wiggle", go.PLAYBACK_NONE)
+-- Set the cursor to the beginning of the animation
+go.set("#model", "cursor", 0)
+-- Tween the cursor between 0 and 1 pingpong with in-out quad easing.
+go.animate("#model", "cursor", go.PLAYBACK_LOOP_PINGPONG, 1, go.EASING_INOUTQUAD, 3)
+```
+
+## Tamamlanma geri çağırımları
+
+Model animasyonu işlevi `model.play_anim()`, son bağımsız değişken olarak isteğe bağlı bir Lua geri çağırım işlevini (callback function) destekler. Bu işlev, animasyon sonuna kadar oynatıldığında çağrılır. İşlev, döngüde oynatılan animasyonlarda veya bir animasyon `go.cancel_animations()` ile elle iptal edildiğinde hiçbir zaman çağrılmaz. Geri çağırım, animasyon tamamlandığında olayları tetiklemek veya birden fazla animasyonu zincirleme bağlamak için kullanılabilir.
+
+```lua
+local function wiggle_done(self, message_id, message, sender)
+    -- Done animating
+end
+
+function init(self)
+    model.play_anim("#model", "wiggle", go.PLAYBACK_ONCE_FORWARD, nil, wiggle_done)
+end
+```
+
+## Oynatma modları
+
+Animasyonlar bir kez veya döngüde oynatılabilir. Animasyonun nasıl oynatılacağını oynatma modu belirler:
+
+* `go.PLAYBACK_NONE`
+* `go.PLAYBACK_ONCE_FORWARD`
+* `go.PLAYBACK_ONCE_BACKWARD`
+* `go.PLAYBACK_ONCE_PINGPONG`
+* `go.PLAYBACK_LOOP_FORWARD`
+* `go.PLAYBACK_LOOP_BACKWARD`
+* `go.PLAYBACK_LOOP_PINGPONG`

--- a/docs/tr/manuals/model.md
+++ b/docs/tr/manuals/model.md
@@ -1,0 +1,157 @@
+---
+title: Defold'da 3B modeller
+brief: Bu kılavuz, 3B modelleri, iskeletleri ve animasyonları oyununuza nasıl aktaracağınızı açıklar.
+---
+
+# Model bileşeni
+
+Defold temelde bir 3B motordur. Yalnızca 2B içerikle çalışırken bile tüm işleme (rendering) 3B olarak yapılır, ancak ekrana ortografik izdüşümle yansıtılır. Defold, 3B varlıkları (asset), yani _modelleri_ (model) koleksiyonlarınıza (collection) ekleyerek tamamen 3B içerik kullanmanıza olanak tanır. Yalnızca 3B varlıklarla tamamen 3B oyunlar geliştirebilir veya 3B ve 2B içeriği istediğiniz gibi birleştirebilirsiniz.
+
+## Model bileşeni oluşturma
+
+Model bileşenleri (model component), diğer oyun nesnesi (game object) bileşenleri gibi oluşturulur. Bunu iki şekilde yapabilirsiniz:
+
+- *Assets* tarayıcısında bir konuma <kbd>sağ tıklayın</kbd> ve <kbd>New... ▸ Model</kbd> seçeneğini seçerek bir *Model dosyası* oluşturun.
+- *Outline* görünümünde bir oyun nesnesine <kbd>sağ tıklayın</kbd> ve <kbd>Add Component ▸ Model</kbd> seçeneğini seçerek bileşeni doğrudan oyun nesnesine gömülü olarak oluşturun.
+
+![Oyun nesnesindeki model](images/model/model_gltf.png)
+
+Modeli oluşturduktan sonra bazı özellikleri belirtmeniz gerekir:
+
+### Model özellikleri {#model-properties}
+
+*Id*, *Position* ve *Rotation* özelliklerine ek olarak bileşene özgü şu özellikler bulunur:
+
+*Scene*
+: Modelin geometrisini içeren glTF *.gltf* veya *.glb* dosyası. Dosya biçim hedefleri (morph target) içeriyorsa bunlar sahneyle birlikte içe aktarılır. Bu özelliğin adı Defold 1.13.2 öncesinde *Mesh* idi.
+
+*Mesh*
+: Seçili *Scene* içindeki isteğe bağlı, adlandırılmış bir örgü (mesh); Defold 1.13.2 sürümünden beri kullanılabilir. Sahnenin tamamını içe aktarılan dönüşümleriyle işlemek için bu alanı boş bırakın. Bir örgüyü glTF düğüm dönüşümleri olmadan kendi yerel koordinatlarında bir kez işlemek için o örgüyü seçin. Seçilen örgüyü yerleştirmek için model bileşenini veya oyun nesnesini konumlandırın, döndürün ve ölçekleyin.
+
+*Create GO Bones*
+: Modelin her kemiği için bir oyun nesnesi oluşturmak üzere bu seçeneği işaretleyin. Bu oyun nesnelerini, örneğin silah gibi başka oyun nesnelerini el kemiklerine bağlamak için kullanabilirsiniz. 
+
+*Skeleton*
+: Bu özelliğin, animasyonda kullanılacak iskeleti (skeleton) içeren glTF *.gltf* veya *.glb* dosyasına başvurması önerilir. Defold'un hiyerarşinizde tek bir kök kemik gerektirdiğini unutmayın.
+
+*Animations*
+: Bunu, modelde kullanmak istediğiniz animasyonları içeren *Animation Set File* dosyasına ayarlayın.
+
+*Default Animation*
+: Animasyon kümesinden (animation set) seçilen ve modelde otomatik olarak oynatılacak animasyondur.
+
+Yukarıdaki özelliklere ek olarak modelin her örgüsüne bir materyal (material) atamak için bir alan da bulunur:
+
+*Material*
+: Bu özellik için dokulu bir 3B nesneye uygun olacak şekilde oluşturduğunuz bir materyal seçin. Başlangıç noktası olarak kullanabileceğiniz birkaç yerleşik materyal vardır:
+
+  * Örnek oluşturma (instancing) kullanılmayan statik modeller için *model.material* kullanın
+  * Örnek oluşturma kullanılan statik modeller için *model_instanced.material* kullanın
+  * İskelete bağlı (animasyonlu), örnek oluşturma kullanılmayan modeller için *model_skinned.material* kullanın
+  * İskelete bağlı (animasyonlu), örnek oluşturma kullanılan modeller için *model_skinned_instanced.material* kullanın
+
+Materyale bağlı olarak bir veya daha fazla doku (texture) özelliği bulunur:
+
+*Texture*
+: Bu özelliğin, nesneye uygulamak istediğiniz doku görüntüsü dosyasını göstermesi önerilir.
+
+
+## Düzenleyicide değiştirme
+
+Model bileşenini ekledikten sonra standart *Scene Editor* araçlarıyla bileşeni ve/veya onu içeren oyun nesnesini düzenleyip değiştirebilir, modeli istediğiniz gibi taşıyabilir, döndürebilir ve ölçekleyebilirsiniz.
+
+## Çalışma sırasında değiştirme
+
+Modelleri çalışma sırasında çeşitli işlevler ve özellikler aracılığıyla değiştirebilirsiniz (kullanım için [API belgelerine](/ref/model/) bakın).
+
+![Oyun içinde Wiggler](images/model/runtime.png)
+
+### Çalışma sırasında animasyon
+
+Defold, animasyonu çalışma sırasında kontrol etmek için güçlü destek sunar. [Model animasyonu kılavuzunda](/manuals/model-animation) daha fazla bilgi bulabilirsiniz:
+
+```lua
+local play_properties = { blend_duration = 0.1 }
+model.play_anim("#model", "jump", go.PLAYBACK_ONCE_FORWARD, play_properties)
+```
+
+Animasyon oynatma imleci, elle veya özellik animasyonu (property animation) sistemi aracılığıyla canlandırılabilir:
+
+```lua
+-- set the run animation
+model.play_anim("#model", "run", go.PLAYBACK_NONE)
+-- animate the cursor
+go.animate("#model", "cursor", go.PLAYBACK_LOOP_PINGPONG, 1, go.EASING_LINEAR, 10)
+```
+
+Modeller glTF biçim hedefi animasyonlarını da kullanabilir. Biçim hedefi ağırlıklarına diğer model animasyonlarında olduğu gibi `model.play_anim()` ile animasyon uygulanır. Bu ağırlıklar çalışma sırasında [`model.get_blend_weights()`](/ref/model#model.get_blend_weights) ve [`model.set_blend_weights()`](/ref/model#model.set_blend_weights) kullanılarak okunabilir veya geçersiz kılınabilir. Ayrıntılar için model animasyonu kılavuzundaki [biçim hedefleri bölümüne](/manuals/model-animation#morph-targets) bakın.
+
+### Özellikleri değiştirme
+
+Bir modelin `go.get()` ve `go.set()` kullanılarak değiştirilebilen çeşitli özellikleri de vardır:
+
+`animation`
+: Geçerli model animasyonu (`hash`) (SALT OKUNUR). Animasyonu `model.play_anim()` kullanarak değiştirirsiniz (yukarıya bakın).
+
+`cursor`
+: Normalleştirilmiş animasyon imleci (`number`).
+
+`material`
+: Modelin materyali (`hash`). Bunu bir materyal kaynak özelliği ve `go.set()` kullanarak değiştirebilirsiniz. Bir örnek için [API başvuru belgelerine](/ref/model/#material) bakın.
+
+`playback_rate`
+: Animasyon oynatma hızı (`number`).
+
+`textureN`
+: N değeri 0-15 arasında olan model dokuları (`hash`). Bu özellikleri `go.get()` ile okuyabilir, bir doku kaynak özelliği ve `go.set()` kullanarak değiştirebilirsiniz. Defold, çizim başına en fazla 16 dokuyu destekler; ancak doku örnekleyici sınırı daha düşük olan grafik bağdaştırıcılarında bir gölgelendiricinin (shader) kullanabileceği sayı daha az olabilir.
+
+
+## Materyal {#material}
+
+3B yazılımlar genellikle nesnenizin köşelerinde (vertex) renklendirme ve doku kaplama gibi özellikler ayarlamanıza olanak tanır. Bu bilgiler, 3B yazılımınızdan dışa aktardığınız glTF *.gltf* veya *.glb* dosyasına yazılır. Oyununuzun gereksinimlerine bağlı olarak nesneleriniz için uygun ve _iyi performans gösteren_ materyaller seçmeniz ve/veya oluşturmanız gerekir. Bir materyal, _gölgelendirici programlarını_ (shader program) nesnenin işlenmesi için kullanılan bir dizi parametreyle birleştirir.
+
+Başlangıç noktası olarak kullanabileceğiniz birkaç yerleşik materyal vardır:
+
+  * Örnek oluşturma (instancing) kullanılmayan statik modeller için *model.material* kullanın
+  * Örnek oluşturma kullanılan statik modeller için *model_instanced.material* kullanın
+  * İskelete bağlı (animasyonlu), örnek oluşturma kullanılmayan modeller için *model_skinned.material* kullanın
+  * İskelete bağlı (animasyonlu), örnek oluşturma kullanılan modeller için *model_skinned_instanced.material* kullanın
+
+Yerleşik model materyalleri yerel köşe uzayını (local vertex space) kullanır. İskelete bağlı modellerde yerel köşe uzayı, köşe gölgelendiricisinin bir kemik matrisi dokusu kullanarak GPU üzerinde iskelete bağlama (skinning) işlemini gerçekleştirmesini sağlar; model örneği oluşturma işlemi için de yerel köşe uzayı gereklidir. Bu nedenle, GPU üzerinde iskelete bağlanan veya örnek oluşturma kullanılan modeller için tasarlanan özel bir materyalin *Local* köşe uzayı ayarını kullanması önerilir.
+
+Kemik matrisi önbelleği bir `RGBA32F` dokusu kullanır. Etkin grafik bağdaştırıcısı bu doku biçimini desteklemiyorsa Defold, yerel uzay materyali kullanan animasyonlu bir Model bileşeni oluşturamaz. Bu nedenle OpenGL ES 2.0 ve WebGL 1.0 üzerindeki destek, bağdaştırıcının kayan noktalı doku uzantısına bağlıdır. Bu uzantıya sahip olmayan bir bağdaştırıcıyla uyumluluk için, CPU üzerinde iskelete bağlama yapan ve model örneği oluşturmayı desteklemeyen özel bir dünya uzayı materyali kullanın. Önbellek boyutları [Model proje ayarları](/manuals/project-settings/#model) ile ayarlanabilir.
+
+Modelleriniz için özel materyaller oluşturmanız gerekiyorsa bilgi için [Materyal belgelerine](/manuals/material) bakın. [Gölgelendirici kılavuzu](/manuals/shader), gölgelendirici programlarının nasıl çalıştığı hakkında bilgi içerir.
+
+
+### Materyal sabitleri
+
+{% include shared/material-constants.md component='model' variable='tint' %}
+
+`tint`
+: Modelin renk çarpanı (`vector4`). Renk çarpanı `vector4` ile temsil edilir; x, y, z ve w sırasıyla kırmızı, yeşil, mavi ve alfa renk çarpanlarına karşılık gelir.
+
+
+## İşleme
+
+Varsayılan işleme betiği (render script), 2B oyunlar için özel olarak hazırlanmıştır ve 3B modellerle çalışmaz. Ancak varsayılan işleme betiğini kopyalayıp betiğe birkaç satır kod ekleyerek modellerinizin işlenmesini etkinleştirebilirsiniz. Örneğin:
+
+  ```lua
+
+  function init(self)
+    self.model_pred = render.predicate({"model"})
+    ...
+  end
+
+  function update()
+    ...
+    render.set_depth_mask(true)
+    render.enable_state(graphics.STATE_DEPTH_TEST)
+    render.set_projection(stretch_projection(-1000, 1000))  -- orthographic
+    render.draw(self.model_pred)
+    render.set_depth_mask(false)
+    ...
+  end
+  ```
+
+İşleme betiklerinin nasıl çalıştığına ilişkin ayrıntılar için [İşleme belgelerine](/manuals/render) bakın.

--- a/docs/tr/manuals/models.md
+++ b/docs/tr/manuals/models.md
@@ -1,0 +1,12 @@
+---
+title: Kullanımdan kaldırılan 3B modeller belgesi
+brief: Bu belgenin yerini başka belgeler almıştır
+---
+
+# Modeller
+
+Bu belgenin yerini aşağıdaki kılavuzlar almıştır:
+
+* [3B grafiklere genel bakış](/manuals/3dgraphics)
+* [3B model bileşeni kılavuzu](/manuals/model)
+* [3B model animasyonu kılavuzu](/manuals/model-animation)

--- a/docs/tr/manuals/modules.md
+++ b/docs/tr/manuals/modules.md
@@ -1,0 +1,239 @@
+---
+title: Defold'da Lua modülleri
+brief: Lua modülleri, projenizi yapılandırmanıza ve yeniden kullanılabilir kütüphane kodu oluşturmanıza olanak tanır. Bu kılavuz, Defold'da bunun nasıl yapılacağını açıklar.
+---
+
+# Lua modülleri
+
+Lua modülleri (Lua modules), projenizi yapılandırmanıza ve yeniden kullanılabilir kütüphane kodu oluşturmanıza olanak tanır. Projelerinizde kod tekrarından kaçınmak genellikle iyi bir fikirdir. Defold, Lua'nın modül özelliğini kullanarak betik (script) dosyalarını başka betik dosyalarına dahil etmenizi sağlar. Böylece işlevselliği (ve verileri) harici bir betik dosyasında kapsülleyerek oyun nesnesi (game object) ve GUI betik dosyalarında yeniden kullanabilirsiniz.
+
+## Lua dosyalarını yükleme
+
+Oyun projenizin dizin yapısında herhangi bir yerde bulunan `.lua` uzantılı dosyalarda saklanan Lua kodu, `require` ile betik ve GUI betik dosyalarına yüklenebilir. Yeni bir Lua modülü dosyası oluşturmak için *Assets* görünümünde dosyayı oluşturmak istediğiniz klasöre sağ tıklayın, ardından <kbd>New... ▸ Lua Module</kbd> seçeneğini seçin. Dosyaya benzersiz bir ad verin ve <kbd>Ok</kbd> düğmesine basın:
+
+![yeni dosya](images/modules/new_name.png)
+
+Aşağıdaki kodun "`main/anim.lua`" dosyasına eklendiğini varsayalım:
+
+```lua
+function direction_animation(direction, char)
+    local d = ""
+    if direction.x > 0 then
+        d = "right"
+    elseif direction.x < 0 then
+        d = "left"
+    elseif direction.y > 0 then
+        d = "up"
+    elseif direction.y < 0 then
+        d = "down"
+    end
+    return hash(char .. "-" .. d)
+end
+```
+
+Ardından herhangi bir betik bu dosyayı `require` ile yükleyip işlevi kullanabilir:
+
+```lua
+require "main.anim"
+
+function update(self, dt)
+    -- update position, set direction etc
+    ...
+
+    -- set animation
+    local anim = direction_animation(self.dir, "player")
+    if anim ~= self.current_anim then
+        sprite.play_flipbook("#sprite", anim)
+        self.current_anim = anim
+    end
+end
+```
+
+`require` işlevi, belirtilen modülü yükler. Önce modülün zaten yüklenmiş olup olmadığını belirlemek için `package.loaded` tablosuna bakar. Modül yüklenmişse `require`, `package.loaded[module_name]` konumunda saklanan değeri döndürür. Aksi takdirde dosyayı bir yükleyici aracılığıyla yükler ve değerlendirir.
+
+`require` işlevine verilen dosya adı dizesinin sözdizimi biraz özeldir. Lua, dosya adı dizesindeki `.` karakterlerini yol ayırıcılarıyla değiştirir: macOS ve Linux'ta `/`, Windows'ta ise `\\` kullanılır.
+
+Yukarıda yaptığımız gibi durum saklamak ve işlev tanımlamak için genel kapsamı (global scope) kullanmanın genellikle iyi bir fikir olmadığını unutmayın. Ad çakışmalarına yol açma, modülün durumunu dışarıya açma veya modülü kullanan kodlar arasında bağımlılık oluşturma riski vardır.
+
+## Modüller
+
+Lua, verileri ve işlevleri kapsüllemek için _modülleri_ kullanır. Lua modülü, işlevleri ve verileri içermek için kullanılan sıradan bir Lua tablosudur. Genel kapsamı kirletmemek için tablo yerel olarak tanımlanır:
+
+```lua
+local M = {}
+
+-- private
+local message = "Hello world!"
+
+function M.hello()
+    print(message)
+end
+
+return M
+```
+
+Ardından modül kullanılabilir. Burada da modülü yerel bir değişkene atamak tercih edilir:
+
+```lua
+local m = require "mymodule"
+m.hello() --> "Hello world!"
+```
+
+## Modülleri çalışma sırasında yeniden yükleme
+
+Basit bir modülü ele alalım:
+
+```lua
+-- module.lua
+local M = {} -- creates a new table in the local scope
+M.value = 4711
+return M
+```
+
+Modülü kullanan kod ise şöyle olsun: 
+
+```lua
+local m = require "module"
+print(m.value) --> "4711" (even if "module.lua" is changed and hot reloaded)
+```
+
+Modül dosyasını çalışma sırasında yeniden yüklerseniz (hot reload) kod yeniden çalıştırılır, ancak `m.value` değişmez. Bunun nedeni nedir?
+
+İlk olarak, `module.lua` içindeki tablo yerel kapsamda (local scope) oluşturulur ve bu tabloya bir _başvuru_ modülü kullanan koda döndürülür. `module.lua` dosyasını yeniden yüklemek modül kodunu yeniden değerlendirir, ancak bu işlem `m` değişkeninin başvurduğu tabloyu güncellemek yerine yerel kapsamda yeni bir tablo oluşturur.
+
+İkinci olarak Lua, `require` ile yüklenen dosyaları önbelleğe alır. Bir dosya ilk kez yüklendiğinde [`package.loaded`](/ref/package/#package.loaded) tablosuna yerleştirilir; böylece sonraki `require` çağrılarında daha hızlı okunabilir. Dosyanın tablodaki girdisini `nil` olarak ayarlayarak dosyanın diskten yeniden okunmasını zorlayabilirsiniz: `package.loaded["my_module"] = nil`.
+
+Bir modülü çalışma sırasında doğru şekilde yeniden yüklemek için modülü yeniden yüklemeniz, önbelleği sıfırlamanız ve ardından modülü kullanan tüm dosyaları yeniden yüklemeniz gerekir. Bu, ideal bir çözüm olmaktan uzaktır.
+
+Bunun yerine, _geliştirme sırasında_ kullanabileceğiniz bir geçici çözümü düşünebilirsiniz: modül tablosunu genel kapsama yerleştirin ve dosya her değerlendirildiğinde yeni bir tablo oluşturmak yerine `M` değişkeninin genel kapsamdaki tabloya başvurmasını sağlayın. Böylece modülü yeniden yüklemek genel kapsamdaki tablonun içeriğini değiştirir:
+
+```lua
+--- module.lua
+
+-- Replace with local M = {} when done
+uniquevariable12345 = uniquevariable12345 or {}
+local M = uniquevariable12345
+
+M.value = 4711
+return M
+```
+
+## Modüller ve durum
+
+Durum tutan (stateful) modüller, modülü kullanan tüm kodlar arasında paylaşılan bir iç durum saklar ve tek örnekli yapılara (singleton) benzetilebilir:
+
+```lua
+local M = {}
+
+-- all users of the module will share this table
+local state = {}
+
+function M.do_something(foobar)
+    table.insert(state, foobar)
+end
+
+return M
+```
+
+Durum tutmayan (stateless) bir modül ise herhangi bir iç durum saklamaz. Bunun yerine, durumu, modülü kullanan kodun yerel kapsamında bulunan ayrı bir tabloya taşıyan bir mekanizma sağlar. Bunu uygulamanın birkaç farklı yolu vardır:
+
+Durum tablosu kullanma
+: Belki de en kolay yaklaşım, yalnızca durum içeren yeni bir tablo döndüren bir yapıcı işlev kullanmaktır. Durum, durum tablosunu değiştiren her işlevin ilk parametresi olarak modüle açıkça aktarılır.
+
+  ```lua
+  local M = {}
+  
+  function M.alter_state(the_state, v)
+      the_state.value = the_state.value + v
+  end
+  
+  function M.get_state(the_state)
+      return the_state.value
+  end
+  
+  function M.new(v)
+      local state = {
+          value = v
+      }
+      return state
+  end
+  
+  return M
+  ```
+  
+  Modülü şu şekilde kullanın:
+  
+  ```lua
+  local m = require "main.mymodule"
+  local my_state = m.new(42)
+  m.alter_state(my_state, 1)
+  print(m.get_state(my_state)) --> 43
+  ```
+
+Meta tablolar kullanma
+: Bir diğer yaklaşım, meta tablolar (metatables) kullanarak her çağrıldığında durumu ve modülün dışarıya açık işlevlerini içeren yeni bir tablo döndüren bir yapıcı işlev kullanmaktır:
+
+  ```lua
+  local M = {}
+  
+  function M:alter_state(v)
+      -- self is added as first argument when using : notation
+      self.value = self.value + v
+  end
+  
+  function M:get_state()
+      return self.value
+  end
+  
+  function M.new(v)
+      local state = {
+          value = v
+      }
+      return setmetatable(state, { __index = M })
+  end
+  
+  return M
+  ```
+
+  Modülü şu şekilde kullanın:
+
+  ```lua
+  local m = require "main.mymodule"
+  local my_state = m.new(42)
+  my_state:alter_state(1) -- "my_state" is added as first argument when using : notation
+  print(my_state:get_state()) --> 43
+  ```
+
+Kapanışlar kullanma
+:  Üçüncü bir yol, tüm durumu ve işlevleri içeren bir kapanış (closure) döndürmektir. Meta tablolar kullanılırken olduğu gibi örneği bir bağımsız değişken olarak (açıkça veya iki nokta üst üste işleciyle örtük olarak) aktarmak gerekmez. İşlev çağrılarının `__index` meta yöntemlerinden geçmesi gerekmediği için bu yöntem meta tablo kullanımından biraz daha hızlıdır; ancak her kapanış yöntemlerin kendi kopyasını içerdiğinden bellek tüketimi daha yüksektir.
+
+  ```lua
+  local M = {}
+  
+  function M.new(v)
+      local state = {
+          value = v
+      }
+  
+      state.alter_state = function(v)
+          state.value = state.value + v
+      end
+  
+      state.get_state = function()
+          return state.value
+      end
+  
+      return state
+  end
+  
+  return M
+  ```
+
+  Modülü şu şekilde kullanın:
+
+  ```lua
+  local m = require "main.mymodule"
+  local my_state = m.new(42)
+  my_state.alter_state(1)
+  print(my_state.get_state()) 
+  ```

--- a/docs/tr/manuals/networking.md
+++ b/docs/tr/manuals/networking.md
@@ -1,0 +1,27 @@
+---
+title: Defold'da ağ iletişimi
+brief: Bu kılavuz, uzak sunuculara nasıl bağlanılacağını ve diğer tür ağ bağlantılarının nasıl kurulacağını açıklar.
+---
+
+# Ağ iletişimi
+
+Oyunların puanları göndermek, eşleştirmeyi yönetmek veya oyun kayıtlarını bulutta saklamak gibi amaçlarla bir arka uç hizmetine (backend service) bağlanması yaygındır. Birçok oyunda, oyun istemcilerinin merkezi bir sunucu olmadan doğrudan birbirleriyle iletişim kurduğu eşler arası (peer to peer) bağlantılar da bulunur. Ağ bağlantıları ve veri alışverişi, çeşitli protokoller ve standartlar kullanılarak gerçekleştirilebilir. Defold'da ağ bağlantılarını kullanmanın farklı yolları hakkında daha fazla bilgi edinin:
+
+* [HTTP istekleri](/manuals/http-requests)
+* [Soket bağlantıları](/manuals/socket-connections)
+* [WebSocket bağlantıları](/manuals/websocket-connections)
+* [Çevrimiçi hizmetler](/manuals/online-services)
+
+
+## Teknik ayrıntılar
+
+### IPv4 ve IPv6
+
+Defold, soketler (socket) ve HTTP istekleri için IPv4 ve IPv6 bağlantılarını destekler.
+
+### Güvenli bağlantılar
+
+Defold, soketler ve HTTP istekleri için güvenli SSL bağlantılarını destekler.
+
+Defold, isteğe bağlı olarak herhangi bir güvenli bağlantının SSL sertifikasını da doğrulayabilir. SSL doğrulaması, kök CA sertifikalarının açık anahtarlarını veya kendinden imzalı bir sertifikanın açık anahtarını içeren bir PEM dosyası [SSL Certificates ayarı](/manuals/project-settings/#network)) alanında belirtildiğinde etkinleştirilir; bu alan *game.project* dosyasının Network bölümündedir. `builtins/ca-certificates` içinde kök CA sertifikalarının bir listesi bulunur, ancak yeni bir PEM dosyası oluşturmanız ve oyunun bağlandığı sunuculara göre gereken kök CA sertifikalarını kopyalayıp yapıştırmanız önerilir.
+

--- a/docs/tr/manuals/nintendo-switch.md
+++ b/docs/tr/manuals/nintendo-switch.md
@@ -1,0 +1,31 @@
+---
+title: Defold ile Nintendo Switch için geliştirme
+brief: Bu kılavuz, Nintendo Switch erişiminin nasıl alınacağını açıklar
+---
+
+# Nintendo Switch için geliştirme
+
+Nintendo lisansının getirdiği kısıtlamalar nedeniyle, Nintendo Switch platformunu destekleyen Defold sürümlerine erişim, Defold'un standart sürümüne dahil değildir. Nintendo Switch desteği sunan Defold sürümlerine erişebilmek için onaylı bir Nintendo Switch oyun geliştiricisi olmanız gerekir.
+
+
+## Nintendo Switch geliştiricisi olarak kaydolma
+
+[Nintendo Developer Portal](https://developer.nintendo.com/register) üzerinden Nintendo Switch oyun geliştiricisi olarak kaydolabilirsiniz:
+
+![](images/nintendo-switch/register-nintendo.png)
+
+Nintendo tarafından onaylandığınızda, Nintendo Developer Portal üzerindeki Tools and Middleware sayfasına erişim kazanırsınız. Bu sayfadan Defold erişimi için kaydolabilirsiniz. Defold erişimi için kaydolduğunuzda, Nintendo bize kayıtlı bir Nintendo geliştiricisi olduğunuzu doğrulayan bir e-posta gönderir.
+
+
+## Defold'da Nintendo Switch erişimi
+
+Onaylı bir Nintendo Switch geliştiricisi olduğunuzu doğruladıktan sonra aşağıdakilere erişim sağlarız:
+
+* Konsola özgü API entegrasyonlarını içeren Nintendo Switch eklentisinin (extension) kaynak koduna erişim.
+* Defold oyun motorunun Nintendo Switch desteği sunan sürümünün kaynak koduna erişim. Nintendo Switch için oyun derlemek üzere kaynak koduna erişmeniz gerekmez; ancak motorun çekirdeğine kaynak kodu katkısında bulunmak isterseniz diye bu erişimi sağlarız.
+* Nintendo Switch platformu için paketleme (bundling) desteği sunan [komut satırı aracı](/manuals/bob). Defold düzenleyicisinden paketleme desteklenmez.
+* Nintendo Switch'e özgü destek alabileceğiniz forum.
+
+
+## Sık sorulan sorular
+:[Consoles FAQ](../shared/consoles-faq.md)

--- a/docs/tr/manuals/online-services.md
+++ b/docs/tr/manuals/online-services.md
@@ -1,0 +1,26 @@
+---
+title: Çevrimiçi hizmetler
+brief: Bu kılavuz, farklı oyun ve arka uç hizmetlerine nasıl bağlanacağınızı açıklar.
+---
+# Oyun hizmetleri
+
+HTTP istekleri ve soket bağlantıları kullanarak internetteki binlerce farklı hizmete bağlanabilir ve bu hizmetlerle etkileşim kurabilirsiniz, ancak çoğu durumda yalnızca bir HTTP isteği göndermek yeterli olmaz. Genellikle bir tür kimlik doğrulama (authentication) kullanmanız gerekir; istek verilerinin belirli bir biçime getirilmesi ve yanıtın kullanılmadan önce ayrıştırılması gerekebilir. Elbette bunları kendiniz elle yapabilirsiniz, ancak bu tür işleri sizin yerinize yapan eklentiler (extensions) ve kütüphaneler (libraries) de vardır. Aşağıda, belirli arka uç (backend) hizmetleriyle daha kolay etkileşim kurmak için kullanılabilecek bazı eklentilerin listesini bulabilirsiniz:
+
+## Genel amaçlı
+* [Colyseus](https://defold.com/assets/colyseus/) - Çok oyunculu oyun istemcisi
+* [Nakama](https://defold.com/assets/nakama/) - Oyununuza kimlik doğrulama, oyuncu eşleştirme (matchmaking), veri analizi, buluta kaydetme, çok oyunculu oyun desteği, sohbet ve daha fazlasını ekleyin
+* [Photon Realtime](https://defold.com/assets/photon-realtime/) - Photon Realtime, kimlik doğrulama, oyuncu eşleştirme ve hızlı, güvenilir iletişim gibi temel özellikler için ölçeklenebilir çözümler sunar.
+* [PlayFab](https://defold.com/assets/playfabsdk/) - Oyununuza kimlik doğrulama, oyuncu eşleştirme, veri analizi, buluta kaydetme ve daha fazlasını ekleyin
+* [AWS SDK](https://github.com/britzl/aws-sdk-lua) - Amazon Web Services hizmetlerini oyununuzun içinden kullanın
+
+## Kimlik doğrulama, skor tabloları, başarımlar
+* [Google Play Game Services](https://defold.com/assets/googleplaygameservices/) - Oyununuzda kimlik doğrulama ve buluta kaydetme için Google Play Game Services hizmetlerini kullanın
+* [Steamworks](https://defold.com/assets/steamworks/) - Oyununuza Steam desteği ekleyin
+* [Apple GameKit Game Center](https://defold.com/assets/gamekit/)
+
+## Veri analizi
+* [Firebase Analytics](https://defold.com/assets/googleanalyticsforfirebase/) - Oyununuza Firebase Analytics ekleyin
+* [Game Analytics](https://gameanalytics.com/docs/item/defold-sdk) - Oyununuza GameAnalytics ekleyin
+* [Google Analytics](https://defold.com/assets/gameanalytics/) - Oyununuza Google Analytics ekleyin
+
+Daha fazla eklenti için [Asset Portal](https://www.defold.com/assets/) sayfasına göz atın!

--- a/docs/tr/manuals/optimization-battery.md
+++ b/docs/tr/manuals/optimization-battery.md
@@ -1,0 +1,18 @@
+---
+title: Bir Defold oyununda pil kullanımını optimize etme
+brief: Bu kılavuz, bir Defold oyununda pil kullanımının nasıl optimize edileceğini açıklar.
+---
+
+# Pil kullanımını optimize etme
+Pil kullanımı, özellikle mobil/elde taşınan cihazları hedefliyorsanız önem taşır. Yüksek CPU veya GPU kullanımı pili hızla tüketir ve cihazın aşırı ısınmasına neden olur.
+
+CPU ve GPU kullanımını azaltmayı öğrenmek için bir oyunun [çalışma zamanı (runtime) performansını optimize etme](/manuals/optimization-speed) konulu kılavuzlara bakın.
+
+## İvmeölçeri devre dışı bırakma
+Cihazın ivmeölçerini (accelerometer) kullanmayan bir mobil oyun oluşturuyorsanız, üretilen girdi olaylarının (input events) sayısını azaltmak için [ivmeölçeri *game.project* dosyasında devre dışı bırakmanız](/manuals/project-settings/#use-accelerometer) önerilir.
+
+# Platforma özgü optimizasyonlar
+
+## Android Device Performance Framework
+
+Android Dynamic Performance Framework, oyunların Android cihazların güç ve termal sistemleriyle daha doğrudan etkileşim kurmasını sağlayan bir API kümesidir. Android sistemlerindeki dinamik davranışı izlemek ve oyun performansını cihazları aşırı ısıtmayan, sürdürülebilir bir düzeyde optimize etmek mümkündür. Android cihazlar için geliştirdiğiniz Defold oyununda performansı izlemek ve optimize etmek için [Android Dynamic Performance Framework eklentisini](https://defold.com/extension-adpf/) kullanın.

--- a/docs/tr/manuals/optimization-memory.md
+++ b/docs/tr/manuals/optimization-memory.md
@@ -1,0 +1,28 @@
+---
+title: Bir Defold oyununun bellek kullanımını optimize etme
+brief: Bu kılavuz, bir Defold oyununun bellek kullanımının nasıl optimize edileceğini açıklar.
+---
+
+# Bellek kullanımını optimize etme
+
+## Doku sıkıştırma
+Doku sıkıştırma (texture compression) kullanmak, oyun arşivinizdeki kaynakların (resource) boyutunu azaltır; sıkıştırılmış dokular gereken GPU belleği miktarını da azaltabilir.
+
+## Dinamik yükleme
+Çoğu oyunda en azından seyrek kullanılan bir miktar içerik bulunur. Bellek kullanımı açısından bu tür içeriği her zaman bellekte yüklü tutmak anlamlı değildir; bunun yerine gerektiğinde yüklemek ve bellekten kaldırmak daha uygundur. Bu, doğal olarak, çalışma sırasında bellek kullanımı pahasına bir içeriği hemen erişilebilir tutmak ile yükleme süresi pahasına onu yüklemek arasında bir ödünleşimdir.
+
+Defold, içeriği dinamik olarak yüklemek için birkaç farklı yol sunar:
+
+* [Koleksiyon vekilleri (collection proxy)](/manuals/collection-proxy/)
+* [Dinamik koleksiyon fabrikaları (collection factory)](/manuals/collection-factory/#dynamic-loading-of-factory-resources)
+* [Dinamik fabrikalar (factory)](/manuals/factory/#dynamic-loading-of-factory-resources)
+* [Live Update](/manuals/live-update/)
+
+## Bileşen sayaçlarını optimize etme
+Defold, bellek parçalanmasını azaltmak için bir koleksiyon (collection) oluşturulduğunda bileşenler (component) ve kaynaklar için belleği tek seferde ayırır. Ayrılan bellek miktarı, *game.project* dosyasındaki çeşitli bileşen sayaçlarının yapılandırmasına bağlıdır. Bileşen ve kaynak kullanımını doğru ölçmek için [profil çıkarıcıyı (profiler)](/manuals/profiling/) kullanın ve oyununuzu, gerçek bileşen ve kaynak sayılarına daha yakın en yüksek değerleri kullanacak şekilde yapılandırın. Bu, oyununuzun kullandığı bellek miktarını azaltır (bileşenlerin [en yüksek sayılarını optimize etme](/manuals/project-settings/#component-max-count-optimizations) hakkındaki bilgilere bakın).
+
+## GUI düğümü sayısını optimize etme
+GUI dosyasındaki en fazla düğüm sayısını yalnızca gereken miktara ayarlayarak GUI düğümlerinin (node) sayısını optimize edin. [GUI bileşeni özelliklerindeki](https://defold.com/manuals/gui/#gui-properties) `Current Nodes` alanı, GUI bileşeninin kullandığı düğüm sayısını gösterir.
+
+:[HTML5 Optimizations](../shared/optimization-memory-html5.md)
+

--- a/docs/tr/manuals/optimization-size.md
+++ b/docs/tr/manuals/optimization-size.md
@@ -1,0 +1,104 @@
+---
+title: Bir Defold oyununun boyutunu optimize etme
+brief: Bu kılavuz, bir Defold oyununun boyutunun nasıl optimize edileceğini açıklar.
+---
+
+# Oyun boyutunu optimize etme
+
+Oyununuzun boyutu, web ve mobil gibi platformlarda başarıyı belirleyen kritik bir etken olabilir. Disk alanının ucuz ve genellikle bol olduğu masaüstü ve konsollarda ise daha az önem taşır.
+
+### iOS ve Android
+Apple ve Google, uygulamaların Wifi yerine mobil ağlar üzerinden indirilmesi için boyut sınırları belirlemiştir. Android'de bu sınır, [Android App Bundle](https://developer.android.com/guide/app-bundle#size_restrictions) biçiminde yayımlanan uygulamalar için 200 MB'tır. iOS'te uygulama 200 MB'tan büyükse kullanıcılara bir uyarı gösterilir, ancak kullanıcılar yine de indirmeye devam edebilir.
+
+::: sidenote
+2017 yılında yapılan bir araştırmada şu sonuç elde edilmiştir: "Bir APK'nın boyutundaki her 6 MB'lık artışta, kurulum dönüşüm oranında %1'lik bir düşüş görüyoruz." ([kaynak](https://medium.com/googleplaydev/shrinking-apks-growing-installs-5d3fcba23ce2))
+:::
+
+### HTML5
+Poki ve diğer birçok web oyunu platformu, ilk indirme boyutunun 5 MB'tan büyük olmamasını önerir.
+
+Facebook, bir Facebook Instant Game oyununun 5 saniyeden kısa sürede, tercihen 3 saniyeden kısa sürede başlamasını önerir. Bunun uygulama boyutu açısından tam olarak ne anlama geldiği açıkça tanımlanmamıştır, ancak burada 20 MB'a kadar olan boyutlardan söz ediyoruz.
+
+Oynanabilir reklamlar, reklam ağına bağlı olarak genellikle 2 ile 5 MB arasında bir boyutla sınırlıdır.
+
+## Boyut optimizasyonu stratejileri
+Uygulama boyutunu iki şekilde optimize edebilirsiniz: motorun boyutunu ve/veya oyun varlıklarının (assets) boyutunu küçülterek.
+
+Uygulamanızın boyutunu hangi öğelerin oluşturduğunu daha iyi anlamak için paketleme sırasında [bir derleme raporu oluşturabilirsiniz](/manuals/bundling/#build-reports). Oyun boyutunun büyük bölümünü seslerin ve grafiklerin oluşturması oldukça yaygındır.
+
+::: important
+Defold, uygulamanızı derlerken ve paketlerken bir bağımlılık ağacı oluşturur. Derleme sistemi, *game.project* dosyasında belirtilen başlangıç koleksiyonundan (bootstrap collection) başlayarak başvurulan her koleksiyonu (collection), oyun nesnesini (game object) ve bileşeni (component) inceler ve kullanılan varlıkların bir listesini oluşturur. Son uygulama dağıtım paketine yalnızca bu varlıklar dahil edilir. Doğrudan başvurulmayan her şey dışarıda bırakılır. Kullanılmayan varlıkların dahil edilmeyeceğini bilmek yararlı olsa da geliştirici olarak son uygulamaya nelerin dahil edildiğini, tek tek varlıkların boyutlarını ve uygulama dağıtım paketinin toplam boyutunu yine de göz önünde bulundurmanız gerekir. 
+:::
+
+## Motor boyutunu optimize etme
+Motor boyutunu küçültmenin hızlı bir yolu, motorda kullanmadığınız işlevleri kaldırmaktır. Bu işlem, ihtiyaç duymadığınız motor bileşenlerini kaldırmanıza olanak tanıyan [uygulama bildirimi dosyasında](https://defold.com/manuals/app-manifest/) yapılır. Örnekler:
+
+* Fizik - Oyununuz Box2D veya Bullet3D fiziğini kullanmıyorsa fizik motorlarını kaldırmanız kuvvetle önerilir
+* GUI, parçacık efektleri ve karo haritaları - Bu bileşenler, [App Manifest bileşen anahtarlarıyla](/manuals/app-manifest/#exclude-gui) ayrı ayrı dışarıda bırakılabilir. Dışarıda bıraktığınız her özelliğe ait bileşen başvurularını ve API çağrılarını kaldırın. Parçacık efektlerini dışarıda bırakmak, GUI sahnelerindeki parçacık düğümlerinin desteğini de kaldırır.
+* Zengin metin - Etiketlerin ve GUI metinlerinin yalnızca düz metne ihtiyacı varsa [Use Rich Text](/manuals/app-manifest/#use-rich-text) ayarını devre dışı bırakın. Bu işlem, normal metin işlemeyi (rendering) korurken zengin metin ayrıştırmasını ve stil efektlerini kaldırır.
+* LiveUpdate - Oyununuz LiveUpdate kullanmıyorsa bu özellik kaldırılabilir
+* Görüntü yükleme - Oyununuz `image.load()` kullanarak görüntüleri elle yüklemiyor ve kodlarını çözmüyorsa
+* BasisU - Oyununuz az sayıda doku (texture) içeriyorsa BasisU olmadan (uygulama bildirimi üzerinden kaldırılarak) ve doku sıkıştırması kullanılmadan alınan derlemenin boyutunu, BasisU ve sıkıştırılmış dokular kullanılan bir derlemeyle karşılaştırın. Az sayıda doku içeren oyunlarda ikili dosyanın boyutunu küçültmek ve doku sıkıştırmasını atlamak daha yararlı olabilir. Ayrıca dönüştürücüyü kullanmamak, oyununuzu çalıştırmak için gereken bellek miktarını azaltabilir.
+
+## Varlık boyutunu optimize etme
+Varlık boyutu optimizasyonunda en büyük kazanımlar genellikle seslerin ve dokuların boyutunu küçülterek elde edilir.
+
+### Sesleri optimize etme
+Defold şu biçimleri destekler:
+* .wav
+* .ogg
+* .opus
+
+Defold, 8 bit ve 16 bit PCM Wave dosyalarını destekler. Ogg Vorbis ve Ogg Opus, bir PCM bit derinliği gereksinimi yerine kendi sıkıştırılmış biçimlerini kullanır. Opus kod çözücüsü varsayılan olarak dahil edilmez; `.opus` kaynaklarını (resources) kullanmadan önce [App Manifest](/manuals/app-manifest/#sound) içinde **Include Sound Decoder: Opus** ayarını etkinleştirin.
+Ses kod çözücülerimiz, geçerli ses cihazının ihtiyaçlarına göre seslerin örnekleme hızlarını artırır veya azaltır.
+
+Ses efektleri gibi kısa sesler genellikle daha yüksek oranda sıkıştırılırken müzik dosyaları daha az sıkıştırılır.
+Defold herhangi bir sıkıştırma yapmaz; bu nedenle geliştiricinin her ses biçimi için sıkıştırmayı ayrıca yapması gerekir.
+
+Sesleri harici bir ses düzenleme yazılımında (veya örneğin [ffmpeg](https://ffmpeg.org) kullanarak komut satırında) düzenleyip kalitelerini düşürebilir veya biçimler arasında dönüştürebilirsiniz. İçeriğin boyutunu daha da küçültmek için sesleri stereodan monoya dönüştürmeyi de değerlendirin.
+
+### Dokuları optimize etme
+Oyununuzda kullanılan dokuları optimize etmek için çeşitli seçenekleriniz vardır, ancak önce bir atlasa eklenen veya karo kaynağı (tile source) olarak kullanılan görüntülerin boyutunu kontrol etmelisiniz. Görüntüleri hiçbir zaman oyununuzda gerçekten gerekenden daha büyük boyutta kullanmayın. Büyük görüntüleri içe aktarıp uygun boyuta küçültmek, doku belleğini boşa harcar ve bundan kaçınılması önerilir. Öncelikle harici bir görüntü düzenleme yazılımı kullanarak görüntülerin boyutunu oyununuzda gereken gerçek boyuta ayarlayın. Arka plan görüntüleri gibi öğelerde küçük bir görüntü kullanıp istenen boyuta büyütmek de uygun olabilir. Görüntüleri doğru boyuta küçültüp atlaslara ekledikten veya karo kaynaklarında kullanmaya başladıktan sonra atlasların kendi boyutlarını da göz önünde bulundurmanız gerekir. Kullanılabilecek en büyük atlas boyutu, platforma ve grafik donanımına göre değişir.
+
+::: sidenote
+[Bu forum gönderisi](https://forum.defold.com/t/texture-management-in-defold/8921/17?u=britzl), betikler veya üçüncü taraf yazılımlar kullanarak birden fazla görüntüyü yeniden boyutlandırmaya yönelik çeşitli ipuçları sunar.
+:::
+
+* HTML5'te [Web3D Survey projesine](https://web3dsurvey.com/webgl/parameters/MAX_TEXTURE_SIZE) bildirilen en büyük doku boyutu
+* iOS'te en büyük doku boyutu:
+  * iPad: 2048x2048
+  * iPhone 4: 2048x2048
+  * iPad 2, 3, Mini, Air, Pro: 4096x4096
+  * iPhone 4s, 5, 6+, 6s: 4096x4096
+* Android'de en büyük doku boyutu büyük ölçüde değişir, ancak genel olarak nispeten yeni tüm cihazlar en az 4096x4096 boyutunu destekler.
+
+Bir atlas çok büyükse onu birkaç küçük atlasa bölmeniz, çok sayfalı atlaslar kullanmanız veya bir doku profili (texture profile) kullanarak atlasın tamamını ölçeklemeniz gerekir. Defold'un doku profili sistemi, atlasların tamamını ölçeklemenin yanı sıra atlasın diskteki boyutunu küçültmek için sıkıştırma algoritmaları uygulamanıza da olanak tanır. [Kılavuzda doku profilleri hakkında daha fazla bilgi edinebilirsiniz](/manuals/texture-profiles/). Ne kullanacağınızı bilmiyorsanız daha sonra yapacağınız özelleştirmeler için başlangıç noktası olarak şu ayarları deneyin:
+
+* mipmaps: false
+* premultiply_alpha: true
+* format: TEXTURE_FORMAT_RGBA
+* compression_level: NORMAL
+* compression_type: COMPRESSION_TYPE_BASIS_UASTC
+
+::: sidenote
+Dokuları optimize etme ve yönetme hakkında daha fazla bilgiyi [bu forum gönderisinde](https://forum.defold.com/t/texture-management-in-defold/8921) bulabilirsiniz.
+:::
+
+### Yazı tiplerini optimize etme
+Kullanacağınız simgeleri belirleyip All Chars onay kutusunu kullanmak yerine bunları [Characters](/manuals/font/#properties) alanında belirtirseniz yazı tiplerinizin boyutu daha küçük olur.
+
+### Gerektiğinde indirmek üzere içeriği dışarıda bırakma
+Uygulamanın başlangıç boyutunu küçültmenin bir başka yolu, oyun içeriğinin bazı bölümlerini uygulama dağıtım paketinin dışında bırakıp gerektiğinde indirmektir. Defold, gerektiğinde indirmek üzere içeriği dışarıda bırakmak için Live Update adlı bir sistem sunar.
+
+Dışarıda bırakılan içerik, bölümlerin tamamından kilidi açılabilen karakterlere, görünümlere, silahlara veya araçlara kadar her şey olabilir. Oyununuz çok fazla içerik barındırıyorsa yükleme sürecini, başlangıç koleksiyonu ve ilk bölümün koleksiyonu yalnızca o bölüm için gereken asgari kaynakları içerecek şekilde düzenleyin. Bunu, "Exclude" onay kutusu etkinleştirilmiş koleksiyon vekilleri (collection proxy) veya fabrikalar (factory) kullanarak yapabilirsiniz. Kaynakları oyuncunun ilerlemesine göre ayırın. Bu yaklaşım, kaynakların verimli yüklenmesini sağlar ve başlangıçtaki bellek kullanımını düşük tutar. Daha fazla bilgi için [Live Update kılavuzuna](/manuals/live-update/) bakın.
+
+## Android'e özgü boyut optimizasyonları
+Android derlemeleri hem 32 bit hem de 64 bit CPU mimarilerini desteklemelidir. [Android için dağıtım paketi oluştururken](/manuals/android) hangi CPU mimarilerinin dahil edileceğini belirtebilirsiniz:
+
+![Android dağıtım paketini imzalama](images/android/sign_bundle.png)
+
+Varsayılan olarak bir dağıtım paketi `armv7-android` ve `arm64-android` mimarilerini içerir. Üçüncü bir mimari olan `x86_64-android` de kullanılabilir, ancak fiziksel cihazlardan çok Android emülatörleri, ChromeOS ve Windows Subsystem for Android için yararlı olduğundan varsayılan olarak dahil edilmez. Özellikle bu ortamlardan birini hedeflemeniz gerekmiyorsa dağıtım paketinin boyutunu düşük tutmak için bu seçeneği işaretlemeyin.
+
+Google Play, bir oyunun her sürümü için [birden fazla APK'yı](https://developer.android.com/google/play/publishing/multiple-apks) destekler. Bu sayede her CPU mimarisi için bir tane olmak üzere iki APK oluşturup ikisini de Google Play'e yükleyerek uygulama boyutunu küçültebilirsiniz.
+
+[APK genişletme dosyalarını](https://developer.android.com/google/play/expansion-files) ve [Live Update içeriğini](/manuals/live-update), [Asset Portal'daki APKX uzantısı](https://defold.com/assets/apkx/) sayesinde birlikte de kullanabilirsiniz.

--- a/docs/tr/manuals/optimization-speed.md
+++ b/docs/tr/manuals/optimization-speed.md
@@ -1,0 +1,89 @@
+---
+title: Bir Defold oyununun çalışma zamanı performansını optimize etme
+brief: Bu kılavuz, bir Defold oyununu yüksek ve kararlı bir kare hızında çalışacak şekilde nasıl optimize edeceğinizi açıklar.
+---
+
+# Çalışma hızını optimize etme
+Bir oyunu yüksek ve kararlı bir kare hızında çalışacak şekilde optimize etmeye girişmeden önce darboğazların nerede olduğunu bilmeniz gerekir. Oyununuzun bir karesinde en çok süreyi gerçekte ne tüketiyor? Görüntüyü oluşturan işleme (rendering) aşaması mı? Oyun mantığınız mı? Sahne grafı (scene graph) mı? Bunu belirlemek için yerleşik profil çıkarma (profiling) araçlarını kullanmanız önerilir. Oyununuzun performansından örnekler almak için [ekran üstü veya web profil çıkarıcısını](/manuals/profiling/) kullanın, ardından optimizasyon gerekip gerekmediğine ve nelerin optimize edileceğine karar verin. Neyin zaman aldığını daha iyi anladıktan sonra sorunları ele almaya başlayabilirsiniz.
+
+## Betik yürütme süresini azaltın
+Profil çıkarıcı `Script` kapsamı için yüksek değerler gösteriyorsa betik (script) yürütme süresini azaltmanız gerekir. Genel bir kural olarak, elbette her karede mümkün olduğunca az kod çalıştırmaya çalışmalısınız. Her karede `update()` ve `on_input()` içinde çok fazla kod çalıştırmanın, özellikle düşük donanımlı cihazlarda oyununuzun performansını etkilemesi muhtemeldir. İzleyebileceğiniz bazı yönergeler şunlardır:
+
+### Tepkisel kod kalıplarını kullanın
+Bir geri çağırım (callback) alabiliyorsanız değişiklikleri düzenli aralıklarla sorgulamayın. Bir nesnenin animasyonunu kendiniz yönetmeyin veya motora devredilebilecek bir işi kendiniz yapmayın (örneğin, animasyonu kendiniz yönetmek yerine `go.animate)()` kullanmak).
+
+### Çöp toplamayı azaltın
+Her karede Lua tabloları gibi çok sayıda kısa ömürlü nesne oluşturursanız bu, eninde sonunda Lua'nın çöp toplayıcısını (garbage collector) tetikler. Bu durum, kare süresinde küçük takılmalar/ani artışlar olarak kendini gösterebilir. Mümkün olduğunda tabloları yeniden kullanın ve döngüler ile benzer yapıların içinde Lua tabloları oluşturmaktan mümkün olduğunca kaçınmaya özen gösterin.
+
+### İleti ve eylem tanımlayıcılarının karma değerlerini önceden hesaplayın
+Çok sayıda ileti işliyorsanız veya çok sayıda girdi olayını ele almanız gerekiyorsa dizelerin karma (hash) değerlerini önceden hesaplamanız önerilir. Şu kod parçasını inceleyin:
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("message1") then
+        msg.post(sender, hash("message3"))
+    elseif message_id == hash("message2") then
+        msg.post(sender, hash("message4"))
+    end
+end
+```
+
+Yukarıdaki senaryoda, her ileti alındığında dizenin karma değeri yeniden oluşturulur. Karma değerlerini bir kez oluşturup ileti işlerken bunları kullanarak bu durumu iyileştirebilirsiniz:
+
+```lua
+local MESSAGE1 = hash("message1")
+local MESSAGE2 = hash("message2")
+local MESSAGE3 = hash("message3")
+local MESSAGE4 = hash("message4")
+
+function on_message(self, message_id, message, sender)
+    if message_id == MESSAGE1 then
+        msg.post(sender, MESSAGE3)
+    elseif message_id == MESSAGE2 then
+        msg.post(sender, MESSAGE4)
+    end
+end
+```
+
+### URL adreslerini tercih edin ve önbelleğe alın
+Bir oyun nesnesine (game object) veya bileşene (component) ileti gönderirken ya da bunları başka bir yolla adreslerken tanımlayıcıyı dize, karma değeri veya URL olarak verebilirsiniz. Dize veya karma değeri kullanılırsa bu değer sistem içinde bir URL adresine dönüştürülür. Bu nedenle, sistemden mümkün olan en iyi performansı elde etmek için sık kullanılan URL adreslerini önbelleğe almanız önerilir. Şu örneği inceleyin:
+
+```lua
+    local pos = go.get_position("enemy")
+    local pos = go.get_position(hash("enemy"))
+    local pos = go.get_position(msg.url("enemy"))
+    -- do something with pos
+```
+
+Her üç durumda da `enemy` tanımlayıcısına sahip oyun nesnesinin konumu alınır. İlk ve ikinci durumda tanımlayıcı (dize veya karma değeri), kullanılmadan önce bir URL adresine dönüştürülür. Bu, mümkün olan en iyi performansı elde etmek için URL adreslerini önbelleğe alıp önbellekteki sürümlerini kullanmanın daha iyi olduğunu gösterir:
+
+```lua
+    function init(self)
+        self.enemy_url = msg.url("enemy")
+    end
+
+    function update(self, dt)
+        local pos = go.get_position(self.enemy_url)
+        -- do something with pos
+    end
+```
+
+## Bir kareyi işlemek için gereken süreyi azaltın
+Profil çıkarıcı `Render` ve `Render Script` kapsamlarında yüksek değerler gösteriyorsa bir kareyi işlemek için gereken süreyi azaltmanız gerekir. Bir kareyi işlemek için gereken süreyi azaltmaya çalışırken dikkate alınacak birkaç konu vardır:
+
+* Çizim çağrılarını (draw call) azaltın - Çizim çağrılarını azaltma hakkında daha fazla bilgi için [bu forum gönderisini](https://forum.defold.com/t/draw-calls-and-defold/4674) okuyun
+* Üst üste çizimi (overdraw) azaltın
+* Gölgelendirici (shader) karmaşıklığını azaltın - GLSL optimizasyonları hakkında [Khronos'un bu makalesini](https://www.khronos.org/opengl/wiki/GLSL_Optimizations) okuyun. Ayrıca Defold'un kullandığı varsayılan gölgelendiricileri (`builtins/materials` içinde bulunurlar) değiştirebilir ve gölgelendiricinin `highp` gerektirmediği yerlerde daha düşük hassasiyet seçebilirsiniz. Çapraz derlenen GLSL ES gölgelendiricilerinde varsayılan hassasiyet, kayan noktalı değerler için `mediump`, tam sayılar için `highp` olur; bu varsayılanlar Shader proje ayarlarından değiştirilebilir. Değişken başına açıkça belirtilen niteleyiciler önceliklidir. [Gölgelendirici hassasiyeti belgelerine](/manuals/shader/#precision) bakın.
+
+## Sahne grafının karmaşıklığını azaltın
+Profil çıkarıcı `GameObject` kapsamında, daha özel olarak da `UpdateTransform` ölçüm örneğinde yüksek değerler gösteriyorsa sahne grafının karmaşıklığını azaltmanız gerekir. Yapabileceklerinizden biri şudur:
+
+* Görünmeyenleri eleme (culling) - Oyun nesneleri o anda görünür değilse bunları (ve bileşenlerini) devre dışı bırakın. Bunun nasıl belirleneceği büyük ölçüde oyunun türüne bağlıdır. 2B bir oyunda bu, dikdörtgen bir alanın dışında kalan oyun nesnelerini her zaman devre dışı bırakmak kadar basit olabilir. Bunu algılamak için bir fizik tetikleyicisi kullanabilir veya nesnelerinizi gruplara ayırabilirsiniz. Hangi nesnelerin devre dışı bırakılacağını veya etkinleştirileceğini belirledikten sonra her oyun nesnesine bir `disable` veya `enable` iletisi göndererek bunu yaparsınız.
+
+## Görüş hacmi dışında kalanları eleme
+İşleme betiği (render script), tanımlı bir sınırlayıcı kutunun (frustum) dışında kalan oyun nesnesi bileşenlerini otomatik olarak işleme dışında bırakabilir. Görüş hacmi dışında kalanları eleme (frustum culling) hakkında daha fazla bilgi için [İşleme hattı kılavuzuna](/manuals/render/#frustum-culling) bakın.
+
+# Platforma özgü optimizasyonlar
+
+## Android Device Performance Framework
+Android Dynamic Performance Framework, oyunların Android cihazların güç ve ısıl sistemleriyle daha doğrudan etkileşim kurmasını sağlayan bir API kümesidir. Android sistemlerindeki dinamik davranışı izlemek ve oyun performansını cihazları aşırı ısıtmayan, sürdürülebilir bir düzeyde optimize etmek mümkündür. Android cihazlar için geliştirdiğiniz Defold oyununun performansını izlemek ve optimize etmek üzere [Android Dynamic Performance Framework uzantısını](https://defold.com/extension-adpf/) kullanın.

--- a/docs/tr/manuals/optimization.md
+++ b/docs/tr/manuals/optimization.md
@@ -1,0 +1,12 @@
+---
+title: Defold oyununu optimize etme
+brief: Bu kılavuz, bir Defold oyununun boyut ve performans açısından nasıl optimize edileceğini açıklar.
+---
+
+# Defold oyununu optimize etme
+Hedef platformlarınızın teknik kısıtlarını anlamanız ve oyununuzu bu gereksinimleri karşılayacak şekilde tasarlamanız, geliştirmeniz ve optimize etmeniz önemlidir. Çoğu platform için dikkate alınması gereken çeşitli konular vardır:
+
+* [Oyun boyutu](/manuals/optimization-size) - Oyunun dağıtım paketinin (bundle) kabul edilebilir en büyük boyutu nedir ve kaliteden ödün vermeden oyunun boyutunu nasıl mümkün olduğunca küçültebilirsiniz?
+* [Çalışma hızı](/manuals/optimization-speed) - Hedef platformun performansı nasıldır ve oyunun en az CPU ve/veya GPU kullanımıyla kararlı bir kare hızında çalışmasını nasıl sağlayabilirsiniz?
+* [Bellek kullanımı](/manuals/optimization-memory) - Hedef platformun bellek kısıtları nelerdir ve bellek kullanımını nasıl azaltabilirsiniz?
+* [Pil kullanımı](/manuals/optimization-battery) - Bu, ağırlıklı olarak mobil/elde taşınan cihazları hedefliyorsanız odaklanmanız gereken bir konudur.

--- a/docs/tr/manuals/particlefx.md
+++ b/docs/tr/manuals/particlefx.md
@@ -1,0 +1,246 @@
+---
+title: Defold'da parçacık efektleri
+brief: Bu kılavuz, parçacık efekti bileşeninin nasıl çalıştığını ve görsel parçacık efektleri oluşturmak için nasıl düzenleneceğini açıklar.
+---
+
+# Parçacık efektleri
+
+Parçacık efektleri (particle effects), oyunların görsel etkisini artırmak için kullanılır. Bunları patlamalar, kan sıçramaları, izler, hava olayları veya başka efektler oluşturmak için kullanabilirsiniz.
+
+![ParticleFX düzenleyicisi](images/particlefx/editor.png)
+
+Parçacık efektleri, bir dizi yayıcıdan ve isteğe bağlı değiştiricilerden oluşur:
+
+Yayıcı
+: Yayıcı (emitter), belirli bir konuma yerleştirilen ve parçacıkları şekli boyunca eşit dağılımla yayan bir şekildir. Yayıcı, parçacıkların oluşturulmasını ve her bir parçacığın görüntüsünü veya animasyonunu, yaşam süresini, rengini, şeklini ve hızını denetleyen özellikler içerir.
+
+Değiştirici
+: Değiştirici (modifier), oluşturulan parçacıkların hızını etkileyerek bunların belirli bir yönde hızlanmasını veya yavaşlamasını, radyal olarak hareket etmesini ya da bir noktanın etrafında dönmesini sağlar. Değiştiriciler, tek bir yayıcının parçacıklarını veya belirli bir yayıcıyı etkileyebilir.
+
+## Efekt oluşturma
+
+*Assets* tarayıcısındaki bağlam menüsünden <kbd>New... ▸ Particle FX</kbd> seçeneğini seçin. Yeni parçacık efekti dosyasına bir ad verin. Düzenleyici, dosyayı [Scene Editor](/manuals/editor/#the-scene-editor) görünümünde açar.
+
+*Outline* bölmesinde varsayılan yayıcı gösterilir. Özelliklerini aşağıdaki *Properties* bölmesinde görmek için yayıcıyı seçin.
+
+![Varsayılan parçacıklar](images/particlefx/default.png)
+
+Efekte yeni bir yayıcı eklemek için *Outline* görünümünün köküne <kbd>sağ tıklayın</kbd> ve bağlam menüsünden <kbd>Add Emitter ▸ [type]</kbd> seçeneğini seçin. Yayıcının türünü yayıcı özelliklerinden değiştirebileceğinizi unutmayın.
+
+Yeni bir değiştirici eklemek için *Outline* görünümünde değiştiricinin yer alacağı konuma (efektin köküne veya belirli bir yayıcıya) <kbd>sağ tıklayın</kbd> ve <kbd>Add Modifier</kbd> seçeneğini, ardından değiştirici türünü seçin.
+
+![Değiştirici ekleme](images/particlefx/add_modifier.png)
+
+![Eklenecek değiştiriciyi seçme](images/particlefx/add_modifier_select.png)
+
+Efektin kökünde bulunan (bir yayıcıya alt öğe olarak bağlanmamış) bir değiştirici, efektteki tüm parçacıkları etkiler.
+
+Bir yayıcıya alt öğe olarak eklenen değiştirici yalnızca o yayıcıyı etkiler.
+
+## Efekti önizleme
+
+* Efekti önizlemek için menüden <kbd>View ▸ Play</kbd> seçeneğini seçin. Efekti düzgün görebilmek için kamerayı uzaklaştırmanız gerekebilir.
+* Efekti duraklatmak için <kbd>View ▸ Play</kbd> seçeneğini yeniden seçin.
+* Efekti durdurmak için <kbd>View ▸ Stop</kbd> seçeneğini seçin. Tekrar oynattığınızda efekt başlangıç durumundan yeniden başlar.
+
+Bir yayıcıyı veya değiştiriciyi düzenlediğinizde, efekt duraklatılmış olsa bile sonuç düzenleyicide hemen görünür:
+
+![Parçacıkları düzenleme](images/particlefx/rotate.gif)
+
+## Yayıcı özellikleri
+
+Id
+: Yayıcı tanımlayıcısı; belirli yayıcılar için işleme (rendering) sabitleri ayarlanırken kullanılır.
+
+Position/Rotation
+: Yayıcının ParticleFX bileşenine (component) göre dönüşümü.
+
+Play Mode
+: Yayıcının nasıl oynatılacağını denetler:
+  - `Once`, süresi dolduğunda yayıcıyı durdurur.
+  - `Loop`, süresi dolduğunda yayıcıyı yeniden başlatır.
+
+Size Mode
+: Kare dizisi animasyonlarının (flipbook animation) nasıl boyutlandırılacağını denetler:
+  - `Auto`, her kare dizisi animasyonu karesinin boyutunu kaynak görüntünün boyutunda tutar.
+  - `Manual`, parçacık boyutunu boyut özelliğine göre ayarlar.
+
+Emission Space
+: Oluşturulan parçacıkların bulunacağı geometrik uzay:
+  - `World`, parçacıkları yayıcıdan bağımsız olarak hareket ettirir.
+  - `Emitter`, parçacıkları yayıcıya göre hareket ettirir.
+
+Duration
+: Yayıcının kaç saniye boyunca parçacık yayacağı.
+
+Start Delay
+: Yayıcının parçacık yaymaya başlamadan önce kaç saniye bekleyeceği.
+
+Start Offset
+: Yayıcının parçacık simülasyonunda kaçıncı saniyeden başlayacağı; başka bir deyişle, efekt için ne kadar süre ön simülasyon yapacağı.
+
+Image
+: Parçacıklara doku ve animasyon uygulamak için kullanılacak görüntü dosyası (karo kaynağı veya atlas).
+
+Animation
+: *Image* dosyasından parçacıklarda kullanılacak animasyon.
+
+Material
+: Parçacıkların gölgelendirilmesinde kullanılacak materyal (material).
+
+Blend Mode
+: Kullanılabilir harmanlama modları `Alpha`, `Add` ve `Multiply` seçenekleridir.
+
+Max Particle Count
+: Bu yayıcının oluşturduğu parçacıklardan aynı anda en fazla kaç tanesinin var olabileceği.
+
+Emitter Type
+: Yayıcının şekli
+  - `Circle`, bir dairenin içindeki rastgele konumlardan parçacık yayar. Parçacıklar merkezden dışarı doğru yönlendirilir. Dairenin çapı *Emitter Size X* ile tanımlanır.
+
+  - `2D Cone`, düz bir koninin (bir üçgenin) içindeki rastgele konumlardan parçacık yayar. Parçacıklar koninin üst kısmından dışarı doğru yönlendirilir. *Emitter Size X* üst kısmın genişliğini, *Y* ise yüksekliği tanımlar.
+
+  - `Box`, bir kutunun içindeki rastgele konumlardan parçacık yayar. Parçacıklar kutunun yerel Y ekseni boyunca yukarı doğru yönlendirilir. *Emitter Size X*, *Y* ve *Z* sırasıyla genişliği, yüksekliği ve derinliği tanımlar. 2B bir dikdörtgen için Z boyutunu sıfırda tutun.
+
+  - `Sphere`, bir kürenin içindeki rastgele konumlardan parçacık yayar. Parçacıklar merkezden dışarı doğru yönlendirilir. Kürenin çapı *Emitter Size X* ile tanımlanır.
+
+  - `Cone`, 3B bir koninin içindeki rastgele konumlardan parçacık yayar. Parçacıklar koninin üst diskinden dışarı doğru yönlendirilir. *Emitter Size X* üst diskin çapını, *Y* ise koninin yüksekliğini tanımlar.
+
+  ![Yayıcı türleri](images/particlefx/emitter_types.png)
+
+Particle Orientation
+: Yayılan parçacıkların nasıl yönlendirileceği:
+  - `Default`, yönelimi birim yönelime ayarlar
+  - `Initial Direction`, yayılan parçacıkların başlangıç yönelimini korur.
+  - `Movement Direction`, parçacıkların yönelimini hızlarına göre ayarlar.
+
+Inherit Velocity
+: Yayıcının hızının ne kadarının parçacıklara aktarılacağını belirleyen ölçek değeri. Bu değer yalnızca *Space* özelliği `World` olarak ayarlandığında kullanılabilir. Yayıcının hızı her karede tahmin edilir.
+
+Stretch With Velocity
+: Parçacıklardaki uzamayı hareket yönünde ölçeklemek için işaretleyin.
+
+### Harmanlama modları
+:[blend-modes](../shared/blend-modes.md)
+
+## Anahtar kare atanabilen yayıcı özellikleri
+
+Bu özelliklerin iki alanı vardır: değer ve sapma. Sapma, oluşturulan her parçacığa rastgele uygulanan bir değişimdir. Örneğin, değer 50 ve sapma 3 ise oluşturulan her parçacık 47 ile 53 arasında (50 +/- 3) bir değer alır.
+
+![Özellik](images/particlefx/property.png)
+
+Anahtar düğmesini işaretlediğinizde, özelliğin değeri yayıcının süresi boyunca bir eğriyle denetlenir. Anahtar kare atanmış bir özelliği sıfırlamak için anahtar düğmesinin işaretini kaldırın.
+
+![Anahtar kare atanmış özellik](images/particlefx/key.png)
+
+Eğriyi değiştirmek için alt görünümdeki sekmeler arasında bulunan *Curve Editor* kullanılır. Anahtar kare atanmış özellikler *Properties* görünümünde düzenlenemez; yalnızca *Curve Editor* içinde düzenlenebilir. Eğrinin şeklini değiştirmek için noktaları ve teğetleri <kbd>tıklayıp sürükleyin</kbd>. Kontrol noktaları eklemek için eğriye <kbd>çift tıklayın</kbd>. Bir kontrol noktasını kaldırmak için üzerine <kbd>çift tıklayın</kbd>.
+
+![ParticleFX için Curve Editor](images/particlefx/curve_editor.png)
+
+Curve Editor görünümünün yakınlaştırma düzeyini tüm eğrileri gösterecek şekilde otomatik ayarlamak için <kbd>F</kbd> tuşuna basın.
+
+Aşağıdaki özelliklere yayıcının oynatma süresi boyunca anahtar kareler atanabilir:
+
+Spawn Rate
+: Saniyede yayılacak parçacık sayısı.
+
+Emitter Size X/Y/Z
+: Yayıcı şeklinin boyutları; yukarıdaki *Emitter Type* açıklamasına bakın.
+
+Particle Life Time
+: Oluşturulan her parçacığın saniye cinsinden yaşam süresi.
+
+Initial Speed
+: Oluşturulan her parçacığın başlangıç hızı.
+
+Initial Size
+: Oluşturulan her parçacığın başlangıç boyutu. *Size Mode* özelliğini `Automatic` olarak ayarlar ve görüntü kaynağı olarak bir kare dizisi animasyonu kullanırsanız bu özellik yok sayılır.
+
+Initial Red/Green/Blue/Alpha
+: Parçacıkların başlangıçtaki renk bileşeni çarpan değerleri.
+
+Initial Rotation
+: Parçacıkların başlangıçtaki dönme değerleri (derece cinsinden).
+
+Initial Stretch X/Y
+: Parçacıkların başlangıçtaki uzama değerleri (birim cinsinden).
+
+Initial Angular Velocity
+: Oluşturulan her parçacığın başlangıç açısal hızı (derece/saniye cinsinden).
+
+Aşağıdaki özelliklere parçacıkların yaşam süresi boyunca anahtar kareler atanabilir:
+
+Life Scale
+: Her parçacığın yaşamı boyunca ölçek değeri.
+
+Life Red/Green/Blue/Alpha
+: Her parçacığın yaşamı boyunca renk bileşeni çarpan değeri.
+
+Life Rotation
+: Her parçacığın yaşamı boyunca dönme değeri (derece cinsinden).
+
+Life Stretch X/Y
+: Her parçacığın yaşamı boyunca uzama değeri (birim cinsinden).
+
+Life Angular Velocity
+: Her parçacığın yaşamı boyunca açısal hızı (derece/saniye cinsinden).
+
+## Değiştiriciler
+
+Parçacıkların hızını etkileyen dört tür değiştirici bulunur:
+
+`Acceleration`
+: Genel bir yönde ivmelenme.
+
+`Drag`
+: Parçacıkların ivmesini, parçacık hızıyla orantılı olarak azaltır.
+
+`Radial`
+: Parçacıkları bir konuma doğru çeker veya o konumdan uzağa iter.
+
+`Vortex`
+: Parçacıkları kendi konumunun etrafında dairesel veya sarmal bir yönde etkiler.
+
+  ![Değiştiriciler](images/particlefx/modifiers.png)
+
+## Değiştirici özellikleri
+
+Position/Rotation
+: Değiştiricinin üst öğesine göre dönüşümü.
+
+Magnitude
+: Değiştiricinin parçacıklar üzerindeki etkisinin miktarı.
+
+Max Distance
+: Parçacıkların bu değiştiriciden etkilenebileceği en uzak mesafe. Yalnızca Radial ve Vortex için kullanılır.
+
+## Parçacık efektini denetleme
+
+Bir betikten parçacık efektini başlatmak ve durdurmak için:
+
+```lua
+-- start the effect component "particles" in the current game object
+particlefx.play("#particles")
+
+-- stop the effect component "particles" in the current game object
+particlefx.stop("#particles")
+```
+
+Bir GUI betiğinden parçacık efektini başlatma ve durdurma hakkında daha fazla bilgi için [GUI parçacık efektleri kılavuzuna](/manuals/gui-particlefx#controlling-the-effect) bakın.
+
+::: sidenote
+Bir parçacık efekti, efekt bileşeninin ait olduğu oyun nesnesi (game object) silinse bile parçacık yaymaya devam eder.
+:::
+Daha fazla bilgi için [Particle FX başvuru belgelerine](/ref/particlefx) bakın.
+
+## Materyal sabitleri
+
+Varsayılan parçacık efekti materyalinin, `particlefx.set_constant()` ile değiştirilebilen ve `particlefx.reset_constant()` ile sıfırlanabilen aşağıdaki sabitleri vardır (ayrıntılar için [Materyal kılavuzuna](/manuals/material/#vertex-and-fragment-constants) bakın):
+
+`tint`
+: Parçacık efektinin renk çarpanı (`vector4`). vector4, x, y, z ve w bileşenleri sırasıyla kırmızı, yeşil, mavi ve alfa renk çarpanlarına karşılık gelecek şekilde renk çarpanını temsil etmek için kullanılır. Bir örnek için [API başvuru belgelerine](/ref/particlefx/#particlefx.set_constant:url-constant-value) bakın.
+
+
+## Proje yapılandırması
+
+*game.project* dosyasında parçacıklarla ilgili birkaç [proje ayarı](/manuals/project-settings#particle-fx) bulunur.

--- a/docs/tr/manuals/physically-based-rendering.md
+++ b/docs/tr/manuals/physically-based-rendering.md
@@ -1,0 +1,392 @@
+---
+title: Defold'da fiziksel tabanlı işleme
+brief: Bu kılavuz, Defold'da fiziksel tabanlı işleme için materyal verilerine erişmenin temellerini açıklar.
+---
+
+# Fiziksel tabanlı işleme (PBR)
+
+Fiziksel tabanlı işleme (Physically Based Rendering, PBR), görüntü oluştururken ışığın yüzeylerle etkileşimini gerçek dünyadaki fizik ilkelerini kullanarak modelleyen bir gölgelendirme yaklaşımıdır. Farklı ortamlarda tutarlı, gerçekçi aydınlatma sağlar ve varlıkların (asset) çok çeşitli aydınlatma koşullarında doğru görünmesini mümkün kılar.
+
+Defold'un PBR uygulaması, glTF 2.0 materyal (material) belirtimini ve ilgili Khronos uzantılarını izler. glTF varlıklarını Defold'a içe aktardığınızda materyal özellikleri otomatik olarak ayrıştırılır ve çalışma sırasında gölgelendiricilerden (shader) erişilebilen yapılandırılmış materyal verileri olarak saklanır.
+
+PBR materyalleri metalik yansımalar, yüzey pürüzlülüğü, ışık geçirimi, saydam kaplama, yüzey altı saçılma, yanardönerlik gibi etkiler ve daha fazlasını içerebilir.
+
+::: sidenote
+Defold şu anda PBR materyal verilerini gölgelendiricilere sunar, ancak yerleşik bir PBR aydınlatma modeli sağlamaz. Fiziksel tabanlı işleme elde etmek için bu verileri kendi aydınlatma ve yansıma gölgelendiricilerinizde kullanabilirsiniz. Defold'a ileride varsayılan bir PBR aydınlatma modeli eklenecektir.
+:::
+
+::: sidenote
+glTF dosyalarındaki gömülü dokular (texture) şu anda Defold'da otomatik olarak atanmaz. Gölgelendiricilere yalnızca materyal parametreleri sunulur. Yine de dokuları model bileşenlerine (model component) elle atayabilir ve gölgelendiricinizde bunlardan örnekleme yapabilirsiniz.
+:::
+
+## Materyal özelliklerine genel bakış
+
+Materyal özellikleri, bir model bileşenine atanan glTF 2.0 kaynak dosyalarından ayrıştırılır. Özelliklerin tümü standart değildir. Bazıları isteğe bağlı glTF uzantıları aracılığıyla sağlanır; glTF dosyasını dışa aktarmak için kullanılan araç bu uzantıları dosyaya dahil edebilir veya etmeyebilir. İlgili uzantı aşağıda özellik adından sonra parantez içinde belirtilmiştir.
+
+Metaliklik ve pürüzlülük
+: Işığın materyalle nasıl etkileştiğini açıklar. Varsayılan PBR modelidir.
+
+Aynasal yansıma ve parlaklık (KHR_materials_pbrSpecularGlossiness)
+: Metaliklik ve pürüzlülük modeline bir alternatiftir. Genellikle eski varlıklarda kullanılır.
+
+Saydam kaplama (KHR_materials_clearcoat)
+: Kendi pürüzlülüğü ve normal haritası olan saydam bir kaplama katmanı ekler.
+
+Kırılma indisi (KHR_materials_ior)
+: Bir kırılma indisi ekler.
+
+Aynasal yansıma (KHR_materials_specular)
+: Aynasal yansımanın şiddeti ve rengi için özel bir kanal ekler.
+
+Yanardönerlik (KHR_materials_iridescence)
+: Sabun köpükleri veya inciler gibi materyaller için ince film girişimini simüle eder.
+
+Parıltı (KHR_materials_sheen)
+: Kumaş benzeri mikro yüzey yansımalarını modeller.
+
+Işık geçirimi (KHR_materials_transmission)
+: Saydam veya cam benzeri materyaller için ışık geçirimini modeller.
+
+Hacim (KHR_materials_volume)
+: Kalınlık ve zayıflama gibi hacimsel etkileri destekler.
+
+Işık yayma gücü (KHR_materials_emissive_strength)
+: Yayılan ışığın parlaklığını temel renkten bağımsız olarak denetler.
+
+Normal haritası
+: Yüzey ayrıntıları için normal haritası.
+
+Örtme haritası
+: Ortam örtme haritası.
+
+Işık yayma haritası
+: Parlayan yüzeyler için kendi ışığını yayan doku.
+
+Işık yayma çarpanı
+: Yayılan ışığın şiddeti için RGB çarpanı
+
+Alfa kesme eşiği
+: Maskeli saydamlık için eşik.
+
+Alfa modu
+: Opaque, Masked veya Blended saydamlık modları.
+
+Çift taraflı
+: Değeri true ise yüzeyin her iki tarafı da işlenir.
+
+Aydınlatmasız
+: Değeri true ise materyal aydınlatma hesaplamalarını atlar.
+
+::: sidenote
+Bu özelliklerden bazıları, materyalin nasıl işlenmesi gerektiğine ilişkin ipuçları sağlar. Bu özelliklerin (alfa kesme eşiği, alfa modu, çift taraflı ve aydınlatmasız) verilerine gölgelendiricilerden erişilebilir, ancak bu veriler materyalin Defold'da nasıl işlendiğini etkilemez.
+:::
+
+## Gölgelendiriciyle bütünleştirme
+
+PBR materyal verileri, türlere ve adlandırma kuralına göre gölgelendiricilere sunulur. PBR materyal sistemi, ayrıştırılan tüm materyal parametrelerini `PbrMaterial` adlı yapılandırılmış bir uniform bloğu aracılığıyla gölgelendiricilere sağlar. Desteklenen her glTF uzantısı, bu blok içinde `#define` bayrakları kullanılarak koşullu olarak derlenebilen bir yapıya (struct) karşılık gelir.
+
+```glsl
+uniform PbrMaterial
+{
+	// Material properties
+};
+```
+
+Materyalin çeşitli özellikleri, gölgelendiricide sabit yapılar olarak tanımlanır. Defold'un iç işleyişinde sabitler bu şekilde ayarlandığından, veriler mümkün olduğunca `vec4` değerleri içinde bir araya getirilmiştir. Verilerin bu şekilde birleştirildiği durumlar, aşağıda her özelliğe ait gölgelendirici kod parçalarında yorumlarla belirtilmiştir:
+
+```glsl
+struct PbrMetallicRoughness
+{
+    vec4 baseColorFactor;
+    // R: metallic (Default=1.0), G: roughness (Default=1.0)
+    vec4 metallicAndRoughnessFactor;
+    // R: use baseColorTexture, G: use metallicRoughnessTexture
+    vec4 metallicRoughnessTextures;
+};
+
+struct PbrSpecularGlossiness
+{
+	vec4 diffuseFactor;
+	// RGB: specular (Default=1.0), A: glossiness (Default=1.0)
+	vec4 specularAndSpecularGlossinessFactor;
+	// R: use diffuseTexture, G: use specularGlossinessTexture
+	vec4 specularGlossinessTextures;
+};
+
+struct PbrClearCoat
+{
+	// R: clearCoat (Default=0.0), G: clearCoatRoughness (Default=0.0)
+	vec4 clearCoatAndClearCoatRoughnessFactor;
+	// R: use clearCoatTexture, G: use clearCoatRoughnessTexture, B: use clearCoatNormalTexture
+	vec4 clearCoatTextures;
+};
+
+struct PbrTransmission
+{
+	// R: transmission (Default=0.0)
+	vec4 transmissionFactor;
+	// R: use transmissionTexture
+	vec4 transmissionTextures;
+};
+
+struct PbrIor
+{
+	// R: ior (Default=0.0)
+	vec4 ior;
+};
+
+struct PbrSpecular
+{
+	// RGB: specularColor, A: specularFactor (Default=1.0);
+	vec4 specularColorAndSpecularFactor;
+	// R: use specularTexture, G: use specularColorTexture
+	vec4 specularTextures;
+};
+
+struct PbrVolume
+{
+	// R: thicknessFactor (Default=0.0), RGB: attenuationColor
+	vec4 thicknessFactorAndAttenuationColor;
+	// R: attentuationDistance (Default=-1.0)
+	vec4 attenuationDistance;
+	// R: use thicknessTexture
+	vec4 volumeTextures;
+};
+
+struct PbrSheen
+{
+	// RGB: sheenColor, A: sheenRoughnessFactor (Default=0.0)
+	vec4 sheenColorAndRoughnessFactor;
+	// R: use sheenColorTexture, G: use sheenRoughnessTexture
+	vec4 sheenTextures;
+};
+
+struct PbrEmissiveStrength
+{
+	// R: emissiveStrength (Default=1.0)
+	vec4 emissiveStrength;
+};
+
+struct PbrIridescence
+{
+	// R: iridescenceFactor (Default=0.0), G: iridescenceIor (Default=1.3), B: iridescenceThicknessMin (Default=100.0), A: iridescenceThicknessMax (Default=400.0)
+	vec4 iridescenceFactorAndIorAndThicknessMinMax;
+	// R: use iridescenceTexture, G: use iridescenceThicknessTexture
+	vec4 iridescenceTextures;
+};
+```
+
+Ortak özellikler doğrudan materyalin uniform bloğunda ayarlanır (burada da verilerin `vec4` içinde bir araya getirildiğine dikkat edin).
+
+```glsl
+// Common textures
+uniform sampler2D PbrMaterial_normalTexture;
+uniform sampler2D PbrMaterial_occlusionTexture;
+uniform sampler2D PbrMaterial_emissiveTexture;
+
+uniform PbrMaterial
+{
+	// Common properties:
+
+	// R: alphaCutoff (Default=0.5), G: doubleSided (Default=false), B: unlit (Default=false)
+	vec4 pbrAlphaCutoffAndDoubleSidedAndIsUnlit;
+	// R: use normalTexture, G: use occlusionTexture, B: use emissiveTexture
+	vec4 pbrCommonTextures;
+
+	// Other properties...
+};
+```
+
+### Örnek gölgelendirici
+
+Aşağıda, tüm özellikleri ve doku bağlamaları için önerilen bir adlandırma şemasını içeren örnek bir gölgelendirici verilmiştir (bu bağlamaların yine elle yapılması gerekir). Aşağıdaki örnekte gösterildiği gibi, `PbrMaterial` bloğunun her bir üyesinin çevresinde `#define` kullanarak özellikleri kapatabileceğinizi unutmayın:
+
+```glsl
+// Feature flags, comment or remove these to slim down the shader.
+#define PBR_METALLIC_ROUGHNESS
+#define PBR_SPECULAR_GLOSSINESS
+#define PBR_CLEARCOAT
+#define PBR_TRANSMISSION
+#define PBR_IOR
+#define PBR_SPECULAR
+#define PBR_VOLUME
+#define PBR_SHEEN
+#define PBR_EMISSIVE_STRENGTH
+#define PBR_IRIDESCENCE
+
+// Common
+uniform sampler2D PbrMaterial_normalTexture;
+uniform sampler2D PbrMaterial_occlusionTexture;
+uniform sampler2D PbrMaterial_emissiveTexture;
+
+// PbrMetallicRoughness
+uniform sampler2D PbrMetallicRoughness_baseColorTexture;
+uniform sampler2D PbrMetallicRoughness_metallicRoughnessTexture;
+
+struct PbrMetallicRoughness
+{
+    vec4 baseColorFactor;
+    // R: metallic (Default=1.0), G: roughness (Default=1.0)
+    vec4 metallicAndRoughnessFactor;
+    // R: use baseColorTexture, G: use metallicRoughnessTexture
+    vec4 metallicRoughnessTextures;
+};
+
+// PbrSpecularGlossiness
+uniform sampler2D PbrSpecularGlossiness_diffuseTexture;
+uniform sampler2D PbrSpecularGlossiness_specularGlossinessTexture;
+
+struct PbrSpecularGlossiness
+{
+	vec4 diffuseFactor;
+	// RGB: specular (Default=1.0), A: glossiness (Default=1.0)
+	vec4 specularAndSpecularGlossinessFactor;
+	// R: use diffuseTexture, G: use specularGlossinessTexture
+	vec4 specularGlossinessTextures;
+};
+
+// PbrClearCoat
+uniform sampler2D PbrClearCoat_clearcoatTexture;
+uniform sampler2D PbrClearCoat_clearcoatRoughnessTexture;
+uniform sampler2D PbrClearCoat_clearcoatNormalTexture;
+
+struct PbrClearCoat
+{
+	// R: clearCoat (Default=0.0), G: clearCoatRoughness (Default=0.0)
+	vec4 clearCoatAndClearCoatRoughnessFactor;
+	// R: use clearCoatTexture, G: use clearCoatRoughnessTexture, B: use clearCoatNormalTexture
+	vec4 clearCoatTextures;
+};
+
+// PbrTransmission
+uniform sampler2D PbrTransmission_transmissionTexture;
+
+struct PbrTransmission
+{
+	// R: transmission (Default=0.0)
+	vec4 transmissionFactor;
+	// R: use transmissionTexture
+	vec4 transmissionTextures;
+};
+
+struct PbrIor
+{
+	// R: ior (Default=0.0)
+	vec4 ior;
+};
+
+// PbrSpecular
+uniform sampler2D PbrSpecular_specularTexture;
+uniform sampler2D PbrSpecular_specularColorTexture;
+
+struct PbrSpecular
+{
+	// RGB: specularColor, A: specularFactor (Default=1.0);
+	vec4 specularColorAndSpecularFactor;
+	// R: use specularTexture, G: use specularColorTexture
+	vec4 specularTextures;
+};
+
+// PbrVolume
+uniform sampler2D PbrVolume_thicknessTexture;
+
+struct PbrVolume
+{
+	// R: thicknessFactor (Default=0.0), RGB: attenuationColor
+	vec4 thicknessFactorAndAttenuationColor;
+	// R: attentuationDistance (Default=-1.0)
+	vec4 attenuationDistance;
+	// R: use thicknessTexture
+	vec4 volumeTextures;
+};
+
+// PbrSheen
+uniform sampler2D PbrSheen_sheenColorTexture;
+uniform sampler2D PbrSheen_sheenRoughnessTexture;
+
+struct PbrSheen
+{
+	// RGB: sheenColor, A: sheenRoughnessFactor (Default=0.0)
+	vec4 sheenColorAndRoughnessFactor;
+	// R: use sheenColorTexture, G: use sheenRoughnessTexture
+	vec4 sheenTextures;
+};
+
+struct PbrEmissiveStrength
+{
+	// R: emissiveStrength (Default=1.0)
+	vec4 emissiveStrength;
+};
+
+// PbrIridescence
+uniform sampler2D PbrEmissive_iridescenceTexture;
+uniform sampler2D PbrEmissive_iridescenceThicknessTexture;
+
+struct PbrIridescence
+{
+	// R: iridescenceFactor (Default=0.0), G: iridescenceIor (Default=1.3), B: iridescenceThicknessMin (Default=100.0), A: iridescenceThicknessMax (Default=400.0)
+	vec4 iridescenceFactorAndIorAndThicknessMinMax;
+	// R: use iridescenceTexture, G: use iridescenceThicknessTexture
+	vec4 iridescenceTextures;
+};
+
+uniform PbrMaterial
+{
+	// Common properties
+	// R: alphaCutoff (Default=0.5), G: doubleSided (Default=false), B: unlit (Default=false)
+	vec4 pbrAlphaCutoffAndDoubleSidedAndIsUnlit;
+	// R: use normalTexture, G: use occlusionTexture, B: use emissiveTexture
+	vec4 pbrCommonTextures;
+
+	// Features
+#ifdef PBR_METALLIC_ROUGHNESS
+	PbrMetallicRoughness  pbrMetallicRoughness;
+#endif
+#ifdef PBR_SPECULAR_GLOSSINESS
+	PbrSpecularGlossiness pbrSpecularGlossiness;
+#endif
+#ifdef PBR_CLEARCOAT
+	PbrClearCoat pbrClearCoat;
+#endif
+#ifdef PBR_TRANSMISSION
+	PbrTransmission pbrTransmission;
+#endif
+#ifdef PBR_IOR
+	PbrIor pbrIor;
+#endif
+#ifdef PBR_SPECULAR
+	PbrSpecular pbrSpecular;
+#endif
+#ifdef PBR_VOLUME
+	PbrVolume pbrVolume;
+#endif
+#ifdef PBR_SHEEN
+	PbrSheen pbrSheen;
+#endif
+#ifdef PBR_EMISSIVE_STRENGTH
+	PbrEmissiveStrength pbrEmissiveStrength;
+#endif
+#ifdef PBR_IRIDESCENCE
+	PbrIridescence pbrIridescence;
+#endif
+};
+```
+
+::: sidenote
+Materyal yapısında belirli veri alanları bulunamazsa bu özelliklere ait veriler ayarlanmaz. Örneğin, materyal yapısında `pbrClearCoat` yoksa saydam kaplama verisi ayarlanmaz. Uniform bloğu bulunamazsa işleme sırasında hiçbir veri ayarlanmaz.
+:::
+
+### Sabitler
+
+Her materyal özelliği, Defold'un iç işleyişindeki bir işleme sabitine karşılık gelir. `pbrFeature.structMember` adlandırma kalıbını izleyerek doğrudan materyal kaynağında sabitler tanımlayabilir ve varsayılan değerleri geçersiz kılabilirsiniz. glTF materyalinde karşılık gelen veriler eksikse bu değerler otomatik olarak uygulanır.
+
+![Materyal sabitleri](images/physically-based-rendering/material-constants.png)
+
+## Sonraki adımlar
+
+Materyal verilerini fiziksel tabanlı aydınlatma için kullanmak üzere, `PbrMaterial` bloğunda sağlanan parametreleri kullanarak parça gölgelendiricinizde bir BRDF uygulayın.
+Ayrıca bakınız:
+
+* [Gölgelendiriciler kılavuzu](/manuals/shader)
+* [İşleme kılavuzu](/manuals/render)
+* [glTF 2.0 belirtimi](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html)

--- a/docs/tr/manuals/physics-events.md
+++ b/docs/tr/manuals/physics-events.md
@@ -1,0 +1,143 @@
+---
+title: Defold'da çarpışma olayları
+brief: Tüm çarpışma ve etkileşim iletilerini belirtilen tek bir işleve yönlendirmek için `physics.set_event_listener()` kullanılarak çarpışma olaylarının işlenmesi merkezileştirilebilir.
+---
+
+# Defold'da fizik olaylarını işleme
+
+Defold, `physics.set_event_listener()` işleviyle fizik olaylarının (physics events) tek merkezden işlenmesini sağlar. Bu işlev, tüm fizik etkileşim olaylarını tek bir yerde işlemek için özel bir dinleyici (listener) belirlemenize olanak tanır; böylece kodunuz sadeleşir ve verimlilik artar.
+
+## Fizik dünyası dinleyicisini ayarlama
+
+Defold'da her koleksiyon vekili (collection proxy), kendine ait ayrı bir fizik dünyası (physics world) oluşturur. Bu nedenle birden çok koleksiyon vekiliyle çalışırken her biriyle ilişkili ayrı fizik dünyalarını yönetmeniz gerekir. Fizik olaylarının her dünyada doğru işlenmesini sağlamak için her koleksiyon vekilinin dünyasına özel bir fizik dünyası dinleyicisi ayarlamanız gerekir.
+
+Bu düzen, fizik olayları dinleyicisinin vekilin temsil ettiği koleksiyonun (collection) bağlamından ayarlanması gerektiği anlamına gelir. Böylece dinleyiciyi doğrudan ilgili fizik dünyasıyla ilişkilendirir ve fizik olaylarını doğru işlemesini sağlarsınız.
+
+Bir koleksiyon vekili içinde fizik dünyası dinleyicisinin nasıl ayarlanacağına ilişkin bir örnek:
+
+```lua
+function init(self)
+    -- Assuming this script is attached to a game object within the collection loaded by the proxy
+    -- Set the physics world listener for the physics world of this collection proxy
+    physics.set_event_listener(physics_world_listener)
+end
+```
+
+Bu yöntemi uygulayarak bir koleksiyon vekilinin oluşturduğu her fizik dünyasının kendine özel bir dinleyicisi olmasını sağlarsınız. Bu, birden çok koleksiyon vekili kullanan projelerde fizik olaylarının etkili biçimde işlenmesi için çok önemlidir.
+
+::: important
+Bir dinleyici ayarlandığında, bu dinleyicinin ayarlandığı fizik dünyası için artık [fizik iletileri](/manuals/physics-messages) gönderilmez.
+:::
+
+## Olay verilerinin yapısı
+
+Dinleyici, `self` ve bir `events` tablosuyla çağrılır. `events` tablosu, geri çağırım (callback) için toplanan tüm fizik olaylarını içeren bir dizidir. Her öğe, olay adının karma değerini içeren bir `type` alanına ve o olay türüne özgü ek alanlara sahip bir olay tablosudur.
+
+Olay tabloları aşağıdaki verileri içerir:
+
+1. **Temas noktası olayı (`contact_point_event`):**
+Bu olay, iki çarpışma nesnesi (collision object) arasındaki bir temas noktasını (contact point) bildirir. Darbe kuvvetlerini veya çarpışmaya özel tepkileri hesaplamak gibi ayrıntılı çarpışma işlemlerinde yararlıdır.
+
+   - `applied_impulse`: Temastan kaynaklanan itme.
+   - `distance`: Nesneler arasındaki iç içe geçme mesafesi.
+   - `a` ve `b`: Çarpışan varlıkları temsil eden nesneler; her biri şunları içerir:
+     - `position`: Temas noktasının dünya konumu (vector3).
+     - `instance_position`: Oyun nesnesi (game object) örneğinin dünya konumu (vector3).
+     - `id`: Örneğin ID değeri (hash).
+     - `group`: Çarpışma grubu (hash).
+     - `relative_velocity`: Diğer nesneye göre hız (vector3).
+     - `mass`: Kilogram cinsinden kütle (number).
+     - `normal`: Diğer nesneden dışarı doğru yönelen temas normali (vector3).
+
+2. **Çarpışma olayı (`collision_event`):**
+Bu olay, iki nesne arasında bir çarpışma gerçekleştiğini belirtir. Temas noktası olayına kıyasla daha genel bir olaydır ve temas noktaları hakkında ayrıntılı bilgi gerektirmeden çarpışmaları algılamak için idealdir.
+
+   - `a` ve `b`: Çarpışan varlıkları temsil eden nesneler; her biri şunları içerir:
+     - `position`: Dünya konumu (vector3).
+     - `id`: Örneğin ID değeri (hash).
+     - `group`: Çarpışma grubu (hash).
+
+3. **Tetikleyici olayı (`trigger_event`):** 
+Bu olay, bir nesne bir tetikleyici (trigger) nesnesiyle etkileşime girdiğinde gönderilir. Oyununuzda bir nesnenin girip çıkmasıyla bir şeylerin gerçekleşmesini sağlayan alanlar oluşturmak için yararlıdır.
+
+   - `enter`: Etkileşimin bir giriş (true) mi yoksa çıkış (false) mı olduğunu belirtir.
+   - `a` ve `b`: Tetikleyici olayına katılan nesneler; her biri şunları içerir:
+     - `id`: Örneğin ID değeri (hash).
+     - `group`: Çarpışma grubu (hash).
+
+4. **Işın sorgusu yanıtı (`ray_cast_response`):**
+Bu olay, bir ışın sorgusuna (raycast) yanıt olarak gönderilir ve ışının isabet ettiği nesne hakkında bilgi sağlar.
+
+   - `group`: İsabet edilen nesnenin çarpışma grubu (hash).
+   - `request_id`: Işın sorgusu isteğinin tanımlayıcısı (number).
+   - `position`: İsabet konumu (vector3).
+   - `fraction`: İsabetin gerçekleştiği uzaklığın ışının uzunluğuna oranı (number).
+   - `normal`: İsabet konumundaki normal (vector3).
+   - `id`: İsabet edilen nesne örneğinin ID değeri (hash).
+
+5. **Işın sorgusunun isabet etmemesi (`ray_cast_missed`):**
+Bu olay, bir ışın sorgusu hiçbir nesneye isabet etmediğinde gönderilir.
+
+   - `request_id`: İsabet etmeyen ışın sorgusu isteğinin tanımlayıcısı (number).
+
+## Kullanım örneği
+
+```lua
+local function physics_world_listener(self, events)
+    for _,event in ipairs(events) do
+        if event.type == hash("contact_point_event") then
+            -- Handle detailed contact point data
+            pprint(event)
+        elseif event.type == hash("collision_event") then
+            -- Handle general collision data
+            pprint(event)
+        elseif event.type == hash("trigger_event") then
+            -- Handle trigger interaction data
+            pprint(event)
+        elseif event.type == hash("ray_cast_response") then
+            -- Handle raycast hit data
+            pprint(event)
+        elseif event.type == hash("ray_cast_missed") then
+            -- Handle raycast miss data
+            pprint(event)
+        end
+    end
+end
+
+function init(self)
+    physics.set_event_listener(physics_world_listener)
+end
+```
+
+## Kısıtlamalar
+
+Dinleyici, olay gerçekleştiği anda eşzamanlı olarak çağrılır. Bu çağrı bir zaman adımının ortasında gerçekleşir; bu da fizik dünyasının kilitli olduğu anlamına gelir. Bu durum, fizik dünyası simülasyonlarını etkileyebilecek işlevlerin, örneğin `physics.create_joint()` işlevinin kullanılmasını imkânsız kılar.
+
+Bu kısıtlamalardan nasıl kaçınılacağını gösteren küçük bir örnek:
+```lua
+local function physics_world_listener(self, events)
+    for _,event in ipairs(events) do
+        if event.type == hash("contact_point_event") then
+            local position_a = event.a.normal * SIZE
+            local position_b =  event.b.normal * SIZE
+            local url_a = msg.url(nil, event.a.id, "collisionobject")
+            local url_b = msg.url(nil, event.b.id, "collisionobject")
+            -- fill the message in the same way arguments should be passed to `physics.create_joint()`
+            local message = {physics.JOINT_TYPE_FIXED, url_a, "joind_id", position_a, url_b, position_b, {max_length = SIZE}}
+            -- send message to the object itself
+            msg.post(".", "create_joint", message)
+        end
+    end
+end
+
+function on_message(self, message_id, message)
+    if message_id == hash("create_joint") then
+        -- unpack message with function arguments
+        physics.create_joint(unpack(message))
+    end
+end
+
+function init(self)
+    physics.set_event_listener(physics_world_listener)
+end
+```

--- a/docs/tr/manuals/physics-groups.md
+++ b/docs/tr/manuals/physics-groups.md
@@ -1,0 +1,17 @@
+---
+title: Defold'da çarpışma grupları
+brief: Fizik motoru, fizik nesnelerinizi gruplandırmanızı ve nasıl çarpışacaklarını filtrelemenizi sağlar.
+---
+
+# Grup ve maske
+
+Fizik motoru, fizik nesnelerinizi gruplandırmanızı ve nasıl çarpışacaklarını filtrelemenizi sağlar. Bu işlem, adlandırılmış _çarpışma grupları_ (collision groups) aracılığıyla yapılır. Oluşturduğunuz her çarpışma nesnesinin (collision object) diğer nesnelerle nasıl çarpışacağını iki özellik kontrol eder: *Group* ve *Mask*.
+
+İki nesne arasındaki bir çarpışmanın algılanabilmesi için her iki nesnenin de *Mask* alanında diğer nesnenin grubunu belirtmesi gerekir.
+
+![Fizik çarpışma grubu](images/physics/collision_group.png)
+
+*Mask* alanı birden fazla grup adı içerebilir; bu da karmaşık etkileşim senaryolarına olanak tanır.
+
+## Çarpışmaları algılama
+Grup ve maske ayarları birbiriyle eşleşen iki çarpışma nesnesi çarpıştığında fizik motoru, oyunlarda çarpışmalara tepki vermek için kullanılabilecek [çarpışma iletileri](/manuals/physics-messages) üretir.

--- a/docs/tr/manuals/physics-joints.md
+++ b/docs/tr/manuals/physics-joints.md
@@ -1,0 +1,61 @@
+---
+title: Defold'da fizik eklemleri
+brief: Defold, 2B fizik için eklemleri destekler. Bu kılavuz, eklemlerin nasıl oluşturulacağını ve kullanılacağını açıklar.
+---
+
+# Eklemler
+
+Eklem (joint), bir kısıt (constraint) kullanarak iki çarpışma nesnesini (collision object) birbirine bağlar. Defold, farklı API'ler aracılığıyla hem 2B hem de 3B fizikte eklemleri destekler.
+
+Bu kılavuz, `physics` modülünün sunduğu 2B eklemleri açıklar. Defold 1.13.2 sürümünden itibaren 3B projeler, [`bullet3d.constraint`](/ref/beta/bullet3d.constraint/) aracılığıyla menteşeler, kayar eklemler ve yaylar dahil çeşitli kısıtlar oluşturabilir ve bunları kontrol edebilir. Bu API'yi, [`bullet3d.get_rigid_body()`](/ref/beta/bullet3d/#bullet3d.get_rigid_body) aracılığıyla elde edilen katı cisimlerle (rigid body) kullanın.
+
+2B `physics` API'sinde desteklenen eklem türleri şunlardır:
+
+* **Sabit (physics.JOINT_TYPE_FIXED)** - İki nokta arasındaki en büyük mesafeyi sınırlayan bir halat eklemidir (rope joint). Box2D'de halat eklemi (Rope joint) olarak adlandırılır.
+* **Menteşe (physics.JOINT_TYPE_HINGE)** - Menteşe eklemi (hinge joint), iki çarpışma nesnesi üzerinde bir bağlantı noktası belirler ve iki çarpışma nesnesi her zaman aynı yerde olacak şekilde onları hareket ettirir; çarpışma nesnelerinin birbirine göre dönmesi kısıtlanmaz. Menteşe eklemi, en yüksek torku ve sürati tanımlanmış bir motoru etkinleştirebilir. Box2D'de [döner eklem (Revolute joint)](https://box2d.org/documentation/group__revolute__joint.html#details) olarak adlandırılır.
+* **Kaynak (physics.JOINT_TYPE_WELD)** - Kaynak eklemi (weld joint), iki çarpışma nesnesi arasındaki tüm göreli hareketi kısıtlamaya çalışır. Kaynak eklemi, frekans ve sönümleme oranı belirlenerek yay gibi esnek hale getirilebilir. Box2D'de [kaynak eklemi (Weld joint)](https://box2d.org/documentation/group__weld__joint.html#details) olarak adlandırılır.
+* **Yay (physics.JOINT_TYPE_SPRING)** - Yay eklemi (spring joint), iki çarpışma nesnesini birbirinden sabit bir mesafede tutar. Yay eklemi, frekans ve sönümleme oranı belirlenerek yay gibi esnek hale getirilebilir. Box2D'de [mesafe eklemi (Distance joint)](https://box2d.org/documentation/group__distance__joint.html#details) olarak adlandırılır.
+* **Kayar (physics.JOINT_TYPE_SLIDER)** - Kayar eklem (slider joint), iki çarpışma nesnesinin belirtilen bir eksen boyunca birbirine göre ötelenmesine izin verir ve göreli dönmeyi önler. Box2D'de [prizmatik eklem (Prismatic joint)](https://box2d.org/documentation/group__prismatic__joint.html#details) olarak adlandırılır.
+* **Tekerlek (physics.JOINT_TYPE_WHEEL)** - Tekerlek eklemi (wheel joint), `bodyB` üzerindeki bir noktayı `bodyA` üzerindeki bir doğru üzerinde hareket edecek şekilde kısıtlar. Tekerlek eklemi ayrıca bir süspansiyon yayı sağlar. Box2D'de [tekerlek eklemi (Wheel joint)](https://box2d.org/documentation/group__wheel__joint.html#details) olarak adlandırılır.
+
+## Eklem oluşturma
+
+Burada açıklanan 2B eklemler, [`physics.create_joint()`](/ref/physics/#physics.create_joint:joint_type-collisionobject_a-joint_id-position_a-collisionobject_b-position_b-[properties]) kullanılarak program yoluyla oluşturulur:
+::: sidenote
+Düzenleyicide eklem oluşturma desteği planlanmaktadır, ancak henüz bir yayımlanma tarihi belirlenmemiştir.
+:::
+
+```lua
+-- connect two collision objects with a fixed joint constraint (rope)
+physics.create_joint(physics.JOINT_TYPE_FIXED, "obj_a#collisionobject", "my_test_joint", vmath.vector3(10, 0, 0), "obj_b#collisionobject", vmath.vector3(0, 20, 0), { max_length = 20 })
+```
+
+Yukarıdaki kod, `obj_a#collisionobject` ve `obj_b#collisionobject` çarpışma nesneleri arasında `my_test_joint` tanımlayıcısına sahip sabit bir eklem oluşturur. Eklem, `obj_a#collisionobject` çarpışma nesnesinin merkezinin 10 piksel sağına ve `obj_b#collisionobject` çarpışma nesnesinin merkezinin 20 piksel yukarısına bağlanır. Eklemin maksimum uzunluğu 20 pikseldir.
+
+## Eklem yok etme
+
+Bir eklem, [`physics.destroy_joint()`](/ref/physics/#physics.destroy_joint:collisionobject-joint_id) kullanılarak yok edilebilir:
+
+```lua
+-- destroy a joint previously connected to the first collision object
+physics.destroy_joint("obj_a#collisionobject", "my_test_joint")
+```
+
+## Eklem özelliklerini okuma ve güncelleme
+
+Bir eklemin özellikleri, [`physics.get_joint_properties()`](/ref/physics/#physics.get_joint_properties:collisionobject-joint_id) kullanılarak okunabilir ve [`physics.set_joint_properties()`](/ref/physics/#physics.set_joint_properties:collisionobject-joint_id-properties) kullanılarak ayarlanabilir:
+
+```lua
+function update(self, dt)
+    if self.accelerating then
+        local hinge_props = physics.get_joint_properties("obj_a#collisionobject", "my_hinge")
+        -- increase motor speed by 100 revolutions per second
+        hinge_props.motor_speed = hinge_props.motor_speed + 100 * 2 * math.pi * dt
+        physics.set_joint_properties("obj_a#collisionobject", "my_hinge", hinge_props)
+    end
+end
+```
+
+## Eklemin tepki kuvvetini ve torkunu alma
+
+Bir ekleme uygulanan tepki kuvveti ve tork, [`physics.get_joint_reaction_force()`](/ref/physics/#physics.get_joint_reaction_force:collisionobject-joint_id) ve [`physics.get_joint_reaction_torque()`](/ref/physics/#physics.get_joint_reaction_torque:collisionobject-joint_id) kullanılarak okunabilir.

--- a/docs/tr/manuals/physics-messages.md
+++ b/docs/tr/manuals/physics-messages.md
@@ -1,0 +1,152 @@
+---
+title: Defold'da çarpışma iletileri
+brief: İki nesne çarpıştığında motor olay geri çağırımını çağırır veya tüm alıcılara iletiler gönderir.
+---
+
+# Çarpışma iletileri
+
+İki nesne çarpıştığında motor olay geri çağırımına (event callback) bir olay (event) gönderir veya her iki nesnenin tüm alıcılarına iletiler (message) gönderir.
+
+## Olay filtreleme
+
+Üretilecek olay türleri, her nesnenin şu bayraklarıyla kontrol edilebilir:
+
+* "Generate Collision Events"
+* "Generate Contact Events"
+* "Generate Trigger Events"
+
+Bunların tümü varsayılan olarak `true` değerindedir.
+İki çarpışma nesnesi (collision object) etkileşime girdiğinde, bu onay kutularına göre kullanıcıya ileti gönderilip gönderilmeyeceğini kontrol ederiz.
+
+Örneğin, "Generate Contact Events" onay kutuları için:
+
+`physics.set_event_listener()` kullanıldığında:
+
+| Bileşen A | Bileşen B | İleti gönderilir mi? |
+|-------------|-------------|--------------|
+| ✅︎          | ✅︎          | Evet         |
+| ❌          | ✅︎          | Evet         |
+| ✅︎          | ❌          | Evet         |
+| ❌          | ❌          | Hayır        |
+
+Varsayılan ileti işleyicisi kullanıldığında:
+
+| Bileşen A | Bileşen B | İleti(ler) gönderilir mi? |
+|-------------|-------------|-------------------|
+| ✅︎          | ✅︎          | Evet (A,B) + (B,A) |
+| ❌          | ✅︎          | Evet (B,A)         |
+| ✅︎          | ❌          | Evet (A,B)         |
+| ❌          | ❌          | Hayır              |
+
+## Çarpışmaya tepki
+
+Çarpışan nesnelerden biri "dynamic", "kinematic" veya "static" türündeyse `"collision_response"` iletisi gönderilir. Bu iletinin aşağıdaki alanları doldurulur:
+
+`other_id`
+: çarpışma nesnesinin çarpıştığı nesne örneğinin (instance) tanımlayıcısı (`hash`)
+
+`other_position`
+: çarpışma nesnesinin çarpıştığı örneğin dünya uzayındaki (world space) konumu (`vector3`)
+
+`other_group`
+: diğer çarpışma nesnesinin çarpışma grubu (collision group) (`hash`)
+
+`own_group`
+: çarpışma nesnesinin çarpışma grubu (`hash`)
+
+`collision_response` iletisi, yalnızca nesnelerin gerçekte nasıl kesiştiğine dair ayrıntılara ihtiyaç duymadığınız çarpışmaları çözmek için yeterlidir; örneğin bir merminin düşmana isabet edip etmediğini algılamak istediğinizde kullanılabilir. Her karede, çarpışan her nesne çifti için bu iletilerden yalnızca bir tane gönderilir.
+
+```Lua
+function on_message(self, message_id, message, sender)
+    -- check for the message
+    if message_id == hash("collision_response") then
+        -- take action
+        print("I collided with", message.other_id)
+    end
+end
+```
+
+## Temas noktası tepkisi
+
+Çarpışan nesnelerden biri "dynamic" veya "kinematic", diğeri ise "dynamic", "kinematic" veya "static" türündeyse `"contact_point_response"` iletisi gönderilir. Bu iletinin aşağıdaki alanları doldurulur:
+
+`position`
+: temas noktasının (contact point) dünya konumu (`vector3`).
+
+`normal`
+: temas noktasının diğer nesneden geçerli nesneye doğru yönelen, dünya uzayındaki normal vektörü (`vector3`).
+
+`relative_velocity`
+: diğer nesneden gözlemlenen çarpışma nesnesinin göreli hızı (`vector3`).
+
+`distance`
+: nesneler arasındaki iç içe geçme mesafesi -- negatif değildir (`number`).
+
+`applied_impulse`
+: temasın neden olduğu itme (`number`).
+
+`life_time`
+: (*şu anda kullanılmıyor!*) temasın yaşam süresi (`number`).
+
+`mass`
+: geçerli çarpışma nesnesinin kg cinsinden kütlesi (`number`).
+
+`other_mass`
+: diğer çarpışma nesnesinin kg cinsinden kütlesi (`number`).
+
+`other_id`
+: çarpışma nesnesinin temas ettiği örneğin tanımlayıcısı (`hash`).
+
+`other_position`
+: diğer çarpışma nesnesinin dünya konumu (`vector3`).
+
+`other_group`
+: diğer çarpışma nesnesinin çarpışma grubu (`hash`).
+
+`own_group`
+: çarpışma nesnesinin çarpışma grubu (`hash`).
+
+Nesneleri tamamen ayırmanız gereken bir oyun veya uygulamada, `"contact_point_response"` iletisi ihtiyacınız olan tüm bilgileri sağlar. Ancak, çarpışmanın niteliğine bağlı olarak, çarpışan herhangi bir nesne çifti için her karede birden fazla `"contact_point_response"` iletisi alınabileceğini unutmayın. Daha fazla bilgi için [Çarpışmaları çözme kılavuzuna](/manuals/physics-resolving-collisions) bakın.
+
+```Lua
+function on_message(self, message_id, message, sender)
+    -- check for the message
+    if message_id == hash("contact_point_response") then
+        -- take action
+        if message.other_mass > 10 then
+            print("I collided with something weighing more than 10 kilos!")
+        end
+    end
+end
+```
+
+## Tetikleyici tepkisi
+
+Çarpışan nesnelerden biri "trigger" türündeyse `"trigger_response"` iletisi gönderilir. İleti, çarpışma ilk algılandığında bir kez, nesnelerin çarpışması sona erdiğinde ise bir kez daha gönderilir. Aşağıdaki alanları içerir:
+
+`other_id`
+: çarpışma nesnesinin çarpıştığı örneğin tanımlayıcısı (`hash`).
+
+`enter`
+: etkileşim tetikleyiciye giriş ise `true`, çıkış ise `false` değerini alır. (`boolean`).
+
+`other_group`
+: diğer çarpışma nesnesinin çarpışma grubu (`hash`).
+
+`own_group`
+: çarpışma nesnesinin çarpışma grubu (`hash`).
+
+```Lua
+function on_message(self, message_id, message, sender)
+    -- check for the message
+    if message_id == hash("trigger_response") then
+        if message.enter then
+            -- take action for entry
+            print("I am now inside", message.other_id)
+        else
+            -- take action for exit
+            print("I am now outside", message.other_id)
+        end
+    end
+end
+```

--- a/docs/tr/manuals/physics-objects.md
+++ b/docs/tr/manuals/physics-objects.md
@@ -1,0 +1,122 @@
+---
+title: Defold'da çarpışma nesneleri
+brief: Çarpışma nesnesi, bir oyun nesnesine fiziksel davranış kazandırmak için kullandığınız bir bileşendir. Çarpışma nesnesinin fiziksel özellikleri ve uzamsal bir şekli vardır.
+---
+
+# Çarpışma nesneleri
+
+Çarpışma nesnesi (collision object), bir oyun nesnesine (game object) fiziksel davranış kazandırmak için kullandığınız bir bileşendir (component). Çarpışma nesnesinin ağırlık, geri sekme katsayısı ve sürtünme gibi fiziksel özellikleri vardır; uzayda kapladığı bölgeyi, bileşene eklediğiniz bir veya daha fazla _şekil_ belirler. Defold aşağıdaki çarpışma nesnesi türlerini destekler:
+
+Statik nesneler
+: Statik nesneler (static objects) hiç hareket etmez, ancak statik bir nesneyle çarpışan dinamik bir nesne sekerek ve/veya kayarak tepki verir. Statik nesneler, hareket etmeyen bölüm geometrisini (örneğin zemin ve duvarları) oluşturmak için çok kullanışlıdır. Ayrıca performans açısından dinamik nesnelerden daha az kaynak tüketirler. Statik nesneleri hareket ettiremez veya başka bir şekilde değiştiremezsiniz.
+
+Dinamik nesneler
+: Dinamik nesneler (dynamic objects) fizik motoru tarafından simüle edilir. Motor tüm çarpışmaları çözümler ve ortaya çıkan kuvvetleri uygular. Dinamik nesneler, gerçekçi davranması gereken nesneler için uygundur. Bu nesneleri etkilemenin en yaygın yolu, [kuvvet uygulamak](/ref/physics/#apply_force) veya açısal [sönümleme](/ref/stable/physics/#angular_damping) ve [hız](/ref/stable/physics/#linear_velocity) ile doğrusal [sönümleme](/ref/stable/physics/#linear_damping) ve [hız](/ref/stable/physics/#angular_velocity) değerlerini değiştirmek gibi dolaylı yöntemlerdir. *game.project* dosyasında [Allow Dynamic Transforms ayarı](/manuals/project-settings/#allow-dynamic-transforms) etkinleştirildiğinde dinamik bir nesnenin konumunu ve yönelimini doğrudan değiştirmek de mümkündür.
+
+Kinematik nesneler
+: Kinematik nesneler (kinematic objects), diğer fizik nesneleriyle çarpışmaları kaydeder, ancak fizik motoru herhangi bir otomatik simülasyon gerçekleştirmez. Çarpışmaları çözümleme veya yok sayma işi size bırakılır ([daha fazla bilgi edinin](/manuals/physics-resolving-collisions)). Kinematik nesneler, oyuncu karakteri gibi fiziksel tepkileri üzerinde hassas denetim gerektiren, oyuncu veya betik tarafından kontrol edilen nesneler için çok uygundur.
+
+Tetikleyiciler
+: Tetikleyiciler (triggers), basit çarpışmaları kaydeden nesnelerdir. Tetikleyiciler, işlem yükü düşük çarpışma nesneleridir. Fizik dünyasıyla etkileşmek yerine onu okumaları bakımından [ışın sorgularına](/manuals/physics-ray-casts) benzerler. Yalnızca bir isabeti kaydetmesi gereken nesneler (mermi gibi) için veya bir nesne belirli bir noktaya ulaştığında belirli eylemleri tetiklemek istediğiniz oyun mantığının bir parçası olarak uygundurlar. Tetikleyiciler, hesaplama açısından kinematik nesnelerden daha az kaynak tüketir ve mümkün olduğunda bunların yerine kullanılmaları önerilir.
+
+
+## Çarpışma nesnesi bileşeni ekleme
+
+Çarpışma nesnesi bileşeninin *Properties* değerleri, türünü ve fiziksel özelliklerini belirler. Ayrıca fizik nesnesinin bütün şeklini tanımlayan bir veya daha fazla *Shapes* öğesi içerir.
+
+Bir oyun nesnesine çarpışma nesnesi bileşeni eklemek için:
+
+1. *Outline* görünümünde oyun nesnesine <kbd>sağ tıklayın</kbd> ve bağlam menüsünden <kbd>Add Component ▸ Collision Object</kbd> seçeneğini seçin. Bu işlem, hiç şekil içermeyen yeni bir bileşen oluşturur.
+2. Yeni bileşene <kbd>sağ tıklayın</kbd> ve <kbd>Add Shape</kbd> seçeneğini seçin, ardından bir şekil seçin: 3B fizik kullanan projelerde <kbd>Box</kbd>, <kbd>Capsule</kbd>, <kbd>Sphere</kbd>, <kbd>Hull</kbd> veya <kbd>Mesh</kbd>; 2B fizik kullanan projelerde <kbd>Box</kbd> veya <kbd>Circle</kbd>. Hull ve Mesh şekilleri Defold 1.13.2 sürümünden beri kullanılabilir ve bir glTF veya GLB sahnesindeki adlandırılmış bir örgüyü (mesh) kullanır. Bileşene birden fazla şekil ekleyebilirsiniz. Ayrıca *Collision Shape* özelliği aracılığıyla bir karo haritası (tilemap) veya `.convexshape` kaynağı kullanabilirsiniz.
+3. Şekilleri düzenlemek için taşıma, döndürme ve ölçekleme araçlarını kullanın.
+4. Bileşeni *Outline* görünümünde seçin ve çarpışma nesnesinin *Properties* değerlerini düzenleyin.
+
+![Fizik çarpışma nesnesi](images/physics/collision_object.png)
+
+
+## Çarpışma şekli ekleme
+
+Bir çarpışma bileşeni, 3B fizikte dışbükey zarflar (hulls) ve üçgen örgüler dahil birden fazla gömülü şekil içerebilir veya bir karo haritası ya da dışbükey şekil kaynağı kullanabilir. Çeşitli şekiller ve bunları bir çarpışma bileşenine ekleme hakkında daha fazla bilgi için [Çarpışma şekilleri kılavuzuna](/manuals/physics-shapes) bakın.
+
+
+## Çarpışma nesnesinin özellikleri
+
+Id
+: Bileşenin kimliği.
+
+Collision Shape
+: Bir karo haritası veya `.convexshape` kaynağı. Bir glTF veya GLB örgüsü kullanmak için bunun yerine bileşene bir Hull veya Mesh şekli ekleyin ve bu şeklin *Scene* ve *Mesh* özelliklerini ayarlayın. [Daha fazla bilgi için Çarpışma şekilleri kılavuzuna](/manuals/physics-shapes) bakın.
+
+Type
+: Çarpışma nesnesinin türü: `Dynamic`, `Kinematic`, `Static` veya `Trigger`. Nesneyi `Dynamic` olarak ayarlarsanız *Mass* özelliğini sıfırdan farklı bir değere ayarlamanız _gerekir_. `Dynamic` veya `Static` nesneler için *Friction* ve *Restitution* değerlerinin kullanım durumunuza uygun olduğunu da kontrol etmeniz önerilir.
+
+Friction
+: Sürtünme, nesnelerin birbirlerinin yüzeyinde gerçekçi biçimde kaymasını sağlar. Sürtünme değeri genellikle `0` (sürtünme yoktur---çok kaygan bir nesne) ile `1` (güçlü sürtünme---aşındırıcı bir nesne) arasında ayarlanır. Ancak herhangi bir pozitif değer geçerlidir.
+
+  Sürtünmenin şiddeti, normal kuvvetle orantılıdır (buna Coulomb sürtünmesi denir). İki şekil (`A` ve `B`) arasındaki sürtünme kuvveti hesaplanırken her iki nesnenin sürtünme değerleri geometrik ortalama alınarak birleştirilir:
+
+```math
+F = sqrt( F_A * F_B )
+```
+
+  Bu, nesnelerden birinin sürtünmesi sıfırsa aralarındaki temasın da sıfır sürtünmeli olacağı anlamına gelir.
+
+Restitution
+: Geri sekme katsayısı, nesnenin "sekme özelliğini" belirler. Değer genellikle 0 (esnek olmayan çarpışma—nesne hiç sekmez) ile 1 (tam esnek çarpışma---nesnenin hız vektörü sekme sırasında tam olarak yansıtılır) arasındadır
+
+  İki şeklin (`A` ve `B`) geri sekme katsayıları şu formülle birleştirilir:
+
+```math
+R = max( R_A, R_B )
+```
+
+  Bir şekil birden fazla noktada temas ettiğinde, Box2D yinelemeli bir çözücü kullandığı için geri sekme yaklaşık olarak simüle edilir. Box2D, sekmeden kaynaklanan titreşimleri önlemek için çarpışma hızı düşük olduğunda esnek olmayan çarpışmalar da kullanır
+
+Linear damping
+: Doğrusal sönümleme, cismin doğrusal hızını azaltır. Yalnızca temas sırasında oluşan sürtünmeden farklıdır ve nesnelere, havadan daha yoğun bir ortamda hareket ediyormuş gibi süzülme görünümü vermek için kullanılabilir. Geçerli değerler 0 ile 1 arasındadır.
+
+  Box2D, kararlılık ve performans için sönümlemeyi yaklaşık olarak hesaplar. Küçük değerlerde sönümleme etkisi zaman adımından bağımsızken daha büyük sönümleme değerlerinde bu etki zaman adımına göre değişir. Oyununuzu sabit bir zaman adımıyla çalıştırırsanız bu durum hiçbir zaman sorun oluşturmaz.
+
+Angular damping
+: Açısal sönümleme, doğrusal sönümleme gibi çalışır, ancak cismin açısal hızını azaltır. Geçerli değerler 0 ile 1 arasındadır.
+
+Locked rotation
+: Bu özellik etkinleştirildiğinde, uygulanan kuvvetler ne olursa olsun çarpışma nesnesinin dönmesi tamamen devre dışı bırakılır.
+
+Bullet
+: Bu özellik etkinleştirildiğinde, çarpışma nesnesi ile diğer dinamik çarpışma nesneleri arasında sürekli çarpışma algılama (continuous collision detection, CCD) etkinleştirilir. *Type* değeri `Dynamic` olarak ayarlanmamışsa *Bullet* özelliği yok sayılır.
+
+Group
+: Nesnenin ait olması gereken çarpışma grubunun adı. 16 farklı grubunuz olabilir ve bu grupları oyununuz için uygun gördüğünüz şekilde adlandırabilirsiniz. Örneğin `players`, `bullets`, `enemies` ve `world`. *Collision Shape* bir karo haritasına ayarlanmışsa bu alan kullanılmaz; grup adları karo kaynağından alınır. [Çarpışma grupları hakkında daha fazla bilgi edinin](/manuals/physics-groups).
+
+Mask
+: Bu nesnenin çarpışması gereken diğer _gruplar_. Bir grubun adını yazabilir veya virgülle ayrılmış bir listede birden fazla grup belirtebilirsiniz. *Mask* alanını boş bırakırsanız nesne hiçbir şeyle çarpışmaz. [Çarpışma grupları hakkında daha fazla bilgi edinin](/manuals/physics-groups).
+
+Generate Collision Events
+: Etkinleştirildiğinde bu nesnenin çarpışma olayları göndermesine izin verir
+
+Generate Contact Events
+: Etkinleştirildiğinde bu nesnenin temas olayları göndermesine izin verir
+
+Generate Trigger Events
+: Etkinleştirildiğinde bu nesnenin tetikleyici olayları göndermesine izin verir
+
+
+## Çalışma zamanı özellikleri
+
+Bir fizik nesnesinin `go.get()` ve `go.set()` kullanılarak okunabilen ve değiştirilebilen çeşitli özellikleri vardır:
+
+`angular_damping`
+: Çarpışma nesnesi bileşeninin açısal sönümleme değeri (`number`). [API başvuru belgeleri](/ref/physics/#angular_damping).
+
+`angular_velocity`
+: Çarpışma nesnesi bileşeninin geçerli açısal hızı (`vector3`). [API başvuru belgeleri](/ref/physics/#angular_velocity).
+
+`linear_damping`
+: Çarpışma nesnesinin doğrusal sönümleme değeri (`number`). [API başvuru belgeleri](/ref/physics/#linear_damping).
+
+`linear_velocity`
+: Çarpışma nesnesi bileşeninin geçerli doğrusal hızı (`vector3`). [API başvuru belgeleri](/ref/physics/#linear_velocity).
+
+`mass`
+: Çarpışma nesnesi bileşeninin tanımlı fiziksel kütlesi. SALT OKUNUR. (`number`). [API başvuru belgeleri](/ref/physics/#mass).

--- a/docs/tr/manuals/physics-ray-casts.md
+++ b/docs/tr/manuals/physics-ray-casts.md
@@ -1,0 +1,29 @@
+---
+title: Defold'da ışın sorguları
+brief: Işın sorguları, fizik dünyasını doğrusal bir ışın boyunca sorgulamak için kullanılır. Bu kılavuz bunun nasıl çalıştığını açıklar.
+---
+
+## Işın sorguları
+
+Işın sorguları (ray cast), fizik dünyasını (physics world) doğrusal bir ışın boyunca sorgulamak için kullanılır. Fizik dünyasında bir ışın sorgusu yapmak için başlangıç ve bitiş konumlarının yanı sıra sınamanın yapılacağı [bir çarpışma grubu (collision group) kümesi](/manuals/physics-groups) belirtin.
+
+Işın bir fizik nesnesine isabet ederse isabet ettiği nesne hakkında bilgi alırsınız. Işınlar dinamik, kinematik ve statik nesnelerle kesişir. Tetikleyicilerle (trigger) etkileşime girmezler.
+
+```lua
+function update(self, dt)
+  -- request ray cast
+  local my_start = vmath.vector3(0, 0, 0)
+  local my_end = vmath.vector3(100, 1000, 1000)
+  local my_groups = { hash("my_group1"), hash("my_group2") }
+
+  local result = physics.raycast(my_start, my_end, my_groups)
+  if result then
+      -- act on the hit (see 'ray_cast_response' message for all values)
+      print(result.id)
+  end
+end
+```
+
+::: sidenote
+Işın sorguları, ışının başlangıç noktasını içeren çarpışma nesnelerini (collision object) yok sayar. Bu, Box2D'nin bir kısıtlamasıdır.
+:::

--- a/docs/tr/manuals/physics-resolving-collisions.md
+++ b/docs/tr/manuals/physics-resolving-collisions.md
@@ -1,0 +1,89 @@
+---
+title: Defold'da kinematik çarpışmaları çözme
+brief: Bu kılavuz, kinematik fizik çarpışmalarının nasıl çözüleceğini açıklar.
+---
+
+# Kinematik çarpışmaları çözme
+
+Kinematik çarpışma nesnelerini (kinematic collision objects) kullanırken çarpışmaları kendiniz çözmeniz ve tepki olarak nesneleri hareket ettirmeniz gerekir. Çarpışan iki nesneyi ayırmak için basit bir uygulama şöyle görünür:
+
+```lua
+function on_message(self, message_id, message, sender)
+  -- Handle collision
+  if message_id == hash("contact_point_response") then
+    local newpos = go.get_position() + message.normal * message.distance
+    go.set_position(newpos)
+  end
+end
+```
+
+Bu kod, kinematik nesnenizi iç içe geçtiği diğer fizik nesnelerinden ayırır; ancak ayırma işlemi çoğu zaman gerekenin ötesine geçer ve birçok durumda titreme görürsünüz. Sorunu daha iyi anlamak için oyuncu karakterinin *A* ve *B* adlı iki nesneyle çarpıştığı aşağıdaki durumu ele alın:
+
+![Fizik çarpışması](images/physics/collision_multi.png)
+
+Fizik motoru, çarpışmanın gerçekleştiği karede biri *A* nesnesi, diğeri *B* nesnesi için olmak üzere birden fazla `"contact_point_response"` iletisi gönderir. Karakteri yukarıdaki basit kodda olduğu gibi her iç içe geçmeye tepki olarak hareket ettirirseniz ayırma işlemi şöyle gerçekleşir:
+
+- Karakteri, iç içe geçme mesafesine (penetration distance) göre *A* nesnesinin dışına çıkarın (siyah ok)
+- Karakteri, iç içe geçme mesafesine göre *B* nesnesinin dışına çıkarın (siyah ok)
+
+Bunların sırası değişebilir, ancak her iki durumda da sonuç aynıdır: toplam ayırma, *tek tek iç içe geçme vektörlerinin toplamına* eşittir:
+
+![Basit fizik ayırma işlemi](images/physics/separation_naive.png)
+
+Karakteri *A* ve *B* nesnelerinden doğru şekilde ayırmak için her temas noktasının (contact point) iç içe geçme mesafesini ele almanız ve önceki ayırma işlemlerinin gerekli ayrılmayı zaten tamamen veya kısmen sağlayıp sağlamadığını kontrol etmeniz gerekir.
+
+İlk temas noktası iletisinin *A* nesnesinden geldiğini ve karakteri *A* nesnesinin iç içe geçme vektörü kadar hareket ettirerek dışarı çıkardığınızı varsayın:
+
+![Fizik ayırma işleminin 1. adımı](images/physics/separation_step1.png)
+
+Bu durumda karakter, *B* nesnesinden de kısmen ayrılmış olur. *B* nesnesinden tamamen ayrılmak için gereken son telafi, yukarıdaki siyah okla gösterilmiştir. Telafi vektörünün uzunluğu, *A* nesnesinin iç içe geçme vektörünün *B* nesnesinin iç içe geçme vektörü üzerine izdüşümü (projection) alınarak hesaplanabilir:
+
+![İzdüşüm](images/physics/projection.png)
+
+```
+l = vmath.project(A, B) * vmath.length(B)
+```
+
+Telafi vektörü, *B* vektörünün uzunluğu *l* kadar azaltılarak bulunabilir. Bunu herhangi bir sayıda iç içe geçme için hesaplamak üzere, uzunluğu sıfır olan bir düzeltme vektörüyle başlayıp her temas noktası için şu adımları uygulayarak gerekli düzeltmeyi bir vektörde biriktirebilirsiniz:
+
+1. Geçerli düzeltmenin, temasın iç içe geçme vektörü üzerine izdüşümünü alın.
+2. İç içe geçme vektöründen geriye ne kadar telafi kaldığını hesaplayın (yukarıdaki formüle göre).
+3. Nesneyi telafi vektörü kadar hareket ettirin.
+4. Telafiyi biriktirilen düzeltmeye ekleyin.
+
+Tam bir uygulama şöyle görünür:
+
+```lua
+function init(self)
+  -- correction vector
+  self.correction = vmath.vector3()
+end
+
+function update(self, dt)
+  -- reset correction
+  self.correction = vmath.vector3()
+end
+
+function on_message(self, message_id, message, sender)
+  -- Handle collision
+  if message_id == hash("contact_point_response") then
+    -- Get the info needed to move out of collision. We might
+    -- get several contact points back and have to calculate
+    -- how to move out of all of them by accumulating a
+    -- correction vector for this frame:
+    if message.distance > 0 then
+      -- First, project the accumulated correction onto
+      -- the penetration vector
+      local proj = vmath.project(self.correction, message.normal * message.distance)
+      if proj < 1 then
+        -- Only care for projections that does not overshoot.
+        local comp = (message.distance - message.distance * proj) * message.normal
+        -- Apply compensation
+        go.set_position(go.get_position() + comp)
+        -- Accumulate correction done
+        self.correction = self.correction + comp
+      end
+    end
+  end
+end
+```

--- a/docs/tr/manuals/physics-shapes.md
+++ b/docs/tr/manuals/physics-shapes.md
@@ -1,0 +1,160 @@
+---
+title: Çarpışma şekilleri
+brief: Çarpışma nesneleri temel şekiller, zarflar veya üçgen örgüleri içerebilir ya da karo haritası ve dışbükey şekil kaynaklarını kullanabilir.
+---
+
+# Çarpışma şekilleri
+
+Bir çarpışma nesnesi (collision object) birden çok gömülü şekil içerebilir. 3B fizikte bunlar glTF veya GLB dosyalarından gelen zarfları (hull) ve üçgen örgülerini (triangle mesh) içerebilir. Çarpışma nesnesinin *Collision Shape* özelliği aracılığıyla bir karo haritası (tilemap) veya dışbükey şekil (convex shape) kaynağı da kullanabilirsiniz.
+
+### Temel şekiller
+Temel şekiller (primitive shapes) *kutu*, *küre* ve *kapsül* şekilleridir. Çarpışma nesnesine <kbd>sağ tıklayıp</kbd> <kbd>Add Shape</kbd> seçeneğini seçerek temel bir şekil ekleyebilirsiniz:
+
+![Temel bir şekil ekleme](images/physics/add_shape.png)
+
+## Kutu şekli
+Bir kutunun konumu, dönmesi ve boyutları (genişlik, yükseklik ve derinlik) vardır:
+
+![Kutu şekli](images/physics/box.png)
+
+## Küre şekli
+Bir kürenin konumu, dönmesi ve çapı vardır:
+
+![Küre şekli](images/physics/sphere.png)
+
+## Kapsül şekli
+Bir kapsülün konumu, dönmesi, çapı ve yüksekliği vardır:
+
+![Küre şekli](images/physics/capsule.png)
+
+::: important
+Kapsül şekilleri yalnızca 3B fizik kullanılırken desteklenir (*game.project* dosyasının Physics bölümünde yapılandırılır).
+:::
+
+### Karmaşık şekiller
+Karmaşık şekiller karo haritası geometrisini veya dışbükey zarf (convex hull) verilerini kullanabilir. Defold 1.13.2 sürümünden itibaren 3B çarpışma nesneleri glTF veya GLB sahnelerindeki örgülerden zarf ve üçgen örgüsü şekilleri de oluşturabilir.
+
+## 3B fizikte zarf ve örgü şekilleri {#hull-and-mesh-shapes-in-3d}
+
+Bir örgünün dışbükey bir yaklaşımını oluşturmak için *Hull* şeklini; çarpışmaların, bölüm geometrisindeki açıklıklar gibi içbükey alanlar da dahil olmak üzere örgünün üçgenlerini izlemesi gerektiğinde ise *Mesh* şeklini kullanın.
+
+1. *game.project* dosyasında **Physics → Type** ayarını `3D` olarak belirleyin.
+2. *Outline* görünümünde çarpışma nesnesine sağ tıklayın ve <kbd>Add Shape ▸ Hull</kbd> veya <kbd>Add Shape ▸ Mesh</kbd> seçeneğini seçin.
+3. Yeni şekli seçin ve *Scene* özelliğini bir *.gltf* veya *.glb* dosyasına ayarlayın.
+4. *Mesh* alanından adlandırılmış bir örgü seçin. Örgü listede yoksa modelleme aracınızda örgüye bir ad verin ve sahneyi yeniden dışa aktarın.
+5. Şekli, oyun nesnesinin (game object) görünür geometrisiyle hizalayacak şekilde konumlandırın ve döndürün. Gerekirse daha fazla şekil eklemek için bu adımları tekrarlayın.
+
+Seçilen örgü, kendi yerel geometrisini sağlar; glTF düğüm dönüşümleri uygulanmaz. Örgü çarpışma şekilleri, statik ve statik olmayan çarpışma nesneleri de dahil olmak üzere Bullet 3D arka ucu tarafından desteklenir. 2B fizik arka uçları tarafından desteklenmezler.
+
+Üçgen örgüsü geometrisi, çalışma zamanı şekil API'leri üzerinden yalnızca okunabilir. Üçgenlerini değiştirmek için kaynak örgüyü düzenleyin ve projeyi yeniden derleyin. Oyun nesnesinin ölçeği için [çarpışma şekillerini ölçekleme](#scaling-collision-shapes) bölümüne bakın.
+
+## Karo haritası çarpışma şekli
+Defold, bir karo haritasının kullandığı karo kaynağı (tile source) için kolayca fizik şekilleri oluşturmanızı sağlayan bir özellik içerir. [Karo kaynağı kılavuzu](/manuals/tilesource/#tile-source-collision-shapes), bir karo kaynağına çarpışma gruplarının nasıl ekleneceğini ve karoların çarpışma gruplarına nasıl atanacağını açıklar ([örnek](/examples/tilemap/collisions/)).
+
+Bir karo haritasına çarpışma eklemek için:
+
+1. Oyun nesnesine <kbd>sağ tıklayıp</kbd> <kbd>Add Component File</kbd> seçeneğini seçerek karo haritasını oyun nesnesine ekleyin. Karo haritası dosyasını seçin.
+2. Oyun nesnesine <kbd>sağ tıklayıp</kbd> <kbd>Add Component ▸ Collision Object</kbd> seçeneğini seçerek oyun nesnesine bir çarpışma nesnesi bileşeni (component) ekleyin.
+3. Bileşene şekiller eklemek yerine *Collision Shape* özelliğini *tilemap* dosyasına ayarlayın.
+4. Çarpışma nesnesi bileşeninin *Properties* ayarlarını her zamanki gibi yapılandırın.
+
+![Karo kaynağı çarpışması](images/physics/collision_tilemap.png)
+
+::: important
+Çarpışma grupları karo haritasının karo kaynağında tanımlandığı için burada *Group* özelliğinin **kullanılmadığını** unutmayın.
+:::
+
+## Dışbükey zarf şekli
+3B fizikte [yukarıdaki düzenleyici iş akışını](#hull-and-mesh-shapes-in-3d) kullanarak doğrudan bir örgüden zarf oluşturabilirsiniz. Eski `.convexshape` kaynağı da desteklenir ve harici bir düzenleyici kullanılarak noktalardan oluşturulabilir:
+
+1. Harici bir düzenleyici kullanarak dışbükey zarf şekli dosyası (`.convexshape` dosya uzantısıyla) oluşturun.
+2. Dosyayı bir metin düzenleyici veya harici araç kullanarak elle düzenleyin (aşağıya bakın)
+3. Çarpışma nesnesi bileşenine şekiller eklemek yerine *Collision Shape* özelliğini *dışbükey şekil* dosyasına ayarlayın.
+
+### Dosya biçimi
+Dışbükey zarf dosya biçimi, diğer tüm Defold dosyalarıyla aynı veri biçimini, yani protobuf metin biçimini kullanır. Bir dışbükey zarf şekli, zarfın noktalarını tanımlar. 2B fizikte noktaların saat yönünün tersine sıralanarak verilmesi önerilir. 3B fizik modunda soyut bir nokta bulutu kullanılır. 2B örneği:
+
+```
+shape_type: TYPE_HULL
+data: 200.000
+data: 100.000
+data: 0.0
+data: 400.000
+data: 100.000
+data: 0.0
+data: 400.000
+data: 300.000
+data: 0.0
+data: 200.000
+data: 300.000
+data: 0.0
+```
+
+Yukarıdaki örnek bir dikdörtgenin dört köşesini tanımlar:
+
+```
+ 200x300   400x300
+    4---------3
+    |         |
+    |         |
+    |         |
+    |         |
+    1---------2
+ 200x100   400x100
+```
+
+## Harici araçlar
+
+Çarpışma şekilleri oluşturmak için kullanılabilecek çeşitli harici araçlar vardır:
+
+* CodeAndWeb'in [Physics Editor](https://www.codeandweb.com/physicseditor/tutorials/how-to-create-physics-shapes-for-defold) aracı, sprite bileşenleri ve bunlarla eşleşen çarpışma şekilleri içeren oyun nesneleri oluşturmak için kullanılabilir.
+* [Defold Polygon Editor](https://rossgrams.itch.io/defold-polygon-editor), dışbükey zarf şekilleri oluşturmak için kullanılabilir.
+* [Physics Body Editor](https://selimanac.github.io/physics-body-editor/), dışbükey zarf şekilleri oluşturmak için kullanılabilir.
+
+
+# Çarpışma şekillerini ölçekleme {#scaling-collision-shapes}
+Çarpışma nesnesi ve şekilleri, oyun nesnesinin ölçeğini devralır. Bu davranışı devre dışı bırakmak için *game.project* dosyasının Physics bölümündeki [Allow Dynamic Transforms](/manuals/project-settings/#allow-dynamic-transforms) onay kutusunun işaretini kaldırın. Yalnızca tüm eksenlerde aynı oranda ölçeklemenin desteklendiğini ve ölçek tüm eksenlerde aynı değilse en küçük ölçek değerinin kullanılacağını unutmayın.
+
+# Çarpışma şekillerini yeniden boyutlandırma
+Temel şekiller, çalışma sırasında `physics.set_shape()` kullanılarak yeniden boyutlandırılabilir. Bu işlev, zarfın köşelerini veya üçgen örgüsü geometrisini değiştirmez. Örnek:
+
+```lua
+-- set capsule shape data
+local capsule_data = {
+  type = physics.SHAPE_TYPE_CAPSULE,
+  diameter = 10,
+  height = 20,
+}
+physics.set_shape("#collisionobject", "my_capsule_shape", capsule_data)
+
+-- set sphere shape data
+local sphere_data = {
+  type = physics.SHAPE_TYPE_SPHERE,
+  diameter = 10,
+}
+physics.set_shape("#collisionobject", "my_sphere_shape", sphere_data)
+
+-- set box shape data
+local box_data = {
+  type = physics.SHAPE_TYPE_BOX,
+  dimensions = vmath.vector3(10, 10, 5),
+}
+physics.set_shape("#collisionobject", "my_box_shape", box_data)
+```
+
+::: sidenote
+Belirtilen kimliğe sahip ve doğru türde bir şekil, çarpışma nesnesinde zaten bulunmalıdır.
+:::
+
+# Çarpışma şekillerini döndürme
+
+## 3B fizikte çarpışma şekillerini döndürme
+3B fizikte çarpışma şekilleri tüm eksenler etrafında döndürülebilir.
+
+
+## 2B fizikte çarpışma şekillerini döndürme
+2B fizikte çarpışma şekilleri yalnızca z ekseni etrafında döndürülebilir. x veya y ekseni etrafında döndürme yanlış sonuçlar verir ve bundan kaçınmanız önerilir; buna, şekli x veya y ekseni boyunca ters çevirmek için 180 derece döndürme de dahildir. Bir fizik şeklini ters çevirmek için [`physics.set_hlip(url, flip)`](/ref/stable/physics/?#physics.set_hflip:url-flip) ve [`physics.set_vlip(url, flip)`](/ref/stable/physics/?#physics.set_vflip:url-flip) kullanılması önerilir.
+
+
+# Hata ayıklama
+Çalışma sırasında çarpışma şekillerini görmek için [fizik hata ayıklamasını etkinleştirebilirsiniz](/manuals/debugging-game-logic/#debugging-problems-with-physics).

--- a/docs/tr/manuals/physics.md
+++ b/docs/tr/manuals/physics.md
@@ -1,0 +1,42 @@
+---
+title: Defold'da fizik
+brief: Defold, 2B ve 3B fizik motorları içerir. Bu motorlar, farklı türdeki çarpışma nesneleri arasındaki Newton fiziği etkileşimlerini simüle etmenizi sağlar.
+---
+
+# Fizik
+
+Defold, iki boyutlu (2B) fizik simülasyonları için [Box2D](https://box2d.org/), üç boyutlu (3B) fizik için ise Bullet içerir. [App Manifest içindeki Physics 2D ayarı](/manuals/app-manifest/#physics-2d), **Box2D Version 3**, **Box2D (Legacy Defold version)** veya **None** seçeneğini belirler. Eski uygulama varsayılandır; Box2D 3'ü kullanmak için ayrıca seçmeniz gerekir. Uygulamayı değiştirmek simülasyon sonuçlarını değiştirebilir ve sürüme özgü [Box2D proje ayarlarını](/manuals/project-settings/#box2d) yeniden düzenlemenizi gerektirebilir.
+
+Bu kılavuzlarda açıklanan bileşen (component) odaklı çarpışma nesnesi (collision object) iş akışı ve `physics` modülü, her iki Box2D uygulamasıyla da çalışır; **None** seçeneğini seçmek 2B fiziği kaldırır. Defold ayrıca 2B cisimlere, şekillere, eklemlere, zincirlere ve dünyalara doğrudan erişim için daha düşük düzeyli [`b2d`](/ref/stable/b2d/), `b2d.body`, `b2d.fixture`, `b2d.shape`, `b2d.joint`, `b2d.chain` ve `b2d.world` API'lerini sunar. Her düşük düzeyli işlev, her iki Box2D uygulamasında da mevcut değildir; her işlevin oluşturulan API belgelerini App Manifest içinde seçilen uygulamaya göre kontrol edin.
+
+Defold'da kullanılan fizik motorlarının temel kavramları şunlardır:
+
+* **Çarpışma nesneleri** - Çarpışma nesnesi, bir oyun nesnesine (game object) fiziksel davranış kazandırmak için kullandığınız bir bileşendir. Çarpışma nesnesinin ağırlık, sürtünme ve şekil gibi fiziksel özellikleri vardır. [Çarpışma nesnesi oluşturmayı öğrenin](/manuals/physics-objects).
+* **Çarpışma şekilleri (collision shapes)** - Bir çarpışma nesnesi, uzayda kapladığı alanı tanımlamak için birkaç temel şekil veya tek bir karmaşık şekil kullanabilir. [Çarpışma nesnesine şekil eklemeyi öğrenin](/manuals/physics-shapes).
+* **Çarpışma grupları (collision groups)** - Tüm çarpışma nesneleri önceden tanımlanmış bir gruba ait olmalıdır ve her çarpışma nesnesi, çarpışabileceği diğer grupların listesini belirtebilir. [Çarpışma gruplarını kullanmayı öğrenin](/manuals/physics-groups).
+* **Çarpışma iletileri (collision messages)** - İki çarpışma nesnesi çarpıştığında fizik motoru, bileşenlerin ait olduğu oyun nesnelerine iletiler gönderir. [Çarpışma iletileri hakkında daha fazla bilgi edinin](/manuals/physics-messages)
+
+Çarpışma nesnelerinin yanı sıra, daha yaygın olarak **eklem (joint)** adıyla bilinen çarpışma nesnesi **kısıtları (constraints)** da tanımlayabilirsiniz. Bunlar iki çarpışma nesnesini birbirine bağlamanızı ve nesneleri sınırlayarak veya başka şekillerde kuvvet uygulayarak fizik simülasyonundaki davranışlarını etkilemenizi sağlar. [Eklemler hakkında daha fazla bilgi edinin](/manuals/physics-joints).
+
+Ayrıca **ışın sorgusu (ray cast)** olarak bilinen işlemle fizik dünyasını doğrusal bir ışın boyunca sorgulayabilir ve okuyabilirsiniz. [Işın sorguları hakkında daha fazla bilgi edinin](/manuals/physics-ray-casts).
+
+
+## Fizik motoru simülasyonunda kullanılan birimler
+
+Fizik motoru Newton fiziğini simüle eder ve metre, kilogram ve saniye (MKS) birimleriyle iyi çalışacak şekilde tasarlanmıştır. Ayrıca fizik motoru, boyutu 0,1 ile 10 metre arasında olan hareketli nesnelerle iyi çalışacak şekilde ayarlanmıştır (statik nesneler daha büyük olabilir) ve varsayılan olarak 1 birimi (pikseli) 1 metre olarak kabul eder. Piksel ile metre arasındaki bu dönüşüm, simülasyon düzeyinde kullanışlıdır, ancak oyun oluşturma açısından pek yararlı değildir. Varsayılan ayarlarla, 200 piksel boyutundaki bir çarpışma şekli 200 metre boyutunda kabul edilir. Bu değer, en azından hareketli bir nesne için, önerilen aralığın oldukça dışındadır.
+
+Genel olarak fizik simülasyonunun, bir oyundaki nesnelerin tipik boyutlarıyla iyi çalışabilmesi için ölçeklendirilmesi gerekir. Fizik simülasyonunun ölçeği, *game.project* dosyasındaki [fizik ölçeği ayarı](/manuals/project-settings/#physics) aracılığıyla değiştirilebilir. Örneğin bu değeri 0.02 olarak ayarlamak, 200 pikselin 4 metre olarak kabul edilmesi anlamına gelir. Ölçekteki değişikliğe uyum sağlamak için yerçekiminin de (yine *game.project* dosyasında değiştirilir) artırılması gerektiğini unutmayın.
+
+
+## Fizik güncellemeleri {#physics-updates}
+
+Kararlı bir simülasyon sağlamak için fizik motorunu, kare hızına bağlı ve düzensiz olabilecek aralıklarla güncellemek yerine düzenli aralıklarla güncellemeniz önerilir. *game.project* dosyasının Physics bölümündeki [Use Fixed Timestep ayarını](/manuals/project-settings/#physics) işaretleyerek fizik için sabit aralıklı güncelleme kullanabilirsiniz. Güncelleme sıklığı, *game.project* dosyasının Engine bölümündeki [Fixed Update Frequency ayarı](/manuals/project-settings/#engine) ile denetlenir. Fizik için sabit zaman adımı kullanırken, oyununuzdaki çarpışma nesneleriyle etkileşim kurmak, örneğin onlara kuvvet uygulamak için `fixed_update(self, dt)` yaşam döngüsü işlevini kullanmanız da önerilir.
+
+
+## Dikkat edilmesi gerekenler ve yaygın sorunlar
+
+Koleksiyon vekilleri
+: Koleksiyon vekilleri (collection proxies) aracılığıyla motora birden fazla en üst düzey koleksiyon (collection) veya *oyun dünyası (game world)* yüklemek mümkündür. Bunu yaparken her en üst düzey koleksiyonun ayrı bir fizik dünyası olduğunu bilmek önemlidir. Fizik etkileşimleri ([çarpışmalar, tetikleyiciler](/manuals/physics-messages) ve [ışın sorguları](/manuals/physics-ray-casts)) yalnızca aynı dünyaya ait nesneler arasında gerçekleşir. Dolayısıyla, iki dünyadaki çarpışma nesneleri görsel olarak tam üst üste dursa bile aralarında herhangi bir fizik etkileşimi gerçekleşemez.
+
+Çarpışmaların algılanmaması
+: Çarpışmaların düzgün işlenmemesi veya algılanmamasıyla ilgili sorun yaşıyorsanız [Hata ayıklama kılavuzundaki fizik hatalarını ayıklama bölümünü](/manuals/debugging-game-logic/#debugging-problems-with-physics) mutlaka okuyun.

--- a/docs/tr/manuals/porting-guidelines.md
+++ b/docs/tr/manuals/porting-guidelines.md
@@ -1,0 +1,122 @@
+---
+title: Platformlara taşıma ve yayımlama yönergeleri
+brief: Bu kılavuz, bir oyunu yeni bir platforma taşırken veya ilk kez yayımlarken dikkat edilmesi gereken bazı noktaları ele alır.
+---
+
+# Platformlara taşıma ve yayımlama yönergeleri
+
+Bu sayfa, bir oyunu yayımlarken veya yeni bir platforma taşırken (porting) dikkat edilmesi gereken noktalar için yararlı bir kılavuz ve kontrol listesi sunar.
+
+Bir Defold oyununu yeni bir platforma taşımak veya ilk kez yayımlamak genellikle basit bir süreçtir. Teoride ilgili bölümlerin *game.project* dosyasında yapılandırıldığından emin olmak yeterlidir; ancak her platformdan en iyi şekilde yararlanmak için oyunu o platformun özelliklerine uyarlamanız önerilir.
+
+
+## Girdi
+Oyunu platformun girdi (input) yöntemlerine uyarladığınızdan emin olun. Platform destekliyorsa [oyun kumandası (gamepad)](/manuals/input-gamepads) desteği eklemeyi değerlendirin! Ayrıca oyunun bir duraklatma menüsünü desteklediğinden emin olun - bir oyun kumandasının bağlantısı aniden kesilirse oyunun duraklatılması gerekir!
+
+## Yerelleştirme
+Oyundaki tüm metinleri çevirin. Avrupa ve Amerika kıtalarında yayımlamak için en azından EFIGS dillerine (İngilizce, Fransızca, İtalyanca, Almanca ve İspanyolca) çevirmeyi değerlendirin. Oyun içinde (duraklatma menüsünden) farklı diller arasında kolayca geçiş yapılabildiğinden emin olun.
+
+::: important
+Yalnızca iOS için - [Localizations](/manuals/project-settings/#localizations) ayarını `game.project` dosyasında belirttiğinizden emin olun; çünkü `sys.get_info()` bu listede bulunmayan bir dili hiçbir zaman döndürmez.
+:::
+
+Mağaza sayfasındaki metinleri çevirin; bu, satışları olumlu etkileyecektir! Bazı platformlar, mağaza sayfasındaki metinlerin oyunun sunulduğu her ülkenin diline çevrilmesini zorunlu tutar.
+
+## Mağaza materyalleri
+
+### Uygulama simgesi
+Oyununuzun rakiplerinden ayrıştığından emin olun. Simge, potansiyel oyuncularla çoğu zaman ilk temas noktanızdır. Oyun simgeleriyle dolu bir sayfada kolayca bulunabilmelidir.
+
+### Mağaza afişleri ve görselleri
+Oyununuz için etkileyici ve heyecan verici görseller kullandığınızdan emin olun. Oyuncuların ilgisini çeken görseller oluşturmak için bir sanatçıyla çalışmaya biraz para harcamak muhtemelen buna değer.
+
+
+## Oyun kayıtları
+
+### Masaüstünde, mobilde ve web üzerinde oyun kayıtları
+Oyun kayıtları ve kaydedilen diğer durum verileri, Defold API işlevi `sys.save(filename, data)` kullanılarak kaydedilebilir ve `sys.load(filename)` kullanılarak yüklenebilir. Dosyaların kaydedilebileceği, işletim sistemine özgü bir konumun yolunu almak için `sys.get_save_file(application_id, name)` işlevini kullanabilirsiniz; bu konum genellikle oturum açmış kullanıcının ev klasöründedir.
+
+### Konsolda oyun kayıtları
+Çoğu platformda `sys.get_save_file()` ve `sys.save()` kullanmak iyi sonuç verir; ancak konsollarda farklı bir yaklaşım benimsemeniz önerilir. Konsol platformları genellikle bağlı her oyun kumandasını bir kullanıcıyla ilişkilendirir; bu nedenle oyun kayıtlarının, başarımların ve diğer özelliklerin de ilgili kullanıcıyla ilişkilendirilmesi önerilir.
+
+Oyun kumandası girdi olayları (input event), kumandanın eylemlerini konsoldaki bir kullanıcıyla ilişkilendirmek için kullanılabilecek bir kullanıcı kimliği içerir.
+
+Konsol platformları ve bunların yerel kod eklentileri (native extension), belirli bir kullanıcıyla ilişkili verileri kaydetmek ve yüklemek için platforma özgü API işlevleri sunar. Konsolda kayıt ve yükleme yaparken bu API'leri kullanın.
+
+Konsol platformlarının dosya işlemlerine yönelik API'leri genellikle eşzamansızdır (asynchronous). Konsolu da hedefleyen çok platformlu bir oyun geliştirirken, platformdan bağımsız olarak tüm dosya işlemleri eşzamansız olacak şekilde oyununuzu tasarlamanız önerilir. Örnek:
+
+```lua
+local function save_game(data, user_id, cb)
+	if console then
+		local filename = "savegame"
+		consoleapi.save(user_id, filename, data, cb)
+	else
+		local filename = sys.get_save_file("mygame", "savegame" .. user_id)
+		local success = sys.save(filename, data)
+		cb(success)
+	end
+end
+```
+
+
+## Derleme çıktıları
+
+Çökmelerde hata ayıklayabilmek için yayımlanan her sürümde [hata ayıklama sembolleri oluşturduğunuzdan](/manuals/debugging-native-code/#symbolicate-a-callstack) emin olun. Bunları uygulamanın dağıtım paketiyle (bundle) birlikte saklayın.
+
+## Uygulama optimizasyonları
+
+Uygulamanızı performans, boyut, bellek ve pil kullanımı açısından nasıl optimize edeceğinizi öğrenmek için [Optimizasyon kılavuzunu](/manuals/optimization) okuyun.
+
+
+
+## Performans
+Her zaman hedef donanımda test edin! Oyun performansını kontrol edin ve gerekirse optimize edin. Koddaki darboğazları bulmak için [profil çıkarıcıyı (profiler)](/manuals/profiling) kullanın.
+
+
+## Ekran çözünürlüğü ve yenileme hızı
+Yönelimi ve ekran çözünürlüğü sabit olan platformlarda: Oyunun hedef platformun ekran çözünürlüğünde ve en boy oranında çalıştığını kontrol edin. Ekran çözünürlüğü ve en boy oranı değişken olan platformlarda: Oyunun çeşitli ekran çözünürlüklerinde ve en boy oranlarında çalıştığını kontrol edin. Görüntü oluşturmayı yöneten işleme betiğinde (render script) ve kamerada kullanılan [görünüm izdüşümünün (view projection)](/manuals/render/#default-view-projection) türünü dikkate alın.
+
+Mobil platformlarda ya ekran yönelimini *game.project* dosyasında kilitleyin ya da oyunun hem yatay hem de dikey modda çalıştığından emin olun.
+
+* **Ekran boyutları** - *game.project* dosyasında ayarlanan varsayılan genişlik ve yükseklikten daha büyük veya daha küçük bir ekranda her şey iyi görünüyor mu?
+  * İşleme betiğinde kullanılan izdüşüm ve GUI'de kullanılan yerleşimler burada rol oynar.
+* **En boy oranları** - *game.project* dosyasında ayarlanan genişlik ve yüksekliğin belirlediği varsayılan en boy oranından farklı bir en boy oranına sahip ekranda her şey iyi görünüyor mu?
+  * İşleme betiğinde kullanılan izdüşüm ve GUI'de kullanılan yerleşimler burada rol oynar.
+* **Yenileme hızı** - Oyun, yenileme hızı 60 Hz'den yüksek olan bir ekranda iyi çalışıyor mu?
+  * vsync ve swap interval (*game.project* dosyasının Display bölümünde) 
+
+
+## Cep telefonları, çentikler ve ekran içi kamera delikleri
+Ön kameraya ve sensörlere yer açmak için ekranda küçük bir lens açıklığı (çentik veya ekran içi kamera deliği olarak da bilinir) kullanmak giderek yaygınlaşmıştır. Bir oyunu mobile taşırken kritik bilgilerin platformun güvenli alanı (safe area) içinde kaldığından emin olun.
+
+Defold, Android ve iOS'ta yerleşik güvenli alan desteğine sahiptir. Hangi karşılıklı güvenli alan kenar paylarının (insets) GUI uyarlamasını etkileyeceğini belirlemek için `gui.safe_area_mode` ayarını *game.project* dosyasında yapılandırın. Varsayılan değer olan `none`, kenar paylarını yok sayar; `long`, yatay modda sol/sağ, dikey modda üst/alt kenar paylarını uygular; `short`, diğer çifti uygular; `both` ise dört kenarın tümünü uygular. Bir GUI betiği, [`gui.set_safe_area_mode()`](/ref/gui/#gui.set_safe_area_mode) ile kendi sahnesi için proje genelindeki modu geçersiz kılabilir. Özel GUI veya işleme (rendering) mantığı için [`window.get_safe_area()`](/ref/window/#window.get_safe_area), güvenli dikdörtgeni ve her bir kenarın payını döndürür. Yerleşik güvenli alan kenar payları olmayan platformlar, pencerenin tamamını ve sıfır kenar payı döndürür.
+
+[Safe Area eklentisi](/extension-safearea), eski projeler veya yerleşik API'lerin sunduğunun ötesinde davranışa ihtiyaç duyan iş akışları için bir alternatif olmaya devam eder; Android ve iOS'ta standart güvenli alan yönetimi için gerekli değildir.
+
+
+## Platforma özgü yönergeler
+
+### Android
+Oyununuzu güncelleyebilmek için [anahtar deponuzu (keystore)](/manuals/android/#creating-a-keystore) güvenli bir yerde sakladığınızdan emin olun.
+
+
+### Konsollar
+Her sürümün dağıtım paketini eksiksiz saklayın. Oyuna yama uygulamak isterseniz bu dosyalara ihtiyacınız olacaktır.
+
+
+### Nintendo Switch
+Platforma özgü kodu entegre edin - Nintendo Switch için kullanıcı seçimi gibi işlemlerde yardımcı olan bazı işlevleri içeren ayrı bir eklenti vardır.
+
+Nintendo Switch için Defold, grafik arka ucu (graphics backend) olarak Vulkan kullanır - Oyunu [Vulkan grafik arka ucunu](https://github.com/defold/extension-vulkan) kullanarak test ettiğinizden emin olun.
+
+
+### PlayStation®4
+Platforma özgü kodu entegre edin - PlayStation®4 için kullanıcı seçimi gibi işlemlerde yardımcı olan bazı işlevleri içeren ayrı bir eklenti vardır.
+
+
+### HTML5
+Cep telefonlarında web oyunları oynamak giderek yaygınlaşıyor - Oyunun mobil tarayıcılarda da iyi çalışmasını sağlamaya çalışın! Web oyunlarının hızlı yüklenmesinin beklendiğini de akılda tutmak önemlidir! - Oyunu boyut açısından optimize ettiğinizden emin olun. Oyuncuları gereksiz yere kaybetmemek için genel yükleme deneyimini de göz önünde bulundurun.
+
+2018'de tarayıcılar, bir kullanıcı etkileşimi olayı (dokunma, düğme, oyun kumandası vb.) gerçekleşene kadar oyunların ve diğer web içeriklerinin ses çalmasını engelleyen bir otomatik oynatma politikası getirdi. HTML5'e taşırken bunu dikkate almak ve sesleri ve müziği yalnızca ilk kullanıcı etkileşiminde çalmaya başlamak önemlidir. Herhangi bir kullanıcı etkileşiminden önce ses çalma girişimleri, tarayıcının geliştirici konsoluna hata olarak kaydedilir; ancak oyunu etkilemez.
+
+Ayrıca oyun reklam gösteriyorsa çalmakta olan tüm sesleri duraklattığınızdan emin olun.

--- a/docs/tr/manuals/profiling.md
+++ b/docs/tr/manuals/profiling.md
@@ -1,0 +1,166 @@
+---
+title: Defold'da profil çıkarma
+brief: Bu kılavuz, Defold'da bulunan profil çıkarma olanaklarını açıklar.
+---
+
+# Profil çıkarma
+
+Defold, motorla ve proje derleme hattıyla bütünleşik profil çıkarma (profiling) araçları içerir. Bunlar performans, bellek ve kaynak (resource) kullanımı sorunlarını bulmaya yardımcı olur. Çalışma zamanına ait profil çıkarma verileri çeşitli araçlar tarafından kullanılabilir:
+
+* Temel profil çıkarıcı (profiler) ve oyun içi görsel profil çıkarıcı tüm platformlarda kullanılabilir.
+* [Remotery profil çıkarıcı](https://github.com/Celtoys/Remotery) ve etkileşimli web tabanlı kare (frame) profil çıkarıcısı masaüstü ve mobil platformlarda kullanılabilir.
+* HTML5 derlemeleri, Defold kapsamlarını (scope) tarayıcının Web Performance API'sine yayımlayabilir.
+
+[App Manifest](/manuals/app-manifest/#profiler) içindeki **Profiler** ayarı, profil çıkarıcı kodunun bir derlemeye bağlanıp bağlanmayacağını denetler. Varsayılan değer **Debug Only** seçeneğidir; **None** kodu dışarıda bırakır, **Always** ise hem hata ayıklama derlemelerine hem de yayıma yönelik derlemelere dahil eder. *game.project* dosyasındaki `profiler` ayarları çalışma zamanı davranışını denetler ancak dışarıda bırakılmış profil çıkarıcı kodunu yeniden derlemeye bağlamaz. Özellikle **Track CPU**, CPU kullanımı örneklemesini denetler; App Manifest seçiminden ayrıdır.
+
+## Çalışma zamanı görsel profil çıkarıcısı
+
+Profil çıkarıcı desteği içeren derlemelerde, canlı bilgileri çalışan uygulamanın üzerinde gösteren bir çalışma zamanı görsel profil çıkarıcısı bulunur:
+
+```lua
+function on_reload(self)
+    -- Toggle the visual profiler on hot reload.
+    profiler.enable_ui(true)
+end
+```
+
+![Görsel profil çıkarıcı](images/profiling/visual_profiler.png)
+
+Görsel profil çıkarıcı, verilerini sunma biçimini değiştirmek için kullanılabilecek çeşitli işlevler sağlar:
+
+```lua
+
+profiler.set_ui_mode()
+profiler.set_ui_view_mode()
+profiler.view_recorded_frame()
+```
+
+Profil çıkarıcı işlevleri hakkında daha fazla bilgi için [profil çıkarıcı API başvuru belgelerine](/ref/stable/profiler/) bakın.
+
+## Web profil çıkarıcısı
+Profil çıkarıcı desteği içeren bir masaüstü veya mobil derlemeyi çalıştırırken, etkileşimli kare ve kaynak profil çıkarıcılarına bir tarayıcı üzerinden erişebilirsiniz.
+
+### Remotery kare profil çıkarıcısı
+Kare profil çıkarıcısı, oyununuz çalışırken örnekler almanızı ve tek tek kareleri ayrıntılı olarak analiz etmenizi sağlar. Profil çıkarıcıya erişmek için:
+
+1. Oyununuzu hedef cihazda başlatın.
+2. <kbd> Debug ▸ Open Web Profiler</kbd> menüsünü seçin.
+
+Kare profil çıkarıcısı, çalışan oyunu farklı açılardan gösteren çeşitli bölümlere ayrılmıştır. Profil çıkarıcının görünümleri güncellemesini geçici olarak durdurmak için sağ üst köşedeki Pause düğmesine basın.
+
+![Web profil çıkarıcısı](images/profiling/webprofiler_page.png)
+
+::: sidenote
+Birden fazla hedefi aynı anda kullandığınızda, sayfanın üst kısmındaki Connection Address alanını, hedef başlatıldığında konsolda gösterilen Remotery profil çıkarıcı URL adresiyle eşleşecek şekilde değiştirerek hedefler arasında elle geçiş yapabilirsiniz:
+
+```
+INFO:ENGINE: Defold Engine 1.3.4 (80b1b73)
+INFO:DLIB: Initialized Remotery (ws://127.0.0.1:17815/rmt)
+INFO:ENGINE: Loading data from: build/default
+```
+:::
+
+Sample Timeline
+: Sample Timeline, motorda yakalanan kare verilerini her iş parçacığı (thread) için bir yatay zaman çizelgesinde gösterir. Main, tüm oyun mantığının ve motor kodunun büyük bölümünün çalıştığı ana iş parçacığıdır. Remotery, profil çıkarıcının kendisi içindir; Sound ise ses karıştırma ve çalma iş parçacığıdır. Yakınlaştırıp uzaklaştırabilir (fare tekerleğini kullanarak) ve bir karenin ayrıntılarını Frame Data görünümünde görmek için tek tek kareleri seçebilirsiniz.
+
+  ![Sample Timeline](images/profiling/webprofiler_sample_timeline.png)
+
+
+Frame Data
+: Frame Data görünümü, seçili kareye ait tüm verilerin ayrıntılı olarak dökümünü içeren bir tablodur. Motorun her kapsamında kaç milisaniye harcandığını görebilirsiniz.
+
+  ![Kare verileri](images/profiling/webprofiler_frame_data.png)
+
+
+Global Properties
+: Global Properties görünümü bir sayaç tablosu gösterir. Bu sayaçlar, örneğin çizim çağrılarının sayısını veya belirli bir türdeki bileşenlerin (component) sayısını izlemeyi kolaylaştırır.
+
+  ![Global Properties](images/profiling/webprofiler_global_properties.png)
+
+::: sidenote
+LuaMem değeri, Lua çöp toplayıcısının bildirdiği üzere Lua VM tarafından kullanılan belleğin kilobayt cinsinden miktarıdır. Memory, motorun kullandığı belleğin kilobayt cinsinden miktarıdır.
+:::
+
+::: important
+[Max Sample Count ayarı](/manuals/project-settings/#max-sample-count), her karede iş parçacığı başına kaydedilen profil çıkarıcı örneklerinin sayısını sınırlar. Profil çıkarıcı sınırın aşıldığını bildirirse önce yerel kod eklentilerindeki (native extension) profil çıkarma kodunda eşleşmeyen bir kapsam başlangıç/bitiş çifti olup olmadığını kontrol edin. Üst sınırı yalnızca geçerli bir kare, yapılandırılmış sınırdan daha fazla kapsam içeriyorsa yükseltin.
+:::
+
+### Kaynak profil çıkarıcısı
+Kaynak profil çıkarıcısı, oyununuzu çalışırken incelemenizi ve kaynak kullanımını ayrıntılı olarak analiz etmenizi sağlar. Profil çıkarıcıya erişmek için:
+
+1. Oyununuzu hedef cihazda başlatın.
+2. Bir tarayıcı açın ve http://localhost:8002 adresine gidin
+
+Kaynak profil çıkarıcısı 2 bölüme ayrılmıştır: biri oyununuzda o anda örnekleri oluşturulmuş koleksiyonların (collection), oyun nesnelerinin (game object) ve bileşenlerin hiyerarşik görünümünü, diğeri ise o anda yüklü olan tüm kaynakları gösterir.
+
+![Kaynak profil çıkarıcısı](images/profiling/webprofiler_resources_page.png)
+
+Koleksiyon görünümü
+: Koleksiyon görünümü, oyunda o anda örnekleri oluşturulmuş tüm oyun nesnelerinin ve bileşenlerin hiyerarşik listesini ve hangi koleksiyondan geldiklerini gösterir. Belirli bir anda oyununuzda nelerin örneklerini oluşturduğunuzu ve nesnelerin nereden geldiğini ayrıntılı olarak inceleyip anlamanız gerektiğinde bu araç çok yararlıdır.
+
+Kaynaklar görünümü
+: Kaynaklar görünümü, o anda belleğe yüklenmiş tüm kaynakları, bunların boyutlarını ve her kaynağa yapılan başvuru sayısını gösterir. Bu, uygulamanızdaki bellek kullanımını optimize ederken belirli bir anda belleğe nelerin yüklendiğini anlamanız gerektiğinde yararlıdır.
+
+## HTML5 tarayıcı performans zaman çizelgesi
+
+HTML5, tarayıcı zaman çizelgesi için Remotery yerine Web Performance API'sini kullanır. Defold kapsamlarını kaydetmek için:
+
+1. Seçili App Manifest profil çıkarıcı modunun, çalıştırdığınız derleme çeşidine profil çıkarıcı desteğini dahil ettiğinden emin olun.
+2. *game.project* dosyasında **Performance Timeline Enabled** (`profiler.performance_timeline_enabled`) ayarını etkinleştirin.
+3. HTML5 derlemesini başlatın ve tarayıcının geliştirici araçlarını açın.
+4. Tarayıcının **Performance** panelinde bir oturum kaydedin ve oluşan zaman çizelgesindeki Defold kapsamlarını inceleyin.
+
+Bu tarayıcı zaman çizelgesi, hem oyun içi görsel profil çıkarıcıdan hem de etkileşimli Remotery web profil çıkarıcısından ayrıdır.
+
+
+## Derleme raporları {#build-reports}
+Oyununuzu paketlerken bir derleme raporu oluşturma seçeneği vardır. Bu, oyun dağıtım paketinizin parçası olan tüm varlıkların (asset) boyutunu anlamak için çok yararlıdır. Oyunu paketlerken *Generate build report* onay kutusunu işaretlemeniz yeterlidir.
+
+![Derleme raporu](images/profiling/build_report.png)
+
+Derleme aracı, oyun dağıtım paketinin yanında `report.html` adlı bir dosya oluşturur. Raporu incelemek için dosyayı bir web tarayıcısında açın:
+
+![Derleme raporu](images/profiling/build_report_html.png)
+
+*Overview*, proje boyutunun kaynak türüne göre genel görsel dökümünü sunar.
+
+*Resources*, boyuta, sıkıştırma oranına, şifrelemeye, türe ve dizin adına göre sıralayabileceğiniz ayrıntılı bir kaynak listesi gösterir. Gösterilen kaynak girdilerini filtrelemek için "search" alanını kullanın.
+
+*Structure* bölümü, kaynakların proje dosya yapısında nasıl düzenlendiğine göre boyutları gösterir. Girdiler, dosyanın ve dizin içeriğinin göreli boyutuna göre yeşilden (hafif) maviye (ağır) doğru renklerle kodlanır.
+
+
+## Harici araçlar
+Yerleşik araçlara ek olarak, ücretsiz ve yüksek kaliteli çok çeşitli izleme ve profil çıkarma araçları mevcuttur. Bunlardan bazıları şunlardır:
+
+ProFi (Lua)
+: Yerleşik bir Lua profil çıkarıcısı sunmuyoruz, ancak kullanımı yeterince kolay harici kütüphaneler vardır. Betiklerinizin nerede zaman harcadığını bulmak için kodunuza kendiniz süre ölçümleri ekleyin veya [ProFi](https://github.com/jgrahamc/ProFi) gibi bir Lua profil çıkarma kütüphanesi kullanın.
+
+  Yalnızca Lua ile yazılmış profil çıkarıcıların, kurdukları her kancayla (hook) oldukça fazla ek yük oluşturduğunu unutmayın. Bu nedenle böyle bir araçtan aldığınız zamanlama profillerine biraz temkinli yaklaşmanız önerilir. Bununla birlikte, sayım profilleri yeterince doğrudur.
+
+Instruments (macOS ve iOS)
+: Xcode'un parçası olan bir performans analiz ve görselleştirme aracıdır. Bir veya daha fazla uygulamanın ya da sürecin davranışını izlemenizi ve incelemenizi, cihaza özgü özellikleri (Wi-Fi ve Bluetooth gibi) incelemenizi ve çok daha fazlasını yapmanızı sağlar.
+
+  ![Instruments](images/profiling/instruments.png)
+
+OpenGL profiler (macOS)
+: Apple'dan indirebileceğiniz "Additional Tools for Xcode" paketinin bir parçasıdır (Xcode menüsünde <kbd>Xcode ▸ Open Developer Tool ▸ More Developer Tools...</kbd> seçeneğini seçin).
+
+  Bu araç, çalışan bir Defold uygulamasını incelemenizi ve OpenGL'i nasıl kullandığını görmenizi sağlar. OpenGL işlev çağrılarını izlemenizi, OpenGL işlevlerine kesme noktaları koymanızı, uygulama kaynaklarını (dokular, programlar, gölgelendiriciler vb.) incelemenizi, arabellek içeriklerine bakmanızı ve OpenGL durumunun diğer yönlerini kontrol etmenizi sağlar.
+
+  ![OpenGL profil çıkarıcısı](images/profiling/opengl.png)
+
+Android Profiler (Android)
+: https://developer.android.com/studio/profile/android-profiler.html
+
+  Oyununuzun CPU, bellek ve ağ etkinliğine ait gerçek zamanlı verileri yakalayan bir profil çıkarma araçları kümesidir. Kod yürütülürken örneklemeye dayalı yöntem izleme gerçekleştirebilir, öbek dökümleri alabilir, bellek ayırma işlemlerini görüntüleyebilir ve ağ üzerinden iletilen dosyaların ayrıntılarını inceleyebilirsiniz. Aracı kullanmak için `AndroidManifest.xml` dosyasında `android:debuggable="true"` ayarını yapmanız gerekir.
+
+  ![Android Profiler](images/profiling/android_profiler.png)
+
+  Not: Android Studio 4.1'den itibaren [Android Studio'yu başlatmadan profil çıkarma araçlarını çalıştırmak](https://developer.android.com/studio/profile/android-profiler.html#standalone-profilers) da mümkündür.
+
+Graphics API Debugger (Android)
+: https://github.com/google/gapid
+
+  Bir uygulamadan grafik sürücüsüne yapılan çağrıları incelemenizi, değiştirmenizi ve yeniden yürütmenizi sağlayan bir araç kümesidir. Aracı kullanmak için `AndroidManifest.xml` dosyasında `android:debuggable="true"` ayarını yapmanız gerekir.
+
+  ![Graphics API Debugger](images/profiling/gapid.png)

--- a/docs/tr/manuals/project-defignore.md
+++ b/docs/tr/manuals/project-defignore.md
@@ -1,0 +1,32 @@
+---
+title: Defold projelerinde dosyaları yok sayma
+brief: Bu kılavuz, Defold'da dosyaların ve klasörlerin nasıl yok sayılacağını açıklar.
+---
+
+# Dosyaları yok sayma
+
+Defold düzenleyicisini ve araçlarını, bir projedeki dosyaları ve klasörleri yok sayacak şekilde yapılandırabilirsiniz. Bu, projede uzantıları Defold'un kullandığı dosya uzantılarıyla çakışan dosyalar varsa yararlı olabilir. Bunun bir örneği, düzenleyicinin oyun nesnesi (game object) dosyaları için kullandığı `.go` uzantısıyla aynı uzantıya sahip olan Go dili dosyalarıdır.
+
+## `.defignore` dosyası
+Hariç tutulacak dosyalar ve klasörler, projenin kök dizinindeki `.defignore` adlı dosyada tanımlanır. Bu dosyada, hariç tutulacak dosyalar ve klasörler her satırda bir tane olacak şekilde listelenmelidir. Örnek:
+
+```
+/path/to/file.png
+/otherpath
+```
+
+Bu, `/path/to/file.png` dosyasını ve `/otherpath` yolundaki her şeyi hariç tutar.
+
+## `.defunload` dosyası
+
+Birden çok bağımsız modül içeren bazı büyük projelerde, düzenleyicideki bellek kullanımını ve yükleme sürelerini azaltmak için projenin bazı bölümlerini yükleme dışında tutmak isteyebilirsiniz. Bunu yapmak için yükleme dışında tutulacak yolları proje dizini altındaki bir `.defunload` dosyasında listeleyebilirsiniz.
+
+Basitçe ifade etmek gerekirse, `.defunload` dosyası projenin bazı bölümlerini düzenleyiciden gizlemenizi sağlar; gizlenen kaynaklara (resource) başvurmak derleme hatasına yol açmaz.
+
+`.defunload` içindeki kalıplar, `.defignore` dosyasıyla aynı kuralları kullanır. Yüklenmemiş koleksiyonlar (collection) ve oyun nesneleri, yüklenmiş kaynaklar bunlara başvurduğunda boşmuş gibi davranır. `.defunload` kalıplarıyla eşleşen diğer kaynaklar yüklenmemiş durumda kalır ve düzenleyicide görüntülenemez. Ancak yüklenmiş bir kaynak bunlara bağımlıysa, yüklenmemiş kaynaklar ve bunların bağımlılıkları otomatik olarak yüklenir.
+
+Örneğin, bir sprite bileşeni bir atlastaki görüntülere bağımlıysa atlası yüklememiz gerekir; aksi takdirde eksik görüntü bir hata olarak bildirilir. Bu olursa bir bildirim, kullanıcıyı durum hakkında uyarır ve yüklenmemiş hangi kaynağa nereden başvurulduğu hakkında bilgi verir.
+
+Düzenleyici, kullanıcının yüklenmiş kaynaklardan `.defunloaded` kaynaklara başvuru eklemesini engeller; dolayısıyla bu durum yalnızca kaynaklar diskten okunduğunda ortaya çıkar.
+
+`.defignore` dosyasından farklı olarak, `.defunload` dosyasını düzenledikten sonra değişikliklerin uygulanması için düzenleyiciyi yeniden başlatmanız gerekir.

--- a/docs/tr/manuals/project-settings.md
+++ b/docs/tr/manuals/project-settings.md
@@ -1,0 +1,873 @@
+---
+title: Defold proje ayarları
+brief: Bu kılavuz, Defold'da projeye özgü ayarların nasıl çalıştığını açıklar.
+---
+
+# Proje ayarları
+
+*game.project* dosyası, proje genelindeki tüm ayarları içerir. Bu dosya projenin kök klasöründe kalmalı ve adı *game.project* olmalıdır. Motor, başlatılıp oyununuzu çalıştırırken ilk olarak bu dosyayı arar.
+
+Dosyadaki her ayar bir kategoriye aittir. Dosyayı açtığınızda Defold, tüm ayarları kategorilere göre gruplandırarak gösterir.
+
+![Proje ayarları](images/project-settings/settings.jpg)
+
+
+## Dosya biçimi
+
+*game.project* içindeki ayarlar genellikle Defold içinden değiştirilir; ancak dosya, herhangi bir standart metin düzenleyicisinde de düzenlenebilir. Dosya, INI dosya biçimi standardına uyar ve şu şekilde görünür:
+
+```ini
+[category1]
+setting1 = value
+setting2 = value
+[category2]
+...
+```
+
+Gerçek bir örnek:
+
+```ini
+[bootstrap]
+main_collection = /main/main.collectionc
+```
+
+Bu, *main_collection* ayarının *bootstrap* kategorisine ait olduğu anlamına gelir. Yukarıdaki örnekte olduğu gibi bir dosya başvurusu kullanıldığında yolun sonuna 'c' karakteri eklenmelidir; bu, dosyanın derlenmiş sürümüne başvurduğunuz anlamına gelir. Ayrıca *game.project* dosyasını içeren klasörün proje kökü olacağını unutmayın; ayar yolunun başında '/' bulunmasının nedeni budur.
+
+
+## Çalışma sırasında erişim {#runtime-access}
+
+Çalışma sırasında *game.project* içindeki değerleri [`sys.get_config_string(key)`](/ref/sys/#sys.get_config_string), [`sys.get_config_number(key)`](/ref/sys/#sys.get_config_number), [`sys.get_config_int(key)`](/ref/sys/#sys.get_config_int) ve [`sys.get_config_boolean(key)`](/ref/sys/#sys.get_config_boolean) işlevleriyle okuyabilirsiniz. Örnekler:
+
+```lua
+local title = sys.get_config_string("project.title")
+local gravity_y = sys.get_config_number("physics.gravity_y")
+local fullscreen = sys.get_config_boolean("display.fullscreen", false)
+```
+
+::: sidenote
+Anahtar, kategori adıyla ayar adının bir noktayla ayrılarak birleştirilmesinden oluşur; tüm harfler küçük yazılır ve boşluk karakterleri alt çizgilerle değiştirilir. Örnekler: "Project" kategorisindeki "Title" alanı `project.title`, "Physics" kategorisindeki "Gravity Y" alanı ise `physics.gravity_y` olur.
+:::
+
+
+## Bölümler ve ayarlar
+
+Kullanılabilir tüm ayarlar aşağıda kategorilere göre sıralanmıştır.
+
+### Project
+
+#### Title
+Uygulamanın başlığı.
+
+#### Version
+Uygulamanın sürümü.
+
+#### Publisher
+Yayımcının adı.
+
+#### Developer
+Geliştiricinin adı.
+
+#### Write Log File
+Motorun ne zaman günlük dosyası yazacağını belirler. Seçenekler:
+
+- "Never": Günlük dosyası yazılmaz.
+- "Debug": Yalnızca Debug derlemeleri için günlük dosyası yazılır.
+- "Always": Hem Debug hem de Release derlemeleri için günlük dosyası yazılır.
+
+Düzenleyiciden birden fazla örnek (instance) çalıştırılıyorsa dosyanın adı *instance_2_log.txt* olur; buradaki `2`, örnek indeksidir. Tek bir örnek çalıştırılıyorsa veya uygulama dağıtım paketinden (bundle) çalıştırılıyorsa dosyanın adı *log.txt* olur. Günlük dosyasının konumu aşağıdaki yollardan biri olacaktır (sırayla denenir):
+
+1. *project.log_dir* içinde belirtilen yol (gizli ayar)
+2. Sistem günlük yolu:
+  * macOS/iOS: `NSDocumentDirectory`
+  * Android: `Context.getExternalFilesDir()`
+  * Diğerleri: Uygulama kökü
+3. Uygulama destek yolu
+  * macOS/iOS: `NSApplicationSupportDirectory`
+  * Windows: `CSIDL_APPDATA` (ör. `C:\Users\<username>\AppData\Roaming`)
+  * Android: `Context.getFilesDir()`
+  * Linux: `HOME` ortam değişkeni
+
+#### Minimum Log Level
+Günlüğe kaydetme sistemi için en düşük günlük düzeyini belirtin. Yalnızca bu düzeydeki veya daha üst düzeylerdeki günlük kayıtları gösterilir.
+
+#### Compress Archive
+Paketleme sırasında arşivlerin sıkıştırılmasını etkinleştirir. Bunun şu anda, apk dosyasının tüm verileri zaten sıkıştırılmış olarak içerdiği Android dışındaki tüm platformlar için geçerli olduğunu unutmayın.
+
+#### Dependencies
+Projenin *Library URL* adreslerinin listesi. Daha fazla bilgi için [Kütüphaneler kılavuzuna](/manuals/libraries/) bakın.
+
+#### Custom Resources
+`custom_resources`
+:[Custom Resources](../shared/custom-resources.md)
+
+Özel kaynakların (custom resource) yüklenmesi, [Dosya erişimi kılavuzunda](/manuals/file-access/#how-to-access-files-bundled-with-the-application) daha ayrıntılı açıklanır.
+
+Eklentilerin `custom_resources.default` üzerinden `ext.properties` dosyasında sağladığı yollar, bu ayarla birleştirilir. Bir örnek için [eklentilerin özel kaynaklarına](/manuals/extensions/#custom-resources) bakın.
+
+#### Bundle Resources
+`bundle_resources`
+:[Bundle Resources](../shared/bundle-resources.md)
+
+Dağıtım paketine eklenen kaynakların yüklenmesi, [Dosya erişimi kılavuzunda](/manuals/file-access/#how-to-access-files-bundled-with-the-application) daha ayrıntılı açıklanır.
+
+#### Bundle Exclude Resources
+`bundle_exclude_resources`
+Dağıtım paketine dahil edilmemesi gereken kaynakların virgülle ayrılmış listesi. Başka bir deyişle bu kaynaklar, `bundle_resources` adımında toplanan kaynaklardan çıkarılır.
+
+---
+
+### Bootstrap
+
+#### Main Collection
+Uygulamayı başlatmak için kullanılacak koleksiyonun (collection) dosya başvurusu; varsayılan olarak `/logic/main.collection`.
+
+#### Render
+Görüntü oluşturma hattını tanımlayan işleme (rendering) yapılandırma dosyası; varsayılan olarak `/builtins/render/default.render`.
+
+---
+
+### Library
+
+#### Include Dirs
+Projenizden kütüphane paylaşımı yoluyla paylaşılacak dizinlerin boşlukla ayrılmış listesi. Daha fazla bilgi için [Kütüphaneler kılavuzuna](/manuals/libraries/) bakın.
+
+---
+
+### Script
+
+#### Shared State
+Tüm betik türleri arasında tek bir Lua durumu paylaşmak için işaretleyin.
+
+---
+
+### Engine
+
+#### Run While Iconified
+Uygulama penceresi simge durumuna küçültüldüğünde motorun çalışmaya devam etmesine izin verir (yalnızca masaüstü platformları).
+
+#### Fixed Update Frequency
+`fixed_update(self, dt)` yaşam döngüsü işlevinin Hertz cinsinden güncelleme sıklığı.
+
+#### Max Time Step
+Tek bir kare sırasında zaman adımı çok büyürse bu en yüksek değerle sınırlandırılır. Saniye cinsindendir.
+
+---
+
+### Display
+
+#### Width
+Uygulama penceresinin piksel cinsinden genişliği.
+
+#### Height
+Uygulama penceresinin piksel cinsinden yüksekliği.
+
+#### High Dpi
+Destekleyen ekranlarda yüksek DPI değerine sahip bir arka arabellek oluşturur. Oyun genellikle *Width* ve *Height* ayarlarında belirtilenin iki katı çözünürlükte işlenir; bu ayarlardaki değerler, betiklerde ve özelliklerde kullanılan mantıksal çözünürlük olarak kalır.
+
+#### Samples
+Süper örneklemeli kenar yumuşatma için kullanılacak örnek sayısı. `GLFW_FSAA_SAMPLES` pencere ipucunu ayarlar. `0` değeri, kenar yumuşatmanın kapalı olduğu anlamına gelir.
+
+Bu ayar pencereyi denetler. Ekran dışı [çok örneklemeli işleme hedeflerinin](/manuals/render/#multisampled-render-targets) kendi örnek sayıları vardır.
+
+#### Fullscreen
+Uygulamanın tam ekran başlaması için işaretleyin. İşaretli değilse uygulama pencerede çalışır.
+
+#### Update Frequency
+Hertz cinsinden istenen kare hızı. Değişken kare hızı için 0 olarak ayarlayın. 0'dan büyük bir değer, çalışma sırasında gerçek kare hızına göre sınırlanan sabit bir kare hızı sağlar (yani oyun döngüsünü bir motor karesinde iki kez güncelleyemezsiniz). Bu değeri çalışma sırasında değiştirmek için [`sys.set_update_frequency(hz)`](https://defold.com/ref/stable/sys/?q=set_update_frequency#sys.set_update_frequency:frequency) işlevini kullanın. Bu ayar, grafik arayüzü olmadan çalışan derlemelerde de geçerlidir.
+
+#### Swap interval
+Bu tam sayı değeri, uygulamanın dikey eşitlemeyi (vsync) nasıl kullanacağını belirler. 0, dikey eşitlemeyi devre dışı bırakır; varsayılan değer 1'dir. OpenGL bağdaştırıcısı kullanılırken bu değer, pencerenin [arabellek takasları arasında güncelleneceği](https://www.khronos.org/opengl/wiki/Swap_Interval) kare sayısını belirler. Vulkan'da yerleşik bir takas aralığı kavramı olmadığından bu değer, dikey eşitlemenin etkinleştirilip etkinleştirilmeyeceğini belirler.
+
+#### Vsync
+Eski sürümlerle uyumluluk ayarı. Bu ayarın kullanımı artık önerilmez; yeni projelerde **Swap Interval** kullanın. Devre dışı bırakılırsa geçerli takas aralığını `0` yapar. Etkinleştirilirse geçerli değeri **Swap Interval** belirler.
+
+#### Display Profiles
+Kullanılacak ekran profilleri dosyasını belirtir; varsayılan olarak `/builtins/render/default.display_profilesc`. Daha fazla bilgi için [GUI yerleşimleri kılavuzuna](/manuals/gui-layouts/#creating-display-profiles) bakın.
+
+#### Dynamic Orientation
+Cihaz döndürüldüğünde uygulamanın dikey ve yatay yönelimler arasında dinamik olarak geçiş yapması için işaretleyin. Geliştirme uygulamasının şu anda bu ayarı dikkate almadığını unutmayın.
+
+#### Display Device Info
+Başlangıçta GPU bilgilerini konsola yazdırır.
+
+---
+
+### Render
+
+#### Clear Color Red
+İşleme betiğinde (render script) ve pencere oluşturulurken kullanılan temizleme renginin kırmızı kanalı.
+
+#### Clear Color Green
+İşleme betiğinde ve pencere oluşturulurken kullanılan temizleme renginin yeşil kanalı.
+
+#### Clear Color Blue
+İşleme betiğinde ve pencere oluşturulurken kullanılan temizleme renginin mavi kanalı.
+
+#### Clear Color Alpha
+İşleme betiğinde ve pencere oluşturulurken kullanılan temizleme renginin alfa kanalı.
+
+---
+
+### Font
+
+#### Runtime Generation
+Çalışma sırasında yazı tipi oluşturmayı kullanır.
+
+---
+
+### Physics
+
+#### Max Collision Object Count
+En fazla çarpışma nesnesi (collision object) sayısı.
+
+#### Type
+Kullanılacak fizik türü: `2D` veya `3D`.
+
+#### Gravity X
+Dünyanın x eksenindeki yer çekimi. Saniyede metre cinsindendir.
+
+#### Gravity Y
+Dünyanın y eksenindeki yer çekimi. Saniyede metre cinsindendir.
+
+#### Gravity Z
+Dünyanın z eksenindeki yer çekimi. Saniyede metre cinsindendir.
+
+#### Debug
+Fiziğin hata ayıklama amacıyla görselleştirilmesi için işaretleyin.
+
+#### Debug Alpha
+Görselleştirilen fiziğin alfa bileşeni değeri, `0`--`1`.
+
+#### World Count
+Aynı anda var olabilecek en fazla fizik dünyası sayısı; varsayılan olarak `4`. Koleksiyon vekilleri (collection proxy) aracılığıyla aynı anda 4'ten fazla dünya yüklüyorsanız bu değeri artırmanız gerekir. Her fizik dünyasının kayda değer miktarda bellek ayırdığını unutmayın.
+
+#### Scale
+Fizik motoruna, sayısal hassasiyet için fizik dünyalarını oyun dünyasına göre nasıl ölçekleyeceğini bildirir; `0.01`--`1.0`. Değer `0.02` olarak ayarlanırsa fizik motoru 50 birimi 1 metre olarak kabul eder ($1 / 0.02$).
+
+#### Allow Dynamic Transforms
+Fizik motorunun bir oyun nesnesinin (game object) dönüşümünü, nesneye bağlı tüm çarpışma nesnesi bileşenlerine (component) uygulaması için işaretleyin. Bu, dinamik olanlar dahil çarpışma şekillerini taşımak, ölçeklemek ve döndürmek için kullanılabilir.
+
+#### Use Fixed Timestep
+Fizik motorunun sabit ve kare hızından bağımsız güncellemeler kullanması için işaretleyin. Fizik motoruyla düzenli aralıklarla etkileşime girmek için bu ayarı, `fixed_update(self, dt)` yaşam döngüsü işlevi ve `engine.fixed_update_frequency` proje ayarıyla birlikte kullanın. Yeni projeler için önerilen ayar `true` değeridir.
+
+#### Debug Scale
+Fizikte eksen üçlüleri ve normaller gibi birim nesnelerin ne büyüklükte çizileceği.
+
+#### Max Collisions
+Betiklere bildirilecek çarpışma sayısı.
+
+#### Max Contacts
+Betiklere bildirilecek temas noktası sayısı.
+
+#### Contact Impulse Limit
+Değeri bu ayardan küçük olan temas itmelerini yok sayar.
+
+#### Ray Cast Limit 2d
+Kare başına en fazla 2B ışın sorgusu isteği sayısı.
+
+#### Ray Cast Limit 3d
+Kare başına en fazla 3B ışın sorgusu isteği sayısı.
+
+#### Trigger Overlap Capacity
+Üst üste gelen en fazla fizik tetikleyicisi sayısı.
+
+#### Velocity Threshold
+Esnek çarpışmayla sonuçlanacak en düşük hız.
+
+#### Max Fixed Timesteps
+Sabit zaman adımı kullanılırken simülasyondaki en fazla adım sayısı (yalnızca 3B).
+
+---
+
+### Graphics
+
+#### Default Texture Min Filter
+Küçültme filtrelemesinde kullanılacak filtreleme türünü belirtir.
+
+#### Default Texture Mag Filter
+Büyütme filtrelemesinde kullanılacak filtreleme türünü belirtir.
+
+#### Max Draw Calls
+En fazla işleme çağrısı sayısı.
+
+#### Max Characters:
+Metin işleme arabelleğinde önceden yer ayrılan karakter sayısı; başka bir deyişle her karede görüntülenebilecek karakter sayısı.
+
+#### Max Font Batches
+Her karede görüntülenebilecek en fazla metin çizim grubu sayısı.
+
+#### Max Debug Vertices
+En fazla hata ayıklama köşesi sayısı. Diğer kullanımların yanı sıra fizik şekillerinin işlenmesinde kullanılır.
+
+#### Texture Profiles
+Bu proje için kullanılacak doku profilleri dosyası; varsayılan olarak `/builtins/graphics/default.texture_profiles`.
+
+#### Verify Graphics Calls
+Her grafik çağrısından sonra dönüş değerini doğrular ve hataları günlüğe kaydeder.
+
+#### WebGL Version Hint
+`graphics.webgl_version_hint`, HTML5 için istenecek WebGL bağlamı sürümünü seçer. Geçerli değerler `1` (WebGL 1) ve `2` (WebGL 2, varsayılan) değerleridir. WebGL 2'yi destekleyen bir tarayıcıda bile WebGL 1'i hedeflemek veya test etmek için `1` olarak ayarlayın. Gerekli gölgelendiricilerin dahil edilmesi için WebGL 1'i hedeflerken [Exclude GLES 2.0](#exclude-gles-20) ayarını devre dışı bırakılmış olarak tutun.
+
+#### OpenGL Version Hint
+OpenGL bağlamı sürüm ipucu. Belirli bir sürüm seçilirse gereken en düşük sürüm olarak kullanılır (OpenGL ES için geçerli değildir).
+
+#### OpenGL Core Profile Hint
+Bağlam oluşturulurken 'core' OpenGL profil ipucunu ayarlar. Çekirdek profil, anında modda işleme gibi kullanımı artık önerilmeyen tüm özellikleri OpenGL'den kaldırır. OpenGL ES için geçerli değildir.
+
+#### Vulkan Version Major
+`graphics.vulkan_version_major`, Vulkan bağlamının/API'sinin ana sürüm ipucudur. Yalnızca Vulkan grafik arka ucu seçildiğinde geçerlidir. Varsayılan değer `1`'dir.
+
+#### Vulkan Version Minor
+`graphics.vulkan_version_minor`, Vulkan bağlamının/API'sinin alt sürüm ipucudur. Yalnızca Vulkan grafik arka ucu seçildiğinde geçerlidir. Varsayılan değer `0`'dır.
+
+---
+
+### Shader
+
+#### Exclude GLES 2.0
+OpenGLES 2.0 / WebGL 1.0 çalıştıran cihazlar için gölgelendiricileri derlemez.
+
+#### GLSL ES Default Precision Float
+`shader.glsl_es_default_precision_float`, çapraz derlenen GLSL ES gölgelendiricilerinde kayan noktalı değerler için varsayılan genel hassasiyet niteleyicisini ayarlar. Geçerli değerler `mediump` ve `highp`; varsayılan değer `mediump`.
+
+#### GLSL ES Default Precision Int
+`shader.glsl_es_default_precision_int`, çapraz derlenen GLSL ES gölgelendiricilerinde tam sayı değerleri için varsayılan genel hassasiyet niteleyicisini ayarlar. Geçerli değerler `mediump` ve `highp`; varsayılan değer `highp`.
+
+---
+
+### Input
+
+#### Repeat Delay
+Basılı tutulan bir girdinin yinelenmeye başlaması için beklenecek saniye sayısı.
+
+#### Repeat Interval
+Basılı tutulan bir girdinin her yinelenmesi arasında beklenecek saniye sayısı.
+
+#### Gamepads
+Oyun kumandası sinyallerini işletim sistemiyle eşleyen oyun kumandaları yapılandırma dosyasının başvurusu; varsayılan olarak `/builtins/input/default.gamepads`.
+
+#### Game Binding
+Donanım girdilerini eylemlere eşleyen girdi yapılandırma dosyasının başvurusu; varsayılan olarak `/input/game.input_binding`.
+
+#### Use Accelerometer
+Motorun her karede ivmeölçer girdi olaylarını alması için işaretleyin. İvmeölçer girdisini devre dışı bırakmak bir miktar performans artışı sağlayabilir.
+
+---
+
+### Resource
+
+#### Http Cache
+İşaretlenirse kaynakların ağ üzerinden cihazda çalışan motora daha hızlı yüklenmesi için bir HTTP önbelleği etkinleştirilir.
+
+#### Uri
+Projenin derleme verilerinin nerede bulunacağı; URI biçimindedir.
+
+#### Max Resources
+Aynı anda yüklenebilecek en fazla kaynak sayısı.
+
+---
+
+### Network
+
+#### Http Timeout
+Saniye cinsinden HTTP zaman aşımı. Zaman aşımını devre dışı bırakmak için `0` olarak ayarlayın.
+
+#### Http Thread Count
+HTTP hizmeti için çalışan iş parçacığı sayısı.
+
+#### Http Cache Enabled
+Ağ istekleri (`http.request()` kullanılarak yapılan) için HTTP önbelleğini etkinleştirmek üzere işaretleyin. HTTP önbelleği, bir istekle ilişkili yanıtı saklar ve saklanan yanıtı sonraki isteklerde yeniden kullanır. HTTP önbelleği, `ETag` ve `Cache-Control: max-age` HTTP yanıt üstbilgilerini destekler.
+
+#### SSL Certificates
+SSL el sıkışmaları sırasında sertifika zincirini doğrulamak için kullanılacak SSL kök sertifikalarını içeren dosya.
+
+---
+
+### Collection
+
+#### Max Instances
+Bir koleksiyondaki en fazla oyun nesnesi örneği sayısı; varsayılan olarak `1024`. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+#### Max Input Stack Entries
+Girdi yığınındaki en fazla oyun nesnesi sayısı.
+
+---
+
+### Sound
+
+#### Gain
+Genel kazanç (ses düzeyi), `0`--`1`.
+
+#### Use Linear Gain
+Etkinleştirilirse kazanç doğrusaldır. Devre dışı bırakılırsa üstel bir eğri kullanılır.
+
+#### Max Sound Data
+En fazla ses kaynağı sayısı; başka bir deyişle çalışma sırasındaki benzersiz ses dosyalarının sayısı.
+
+#### Max Sound Buffers
+(Şu anda kullanılmıyor) Aynı anda var olabilecek en fazla ses arabelleği sayısı.
+
+#### Max Sound Sources
+(Şu anda kullanılmıyor) Aynı anda çalınabilecek en fazla ses sayısı.
+
+#### Max Sound Instances
+Aynı anda var olabilecek en fazla ses örneği sayısı; başka bir deyişle aynı anda gerçekten çalınan sesler.
+
+#### Max Component Count
+Koleksiyon başına en fazla ses bileşeni sayısı.
+
+#### Sample Frame Count
+Her ses güncellemesinde kullanılan örnek sayısı. 0, otomatik anlamına gelir (48 kHz için 1024, 44,1 kHz için 768).
+
+#### Use Thread
+İşaretlenirse ses sistemi, ana iş parçacığı yoğun yük altındayken takılma riskini azaltmak için ses oynatmada iş parçacıkları kullanır.
+
+#### Stream Enabled
+İşaretlenirse ses sistemi, kaynak dosyaları yüklemek için akış yöntemini kullanır.
+
+#### Stream Cache Size
+_Tüm_ parçaları içeren ses parçası önbelleğinin en büyük boyutu. Varsayılan olarak `2097152` bayt.
+Bu sayının, yüklü ses dosyası sayısıyla akış parçası boyutunun çarpımından büyük olması önerilir.
+Aksi takdirde yeni parçaların her karede önbellekten çıkarılması riski doğar.
+
+#### Stream Chunk Size
+Akışla aktarılan her parçanın bayt cinsinden boyutu.
+
+#### Stream Preload Size
+Arşivden okunan ses dosyaları için ilk parçanın bayt cinsinden boyutunu belirler.
+
+---
+
+### Sprite
+
+#### Max Count
+Koleksiyon başına en fazla sprite bileşeni sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+#### Subpixels
+Sprite bileşenlerinin piksellere hizalanmadan görüntülenmesine izin vermek için işaretleyin.
+
+---
+
+### Tilemap
+
+#### Max Count
+Koleksiyon başına en fazla karo haritası (tile map) sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+#### Max Tile Count
+Koleksiyon başına aynı anda görünür olabilecek en fazla karo sayısı.
+
+---
+
+### Spine
+
+#### Max Count
+En fazla Spine model bileşeni sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+---
+
+### Mesh
+
+#### Max Count
+Koleksiyon başına en fazla örgü (mesh) bileşeni sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+---
+
+### Model
+
+#### Max Count
+Koleksiyon başına en fazla model bileşeni sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+#### Split Meshes
+65536'dan fazla köşesi olan örgüleri yeni örgülere böler.
+
+#### Max Bone Matrix Texture Width
+Kemik matrisi dokusunun en büyük genişliği. Yalnızca animasyonlar için gereken boyut kullanılır ve yukarı doğru ikinin en yakın kuvvetine yuvarlanır.
+
+#### Max Bone Matrix Texture Height
+Kemik matrisi dokusunun en büyük yüksekliği. Yalnızca animasyonlar için gereken boyut kullanılır ve yukarı doğru ikinin en yakın kuvvetine yuvarlanır.
+
+---
+
+### GUI
+
+#### Max Count
+En fazla GUI bileşeni sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+#### Max Particle Count
+GUI'de aynı anda var olabilecek en fazla parçacık sayısı.
+
+#### Max Animation Count
+GUI'deki en fazla etkin animasyon sayısı.
+
+---
+
+### Label
+
+#### Max Count
+En fazla etiket (label) sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+#### Subpixels
+Etiketlerin piksellere hizalanmadan görüntülenmesine izin vermek için işaretleyin.
+
+---
+
+### Particle FX
+
+#### Max Count
+Aynı anda var olabilecek en fazla yayıcı (emitter) sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+#### Max Particle Count
+Aynı anda var olabilecek en fazla parçacık sayısı.
+
+---
+
+### Box2D
+
+#### Velocity Iterations
+Box2D 2.2 fizik çözücüsü için hız yinelemesi sayısı.
+
+#### Position Iterations
+Box2D 2.2 fizik çözücüsü için konum yinelemesi sayısı.
+
+#### Sub Step Count
+Box2D 3.x fizik çözücüsü için alt adım sayısı.
+
+---
+
+### Collection proxy
+
+#### Max Count
+En fazla koleksiyon vekili sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+---
+
+### Collection factory
+
+#### Max Count
+En fazla koleksiyon fabrikası (collection factory) sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+---
+
+### Factory
+
+#### Max Count
+En fazla oyun nesnesi fabrikası (factory) sayısı. [(Bileşen sayısı üst sınırı optimizasyonlarıyla ilgili bilgilere bakın)](#component-max-count-optimizations).
+
+---
+
+### iOS
+
+#### App Icon 57x57--180x180
+Belirtilen `W` &times; `H` genişlik ve yükseklik boyutlarında uygulama simgesi olarak kullanılacak görüntü dosyası (.png).
+
+#### Launch Screen
+Storyboard dosyası (.storyboard). Böyle bir dosyanın nasıl oluşturulacağını [iOS kılavuzundan](/manuals/ios/#creating-a-storyboard) öğrenebilirsiniz.
+
+#### Icons Asset
+Uygulama simgelerini içeren simge varlığı dosyası (.car).
+
+#### Prerendered Icons
+(iOS 6 ve öncesi) Simgeleriniz önceden işlenmişse işaretleyin. İşaretli değilse simgelere otomatik olarak parlak bir vurgu eklenir.
+
+#### Bundle Identifier
+Paket tanımlayıcısı, iOS'un uygulamanızın güncellemelerini tanımasını sağlar. Paket kimliğiniz Apple'a kaydedilmeli ve uygulamanıza özgü olmalıdır. iOS ve macOS uygulamaları için aynı tanımlayıcıyı kullanamazsınız. Noktayla ayrılmış iki veya daha fazla bölümden oluşmalıdır. Her bölüm bir harfle başlamalıdır. Her bölüm yalnızca harflerden, rakamlardan, alt çizgi veya kısa çizgi (-) karakterinden oluşmalıdır (bkz. [`CFBundleIdentifier`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430))
+
+#### Bundle Name
+Paketin kısa adı (15 karakter) (bkz. [`CFBundleName`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430)).
+
+#### Bundle Version
+Paketin sürümü; bir sayı veya x.y.z biçiminde (bkz. [`CFBundleVersion`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430))
+
+#### Info.plist
+Belirtilirse uygulamanız paketlenirken yerleşik iOS temel bildirimi yerine bu *`Info.plist`* dosyası kullanılır. Yerleşik bildirim, yayıma yönelik olmayan derlemelerde düzenleyicinin hedef keşfi için gereken yerel ağ ve Bonjour girdilerini içerir. Özel bir bildirim sağlıyorsanız ve bir cihazda hedef keşfine, profil çıkarmaya, çalışma sırasında yeniden yüklemeye (hot reload) veya günlük akışına ihtiyaç duyuyorsanız bu girdileri [iOS kılavuzunda](/manuals/ios/#creating-an-ios-application-bundle) açıklandığı şekilde koruyun.
+
+#### Privacy Manifest
+Uygulamanın Apple Privacy Manifest dosyası. Alanın varsayılan değeri `/builtins/manifests/ios/PrivacyInfo.xcprivacy` olacaktır.
+
+#### Custom Entitlements
+Belirtilirse sağlanan sağlama profilindeki (provisioning profile; `.entitlements`, `.xcent`, `.plist`) yetkiler, uygulama paketlenirken sağlanan sağlama profilindeki yetkilerle birleştirilir.
+
+#### Default Language
+Uygulamanın `Localizations` listesinde kullanıcının tercih ettiği dil bulunmuyorsa kullanılacak dil (bkz. [`CFBundleDevelopmentRegion`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430)). Tercih edilen dil iki harfli ISO 639-1 standardında bulunuyorsa bu standardı, bulunmuyorsa üç harfli ISO 639-2 standardını kullanın.
+
+#### Localizations
+Bu alan, desteklenen yerelleştirmelerin dil adını veya ISO dil kodunu belirten, virgülle ayrılmış dizeleri içerir (bkz. [`CFBundleLocalizations`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-109552)).
+
+---
+
+### Android
+
+#### App Icon 36x36--192x192
+Belirtilen `W` &times; `H` genişlik ve yükseklik boyutlarında uygulama simgesi olarak kullanılacak görüntü dosyası (.png).
+
+#### Push Icon Small--LargeXxxhdpi
+Android'de özel anlık bildirim simgesi olarak kullanılacak görüntü dosyaları (.png). Simgeler hem yerel hem de uzak anlık bildirimlerde otomatik olarak kullanılır. Ayarlanmazsa varsayılan olarak uygulama simgesi kullanılır.
+
+#### Push Field Title
+Bildirim başlığı olarak JSON yükündeki hangi alanın kullanılacağını belirtir. Bu ayar boş bırakılırsa anlık bildirimlerin başlığı varsayılan olarak uygulama adı olur.
+
+#### Push Field Text
+Bildirim metni olarak JSON yükündeki hangi alanın kullanılacağını belirtir. Boş bırakılırsa iOS'ta olduğu gibi `alert` alanındaki metin kullanılır.
+
+#### Version Code
+Uygulamanın sürümünü belirten bir tam sayı değeri. Sonraki her güncellemede bu değeri artırın.
+
+#### Minimum SDK Version
+Uygulamanın çalışması için gereken en düşük API düzeyi (`android:minSdkVersion`).
+
+#### Target SDK Version
+Uygulamanın hedeflediği API düzeyi (`android:targetSdkVersion`).
+
+#### Package
+Paket tanımlayıcısı. Noktayla ayrılmış iki veya daha fazla bölümden oluşmalıdır. Her bölüm bir harfle başlamalıdır. Her bölüm yalnızca harflerden, rakamlardan veya alt çizgi karakterinden oluşmalıdır.
+
+#### GCM Sender Id
+Google Cloud Messaging gönderen tanımlayıcısı. Anlık bildirimleri etkinleştirmek için bunu Google'ın atadığı dizeye ayarlayın.
+
+#### FCM Application Id
+Firebase Cloud Messaging uygulama tanımlayıcısı.
+
+#### Manifest
+Ayarlanırsa paketleme sırasında belirtilen Android bildirim XML dosyası kullanılır. Özel bir bildirim, Defold'un yerleşik temel bildiriminin yerini alır. Yerel kod eklentilerinin (native extension) bildirim parçaları yine bu dosyayla birleştirilir; ancak yerleşik temel bildirimde daha sonra yapılan değişiklikler otomatik olarak aktarılmaz. Bu nedenle sürüm yükseltirken özel bildirimleri geçerli yerleşik bildirimle karşılaştırın. Oyunlar için `android:appCategory="game"` ayarını `<application>` öğesinde yapın. Oyun olmayan uygulamalarda `android:appCategory` ayarını yalnızca Android'in tanımlı [uygulama kategorilerinden](https://developer.android.com/guide/topics/manifest/application-element#appCategory) biri uygulamayı doğru şekilde tanımlıyorsa yapın.
+
+#### Iap Provider
+Kullanılacak mağazayı belirtir. `Amazon` ve `GooglePlay` seçenekleri geçerlidir. Daha fazla bilgi için [extension-iap](/extension-iap/) sayfasına bakın.
+
+#### Input Method
+Android cihazlarda klavye girdisi almak için kullanılacak yöntemi belirtir. Geçerli seçenekler `KeyEvent` (eski yöntem) ve `HiddenInputField` (yeni).
+
+#### Immersive Mode
+Ayarlanırsa gezinme ve durum çubuklarını gizler ve uygulamanızın ekrandaki tüm dokunma olaylarını yakalamasını sağlar.
+
+#### Display Cutout
+Ekran çentiğine kadar genişletir.
+
+#### Debuggable
+[GAPID](https://github.com/google/gapid) veya [Android Studio](https://developer.android.com/studio/profile/android-profiler) gibi araçlarla uygulamada hata ayıklanıp ayıklanamayacağını belirler. Android bildirimindeki `android:debuggable` bayrağını ayarlar ([resmî belgeler](https://developer.android.com/guide/topics/manifest/application-element#debug)).
+
+#### R8 Keep Rules
+`android.r8_keep_rules`, Android derlemelerinde Java kodunun R8 ile küçültülmesini, optimize edilmesini ve karartılmasını etkinleştirmek için bir `.keep` dosyası seçer. D8'i küçültme yapmadan kullanmak için ayarı boş bırakın.
+
+Defold'un varsayılan kurallarını doğrudan kullanmak için `/builtins/manifests/android/dmengine.keep` dosyasını seçin. Eklentiler kendi [koruma kurallarını](/manuals/extensions/#r8-keep-rules-for-android) sağlar; bu kurallar bu dosyayla birleştirilir.
+
+Yerleşik dosyayı yalnızca projeye özgü kurallar eklemeniz gerekiyorsa projenize kopyalayın. Kopyadaki yerleşik kuralları koruyun: özel bir dosya seçmek, projenin tüm kural kümesini değiştirir.
+
+R8'i etkinleştirmek ve karartma eşlemesini yayıma yönelik bir dağıtım paketiyle birlikte saklamak için [Android kılavuzuna](/manuals/android/#shrinking-java-code-with-r8) bakın.
+
+#### Extract Native Libraries
+Paket yükleyicisinin yerel kod kütüphanelerini APK dosyasından dosya sistemine çıkarıp çıkarmayacağını belirtir. `false` olarak ayarlanırsa yerel kod kütüphaneleriniz APK içinde sıkıştırılmadan saklanır. APK dosyanız daha büyük olsa da kütüphaneler çalışma sırasında doğrudan APK dosyasından yüklendiği için uygulamanız daha hızlı yüklenir. Android bildirimindeki `android:extractNativeLibs` bayrağını ayarlar ([resmî belgeler](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs)).
+
+---
+
+### macOS
+
+#### App Icon
+macOS'ta uygulama simgesi olarak kullanılacak paket simgesi dosyası (.icns).
+
+#### Info.plist
+Ayarlanırsa paketleme sırasında belirtilen info.plist dosyası kullanılır.
+
+#### Privacy Manifest
+Uygulamanın Apple Privacy Manifest dosyası. Alanın varsayılan değeri `/builtins/manifests/osx/PrivacyInfo.xcprivacy` olacaktır.
+
+#### Bundle Identifier
+Paket tanımlayıcısı, macOS'un uygulamanızın güncellemelerini tanımasını sağlar. Paket kimliğiniz Apple'a kaydedilmeli ve uygulamanıza özgü olmalıdır. iOS ve macOS uygulamaları için aynı tanımlayıcıyı kullanamazsınız. Noktayla ayrılmış iki veya daha fazla bölümden oluşmalıdır. Her bölüm bir harfle başlamalıdır. Her bölüm yalnızca harflerden, rakamlardan, alt çizgi veya kısa çizgi (-) karakterinden oluşmalıdır.
+
+#### Default Language
+Uygulamanın `Localizations` listesinde kullanıcının tercih ettiği dil bulunmuyorsa kullanılacak dil (bkz. [`CFBundleDevelopmentRegion`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-130430)). Tercih edilen dil iki harfli ISO 639-1 standardında bulunuyorsa bu standardı, bulunmuyorsa üç harfli ISO 639-2 standardını kullanın.
+
+#### Localizations
+Bu alan, desteklenen yerelleştirmelerin dil adını veya ISO dil kodunu belirten, virgülle ayrılmış dizeleri içerir (bkz. [`CFBundleLocalizations`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-109552)).
+
+---
+
+### Windows
+
+#### App Icon
+Windows'ta uygulama simgesi olarak kullanılacak görüntü dosyası (.ico). .ico dosyası oluşturma hakkında daha fazla bilgi için [Windows kılavuzuna](/manuals/windows) bakın.
+
+---
+
+### HTML5
+
+Bu seçeneklerin çoğu hakkında daha fazla bilgi için [HTML5 platformu kılavuzuna](/manuals/html5/) bakın.
+
+#### Heap Size
+Emscripten'in kullanacağı öbeğin megabayt cinsinden boyutu.
+
+#### .html Shell
+Paketleme sırasında belirtilen HTML şablon dosyasını kullanır. Varsayılan olarak `/builtins/manifests/web/engine_template.html`.
+
+#### Custom .css
+Paketleme sırasında belirtilen CSS tema dosyasını kullanır. Varsayılan olarak `/builtins/manifests/web/light_theme.css`.
+
+#### Splash Image
+Ayarlanırsa oluşturulan dağıtım paketinde, başlangıçta Defold logosu yerine belirtilen açılış görüntüsü kullanılır.
+
+#### Archive Location Prefix
+HTML5 için paketleme yapılırken oyun verileri bir veya daha fazla arşiv veri dosyasına bölünür. Motor oyunu başlattığında bu arşiv dosyaları belleğe okunur. Verilerin konumunu belirtmek için bu ayarı kullanın.
+
+#### Archive Location Suffix
+Arşiv dosyalarının sonuna eklenecek son ek. Örneğin bir CDN'den önbelleğe alınmamış içeriğin alınmasını zorlamak için yararlıdır (örneğin `?version2`).
+
+#### Engine Arguments
+Motora geçirilecek bağımsız değişkenlerin listesi.
+
+#### Wasm Streaming
+wasm dosyasının akışla aktarılmasını etkinleştirir (daha hızlıdır ve daha az bellek kullanır, ancak `application/wasm` MIME türünü gerektirir).
+
+#### Show Fullscreen Button
+`index.html` dosyasında Fullscreen Button düğmesini etkinleştirir.
+
+#### Show Made With Defold
+`index.html` dosyasında Made With Defold bağlantısını etkinleştirir.
+
+#### Show Console Banner
+Bu seçenek etkinleştirildiğinde, motor başladığında motor ve sürümü hakkında bilgiler tarayıcı konsoluna yazdırılır (`console.log()` kullanılarak).
+
+#### Scale Mode
+Oyun tuvalini ölçeklemek için kullanılacak yöntemi belirtir.
+
+#### Retry Count
+Başlangıç sırasında başarısız bir indirmeden sonraki yeniden deneme sayısı; ağ hatalarını, başarısız HTTP durumlarını ve motorun JavaScript veya WebAssembly dosyasındaki boyut uyuşmazlıklarını kapsar. İlk istek ayrı sayılır. Arşiv dosyası doğrulamasının kendi yeniden deneme sınırı vardır; [indirme doğrulamasına](/manuals/html5/#download-verification) ve `Retry Time` ayarına bakın.
+
+#### Retry Time
+İndirme başarısız olduğunda dosyayı indirme girişimleri arasında beklenecek saniye sayısı (bkz. `Retry Count`).
+
+#### Verify Downloaded File Size
+`html5.verify_downloaded_file_size`, indirilen motor ve arşiv dosyalarını beklenen boyutlarıyla karşılaştırır. Varsayılan olarak etkindir (`true`). Yalnızca bir sunucu, ara sunucu veya CDN dosyaları bilerek yeniden yazıp boyutlarını değiştiriyorsa `false` olarak ayarlayın. Doğrulama başarısız olursa başlatma başarısızlıkla sonuçlanmadan önce indirme yeniden denenir. Motor indirmeleriyle arşiv dosyası doğrulamasının yeniden deneme sınırları farklıdır; [indirme doğrulamasına](/manuals/html5/#download-verification) bakın.
+
+#### Transparent Graphics Context
+Grafik bağlamının saydam bir arka plana sahip olması için işaretleyin.
+
+---
+
+### IAP
+
+#### Auto Finish Transactions
+IAP işlemlerini otomatik olarak tamamlamak için işaretleyin. İşaretli değilse başarılı bir işlemden sonra `iap.finish()` işlevini açıkça çağırmanız gerekir.
+
+---
+
+### Live update
+
+#### Settings
+Paketleme sırasında kullanılacak Live Update ayarları kaynak dosyası.
+
+---
+
+### Native extension
+
+#### _App Manifest_
+Ayarlanırsa motor derlemesini özelleştirmek için uygulama bildirimi (app manifest) kullanılır. Bu, son ikili dosyanın boyutunu azaltmak için motorun kullanılmayan bölümlerini kaldırmanızı sağlar. Kullanılmayan özellikleri nasıl hariç tutacağınızı [uygulama bildirimi kılavuzundan](/manuals/app-manifest) öğrenebilirsiniz.
+
+---
+
+### Profiler
+
+App Manifest içindeki **Profiler** ayarı, profil çıkarıcı kodunun hata ayıklama derlemelerine ve yayıma yönelik derlemelere bağlanıp bağlanmayacağını belirler. Aşağıdaki ayarlar, seçilen derlemede bulunan profil çıkarıcı kodunun çalışma sırasındaki davranışını denetler. Ayrıntılar için [Profil çıkarma kılavuzuna](/manuals/profiling/) bakın.
+
+#### Enabled
+Oyun içi profil çıkarıcıyı etkinleştirir.
+
+#### Track Cpu
+CPU kullanımı örneklemesi, hata ayıklama derlemelerinde varsayılan olarak etkindir. App Manifest aracılığıyla profil çıkarıcı desteği içeren, yayıma yönelik bir derlemede de CPU örneklemesi gerekiyorsa bu ayarı etkinleştirin.
+
+#### Sleep Between Server Updates
+Sunucu güncellemeleri arasında beklenecek milisaniye sayısı.
+
+#### Performance Timeline Enabled
+Tarayıcı içi performans zaman çizelgesini etkinleştirir (yalnızca HTML5).
+
+#### Max Sample Count
+`profiler.max_sample_count`, her karede iş parçacığı başına kaydedilen en fazla profil çıkarıcı örneği sayısıdır. Varsayılan değer `4096`, en düşük değer ise `128`'dir. Bunu yalnızca geçerli bir profil sınırı aşıyorsa artırın; önce yerel kod eklentilerinin profil çıkarma kodunda eşleşmeyen kapsam başlatma/bitirme çağrılarını kontrol edin.
+
+---
+
+## Motor başlangıcında yapılandırma değerlerini ayarlama
+
+Motor başlarken komut satırından *game.project* ayarlarını geçersiz kılan yapılandırma değerleri sağlanabilir:
+
+```bash
+# Specify a bootstrap collection
+$ dmengine --config=bootstrap.main_collection=/my.collectionc
+
+# Set two custom config values
+$ dmengine --config=test.my_value=4711 --config=test2.my_value2=foobar
+```
+
+Özel değerler---tıpkı diğer yapılandırma değerleri gibi---[Çalışma sırasında erişim](#runtime-access) bölümünde açıklanan uygun işlevle okunabilir:
+
+```lua
+local my_value = sys.get_config_number("test.my_value")
+local my_value2 = sys.get_config_string("test.my_value2")
+local my_flag = sys.get_config_boolean("test.my_flag", false)
+```
+
+
+:[Component max count optimizations](../shared/component-max-count-optimizations.md)
+
+
+## Özel proje ayarları
+
+Ana proje veya bir [yerel kod eklentisi](/manuals/extensions/) için özel ayarlar tanımlanabilir. Ana projenin özel ayarları, proje kökündeki bir `game.properties` dosyasında tanımlanmalıdır. `ext.properties` adlı dosyalar, projenin ve alınan kütüphane bağımlılıklarının herhangi bir yerinde bulunabilir; aynı dizinde bir `ext.manifest` bulunmasını gerektirmezler. Bulunan tüm eklenti üst verileri birleştirilir, ardından kökteki `game.properties` dosyası uygulanır ve bu üst verileri geçersiz kılabilir.
+
+Ayarlar dosyası, *game.project* ile aynı INI biçimini kullanır ve özellik öznitelikleri, son ek içeren noktalı bir gösterimle tanımlanır:
+
+```
+[my_category]
+my_property.private = 1
+...
+```
+
+Her zaman uygulanan varsayılan üst veri dosyası [burada](https://github.com/defold/defold/blob/dev/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties) bulunur
+
+Şu anda aşağıdaki öznitelikler kullanılabilir:
+
+```
+[my_extension]
+// `type` - used for the value string parsing
+my_property.type = string // one of the following values: bool, string, number, integer, string_array, resource
+
+// `help` - displayed as a help tooltip in the editor
+my_property.help = string
+
+// `default` - value used as default if user didn't set value manually
+my_property.default = string
+
+// `private` - private value used during the bundle process but will be removed from the bundle itself
+my_property.private = 1 // boolean value 1 or 0
+
+// `label` - editor input label
+my_property.label = My Awesome Property
+
+// `minimum` and/or `maximum` - valid range for numeric properties, validated in the editor UI
+my_property.minimum = 0
+my_property.maximum = 255
+
+// `options` - drop-down choices for the editor UI, comma-separated value[:label] pairs
+my_property.options = android: Android, ios: iOS
+
+// `resource` type only:
+my_property.filter = jpg,png // allowed file extensions for resource selector dialog
+my_property.preserve-extension = 1 // use original resource extension instead of a built one
+
+// deprecation
+my_property.deprecated = 1 // mark property as deprecated
+my_property.severity-default = warning // if deprecated property is specified, but set to a default value
+my_property.severity-override = error  // if deprecated property is specified and set to a non-default value
+
+```
+Ayrıca bir ayar kategorisinde aşağıdaki öznitelikleri ayarlayabilirsiniz:
+```
+[my_extension]
+// `group` - game.project category group, e.g. Main, Platforms, Components, Runtime, Distribution
+group = Runtime
+// `title` - displayed category title
+title = My Awesome Extension
+// `help` - displayed category help
+help = Settings for My Awesome Extension
+```
+
+
+Hem Bob hem de düzenleyici bu üst veri dosyalarını ayrıştırır. Düzenleyici, *game.project* görüntüleyicisinde ilgili alanları, seçenekleri, doğrulamayı ve yardım araç ipuçlarını oluşturmak için bunları kullanır.

--- a/docs/tr/manuals/project-setup.md
+++ b/docs/tr/manuals/project-setup.md
@@ -1,0 +1,42 @@
+---
+title: Proje kurulumu
+brief: Bu kılavuz, Defold'da proje oluşturmayı veya açmayı açıklar.
+---
+
+# Proje kurulumu
+
+Defold düzenleyicisinden kolayca yeni bir proje oluşturabilirsiniz. Ayrıca bilgisayarınızda bulunan mevcut bir projeyi de açabilirsiniz.
+
+## Yeni bir yerel proje oluşturma {#creating-a-new-project}
+
+<kbd>New Project</kbd> seçeneğine tıklayın ve oluşturmak istediğiniz proje türünü seçin. Proje dosyalarının saklanacağı konumu sabit diskinizde belirtin. Projeyi seçtiğiniz konumda oluşturmak için <kbd>Create New Project</kbd> seçeneğine tıklayın. Bir şablondan (Template) yeni proje oluşturabilirsiniz:
+
+![proje açma](images/workflow/open_project.png)
+
+Veya adım adım yönergeler içeren bir öğreticiden (Tutorial):
+
+![öğreticiden proje oluşturma](images/workflow/create_from_tutorial.png)
+
+Veya tamamlanmış bir örnek oyundan (Sample):
+
+![örnekten proje oluşturma](images/workflow/create_from_sample.png)
+
+### Projeyi GitHub'a ekleme
+
+Yerel bir proje herhangi bir sürüm kontrol sistemiyle (version control system) bütünleşik değildir; yani dosyalar yalnızca sabit diskinizde bulunur ve değişiklikleri geri alabileceğiniz bir geçmiş yoktur. Düzenleyicinin *Assets* bölmesinden silinen dosyalar, desteklendiğinde sistemin Trash veya Recycle Bin klasörüne taşınır; ancak bu işlem kullanılamıyorsa veya başarısız olursa dosyalar kalıcı olarak silinebilir. Çöp kutusu, dosyalarda yapılan düzenlemelere karşı koruma sağlamaz ve sürüm geçmişi tutmaz; bu nedenle dosyalarınızdaki değişiklikleri izlemek için Git gibi bir sürüm kontrol sistemi kullanmanız önerilir. Bu, bir projede başkalarıyla birlikte çalışmayı da çok kolaylaştırır. Yerel bir projeyi GitHub'a yüklemek yalnızca birkaç adımda yapılabilir:
+
+1. [GitHub](https://github.com/) üzerinde bir hesap oluşturun veya hesabınıza giriş yapın
+2. [New Repository](https://help.github.com/en/articles/creating-a-new-repository) seçeneğini kullanarak bir depo oluşturun
+3. [Upload Files](https://help.github.com/en/articles/adding-a-file-to-a-repository) seçeneğiyle tüm proje dosyalarını yükleyin
+
+Proje artık sürüm kontrolü altındadır; [projeyi klonlayarak](https://help.github.com/en/articles/cloning-a-repository) yerel sabit diskinize kopyalamanız ve artık bu yeni konumda çalışmanız önerilir.
+
+## Mevcut bir projeyi açma
+
+Bilgisayarınızda bulunan bir projeyi açmak için <kbd>Open From Disk</kbd> seçeneğine tıklayın.
+
+![projeyi içe aktarma](images/workflow/open_from_disk.png)
+
+## Son kullanılan bir projeyi açma
+
+Bir proje bir kez açıldıktan sonra son kullanılan projeler listesinde görünür. Bu liste, en son üzerinde çalıştığınız projeleri gösterir ve listedeki bir projeye çift tıklayarak onu hızla açmanızı sağlar.

--- a/docs/tr/manuals/properties.md
+++ b/docs/tr/manuals/properties.md
@@ -1,0 +1,166 @@
+---
+title: Defold'da özellikler
+brief: Bu kılavuz, Defold'da hangi özellik türlerinin bulunduğunu, bunların nasıl kullanıldığını ve bunlara nasıl animasyon uygulandığını açıklar.
+---
+
+# Özellikler
+
+Defold, oyun nesneleri (game object), bileşenler (component) ve GUI düğümleri (GUI node) için okunabilen, ayarlanabilen ve animasyon uygulanabilen özellikler (property) sunar. Aşağıdaki özellik türleri bulunur:
+
+* Sistem tarafından tanımlanan oyun nesnesi dönüşümleri (konum, dönme ve ölçek) ve bileşene özgü özellikler (örneğin bir sprite bileşeninin piksel boyutu veya bir çarpışma nesnesinin (collision object) kütlesi)
+* Lua betiklerinde tanımlanan, kullanıcı tanımlı betik bileşeni (script component) özellikleri (ayrıntılar için [Betik özellikleri belgelerine](/manuals/script-properties) bakın)
+* GUI düğümü özellikleri
+* Gölgelendiricilerde (shader) ve materyal (material) dosyalarında tanımlanan gölgelendirici sabitleri (ayrıntılar için [Materyal belgelerine](/manuals/material) bakın)
+
+Sayısal özelliklerin giriş alanının üzerine geldiğinizde bir sürükleme tutamacı görünür. Tutamacı sağa/sola veya yukarı/aşağı sürükleyerek değeri sırasıyla artırabilir/azaltabilirsiniz.
+
+Bir özelliğe, bulunduğu yere bağlı olarak genel amaçlı bir işlev veya özelliğe özgü bir işlev aracılığıyla erişirsiniz. Özelliklerin birçoğuna otomatik olarak animasyon uygulanabilir. Hem performans hem de kullanım kolaylığı açısından, özellikleri kendiniz değiştirmek (bir `update()` işlevinin içinde) yerine yerleşik sistem aracılığıyla animasyon uygulamanız özellikle önerilir.
+
+`vector3`, `vector4` veya kuaterniyon (`quaternion`) türündeki bileşik özellikler, alt bileşenlerini (`x`, `y`, `z` ve `w`) de erişime açar. Adın sonuna bir nokta (`.`) ve bileşenin adını ekleyerek bileşenleri ayrı ayrı adresleyebilirsiniz. Örneğin, bir oyun nesnesinin konumunun x bileşenini ayarlamak için:
+
+```lua
+-- Set the x position of "game_object" to 10.
+go.set("game_object", "position.x", 10)
+```
+
+`go.get()`, `go.set()` ve `go.animate()` işlevleri ilk parametre olarak bir başvuru, ikinci parametre olarak bir özellik tanımlayıcısı alır. Başvuru, oyun nesnesini veya bileşeni tanımlar ve bir dize, karma (hash) değeri veya URL olabilir. URL'ler [adresleme kılavuzunda](/manuals/addressing) ayrıntılı olarak açıklanır. Özellik tanımlayıcısı, özelliği adlandıran bir dize veya karma değeridir:
+
+```lua
+-- Set the x-scale of the sprite component
+local url = msg.url("#sprite")
+local prop = hash("scale.x")
+go.set(url, prop, 2.0)
+```
+
+GUI düğümleri için düğüm, özelliğe özgü bir işleve veya genel amaçlı `gui.get()` ve `gui.set()` işlevlerine ilk parametre olarak verilir:
+
+```lua
+-- Get the color of the button
+local node = gui.get_node("button")
+local color = gui.get_color(node)
+local same_color = gui.get(node, "color")
+gui.set(node, "color.x", 1)
+```
+
+## Oyun nesnesi ve bileşen özellikleri
+
+Tüm oyun nesneleri ve bazı bileşen türleri, çalışma sırasında okunabilen ve değiştirilebilen özelliklere sahiptir. Bu değerleri [`go.get()`](/ref/go#go.get) ile okuyun ve [`go.set()`](/ref/go#go.set) ile yazın. Özellik değerinin türüne bağlı olarak, değerlere [`go.animate()`](/ref/go#go.animate) ile animasyon uygulayabilirsiniz. Özelliklerin küçük bir bölümü salt okunurdur.
+
+`get`{.mark}
+: [`go.get()`](/ref/go#go.get) ile okunabilir.
+
+`get+set`{.mark}
+: [`go.get()`](/ref/go#go.get) ile okunabilir ve [`go.set()`](/ref/go#go.set) ile yazılabilir. Sayısal değerlere [`go.animate()`](/ref/go#go.animate) ile animasyon uygulanabilir.
+
+*Oyun nesnesi özellikleri*
+
+| özellik   | açıklama                            | tür            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *position* | Oyun nesnesinin yerel konumu. | `vector3`      | `get+set`{.mark} |
+| *rotation* | Oyun nesnesinin `quaternion` olarak ifade edilen yerel dönmesi.  | `quaternion` | `get+set`{.mark} |
+| *euler*    | Oyun nesnesinin Euler açılarıyla ifade edilen yerel dönmesi. | `vector3` | `get+set`{.mark} |
+| *scale*    | Oyun nesnesinin yerel, eşit olmayan ölçeği; her bileşeni ilgili eksen boyunca bir çarpan içeren bir vektör olarak ifade edilir. Z'yi değiştirmeden X ve Y boyutlarını iki katına çıkarmak için `vmath.vector3(2.0, 2.0, 1.0)` kullanın. | `vector3` | `get+set`{.mark} |
+| *scale.xy*    | Oyun nesnesinin X ve Y eksenleri boyunca yerel, eşit olmayan ölçeği. Z ekseninde ölçekleme amaçlanmadığında bu özelliği veya `go.set_scale_xy()` işlevini kullanın. | `vector3` | `get+set`{.mark} |
+
+::: sidenote
+Oyun nesnesi dönüşümüyle çalışmak için özel işlevler de bulunur: `go.get_position()`, `go.set_position()`, `go.get_rotation()`, `go.set_rotation()`,  `go.get_scale()`, `go.set_scale()` ve `go.set_scale_xy()`.
+:::
+
+*Sprite bileşeni özellikleri*
+
+| özellik   | açıklama                            | tür            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *size*     | Sprite bileşeninin ölçeklenmemiş boyutu---kaynak atlastan alınan boyutu. | `vector3` | `get`{.mark} |
+| *image* | Sprite bileşeninin doku yolunun karma değeri. | `hash` | `get`{.mark}|
+| *scale* | Sprite bileşeninin eşit olmayan ölçeği. | `vector3` | `get+set`{.mark}|
+| *scale.xy* | Sprite bileşeninin X ve Y eksenleri boyunca eşit olmayan ölçeği. | `vector3` | `get+set`{.mark}|
+| *material* | Sprite bileşeninin kullandığı materyal. | `hash` | `get+set`{.mark}|
+| *cursor* | Oynatma imlecinin konumu (0--1 arasında). | `number` | `get+set`{.mark}|
+| *playback_rate* | Kare dizisi animasyonunun (flipbook animation) kare hızı. | `number` | `get+set`{.mark}|
+
+*Çarpışma nesnesi bileşeni özellikleri*
+
+| özellik   | açıklama                            | tür            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *mass*     | Çarpışma nesnesinin kütlesi. | `number` | `get`{.mark} |
+| *linear_velocity* | Çarpışma nesnesinin geçerli doğrusal hızı. | `vector3` | `get`{.mark} |
+| *angular_velocity* | Çarpışma nesnesinin geçerli açısal hızı. | `vector3` | `get`{.mark} |
+| *linear_damping* | Çarpışma nesnesinin doğrusal sönümlemesi. | `vector3` | `get+set`{.mark} |
+| *angular_damping* | Çarpışma nesnesinin açısal sönümlemesi. | `vector3` | `get+set`{.mark} |
+
+*Model (3B) bileşeni özellikleri*
+
+| özellik   | açıklama                            | tür            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *animation* | Geçerli animasyon.                | `hash`          | `get`{.mark}     |
+| *texture0*--*texture15* | Modelin doku yollarının karma değerleri. | `hash` | `get+set`{.mark}|
+| *cursor*  | Oynatma imlecinin konumu (0--1 arasında). | `number`   | `get+set`{.mark} |
+| *playback_rate* | Animasyonun oynatma hızı. Animasyonun oynatma hızı için bir çarpandır. | `number` | `get+set`{.mark} |
+| *material* | Modelin kullandığı materyal. | `hash` | `get+set`{.mark}|
+
+*Etiket bileşeni özellikleri*
+
+| özellik   | açıklama                            | tür            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *text* | Etiketin (label) metin içeriği. Defold 1.13.2 sürümünden itibaren kullanılabilir. | `string` | `get+set`{.mark} |
+| *scale* | Etiketin ölçeği. | `vector3` | `get+set`{.mark} |
+| *scale.xy* | Etiketin X ve Y eksenleri boyunca ölçeği. | `vector3` | `get+set`{.mark}|
+| *color*     | Etiketin rengi. | `vector4` | `get+set`{.mark} |
+| *outline* | Etiketin dış çizgi rengi. | `vector4` | `get+set`{.mark} |
+| *shadow* | Etiketin gölge rengi. | `vector4` | `get+set`{.mark} |
+| *size* | Etiketin boyutu. Satır kaydırma etkinse boyut, metni sınırlar. | `vector3` | `get+set`{.mark} |
+| *material* | Etiketin kullandığı materyal. | `hash` | `get+set`{.mark}|
+| *font* | Etiketin kullandığı yazı tipi. | `hash` | `get+set`{.mark}|
+
+
+## GUI düğümü özellikleri
+
+GUI düğümlerinin `gui.get_position()` ve `gui.set_position()` gibi, özellik değerlerini okumaya ve ayarlamaya özgü işlevleri vardır. Aşağıda listelenen yerleşik özellikler, alternatif olarak `gui.get(node, property)` ve `gui.set(node, property, value)` ile de okunup yazılabilir. Diğer düğüm değerleri yine de kendilerine özgü işlevleri gerektirebilir. GUI düğümlerindeki materyal sabitleri de genel amaçlı işlevleri kullanır. Bir vektör özelliğinin tek bir bileşenini adreslemek için sonuna bileşen adını ekleyin; örneğin `gui.set(node, "color.x", 1)`.
+
+Genel amaçlı ve özelliğe özgü işlevler her zaman aynı değer türlerini kullanmaz. `gui.get()` işleviyle `position`, `scale`, `size` ve `euler` özellikleri bütün olarak okunduğunda bir `vector4` döndürülür; karşılık gelen özelliğe özgü işlevler ise bir `vector3` döndürür. `gui.set()` bu özellikler için hem `vector3` hem de `vector4` kabul eder. Genel amaçlı `rotation` özelliği bir kuaterniyon kullanır; dönmeyi derece cinsinden ayarlarken `euler` kullanın.
+
+* `position` (veya `gui.PROP_POSITION`)
+* `rotation` (veya `gui.PROP_ROTATION`)
+* `euler` (veya `gui.PROP_EULER`)
+* `scale` (veya `gui.PROP_SCALE`)
+* `color` (veya `gui.PROP_COLOR`)
+* `outline` (veya `gui.PROP_OUTLINE`)
+* `shadow` (veya `gui.PROP_SHADOW`)
+* `size` (veya `gui.PROP_SIZE`)
+* `fill_angle` (veya `gui.PROP_FILL_ANGLE`)
+* `inner_radius` (veya `gui.PROP_INNER_RADIUS`)
+* `leading` (veya `gui.PROP_LEADING`)
+* `tracking` (veya `gui.PROP_TRACKING`)
+* `slice9` (veya `gui.PROP_SLICE9`)
+
+Tüm renk değerlerinin, bileşenleri RGBA değerlerine karşılık gelen bir `vector4` içinde kodlandığını unutmayın:
+
+`x`
+: Kırmızı renk bileşeni
+
+`y`
+: Yeşil renk bileşeni
+
+`z`
+: Mavi renk bileşeni
+
+`w`
+: Alfa bileşeni
+
+*GUI düğümü özellikleri*
+
+| özellik   | açıklama                            | tür            |                  |
+| ---------- | -------------------------------------- | --------------- | ---------------- |
+| *color*   | Düğümün yüzey rengi.            | `vector4`      | `gui.get_color()` `gui.set_color()` |
+| *outline* | Düğümün dış çizgi rengi.         | `vector4`       | `gui.get_outline()` `gui.set_outline()` |
+| *position* | Düğümün konumu. | `vector3` | `gui.get_position()` `gui.set_position()` |
+| *rotation* | Düğümün dönmesi. Okuma işlevi bir kuaterniyon döndürür; ayarlama işlevi bir kuaterniyon veya vektör biçiminde Euler açıları kabul eder. | `quaternion`, `vector3` veya `vector4` | `gui.get_rotation()` `gui.set_rotation()` |
+| *euler* | Düğümün derece cinsinden Euler açılarıyla ifade edilen dönmesi. | `vector3` | `gui.get_euler()` `gui.set_euler()` |
+| *scale* | Düğümün her eksen boyunca bir çarpan olarak ifade edilen ölçeği. | `vector3` |`gui.get_scale()` `gui.set_scale()` |
+| *shadow* | Düğümün gölge rengi. | `vector4` | `gui.get_shadow()` `gui.set_shadow()` |
+| *size* | Düğümün ölçeklenmemiş boyutu. | `vector3` | `gui.get_size()` `gui.set_size()` |
+| *fill_angle* | Daire dilimi düğümünün (pie node) saat yönünün tersine, derece cinsinden ifade edilen dolgu açısı. | `number` | `gui.get_fill_angle()` `gui.set_fill_angle()` |
+| *inner_radius* | Daire dilimi düğümünün iç yarıçapı. | `number` | `gui.get_inner_radius()` `gui.set_inner_radius()` |
+| *leading* | Metin düğümünün satır aralığı ölçeği. | `number` | `gui.get_leading()` `gui.set_leading()` |
+| *tracking* | Metin düğümünün harf aralığı ölçeği. | `number` | `gui.get_tracking()` `gui.set_tracking()` |
+| *slice9* | Bir slice9 düğümünün kenar mesafeleri. | `vector4` | `gui.get_slice9()` `gui.set_slice9()` |

--- a/docs/tr/manuals/property-animation.md
+++ b/docs/tr/manuals/property-animation.md
@@ -1,0 +1,180 @@
+---
+title: Defold özellik animasyonları kılavuzu
+brief: Bu kılavuz, Defold'da özellik animasyonlarının nasıl kullanılacağını açıklar.
+---
+
+# Özellik animasyonu
+
+Tüm sayısal özelliklere (`numbers`, `vector3`, `vector4` ve kuaterniyonlar (quaternion)) ve gölgelendirici (shader) sabitlerine, `go.animate()` işlevini kullanarak yerleşik animasyon sistemiyle animasyon uygulanabilir. Motor, verilen oynatma modlarına ve geçiş eğrisi (easing) işlevlerine göre özelliklere otomatik olarak "ara geçiş animasyonu" (tween) uygular. Özel geçiş eğrisi işlevleri de belirtebilirsiniz.
+
+  ![Özellik animasyonu](images/animation/property_animation.png)
+  ![Sıçrama döngüsü](images/animation/bounce.gif)
+
+## Özellik animasyonu
+
+Bir oyun nesnesinin (game object) veya bileşenin (component) özelliğine özellik animasyonu (property animation) uygulamak için `go.animate()` işlevini kullanın. GUI düğümü (GUI node) özellikleri için karşılık gelen işlev `gui.animate()` işlevidir.
+
+```lua
+-- Set the position property y component to 200
+go.set(".", "position.y", 200)
+-- Then animate it
+go.animate(".", "position.y", go.PLAYBACK_LOOP_PINGPONG, 100, go.EASING_OUTBOUNCE, 2)
+```
+
+Belirli bir özelliğin tüm animasyonlarını durdurmak için `go.cancel_animations()` işlevini, GUI düğümleri için ise `gui.cancel_animations()` işlevini çağırın:
+
+```lua
+-- Stop euler z rotation animation on the current game object
+go.cancel_animations(".", "euler.z")
+```
+
+`position` gibi bileşik bir özelliğin animasyonunu iptal ederseniz alt bileşenlerin (`position.x`, `position.y` ve `position.z`) tüm animasyonları da iptal edilir.
+
+[Özellikler kılavuzu](/manuals/properties), oyun nesnelerinde, bileşenlerde ve GUI düğümlerinde kullanılabilen tüm özellikleri içerir.
+
+## GUI düğümü özellik animasyonu
+
+GUI düğümü özelliklerinin neredeyse tamamına animasyon uygulanabilir. Örneğin, bir düğümün `color` özelliğini tam saydamlığa ayarlayarak onu görünmez yapabilir, ardından rengi animasyonla beyaza (yani renklendirme uygulanmayan duruma) dönüştürerek düğümü yavaşça görünür hâle getirebilirsiniz.
+
+```lua
+local node = gui.get_node("button")
+local color = gui.get_color(node)
+-- Animate the color to white
+gui.animate(node, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_INOUTQUAD, 0.5)
+-- Animate the outline red color component
+gui.animate(node, "outline.x", 1, gui.EASING_INOUTQUAD, 0.5)
+-- And move to x position 100
+gui.animate(node, hash("position.x"), 100, gui.EASING_INOUTQUAD, 0.5)
+```
+
+## Tamamlanma geri çağırımları
+
+Özellik animasyonu işlevleri `go.animate()` ve `gui.animate()`, son bağımsız değişken olarak isteğe bağlı bir Lua geri çağırım (callback) işlevini destekler. Bu işlev, animasyon sonuna kadar oynatıldığında çağrılır. Döngüde oynatılan animasyonlarda veya bir animasyon `go.cancel_animations()` ya da `gui.cancel_animations()` aracılığıyla elle iptal edildiğinde bu işlev hiçbir zaman çağrılmaz. Geri çağırım, animasyon tamamlandığında olayları tetiklemek veya birden çok animasyonu birbirine zincirlemek için kullanılabilir.
+
+## Geçiş eğrileri {#easing}
+
+Geçiş eğrisi, animasyon uygulanan değerin zaman içinde nasıl değiştiğini tanımlar. Aşağıdaki görüntüler, geçiş eğrisini oluşturmak için zaman içinde uygulanan işlevleri gösterir.
+
+`go.animate()` için geçerli geçiş eğrisi değerleri şunlardır:
+
+|---|---|
+| `go.EASING_LINEAR` | |
+| `go.EASING_INBACK` | `go.EASING_OUTBACK` |
+| `go.EASING_INOUTBACK` | `go.EASING_OUTINBACK` |
+| `go.EASING_INBOUNCE` | `go.EASING_OUTBOUNCE` |
+| `go.EASING_INOUTBOUNCE` | `go.EASING_OUTINBOUNCE` |
+| `go.EASING_INELASTIC` | `go.EASING_OUTELASTIC` |
+| `go.EASING_INOUTELASTIC` | `go.EASING_OUTINELASTIC` |
+| `go.EASING_INSINE` | `go.EASING_OUTSINE` |
+| `go.EASING_INOUTSINE` | `go.EASING_OUTINSINE` |
+| `go.EASING_INEXPO` | `go.EASING_OUTEXPO` |
+| `go.EASING_INOUTEXPO` | `go.EASING_OUTINEXPO` |
+| `go.EASING_INCIRC` | `go.EASING_OUTCIRC` |
+| `go.EASING_INOUTCIRC` | `go.EASING_OUTINCIRC` |
+| `go.EASING_INQUAD` | `go.EASING_OUTQUAD` |
+| `go.EASING_INOUTQUAD` | `go.EASING_OUTINQUAD` |
+| `go.EASING_INCUBIC` | `go.EASING_OUTCUBIC` |
+| `go.EASING_INOUTCUBIC` | `go.EASING_OUTINCUBIC` |
+| `go.EASING_INQUART` | `go.EASING_OUTQUART` |
+| `go.EASING_INOUTQUART` | `go.EASING_OUTINQUART` |
+| `go.EASING_INQUINT` | `go.EASING_OUTQUINT` |
+| `go.EASING_INOUTQUINT` | `go.EASING_OUTINQUINT` |
+
+`gui.animate()` için geçerli geçiş eğrisi değerleri şunlardır:
+
+|---|---|
+| `gui.EASING_LINEAR` | |
+| `gui.EASING_INBACK` | `gui.EASING_OUTBACK` |
+| `gui.EASING_INOUTBACK` | `gui.EASING_OUTINBACK` |
+| `gui.EASING_INBOUNCE` | `gui.EASING_OUTBOUNCE` |
+| `gui.EASING_INOUTBOUNCE` | `gui.EASING_OUTINBOUNCE` |
+| `gui.EASING_INELASTIC` | `gui.EASING_OUTELASTIC` |
+| `gui.EASING_INOUTELASTIC` | `gui.EASING_OUTINELASTIC` |
+| `gui.EASING_INSINE` | `gui.EASING_OUTSINE` |
+| `gui.EASING_INOUTSINE` | `gui.EASING_OUTINSINE` |
+| `gui.EASING_INEXPO` | `gui.EASING_OUTEXPO` |
+| `gui.EASING_INOUTEXPO` | `gui.EASING_OUTINEXPO` |
+| `gui.EASING_INCIRC` | `gui.EASING_OUTCIRC` |
+| `gui.EASING_INOUTCIRC` | `gui.EASING_OUTINCIRC` |
+| `gui.EASING_INQUAD` | `gui.EASING_OUTQUAD` |
+| `gui.EASING_INOUTQUAD` | `gui.EASING_OUTINQUAD` |
+| `gui.EASING_INCUBIC` | `gui.EASING_OUTCUBIC` |
+| `gui.EASING_INOUTCUBIC` | `gui.EASING_OUTINCUBIC` |
+| `gui.EASING_INQUART` | `gui.EASING_OUTQUART` |
+| `gui.EASING_INOUTQUART` | `gui.EASING_OUTINQUART` |
+| `gui.EASING_INQUINT` | `gui.EASING_OUTQUINT` |
+| `gui.EASING_INOUTQUINT` | `gui.EASING_OUTINQUINT` |
+
+![Doğrusal ara değerleme](images/properties/easing_linear.png)
+![Başlangıçta geri taşma](images/properties/easing_inback.png)
+![Bitişte geri taşma](images/properties/easing_outback.png)
+![Başlangıçta ve bitişte geri taşma](images/properties/easing_inoutback.png)
+![Bitişte ve başlangıçta geri taşma](images/properties/easing_outinback.png)
+![Başlangıçta sıçrama](images/properties/easing_inbounce.png)
+![Bitişte sıçrama](images/properties/easing_outbounce.png)
+![Başlangıçta ve bitişte sıçrama](images/properties/easing_inoutbounce.png)
+![Bitişte ve başlangıçta sıçrama](images/properties/easing_outinbounce.png)
+![Başlangıçta esnek geçiş](images/properties/easing_inelastic.png)
+![Bitişte esnek geçiş](images/properties/easing_outelastic.png)
+![Başlangıçta ve bitişte esnek geçiş](images/properties/easing_inoutelastic.png)
+![Bitişte ve başlangıçta esnek geçiş](images/properties/easing_outinelastic.png)
+![Başlangıçta sinüs geçişi](images/properties/easing_insine.png)
+![Bitişte sinüs geçişi](images/properties/easing_outsine.png)
+![Başlangıçta ve bitişte sinüs geçişi](images/properties/easing_inoutsine.png)
+![Bitişte ve başlangıçta sinüs geçişi](images/properties/easing_outinsine.png)
+![Başlangıçta üstel geçiş](images/properties/easing_inexpo.png)
+![Bitişte üstel geçiş](images/properties/easing_outexpo.png)
+![Başlangıçta ve bitişte üstel geçiş](images/properties/easing_inoutexpo.png)
+![Bitişte ve başlangıçta üstel geçiş](images/properties/easing_outinexpo.png)
+![Başlangıçta dairesel geçiş](images/properties/easing_incirc.png)
+![Bitişte dairesel geçiş](images/properties/easing_outcirc.png)
+![Başlangıçta ve bitişte dairesel geçiş](images/properties/easing_inoutcirc.png)
+![Bitişte ve başlangıçta dairesel geçiş](images/properties/easing_outincirc.png)
+![Başlangıçta ikinci dereceden geçiş](images/properties/easing_inquad.png)
+![Bitişte ikinci dereceden geçiş](images/properties/easing_outquad.png)
+![Başlangıçta ve bitişte ikinci dereceden geçiş](images/properties/easing_inoutquad.png)
+![Bitişte ve başlangıçta ikinci dereceden geçiş](images/properties/easing_outinquad.png)
+![Başlangıçta üçüncü dereceden geçiş](images/properties/easing_incubic.png)
+![Bitişte üçüncü dereceden geçiş](images/properties/easing_outcubic.png)
+![Başlangıçta ve bitişte üçüncü dereceden geçiş](images/properties/easing_inoutcubic.png)
+![Bitişte ve başlangıçta üçüncü dereceden geçiş](images/properties/easing_outincubic.png)
+![Başlangıçta dördüncü dereceden geçiş](images/properties/easing_inquart.png)
+![Bitişte dördüncü dereceden geçiş](images/properties/easing_outquart.png)
+![Başlangıçta ve bitişte dördüncü dereceden geçiş](images/properties/easing_inoutquart.png)
+![Bitişte ve başlangıçta dördüncü dereceden geçiş](images/properties/easing_outinquart.png)
+![Başlangıçta beşinci dereceden geçiş](images/properties/easing_inquint.png)
+![Bitişte beşinci dereceden geçiş](images/properties/easing_outquint.png)
+![Başlangıçta ve bitişte beşinci dereceden geçiş](images/properties/easing_inoutquint.png)
+![Bitişte ve başlangıçta beşinci dereceden geçiş](images/properties/easing_outinquint.png)
+
+## Özel geçiş eğrileri
+
+Bir değer kümesi içeren bir `vector` tanımlayarak özel geçiş eğrileri oluşturabilir, ardından yukarıdaki önceden tanımlanmış geçiş eğrisi sabitlerinden biri yerine bu vektörü verebilirsiniz. Vektör değerleri, başlangıç değerinden (`0`) hedef değere (`1`) uzanan bir eğriyi ifade eder. Çalışma zamanı ortamı, vektörden değerleri örnekler ve vektörde belirtilen noktalar arasındaki değerleri hesaplarken doğrusal ara değerleme (interpolation) uygular.
+
+Örneğin şu vektör:
+
+```lua
+local values = { 0, 0.4, 0.2, 0.2, 0.5, 1 }
+local my_easing = vmath.vector(values)
+```
+
+aşağıdaki eğriyi oluşturur:
+
+![Özel eğri](images/animation/custom_curve.png)
+
+Aşağıdaki örnek, bir oyun nesnesinin y konumunun kare dalga biçimindeki bir eğriye göre geçerli konum ile 200 arasında sıçramasını sağlar:
+
+```lua
+local values = { 0, 0, 0, 0, 0, 0, 0, 0,
+                 1, 1, 1, 1, 1, 1, 1, 1,
+                 0, 0, 0, 0, 0, 0, 0, 0,
+                 1, 1, 1, 1, 1, 1, 1, 1,
+                 0, 0, 0, 0, 0, 0, 0, 0,
+                 1, 1, 1, 1, 1, 1, 1, 1,
+                 0, 0, 0, 0, 0, 0, 0, 0,
+                 1, 1, 1, 1, 1, 1, 1, 1 }
+local square_easing = vmath.vector(values)
+go.animate("go", "position.y", go.PLAYBACK_LOOP_PINGPONG, 200, square_easing, 2.0)
+```
+
+![Kare dalga eğrisi](images/animation/square_curve.png)

--- a/docs/tr/manuals/push.md
+++ b/docs/tr/manuals/push.md
@@ -1,0 +1,6 @@
+---
+title: Defold'da iOS ve Android anlık bildirimleri
+brief: Bu belge, oyununuz veya uygulamanız için iOS ve Android'de uzak ve yerel anlık bildirimlerin (push notifications) nasıl yapılandırılacağını ve uygulanacağını açıklar.
+---
+
+[Bu kılavuz taşındı](/extension-push)

--- a/docs/tr/manuals/refactoring.md
+++ b/docs/tr/manuals/refactoring.md
@@ -1,0 +1,20 @@
+---
+title: Yeniden düzenleme
+brief: Bu kılavuz, güçlü yeniden düzenleme desteğiyle projenizin yapısını nasıl kolayca değiştirebileceğinizi açıklar.
+---
+
+# Yeniden düzenleme
+
+Yeniden düzenleme (refactoring), mevcut kodun ve varlıkların (asset) yapısını değiştirme sürecidir. Bir proje geliştirilirken öğeleri değiştirme veya taşıma gereksinimi sık sık ortaya çıkar: adlandırma kurallarına uymak ya da daha anlaşılır olmak için adların değiştirilmesi, kod veya varlık dosyalarının ise proje hiyerarşisinde daha mantıklı bir yere taşınması gerekir.
+
+Defold, varlıkların nasıl kullanıldığını izleyerek verimli biçimde yeniden düzenleme yapmanıza yardımcı olur. Yeniden adlandırılan ve/veya taşınan varlıklara yapılan başvuruları otomatik olarak günceller. Bir geliştirici olarak çalışırken kendinizi özgür hissetmelisiniz. Projeniz, her şeyin bozulup dağılmasından korkmadan dilediğiniz gibi değiştirebileceğiniz esnek bir yapıdır.
+
+::: important
+Otomatik yeniden düzenleme yalnızca değişiklikler düzenleyici içinden yapılırsa çalışır. Bir dosyayı düzenleyici dışında yeniden adlandırır veya taşırsanız bu dosyaya yapılan başvurular otomatik olarak değiştirilmez.
+:::
+
+Ancak, örneğin bir varlığı silerek bir başvuruyu bozarsanız düzenleyici sorunu çözemez, fakat yararlı hata bildirimleri sağlar. Örneğin, bir atlastan bir animasyonu silerseniz ve bu animasyon herhangi bir yerde kullanılıyorsa Defold, oyunu başlatmaya çalıştığınızda bir hata bildirir. Düzenleyici, sorunu hızla bulmanıza yardımcı olmak için hataların oluştuğu yerleri de işaretler:
+
+![Yeniden düzenleme hatası](images/workflow/delete_error.png)
+
+Derleme hataları, düzenleyicinin alt kısmındaki *Build Errors* bölmesinde görünür. Bir hataya <kbd>çift tıkladığınızda</kbd> sorunun bulunduğu yere gidersiniz.

--- a/docs/tr/manuals/render.md
+++ b/docs/tr/manuals/render.md
@@ -1,0 +1,538 @@
+---
+title: Defold'da işleme hattı
+brief: Bu kılavuz, Defold'un işleme hattının nasıl çalıştığını ve nasıl programlanabileceğini açıklar.
+---
+
+# İşleme
+
+Motorun ekranda gösterdiği tüm nesneler (sprite bileşenleri, modeller, karolar, parçacıklar veya GUI düğümleri) bir işleyici (renderer) tarafından çizilir. İşleyicinin merkezinde işleme hattını (render pipeline) yöneten bir işleme betiği (render script) bulunur. Varsayılan olarak her 2B nesne, belirtilen harmanlama ile doğru bit eşlem kullanılarak ve doğru Z derinliğinde çizilir---bu nedenle sıralama ve basit harmanlama dışında işleme (rendering), yani görüntü oluşturma hakkında hiç düşünmeniz gerekmeyebilir. Çoğu 2B oyun için varsayılan hat iyi çalışır, ancak oyununuzun özel gereksinimleri olabilir. Bu durumda Defold, gereksinimlerinize özel bir işleme hattı yazmanıza olanak tanır.
+
+### İşleme hattı - Ne, ne zaman ve nerede?
+
+İşleme hattı neyin, ne zaman ve nerede işleneceğini denetler. Neyin işleneceği [işleme yüklemleri](#render-predicates) (render predicates) ile denetlenir. Bir yüklemin ne zaman işleneceği [işleme betiğinde](#the-render-script), nerede işleneceği ise [görünüm izdüşümü](#default-view-projection) ile denetlenir. İşleme hattı, bir işleme yükleminin çizdiği grafiklerden tanımlı bir sınırlayıcı kutunun veya görüş hacminin (frustum) dışında kalanları da eleyebilir. Bu işleme görüş hacmi dışında kalanları eleme (frustum culling) denir.
+
+
+## Varsayılan işleme
+
+İşleme dosyası, geçerli işleme betiğine bir başvurunun yanı sıra işleme betiğinde kullanılabilir olması gereken özel materyalleri (material) içerir ([`render.enable_material()`](/ref/render/#render.enable_material) ile kullanın)
+
+İşleme hattının merkezinde _işleme betiği_ bulunur. Bu, `init()`, `update()` ve `on_message()` işlevlerini içeren bir Lua betiğidir ve öncelikle altta yatan grafik API'siyle etkileşim kurmak için kullanılır. İşleme betiğinin oyununuzun yaşam döngüsünde özel bir yeri vardır. Ayrıntıları [Uygulama yaşam döngüsü belgesinde](/manuals/application-lifecycle) bulabilirsiniz.
+
+Projelerinizin "Builtins" klasöründe varsayılan işleme kaynağını ("default.render") ve varsayılan işleme betiğini ("default.render_script") bulabilirsiniz.
+
+![Yerleşik işleme](images/render/builtin.png)
+
+Özel bir işleyici hazırlamak için:
+
+1. "default.render" ve "default.render_script" dosyalarını proje hiyerarşinizde bir konuma kopyalayın. Elbette sıfırdan bir işleme betiği oluşturabilirsiniz; ancak özellikle Defold'a ve/veya grafik programlamaya yeni başlıyorsanız varsayılan betiğin bir kopyasıyla başlamanız iyi olur.
+
+2. "default.render" dosyasının kopyasını düzenleyin ve *Script* özelliğini, işleme betiğinizin kopyasına başvuracak şekilde değiştirin.
+
+3. *game.project* ayar dosyasındaki (*bootstrap* altında bulunan) *Render* özelliğini, "default.render" dosyasının kopyasına başvuracak şekilde değiştirin.
+
+
+## İşleme yüklemleri {#render-predicates}
+
+Nesnelerin çizim sırasını denetleyebilmek için işleme _yüklemleri_ oluşturursunuz. Bir yüklem, seçilen materyal _etiketlerine_ göre neyin çizileceğini bildirir.
+
+Ekrana çizilen her nesneye, nesnenin ekrana nasıl çizileceğini denetleyen bir materyal bağlıdır. Materyalde, materyalle ilişkilendirilecek bir veya daha fazla _etiket_ belirtirsiniz.
+
+Ardından işleme betiğinizde bir *işleme yüklemi* oluşturabilir ve bu yükleme hangi etiketlerin ait olacağını belirtebilirsiniz. Motora yüklemi çizmesini söylediğinizde, materyali bu yüklem için belirtilen etiketlerin tamamını içeren her nesne çizilir.
+
+```
+Sprite 1        Sprite 2        Sprite 3        Sprite 4
+Material A      Material A      Material B      Material C
+  outlined        outlined        greyscale       outlined
+  tree            tree            tree            house
+```
+
+```lua
+-- a predicate matching all sprites with tag "tree"
+local trees = render.predicate({"tree"})
+-- will draw Sprite 1, 2 and 3
+render.draw(trees)
+
+-- a predicate matching all sprites with tag "outlined"
+local outlined = render.predicate({"outlined"})
+-- will draw Sprite 1, 2 and 4
+render.draw(outlined)
+
+-- a predicate matching all sprites with tags "outlined" AND "tree"
+local outlined_trees = render.predicate({"outlined", "tree"})
+-- will draw Sprite 1 and 2
+render.draw(outlined_trees)
+```
+
+
+Materyallerin nasıl çalıştığına ilişkin ayrıntılı açıklamayı [Materyal belgesinde](/manuals/material) bulabilirsiniz.
+
+
+## Varsayılan görünüm izdüşümü {#default-view-projection}
+
+Varsayılan işleme betiği, 2B oyunlara uygun bir ortografik izdüşüm (orthographic projection) kullanacak şekilde yapılandırılmıştır. Üç farklı ortografik izdüşüm sunar: `Stretch` (varsayılan), `Fixed Fit` ve `Fixed`. Varsayılan işleme betiğindeki ortografik izdüşümlere alternatif olarak, bir kamera bileşeninin (camera component) sağladığı izdüşüm matrisini kullanma seçeneğiniz de vardır.
+
+### Esnetme izdüşümü
+
+Esnetme izdüşümü, pencere yeniden boyutlandırıldığında bile her zaman oyununuzun *game.project* dosyasında ayarlanan boyutlara eşit bir alanını çizer. En boy oranı değişirse oyun içeriği dikey veya yatay olarak esnetilir:
+
+![Esnetme izdüşümü](images/render/stretch_projection.png)
+
+*Özgün pencere boyutuyla esnetme izdüşümü*
+
+![Yeniden boyutlandırıldığında esnetme izdüşümü](images/render/stretch_projection_resized.png)
+
+*Pencere yatay olarak esnetildiğinde esnetme izdüşümü*
+
+Esnetme izdüşümü varsayılan izdüşümdür; ancak başka bir izdüşüme geçtiyseniz ve geri dönmeniz gerekiyorsa bunu işleme betiğine bir ileti (message) göndererek yapabilirsiniz:
+
+```lua
+msg.post("@render:", "use_stretch_projection", { near = -1, far = 1 })
+```
+
+### Sabit sığdırma izdüşümü
+
+Esnetme izdüşümü gibi sabit sığdırma izdüşümü de her zaman oyunun *game.project* dosyasında ayarlanan boyutlara eşit bir alanını gösterir; ancak pencere yeniden boyutlandırılır ve en boy oranı değişirse oyun içeriği özgün en boy oranını korur ve dikey veya yatay yönde daha fazla oyun içeriği gösterilir:
+
+![Sabit sığdırma izdüşümü](images/render/fixed_fit_projection.png)
+
+*Özgün pencere boyutuyla sabit sığdırma izdüşümü*
+
+![Yeniden boyutlandırıldığında sabit sığdırma izdüşümü](images/render/fixed_fit_projection_resized.png)
+
+*Pencere yatay olarak esnetildiğinde sabit sığdırma izdüşümü*
+
+![Küçültüldüğünde sabit sığdırma izdüşümü](images/render/fixed_fit_projection_resized_smaller.png)
+
+*Pencere özgün boyutunun %50'sine küçültüldüğünde sabit sığdırma izdüşümü*
+
+Sabit sığdırma izdüşümünü işleme betiğine bir ileti göndererek etkinleştirebilirsiniz:
+
+```lua
+msg.post("@render:", "use_fixed_fit_projection", { near = -1, far = 1 })
+```
+
+### Sabit izdüşüm {#fixed-projection}
+
+Sabit izdüşüm, özgün en boy oranını korur ve oyun içeriğinizi sabit bir yakınlaştırma düzeyiyle işler. Bu, yakınlaştırma düzeyi %100'den farklı bir değere ayarlanırsa oyunun *game.project* dosyasındaki boyutlarla tanımlanan alanından daha fazlasının veya daha azının gösterileceği anlamına gelir:
+
+![Sabit izdüşüm](images/render/fixed_projection_zoom_2_0.png)
+
+*Yakınlaştırma 2 olarak ayarlandığında sabit izdüşüm*
+
+![Sabit izdüşüm](images/render/fixed_projection_zoom_0_5.png)
+
+*Yakınlaştırma 0,5 olarak ayarlandığında sabit izdüşüm*
+
+![Sabit izdüşüm](images/render/fixed_projection_zoom_2_0_resized.png)
+
+*Yakınlaştırma 2 olarak ayarlandığında ve pencere özgün boyutunun %50'sine küçültüldüğünde sabit izdüşüm*
+
+Sabit izdüşümü işleme betiğine bir ileti göndererek etkinleştirebilirsiniz:
+
+```lua
+msg.post("@render:", "use_fixed_projection", { near = -1, far = 1, zoom = 2 })
+```
+
+### Kamera izdüşümü
+
+Varsayılan işleme betiği kullanılırken projede etkin [kamera bileşenleri](/manuals/camera) varsa, bunlar işleme betiğinde ayarlanan diğer tüm görünüm / izdüşümlere göre önceliklidir. İşleme betiklerinde kamera bileşenleriyle nasıl çalışılacağı hakkında daha fazla bilgi için [Kamera belgesine](/manuals/camera) bakın.
+
+Ortografik kameralar, kameranın pencereye nasıl uyum sağlayacağını denetleyen bir `Orthographic Mode` ayarını destekler:
+- `Fixed`, kameranın `Orthographic Zoom` değerini kullanır.
+- `Auto Fit` (sığdırma), tasarım alanının tamamını görünür tutar.
+- `Auto Cover` (kaplama), pencereyi doldurur ve kırpma yapabilir.
+
+Modlar arasında düzenleyicide veya çalışma sırasında Camera API'si aracılığıyla geçiş yapabilirsiniz:
+
+```lua
+-- Use auto-fit behavior with an orthographic camera
+camera.set_orthographic_mode("main:/go#camera", camera.ORTHO_MODE_AUTO_FIT)
+-- Query current mode
+local mode = camera.get_orthographic_mode("main:/go#camera")
+```
+
+## Görüş hacmi dışında kalanları eleme {#frustum-culling}
+
+Defold'un işleme API'si, geliştiricilerin görüş hacmi dışında kalanları eleme adı verilen işlemi gerçekleştirmesine olanak tanır. Görüş hacmi dışında kalanları eleme etkinleştirildiğinde, tanımlı bir sınırlayıcı kutunun veya görüş hacminin dışında kalan grafikler yok sayılır. Aynı anda yalnızca bir bölümü görülebilen büyük bir oyun dünyasında, görüş hacmi dışında kalanları eleme, işleme için GPU'ya gönderilmesi gereken veri miktarını önemli ölçüde azaltabilir; böylece performansı artırır ve (mobil cihazlarda) pil tasarrufu sağlar. Sınırlayıcı kutuyu oluşturmak için kameranın görünümünü ve izdüşümünü kullanmak yaygındır. Varsayılan işleme betiği, bir görüş hacmi hesaplamak için (kameradan gelen) görünümü ve izdüşümü kullanır.
+
+`render.draw()` işlevine `frustum` seçeneğinde bir görünüm-izdüşüm matrisi geçirerek bir çizim çağrısı için görüş hacmi dışında kalanları elemeyi etkinleştirin:
+
+```lua
+local frustum = self.proj * self.view
+render.draw(predicates.particle, { frustum = frustum })
+```
+
+Bir kamera bileşeniyle işleme yaparken `render.set_camera()`, sonraki çizim çağrıları için kameranın görünüm-izdüşüm matrisini otomatik olarak kullanabilir:
+
+```lua
+render.set_camera("main:/go#camera", { use_frustum = true })
+render.draw(predicates.particle)
+render.set_camera()
+```
+
+Bu yöntemlerden biri kullanıldığında parçacık efekti yayıcıları kendi sınırlarına göre elenir.
+
+Görüş hacmi dışında kalanları eleme, motorda her bileşen türü için ayrı uygulanır. Geçerli durum:
+
+| Bileşen     | Destekleniyor |
+|-------------|-----------|
+| Sprite      | EVET      |
+| Model       | EVET      |
+| Örgü        | EVET (1)  |
+| Etiket      | EVET      |
+| Spine       | EVET      |
+| Parçacık efekti | EVET   |
+| Karo haritası | EVET    |
+| Rive        | HAYIR     |
+
+1 = Örgünün sınırlayıcı kutusunun geliştirici tarafından ayarlanması gerekir. [Daha fazla bilgi](/manuals/mesh/#frustum-culling).
+
+
+::: sidenote
+Defold 1.13.0'dan itibaren bileşenlerin temel geometrik şekilleri (primitive), köşelerin saat yönünün tersine sıralanmasını (vertex winding) kullanır ve şeklin normali kameraya doğru bakar. Sprite bileşenleri, GUI düğümleri, karo haritaları (karo ızgaraları) ve parçacık efektleri diğer bileşen türleriyle aynı sıralamayı kullanır; böylece tüm bileşenler için aynı yüz eleme ayarları kullanılabilir.
+
+Bu durum, model dışındaki bileşenler için yüz eleme ayarlayan projeleri etkileyebilir. Bir bileşen beklenmedik şekilde elenirse, `render.set_cull_face(graphics.FACE_TYPE_BACK)` ile arka yüzlerin seçildiğinden emin olun veya varsayılan `graphics.FACE_TYPE_BACK` modunu kullanmak için `render.set_cull_face()` çağrısını kaldırın.
+:::
+
+## Koordinat sistemleri
+
+Bileşenlerin işlenmesinden söz ederken genellikle hangi koordinat sisteminde işlendikleri belirtilir. Çoğu oyunda bazı bileşenler dünya uzayında (world space), bazıları ise ekran uzayında (screen space) çizilir.
+
+GUI bileşenleri ve bunların düğümleri genellikle ekran uzayı koordinatlarında çizilir; ekranın sol alt köşesinin koordinatı (0,0), sağ üst köşesininki ise (ekran genişliği, ekran yüksekliği) olur. Ekran uzayı koordinat sistemi, bir kamera tarafından hiçbir zaman kaydırılmaz veya başka bir şekilde ötelenmez. Böylece dünya nasıl işlenirse işlensin GUI düğümleri her zaman ekranda çizilir.
+
+Oyun dünyanızdaki oyun nesnelerinin (game object) kullandığı sprite bileşenleri, karo haritaları ve diğer bileşenler genellikle dünya uzayı koordinat sisteminde çizilir. İşleme betiğinizde hiçbir değişiklik yapmaz ve görünüm izdüşümünü değiştirmek için kamera bileşeni kullanmazsanız bu koordinat sistemi ekran uzayı koordinat sistemiyle aynıdır; ancak bir kamera ekleyip onu hareket ettirdiğiniz veya görünüm izdüşümünü değiştirdiğiniz anda iki koordinat sistemi farklılaşır. Kamera hareket ederken dünyanın diğer bölümlerinin işlenmesi için ekranın sol alt köşesi (0, 0) konumundan kaydırılır. İzdüşüm değişirse koordinatlar hem ötelenir (yani 0, 0 konumundan kaydırılır) hem de bir ölçek katsayısıyla değiştirilir.
+
+
+## İşleme betiği {#the-render-script}
+
+Aşağıda, yerleşik betiğin biraz değiştirilmiş bir sürümü olan özel bir işleme betiğinin kodu yer alır.
+
+init()
+: `init()` işlevi, yüklemleri, görünümü ve temizleme rengini ayarlamak için kullanılır. Bu değişkenler asıl işleme sırasında kullanılır.
+
+```lua
+function init(self)
+    -- Define the render predicates. Each predicate is drawn by itself and
+    -- that allows us to change the state of OpenGL between the draws.
+    self.predicates = create_predicates("tile", "gui", "text", "particle", "model")
+
+    -- Create and fill data tables will be used in update()
+    local state = create_state()
+    self.state = state
+    local camera_world = create_camera(state, "camera_world", true)
+    init_camera(camera_world, get_stretch_projection)
+    local camera_gui = create_camera(state, "camera_gui")
+    init_camera(camera_gui, get_gui_projection)
+    update_state(state)
+end
+```
+
+update()
+: `update()` işlevi her karede bir kez çağrılır. Görevi, altta yatan OpenGL ES API'lerini (OpenGL Embedded Systems API) çağırarak asıl çizimi gerçekleştirmektir. `update()` işlevinde neler olduğunu doğru anlamak için OpenGL'in nasıl çalıştığını anlamanız gerekir. OpenGL ES hakkında birçok iyi kaynak bulunur. Resmî site iyi bir başlangıç noktasıdır. Siteye https://www.khronos.org/opengles/ adresinden ulaşabilirsiniz.
+
+  Bu örnek, 3B modelleri çizmek için gereken hazırlığı içerir. `init()` işlevi bir `self.predicates.model` yüklemi tanımlamıştır. Başka bir yerde "model" etiketine sahip bir materyal oluşturulmuştur. Bu materyali kullanan bazı model bileşenleri de vardır:
+
+```lua
+function update(self)
+    local state = self.state
+     if not state.valid then
+        if not update_state(state) then
+            return
+        end
+    end
+
+    local predicates = self.predicates
+    -- clear screen buffers
+    --
+    render.set_depth_mask(true)
+    render.set_stencil_mask(0xff)
+    render.clear(state.clear_buffers)
+
+    local camera_world = state.cameras.camera_world
+    render.set_viewport(0, 0, state.window_width, state.window_height)
+    render.set_view(camera_world.view)
+    render.set_projection(camera_world.proj)
+
+
+    -- render models
+    --
+    render.set_blend_func(graphics.BLEND_FACTOR_SRC_ALPHA, graphics.BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
+    render.enable_state(graphics.STATE_CULL_FACE)
+    render.enable_state(graphics.STATE_DEPTH_TEST)
+    render.set_depth_mask(true)
+    render.draw(predicates.model_pred)
+    render.set_depth_mask(false)
+    render.disable_state(graphics.STATE_DEPTH_TEST)
+    render.disable_state(graphics.STATE_CULL_FACE)
+
+     -- render world (sprites, tilemaps, particles etc)
+     --
+    render.set_blend_func(graphics.BLEND_FACTOR_SRC_ALPHA, graphics.BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
+    render.enable_state(graphics.STATE_DEPTH_TEST)
+    render.enable_state(graphics.STATE_STENCIL_TEST)
+    render.enable_state(graphics.STATE_BLEND)
+    render.draw(predicates.tile)
+    render.draw(predicates.particle)
+    render.disable_state(graphics.STATE_STENCIL_TEST)
+    render.disable_state(graphics.STATE_DEPTH_TEST)
+
+    -- debug
+    render.draw_debug3d()
+
+    -- render GUI
+    --
+    local camera_gui = state.cameras.camera_gui
+    render.set_view(camera_gui.view)
+    render.set_projection(camera_gui.proj)
+    render.enable_state(graphics.STATE_STENCIL_TEST)
+    render.draw(predicates.gui, camera_gui.frustum)
+    render.draw(predicates.text, camera_gui.frustum)
+    render.disable_state(graphics.STATE_STENCIL_TEST)
+end
+```
+
+Buraya kadar betik basit ve anlaşılır bir işleme betiğidir. Her karede aynı şekilde çizim yapar. Ancak bazen işleme betiğine durum bilgisi eklemek ve bu duruma bağlı olarak farklı işlemler gerçekleştirmek istenebilir. Oyun kodunun diğer bölümlerinden işleme betiğiyle iletişim kurmak da istenebilir.
+
+on_message()
+: Bir işleme betiği, bir `on_message()` işlevi tanımlayarak oyununuzun veya uygulamanızın diğer bölümlerinden iletiler alabilir. Harici bir bileşenin işleme betiğine bilgi gönderdiği yaygın durumlardan biri _kameradır_. Kamera odağını edinmiş bir kamera bileşeni, her karede görünümünü ve izdüşümünü otomatik olarak işleme betiğine gönderir. Bu iletinin adı `"set_view_projection"` olur:
+
+```lua
+local MSG_CLEAR_COLOR =         hash("clear_color")
+local MSG_WINDOW_RESIZED =      hash("window_resized")
+local MSG_SET_VIEW_PROJ =       hash("set_view_projection")
+
+function on_message(self, message_id, message)
+    if message_id == MSG_CLEAR_COLOR then
+        -- Someone sent us a new clear color to be used.
+        update_clear_color(state, message.color)
+    elseif message_id == MSG_SET_VIEW_PROJ then
+        -- The camera component that has camera focus will sent set_view_projection
+        -- messages to the @render socket. We can use the camera information to
+        -- set view (and possibly projection) of the rendering.
+        camera.view = message.view
+        self.camera_projection = message.projection or vmath.matrix4()
+        update_camera(camera, state)
+    end
+end
+```
+
+Bununla birlikte herhangi bir betik veya GUI betiği, özel `@render` soketi üzerinden işleme betiğine ileti gönderebilir:
+
+```lua
+-- Change the clear color.
+msg.post("@render:", "clear_color", { color = vmath.vector4(0.3, 0.4, 0.5, 0) })
+```
+
+## İşleme kaynakları
+Belirli motor kaynaklarını işleme betiğine geçirmek için bunları projeye atanmış `.render` dosyasındaki `Render Resources` tablosuna ekleyebilirsiniz:
+
+![İşleme kaynakları](images/render/render_resources.png)
+
+Bu kaynakların bir işleme betiğinde kullanımı:
+
+```lua
+-- "my_material" will now be used for all draw calls associated with the predicate
+render.enable_material("my_material")
+-- anything drawn by the predicate will end up in "my_render_target"
+render.set_render_target("my_render_target")
+render.draw(self.my_full_screen_predicate)
+render.set_render_target(render.RENDER_TARGET_DEFAULT)
+render.disable_material()
+
+-- bind the render target result texture to whatever is getting rendered via the predicate
+render.enable_texture(0, "my_render_target", graphics.BUFFER_TYPE_COLOR0_BIT)
+render.draw(self.my_tile_predicate)
+```
+
+::: sidenote
+Defold şu anda başvurulan işleme kaynakları olarak yalnızca `Materials` ve `Render Targets` türlerini destekler; ancak bu sistem zamanla daha fazla kaynak türünü destekleyecektir.
+:::
+
+### Çok örnekli işleme hedefleri {#multisampled-render-targets}
+
+İşleme hedefleri (render targets), çok örnekli kenar yumuşatmayı (multisample anti-aliasing, MSAA) destekler. Bu, ekran dışı bir işleme geçişinde geometrinin kenarlarını yumuşatır. Hedefin örnek sayısı, pencerenin kenar yumuşatmasını denetleyen [Display ▸ Samples](/manuals/project-settings/#samples) ayarından bağımsızdır.
+
+Bir `.render_target` kaynağı için düzenleyicide **Sample Count** değerini `1`, `2`, `4`, `8` veya `16` olarak ayarlayın. `1` değeri çoklu örneklemeyi devre dışı bırakır. Kaynağı `.render` dosyanızın **Render Resources** tablosuna ekleyin ve yukarıdaki örnekte olduğu gibi atanan adını `render.set_render_target()` ile kullanın.
+
+Alternatif olarak, işleme betiğinizin `init()` işlevinde bir hedef oluşturun. `sample_count` alanını dış parametre tablosuna, eklerin (attachments) yanına yerleştirin:
+
+```lua
+self.offscreen = render.render_target({
+    sample_count = 4,
+    [graphics.BUFFER_TYPE_COLOR0_BIT] = {
+        format = graphics.TEXTURE_FORMAT_RGBA,
+        width = 1024,
+        height = 1024,
+        min_filter = graphics.TEXTURE_FILTER_LINEAR,
+        mag_filter = graphics.TEXTURE_FILTER_LINEAR,
+        u_wrap = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE,
+        v_wrap = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE,
+    },
+})
+self.scene_predicate = render.predicate({"scene"})
+self.present_predicate = render.predicate({"present"})
+```
+
+Bu örnekte yalnızca renk içeren bir hedef kullanılır. Bir hedefteki tüm renk, derinlik ve şablon ekleri, hedefin örnek sayısını paylaşır. Geçiş derinlik testi gerektiriyorsa bir derinlik eki ve olağan derinlik testi durumunu ekleyin.
+
+Aşağıdaki `update()` kod parçası için sahne materyallerine `scene` etiketini, tam ekran bir dörtgenin (quad) materyaline de `present` etiketini verin. Dörtgenin materyalinin `0` numaralı doku biriminden örnekleme yapması gerekir. Her geçiş için uygun görünümü ve izdüşümü ayarlayın:
+
+```lua
+render.set_render_target(self.offscreen)
+render.set_viewport(0, 0, 1024, 1024)
+render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = vmath.vector4(0, 0, 0, 1)})
+-- Set the scene view and projection here.
+render.draw(self.scene_predicate)
+
+render.set_render_target(render.RENDER_TARGET_DEFAULT)
+render.set_viewport(0, 0, render.get_window_width(), render.get_window_height())
+-- Set the full-screen quad view and projection here.
+render.enable_texture(0, self.offscreen, graphics.BUFFER_TYPE_COLOR0_BIT)
+render.draw(self.present_predicate)
+render.disable_texture(0)
+```
+
+Başka bir hedefe geçildiğinde işleme geçişi tamamlanır ve önceki hedefin çok örnekli renk eklerindeki örnekler otomatik olarak birleştirilir (resolve). `render.enable_texture()`, örnekleri birleştirilmiş renk dokusunu bağlar; böylece dörtgen sıradan bir doku örnekleyicisi kullanır. Ayrı bir örnek birleştirme komutu gerekmez.
+
+İstenen örnek sayısı varsayılan olarak `1` değerindedir ve pozitif bir tam sayı olmalıdır. Grafik arka uçları, desteklenmeyen örnek sayısı isteklerini desteklenen ve ikinin kuvveti olan bir sayıya indirir; gerekirse `1` değerine döner ve sayı değiştiğinde günlüğe bir uyarı kaydeder. Daha yüksek örnek sayıları, eklerin gerektirdiği belleği artırır.
+
+Bir işleme hedefi kaynağı kullanırken, fiilen kullanılan örnek sayısını bir oyun nesnesinin `.script` dosyasından `resource.get_render_target_info()` ile inceleyin. Örneğin, `/render/offscreen.render_target` kaynağını **Render Resources** tablosuna ekledikten sonra:
+
+```lua
+function init(self)
+    local info = resource.get_render_target_info("/render/offscreen.render_targetc")
+    print("Render target sample count:", info.sample_count)
+end
+```
+
+Cihaz desteğini kontrol ederken istenen örnek sayısının kullanılabildiğini varsaymak yerine fiilen kullanılan bu sayıyı kullanın. Parametre ve sonuç tablolarının tamamı için [`render.render_target()`](/ref/beta/render/#render.render_target:parameters) ve [`resource.get_render_target_info()`](/ref/beta/resource/#resource.get_render_target_info:path) belgelerine bakın.
+
+## Doku tanıtıcıları
+
+Defold'da dokular, motor içinde bir tanıtıcı (handle) ile temsil edilir; bu, temelde bir doku nesnesini motorun her yerinde benzersiz olarak tanımlaması gereken bir sayıya karşılık gelir. Bu, söz konusu tanıtıcıları işleme sistemi ile bir oyun nesnesi betiği arasında geçirerek oyun nesneleri dünyası ile işleme dünyası arasında köprü kurabileceğiniz anlamına gelir. Örneğin, bir oyun nesnesine bağlı betikte dinamik bir doku oluşturulabilir ve bir çizim komutunda genel doku olarak kullanılmak üzere işleyiciye gönderilebilir.
+
+Bir `.script` dosyasında:
+
+```lua
+local my_texture_resource = resource.create_texture("/my_texture.texture", tparams)
+-- note: my_texture_resource is a hash to the resource path, which can't be used as a handle!
+local my_texture_handle = resource.get_texture_info(my_texture_resource)
+-- my_texture_handle contains information about the texture, such as width, height and so on
+-- it does also contain the handle, which is what we are after
+msg.post("@render:", "set_texture", { handle = my_texture_handle.handle })
+```
+
+Bir `.render_script` dosyasında:
+
+```lua
+function on_message(self, message_id, message)
+    if message_id == hash("set_texture") then
+        self.my_texture = message.handle
+    end
+end
+
+function update(self)
+    -- bind the custom texture to the draw state
+    render.enable_texture(0, self.my_texture)
+    -- do drawing..
+end
+```
+
+::: sidenote
+Şu anda bir kaynağın hangi dokuya işaret etmesi gerektiğini değiştirmenin bir yolu yoktur; ham tanıtıcıları bu şekilde yalnızca işleme betiğinde kullanabilirsiniz.
+:::
+
+## Desteklenen grafik API'leri
+Defold işleme betiği API'si, işleme işlemlerini aşağıdaki grafik API'lerine dönüştürür:
+
+:[Graphics API](../shared/graphics-api.md)
+
+
+## Sistem iletileri
+
+`"set_view_projection"`
+: Bu ileti, kamera odağını edinmiş kamera bileşenleri tarafından gönderilir.
+
+`"window_resized"`
+: Motor, pencere boyutu değiştiğinde bu iletiyi gönderir. Hedef pencere boyutu değiştiğinde işlemeyi değiştirmek için bu iletiyi dinleyebilirsiniz. Masaüstünde bu, gerçek oyun penceresinin yeniden boyutlandırıldığı anlamına gelir; mobil cihazlarda ise bu ileti her yönelim değişikliğinde gönderilir.
+
+```lua
+local MSG_WINDOW_RESIZED =      hash("window_resized")
+
+function on_message(self, message_id, message)
+  if message_id == MSG_WINDOW_RESIZED then
+    -- The window was resized. message.width and message.height contain the new dimensions.
+    ...
+  end
+end
+```
+
+`"draw_line"`
+: Hata ayıklama çizgisi çizer. `ray_casts`, vektörler ve daha fazlasını görselleştirmek için kullanın. Çizgiler `render.draw_debug3d()` çağrısıyla çizilir.
+
+```lua
+-- draw a white line
+local p1 = vmath.vector3(0, 0, 0)
+local p2 = vmath.vector3(1000, 1000, 0)
+local col = vmath.vector4(1, 1, 1, 1)
+msg.post("@render:", "draw_line", { start_point = p1, end_point = p2, color = col } )  
+```
+
+`"draw_text"`
+: Hata ayıklama metni çizer. Hata ayıklama bilgilerini yazdırmak için kullanın. Metin, yerleşik `always_on_top.font` yazı tipiyle çizilir. Sistem yazı tipinin `debug_text` etiketine sahip bir materyali vardır ve varsayılan işleme betiğinde diğer metinlerle birlikte işlenir.
+
+```lua
+-- draw a text message
+local pos = vmath.vector3(500, 500, 0)
+msg.post("@render:", "draw_text", { text = "Hello world!", position = pos })  
+```
+
+`@system` soketine gönderilen `"toggle_profile"` iletisiyle erişilen görsel profil çıkarıcı, betikle programlanabilir işleyicinin bir parçası değildir. İşleme betiğinizden ayrı olarak çizilir.
+
+
+## Çizim çağrıları ve toplu çizim {#draw-calls-and-batching}
+
+Çizim çağrısı (draw call), bir doku, bir materyal ve isteğe bağlı ek ayarlar kullanarak bir nesneyi ekrana çizmek üzere GPU'yu hazırlama sürecini tanımlayan terimdir. Bu süreç genellikle yoğun kaynak kullanır ve çizim çağrısı sayısının olabildiğince az tutulması önerilir. Çizim çağrılarının sayısını ve işlenmelerinin ne kadar sürdüğünü [yerleşik profil çıkarıcı](/manuals/profiling/) ile ölçebilirsiniz.
+
+Defold, aşağıda tanımlanan kurallara göre çizim çağrılarının sayısını azaltmak için işleme işlemlerini toplu çizim (batching) için gruplamaya çalışır. Kurallar GUI bileşenleri ile diğer tüm bileşen türleri arasında farklılık gösterir.
+
+
+### GUI dışındaki bileşenler için toplu çizim kuralları
+
+Her `render.draw()` çağrısı, dünya uzayında sıralanan eşleşen öğelerin nasıl sıralanacağını denetler. Varsayılan değer `render.SORT_BACK_TO_FRONT` olur; yakından uzağa işleme için `render.SORT_FRONT_TO_BACK`, eklenme sırasını korumak için ise `render.SORT_NONE` kullanın:
+
+```lua
+render.draw(self.opaque_predicate, {
+    sort_order = render.SORT_FRONT_TO_BACK
+})
+render.draw(self.transparent_predicate, {
+    sort_order = render.SORT_BACK_TO_FRONT
+})
+```
+
+Seçilen sıra, hangi öğelerin yan yana geleceğini belirler ve bu nedenle toplu çizimi etkileyebilir. Bu sıralı listede her nesne, aşağıdaki koşullar karşılandığında önceki nesneyle aynı çizim çağrısında gruplanır:
+
+* Aynı koleksiyon vekiline (collection proxy) ait olması
+* Aynı bileşen türünde olması (sprite, parçacık efekti, karo haritası vb.)
+* Aynı dokuyu kullanması (atlas veya karo kaynağı)
+* Aynı materyale sahip olması
+* Aynı gölgelendirici sabitlerine sahip olması (renk çarpanı gibi)
+
+Bu, aynı koleksiyon vekilindeki iki sprite bileşeni seçilen sıralama sonrasında yan yana gelirse ve aynı dokuyu, materyali ve sabitleri kullanırsa aynı çizim çağrısında gruplanacakları anlamına gelir.
+
+
+### GUI bileşenleri için toplu çizim kuralları
+
+Bir GUI bileşenindeki düğümler, düğüm listesinde yukarıdan aşağıya doğru işlenir. Listedeki her düğüm, aşağıdaki koşullar karşılandığında önceki düğümle aynı çizim çağrısında gruplanır:
+
+* Aynı türde olması (kutu, metin, daire dilimi vb.)
+* Aynı dokuyu kullanması (atlas veya karo kaynağı)
+* Aynı harmanlama moduna sahip olması.
+* Aynı yazı tipine sahip olması (yalnızca metin düğümleri için)
+* Aynı şablon ayarlarına sahip olması
+
+::: sidenote
+Düğümler bileşen bazında işlenir. Bu, farklı GUI bileşenlerindeki düğümlerin toplu çizim için gruplanmayacağı anlamına gelir.
+:::
+
+Düğümleri hiyerarşiler halinde düzenleyebilmek, düğümleri yönetilebilir birimler halinde gruplamayı kolaylaştırır. Ancak farklı düğüm türlerini karıştırırsanız hiyerarşiler toplu çizimi bozabilir. GUI katmanlarını kullanarak düğüm hiyerarşilerini korurken GUI düğümlerini daha etkili biçimde toplu çizim için gruplamak mümkündür. GUI katmanları ve bunların çizim çağrılarını nasıl etkilediği hakkında daha fazla bilgiyi [GUI kılavuzunda](/manuals/gui#layers-and-draw-calls) bulabilirsiniz.

--- a/docs/tr/manuals/resource.md
+++ b/docs/tr/manuals/resource.md
@@ -1,0 +1,67 @@
+---
+title: Defold kaynak yönetimi
+brief: Bu kılavuz, Defold'un kaynakları otomatik olarak nasıl yönettiğini ve bellekte kaplanan alan ile dağıtım paketi boyutu kısıtlamalarına uymak için kaynakların yüklenmesini elle nasıl yönetebileceğinizi açıklar.
+---
+
+# Kaynak yönetimi
+
+Çok küçük bir oyun yapıyorsanız hedef platformun kısıtlamaları (bellekte kaplanan alan, dağıtım paketi boyutu, işlem gücü ve pil tüketimi) hiçbir zaman sorun oluşturmayabilir. Ancak daha büyük oyunlar yaparken, özellikle de elde taşınan cihazlarda, bellek tüketimi büyük olasılıkla en önemli kısıtlamalardan biri olacaktır. Deneyimli bir ekip, platform kısıtlamalarına göre kaynak (resource) bütçelerini özenle belirler. Defold, belleği ve dağıtım paketi boyutunu yönetmeye yardımcı olan çeşitli özellikler sunar. Bu kılavuz, bu özelliklere genel bir bakış sunar.
+
+## Statik kaynak ağacı
+
+Defold'da bir oyunu derlerken kaynak ağacını (resource tree) statik olarak tanımlarsınız. Oyunun her bir parçası, genellikle "main.collection" olarak adlandırılan başlangıç koleksiyonundan (bootstrap collection) başlayarak ağaca bağlanır. Kaynak ağacı her başvuruyu izler ve bu başvurularla ilişkili tüm kaynakları içerir:
+
+- Oyun nesnesi (game object) ve bileşen (component) verileri (atlaslar, sesler vb.).
+- Fabrika (factory) bileşeni prototipleri (oyun nesneleri ve koleksiyonlar).
+- Koleksiyon vekili (collection proxy) bileşeni başvuruları (koleksiyonlar).
+- *game.project* dosyasında tanımlanan [özel kaynaklar](/manuals/project-settings/#custom-resources).
+
+![Kaynak ağacı](images/resource/resource_tree.png)
+
+::: sidenote
+Defold'da [dağıtım paketine eklenen kaynaklar](/manuals/project-settings/#bundle-resources) kavramı da vardır. Bu kaynaklar uygulamanın dağıtım paketine dahil edilir, ancak kaynak ağacının bir parçası değildir. Dağıtım paketine eklenen kaynaklar, platforma özgü destek dosyalarından [dosya sisteminden yüklenen](/manuals/file-access/#how-to-access-files-bundled-with-the-application) ve oyununuzun kullandığı harici dosyalara (örneğin FMOD ses bankaları) kadar her tür dosya olabilir.
+:::
+
+Oyun *paketlendiğinde* yalnızca kaynak ağacında bulunanlar pakete dahil edilir. Ağaçta başvurulmayan hiçbir şey pakete eklenmez. Dağıtım paketine nelerin dahil edileceğini veya paketten nelerin hariç tutulacağını elle seçmeniz gerekmez.
+
+Oyun *çalıştırıldığında* motor, ağacın başlangıç koleksiyonunun bulunduğu kökünden başlayarak kaynakları belleğe yükler:
+
+- Başvurulan her koleksiyon ve içeriği.
+- Oyun nesneleri ve bileşen verileri.
+- Fabrika bileşeni prototipleri (oyun nesneleri ve koleksiyonlar).
+
+Ancak motor, başvurulan kaynakların aşağıdaki türlerini çalışma sırasında otomatik olarak yüklemez:
+
+- Koleksiyon vekilleri aracılığıyla başvurulan oyun dünyası koleksiyonları. Oyun dünyaları nispeten büyüktür; bu nedenle bunların yüklenmesini ve bellekten kaldırılmasını kodda elle tetiklemeniz gerekir. Ayrıntılar için [Koleksiyon vekili kılavuzuna](/manuals/collection-proxy) bakın.
+- *game.project* dosyasındaki *Custom Resources* ayarıyla eklenen dosyalar. Bu dosyalar, [`sys.load_resource()`](/ref/sys/#sys.load_resource) işleviyle elle yüklenir.
+
+Defold'un kaynakları varsayılan paketleme ve yükleme biçimi, kaynakların belleğe nasıl ve ne zaman yüklendiği üzerinde ayrıntılı denetim sağlamak için değiştirilebilir.
+
+![Kaynak yükleme](images/resource/loading.png)
+
+## Fabrika kaynaklarını dinamik olarak yükleme
+
+Fabrika bileşenlerinin başvurduğu kaynaklar normalde bileşen yüklendiğinde belleğe yüklenir. Böylece kaynaklar, fabrika çalışma zamanı ortamında var olur olmaz oyunda nesne oluşturmak için hazır olur. Varsayılan davranışı değiştirmek ve fabrika kaynaklarının yüklenmesini ertelemek için fabrikanın *Load Dynamically* onay kutusunu işaretlemeniz yeterlidir.
+
+![Dinamik yükleme](images/resource/load_dynamically.png)
+
+Bu kutu işaretliyken motor, başvurulan kaynakları oyunun dağıtım paketine dahil etmeye devam eder, ancak fabrika kaynaklarını otomatik olarak yüklemez. Bunun yerine iki seçeneğiniz vardır:
+
+1. Nesne oluşturmak istediğinizde [`factory.create()`](/ref/factory/#factory.create) veya [`collectionfactory.create()`](/ref/collectionfactory/#collectionfactory.create) işlevini çağırın. Bu işlem, kaynakları eşzamanlı olarak yükler, ardından yeni örnekler oluşturur.
+2. Kaynakları eşzamansız olarak yüklemek için [`factory.load()`](/ref/factory/#factory.load) veya [`collectionfactory.load()`](/ref/collectionfactory/#collectionfactory.load) işlevini çağırın. Kaynaklar nesne oluşturmak için hazır olduğunda bir geri çağırım (callback) alınır.
+
+Bunun nasıl çalıştığıyla ilgili ayrıntılar için [Fabrika kılavuzunu](/manuals/factory) ve [Koleksiyon fabrikası (collection factory) kılavuzunu](/manuals/collection-factory) okuyun.
+
+## Dinamik olarak yüklenen kaynakları bellekten kaldırma
+
+Defold, tüm kaynaklar için başvuru sayaçları tutar. Bir kaynağın sayacı sıfıra ulaşırsa bu, artık hiçbir şeyin o kaynağa başvurmadığı anlamına gelir. Kaynak daha sonra otomatik olarak bellekten kaldırılır. Örneğin, bir fabrikanın oluşturduğu tüm nesneleri ve fabrika bileşenini barındıran nesneyi silerseniz fabrikanın daha önce başvurduğu kaynaklar bellekten kaldırılır.
+
+*Load Dynamically* seçeneği işaretli fabrikalar için [`factory.unload()`](/ref/factory/#factory.unload) veya [`collectionfactory.unload()`](/ref/collectionfactory/#collectionfactory.unload) işlevini çağırabilirsiniz. Bu çağrı, fabrika bileşeninin kaynağa olan başvurusunu kaldırır. Kaynağa başka hiçbir şey başvurmuyorsa (örneğin oluşturulan tüm nesneler silinmişse) kaynak bellekten kaldırılır.
+
+## Kaynakları dağıtım paketinden hariç tutma
+
+Koleksiyon vekilleriyle, bileşenin başvurduğu tüm kaynakları paketleme işleminin dışında tutmak mümkündür. Bu, dağıtım paketi boyutunu en düşük düzeyde tutmanız gerektiğinde yararlıdır. Örneğin, oyunları web üzerinde HTML5 olarak çalıştırırken tarayıcı oyunu yürütmeden önce dağıtım paketinin tamamını indirir.
+
+![Hariç tutma](images/resource/exclude.png)
+
+Bir koleksiyon vekilinde *Exclude* seçeneğini işaretlediğinizde başvurulan kaynak oyunun dağıtım paketinin dışında tutulur. Bunun yerine, hariç tutulan koleksiyonları seçtiğiniz bir bulut depolama hizmetinde saklayabilirsiniz. [Live Update kılavuzu](/manuals/live-update/) bu özelliğin nasıl çalıştığını açıklar.

--- a/docs/tr/manuals/scene-editing.md
+++ b/docs/tr/manuals/scene-editing.md
@@ -1,0 +1,244 @@
+---
+title: Defold sahne düzenleyicisi
+brief: Sahne düzenleyicisinde koleksiyonları, oyun nesnelerini, GUI'leri, parçacık efektlerini ve diğer görsel varlıkları düzenlersiniz. Bu kılavuz seçimi, araçları ve serbest kamera modu ile kamera ayarları dahil olmak üzere sahne görünümünde 2B ve 3B gezinmeyi açıklar.
+---
+
+# Defold sahne düzenleyicisi
+
+**Sahne düzenleyicisi (Scene Editor)**, koleksiyonlar (collection), oyun nesneleri (game object) ve diğer görsel varlıklar (asset) gibi sahneleri oluşturmak ve düzenlemek için kullanılan görsel düzenleyicidir.
+
+Başlangıçtaki kamera görünümü kaynağa (resource) bağlıdır. Modeller ve glTF sahneleri gibi 3B kaynaklarda varsayılan olarak **perspektif (perspective)**, sprite bileşenleri, karo haritaları ve GUI sahneleri gibi 2B kaynaklarda ise **ortografik (orthographic)** izdüşüm kullanılır. Kamera yönelimini, izdüşümü ve ızgarayı sahne araç çubuğundan değiştirebilirsiniz.
+
+## Sahne düzenleyicisini açma
+
+Sahne düzenleyicisini açmak için *Assets* bölmesinde aşağıdakiler gibi bir görsel kaynağa çift tıklayın:
+
+- **Sahne yapısı** — koleksiyonlar (`.collection`), oyun nesneleri (`.go`)
+- **2B varlıklar** — atlas (`.atlas`), karo haritaları (`.tilemap`), sprite bileşenleri (`.sprite`), karo kaynakları (`.tilesource`)
+- **3B varlıklar** — modeller (`.model`, `.glb`, `.gltf`)
+- **Kullanıcı arayüzü (UI)** — GUI sahneleri (`.gui`)
+- **Efektler** — parçacık efektleri (particle effect) (`.particlefx`)
+- Ve diğerleri
+
+## Hatırlanan sahne görünümleri
+
+Düzenleyici, bir sahne kaynağının sekmesi kapatıldığında veya düzenleyiciden çıkıldığında o kaynağın kamera durumunu hatırlar. Aynı kaynağı yeniden açmak görünümünü geri yükler; böylece farklı koleksiyonlar veya modeller farklı kamera konumlarını, yönelimlerini ve izdüşümlerini koruyabilir.
+
+Görünürlük filtreleri de her sahne için ayrı ayrı hatırlanır. Bir sahnede modelleri veya bileşen kılavuzlarını gizlemek, başka bir sahnede aynı filtreleri kullanmanızı gerektirmez. Bunlar düzenleyicinin görünüm ayarlarıdır ve oyunun kamerasını veya çalışma sırasındaki görünürlüğü değiştirmez.
+
+Kaydedilmiş kamera durumu olmayan kaynaklarda model, örgü (mesh) ve glTF kaynakları perspektif görünümde başlar. Çarpışma nesnelerinin görünümü projenin 2B/3B fizik ayarına göre seçilir; koleksiyonların ve oyun nesnelerinin başlangıç görünümü ise sahne geometrilerine göre seçilir.
+
+## Sahne görünümünde gezinme (kamera denetimleri)
+
+Sahne düzenleyicisinin kamerası fare ve klavyeyle denetlenebilir. Kullanılabilir denetimler, standart kamera gezinmesini mi yoksa **serbest kamera modunu (Free Camera Mode)** mu kullandığınıza bağlıdır.
+
+### Standart gezinme (tüm görsel düzenleyiciler)
+
+Görsel düzenleyicilerde şu denetimler kullanılabilir:
+
+- **Kaydırma**
+  - <kbd>Alt</kbd>/<kbd>⌥ Option</kbd> + <kbd>Left Mouse Button</kbd>
+- **Yakınlaştırma/uzaklaştırma**
+  - <kbd>Mouse Wheel</kbd> veya
+  - <kbd>Ctrl</kbd>/<kbd>^ Control</kbd> + <kbd>Alt</kbd>/<kbd>⌥ Option</kbd> + <kbd>Left Mouse Button</kbd>
+- **Seçimin etrafında döndürme/dolanma (3B)**
+  - <kbd>Ctrl</kbd>/<kbd>^ Control</kbd> + <kbd>Left Mouse Button</kbd>
+
+Kamerayı geçerli seçime odaklamak için **Frame Selection** (<kbd>F</kbd>) komutunu da kullanabilirsiniz.
+
+## 2B ve 3B sahne yönelimi {#2d-and-3d-scene-orientation}
+
+Sahne görünümü hem 2B hem de 3B iş akışlarında kullanılabilir:
+
+- **2B** çalışırken genellikle 2B yönelimli bir ızgaraya sahip ortografik görünüm kullanırsınız.
+- **3B** çalışırken genellikle:
+  - Görünümü 3B yönelime yeniden hizalarsınız,
+  - **Perspektif** kamera kullanırsınız,
+  - Uygun bir ızgara düzlemi seçersiniz ("zemin" için genellikle **Y**).
+
+Bu işlevlere araç çubuğundan ve **View** menüsünden erişebilirsiniz.
+
+![3B sahne düzenleyicisi](images/editor/3d_scene.png)
+
+## Araç çubuğuna genel bakış
+
+Sahne görünümünün sağ üst köşesinde, sık kullanılan araçları ve görünüm seçeneklerini içeren bir araç çubuğu bulunur (soldan sağa):
+
+- **Move tool** (<kbd>W</kbd>)
+- **Rotate tool** (<kbd>E</kbd>)
+- **Scale tool** (<kbd>R</kbd>)
+- **Grid Settings** (`▦`)
+- **Align/Realign Camera 2D/3D** (`2D`) — 2B ve 3B yönelim arasında geçiş yapar (kısayol <kbd>.</kbd>)
+- **Camera Perspective/Orthographic**
+- **Visibility Filters** (`👁`)
+
+![Araç çubuğu](images/editor/toolbar.png)
+
+## Nesneleri seçme ve değiştirme {#manipulating-objects}
+
+### Nesneleri seçme
+
+Nesneleri seçmek için ana pencerede üzerlerine <kbd>farenin sol düğmesiyle tıklayın</kbd>. Düzenleyici görünümünde nesneyi çevreleyen dikdörtgen (veya dikdörtgenler prizması), hangi öğenin seçildiğini belirtmek için camgöbeği renkle vurgulanır. Seçilen nesne, yukarıdaki resimde olduğu gibi `Outline` görünümünde de vurgulanır.
+
+  Nesneleri şu yollarla da seçebilirsiniz:
+
+- <kbd>Farenin sol düğmesiyle tıklayın</kbd> ve seçim bölgesindeki tüm nesneleri seçmek için <kbd>sürükleyin</kbd>.
+- <kbd>Farenin sol düğmesiyle tıklayarak</kbd> `Outline` görünümündeki nesneleri seçin; <kbd>⇧ Shift</kbd> tuşunu basılı tutarken seçimi genişletebilir veya <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> tuşunu basılı tutarken tıkladığınız nesneleri seçebilir ya da seçimden çıkarabilirsiniz.
+
+#### Taşıma aracı
+
+![Taşıma aracı](images/editor/icon_move.png){.left}
+
+Nesneleri taşımak için *Move Tool* aracını kullanın. Aracı sahne düzenleyicisinin sağ üst köşesindeki araç çubuğunda bulabilir veya <kbd>W</kbd> tuşuna basarak seçebilirsiniz.
+
+![Nesneyi taşıma](images/editor/move.png){.inline}![Nesneyi 3B taşıma](images/editor/move_3d.png){.inline}
+
+Dönüşüm denetimi (gizmo) değişerek kareler ve oklardan oluşan bir dizi tutamaç gösterir (seçili tutamaç turuncuya döner). Taşımak için bu tutamaçları <kbd>sürükleyebilirsiniz</kbd>:
+
+- ortadaki camgöbeği kare tutamaç, nesneyi yalnızca ekran uzayında (screen space) taşır,
+- her eksen boyunca uzanan kırmızı, yeşil ve mavi 3 ok, nesneyi yalnızca ilgili X, Y veya Z ekseni boyunca taşır.
+- kırmızı, yeşil ve mavi 3 kare tutamaç (dış çizgileri görünür, içleri saydam), nesneyi yalnızca ilgili düzlemde taşır; örneğin X-Y (mavi) düzleminde ve (kamera 3B olarak döndürüldüğünde görünen) X-Z (yeşil) ve Y-Z (kırmızı) düzlemlerinde.
+
+#### Döndürme aracı
+
+![Döndürme aracı](images/editor/icon_rotate.png){.left}
+
+Nesneleri döndürmek için araç çubuğundan *Rotate Tool* aracını seçin veya <kbd>E</kbd> tuşuna basın.
+
+![Nesneyi döndürme](images/editor/rotate.png){.inline}![Nesneyi 3B döndürme](images/editor/rotate_3d.png){.inline}
+
+Bu araç, döndürmek için <kbd>sürükleyebileceğiniz</kbd> dört dairesel tutamaçtan oluşur (seçili tutamaç turuncuya döner):
+
+- camgöbeği tutamaç (dıştaki, en büyük daire), nesneyi ekran uzayında döndürür
+- daha küçük kırmızı, yeşil ve mavi 3 dairesel tutamaç, X, Y ve Z eksenlerinin her biri etrafında ayrı ayrı döndürmeye olanak tanır. 2B ortografik görünümde bunlardan ikisi X ve Y eksenlerine dik olduğundan, daireler yalnızca nesnenin içinden geçen iki çizgi olarak görünür.
+
+#### Ölçekleme aracı
+
+![Ölçekleme aracı](images/editor/icon_scale.png){.left}
+
+Nesneleri ölçeklemek için araç çubuğundan *Scale Tool* aracını seçin veya <kbd>R</kbd> tuşuna basın.
+
+![Nesneyi ölçekleme](images/editor/scale.png){.inline}![Nesneyi 3B ölçekleme](images/editor/scale_3d.png){.inline}
+
+Bu araç, ölçeklemek için <kbd>sürükleyebileceğiniz</kbd> kare/küp şeklindeki bir dizi tutamaçtan oluşur (seçili tutamaç turuncuya döner):
+
+- ortadaki camgöbeği küp, nesneyi tüm eksenlerde (Z dahil) aynı oranda ölçekler.
+- kırmızı, mavi ve yeşil 3 küp tutamaç, nesneyi X, Y ve Z eksenlerinin her biri boyunca ayrı ayrı ölçekler.
+- kırmızı, yeşil ve mavi 3 kare tutamaç (dış çizgileri görünür, içleri saydam), nesneyi X-Y, X-Z veya Y-Z düzlemlerinde ayrı ayrı ölçekler.
+
+### Görünürlük filtreleri {#visibility-filters}
+
+Çeşitli bileşen (component) türlerinin yanı sıra sınırlayıcı kutuların ve kılavuz çizgilerinin görünürlüğünü açıp kapatmak için araç çubuğundaki **görünürlük göz simgesine** (`👁`) tıklayın (`Component Guides` veya <kbd>Ctrl</kbd> + <kbd>H</kbd> (Win/Linux) ya da <kbd>^ Ctrl</kbd> + <kbd>⌘ Cmd</kbd> + <kbd>H</kbd>(Mac) kısayolu).
+
+![Görünürlük filtreleri](images/editor/visibilityfilters.png)
+
+## Izgara ayarları {#grid-settings}
+
+Izgara, iş akışınıza uyacak şekilde özelleştirilebilir (özellikle 3B çalışırken yararlıdır). Izgara ayarları açılır penceresini açmak için **Grid Settings** düğmesine (`▦`) tıklayın.
+
+Düzenleyici, 2B ve 3B görünümler için ayrı ızgara ayarları tutar. İstediğiniz mod etkinken boyutu, düzlemi ve görünümü ayarlayın; mod değiştirdiğinizde o modun ızgara ayarları geri yüklenir. **Reset to Defaults**, etkin modun ayarlarını sıfırlar.
+
+![Izgara ayarları](images/editor/grid_popup.png)
+
+Ayarlar şunları içerir:
+
+- **Grid size (X/Y/Z)**
+  Her eksen boyunca ızgara çizgileri arasındaki aralığı ayarlar. Küçük nesneleri hassas biçimde yerleştirmek için daha küçük, daha geniş bir genel görünüm için daha büyük değerler kullanın.
+- **Active plane (X/Y/Z)**
+  Izgaranın hangi düzlemde çizileceğini seçer. 2B iş akışlarında bu genellikle **Z** düzlemidir (varsayılan X-Y düzlemi). 3B iş akışlarında, zemin/taban düzlemini temsil etmek için yaygın olarak **Y** kullanılır.
+- **Grid color**
+  Izgara çizgilerinin rengini ayarlar. Farklı sahne arka planlarıyla karşıtlık oluşturmak için yararlıdır.
+- **Grid opacity**
+  Izgara çizgilerinin ne kadar saydam olduğunu denetler. Düşük değerler, ızgaranın referans sağlamayı sürdürürken daha az dikkat dağıtmasını sağlar.
+- **Reset to Defaults** düğmesi
+  Tüm ızgara ayarlarını özgün değerlerine geri yükler.
+
+## Kamera türü: perspektif ve ortografik
+
+Sahne düzenleyicisi her ikisini de destekler:
+
+- **Ortografik** kamera (2B iş akışlarında yaygındır)
+- **Perspektif** kamera (3B iş akışlarında yaygındır)
+
+Aralarında geçiş yapmak için araç çubuğundaki kamera düğmesini kullanın. 3B sahnelerde perspektif görünümde gezinmek genellikle daha doğal hissettirir.
+
+## Serbest kamera modu {#free-camera-mode}
+
+Sahne düzenleyicisi, 3B sahnelerde hızlı gezinmek için birinci şahıs / "FPS tarzı" bir kamera olan **serbest kamera modunu (Free Camera Mode)** sunar.
+
+### Serbest kamera modunu etkinleştirme
+
+- <kbd>Right Mouse Button</kbd> düğmesini basılı tutun — serbest kamera modu, düğme basılı tutulduğu sürece etkindir
+- <kbd>Shift</kbd> + <kbd>`</kbd> (ters tırnak) — serbest kamera modunu açar ve tuşlar bırakıldıktan sonra da etkin tutar
+
+::: sidenote
+Bazı klavye düzenlerinde (ör. İsveççe) ters tırnak tuşu bir ölü tuştur ve kısayolu beklendiği gibi tetiklemeyebilir. Bu kısayolu
+`File ▸ Preferences ▸ Keys` bölümünde yeniden atayabilir ve `Scene -> Free Camera -> Activate` için bir kısayol girebilirsiniz
+:::
+
+Serbest kamera modu etkinken sahne görünümü, kenarları boyunca uzanan bir çizgiyle vurgulanır.
+
+### Serbest kamera modundan çıkma
+
+- <kbd>Right Mouse Button</kbd> düğmesini bırakın (basılı tutarak etkinleştirildiğinde) veya
+- Serbest kamera modu açılıp kapanabilen bir mod olarak etkinleştirildiyse <kbd>Left Mouse Button</kbd> veya <kbd>Right Mouse Button</kbd> düğmesine basıp bırakın ya da <kbd>Esc</kbd> tuşuna basın.
+
+### Etrafa bakma (fareyle bakış)
+
+Serbest kamera modu etkinken aşağıdaki tuşlar (düzenleyici araçları yerine) kamera hareketini denetler:
+
+- **Yatay dönüşü (yaw)** (sol/sağ) ve **dikey dönüşü (pitch)** (yukarı/aşağı) denetlemek için fareyi hareket ettirin
+- Kameranın ters dönmesini önlemek için dikey dönüş sınırlandırılır
+
+İsteğe bağlı olarak Y eksenini tersine de çevirebilirsiniz (aşağıdaki **Serbest kamera ayarları** bölümüne bakın).
+
+### Hareket etme
+
+Serbest kamera modu etkinken:
+
+- <kbd>W</kbd> — ileri
+- <kbd>S</kbd> — geri
+- <kbd>A</kbd> — sol
+- <kbd>D</kbd> — sağ
+- <kbd>E</kbd> — yukarı
+- <kbd>Q</kbd> — aşağı
+
+::: sidenote
+Tüm hareket tuşları `File ▸ Preferences ▸ Keys` bölümünden yeniden atanabilir. Ardından `Scene -> Free Camera` ifadesini arayın
+:::
+
+Hızı değiştiren tuşlar:
+
+- <kbd>Shift</kbd> tuşunu basılı tutun — daha hızlı hareket edin
+- <kbd>Alt</kbd>/<kbd>⌥ Option</kbd> tuşunu basılı tutun — daha yavaş / daha hassas hareket edin
+
+### Yürüme modu (isteğe bağlı)
+
+Serbest kamera modu, **Walking Mode** özelliğini destekler.
+
+Etkinleştirildiğinde:
+- Yukarı/aşağı hareket, bir zemin düzleminde yere basarak birinci şahıs bakış açısıyla yürümeye daha çok benzeyecek şekilde kısıtlanır.
+- Bu, bir bölümü keşfederken tutarlı bir "yere basma" hareketi istediğinizde yararlıdır.
+
+## Kamera ayarları açılır penceresi
+
+Araç çubuğundaki perspektif kamera düğmesinde, kamerayla ilgili tercihleri içeren bir açılır pencere bulunur.
+
+![Perspektif kamera ayarları](images/editor/camera_popup.png)
+
+Açılır pencere şunları içerir:
+
+- **Move Speed**
+  Serbest kameranın hareket hızını ayarlar.
+
+- **Look Sensitivity**
+  Kameranın fare hareketine tepki olarak ne kadar hızlı döndüğünü ayarlar.
+
+- **Invert Y**
+  Fareyle dikey bakış yönünü tersine çevirir.
+
+- **Walking Mode**
+  Zeminde gezinmeye benzer bir hareket sağlamak için hareketi kısıtlar.
+
+- **Reset to Defaults**
+  Varsayılan kamera ayarlarını geri yükler.

--- a/docs/tr/manuals/script-properties.md
+++ b/docs/tr/manuals/script-properties.md
@@ -1,0 +1,175 @@
+---
+title: Betik bileşeni özellikleri
+brief: Bu kılavuz, betik bileşenlerine özel özelliklerin nasıl ekleneceğini ve bunlara düzenleyiciden ve çalışma zamanı betiklerinden nasıl erişileceğini açıklar.
+---
+
+# Betik özellikleri
+
+Betik özellikleri (script properties), belirli bir oyun nesnesi (game object) örneği için özel özellikler tanımlamanın ve bunları dışarıya açmanın basit ve güçlü bir yolunu sunar. Betik özellikleri, belirli örneklerde doğrudan düzenleyicide değiştirilebilir ve ayarları, bir oyun nesnesinin davranışını değiştirmek için kodda kullanılabilir. Betik özelliklerinin çok yararlı olduğu birçok durum vardır:
+
+* Düzenleyicide belirli örnekler için değerleri geçersiz kılmak ve böylece betiğin yeniden kullanılabilirliğini artırmak istediğinizde.
+* Bir oyun nesnesini başlangıç değerleriyle çalışma sırasında oluşturmak istediğinizde.
+* Bir özelliğin değerlerine animasyon uygulamak istediğinizde.
+* Bir betikteki durum verilerine başka bir betikten erişmek istediğinizde. (Nesneler arasında özelliklere sık sık erişiyorsanız verileri paylaşılan bir depolama alanına taşımanın daha iyi olabileceğini unutmayın.)
+
+Yaygın kullanım örnekleri arasında belirli bir düşman yapay zekâsının canını veya hızını, toplanabilir bir nesnenin renk çarpanını (tint), bir sprite bileşeninin atlasını ya da bir düğme nesnesine basıldığında hangi iletinin gönderileceğini ve/veya nereye gönderileceğini ayarlamak yer alır.
+
+## Betik özelliği tanımlama
+
+Betik özellikleri, özel `go.property()` işleviyle tanımlanarak bir betik bileşenine (script component) eklenir. Bu işlevin en üst düzeyde, yani `init()` ve `update()` gibi yaşam döngüsü işlevlerinin dışında kullanılması gerekir. Özellik için verilen varsayılan değer, özelliğin türünü belirler: `number`, `boolean`, `string`, `hash`, `msg.url`, `vmath.vector3`, `vmath.vector4`, `vmath.quaternion` ve `resource` (aşağıya bakın).
+
+::: important
+Karma değerinden (hash value) özgün dizeyi geri elde etmenin, hata ayıklamayı kolaylaştırmak amacıyla yalnızca Debug derlemesinde çalıştığını unutmayın. Release derlemesinde geri elde edilebilecek dize değeri bulunmaz; bu nedenle `tostring()` işlevini bir `hash` değeri üzerinde kullanarak bu değerden dizeyi elde etmeye çalışmak anlamsızdır.
+:::
+
+
+```lua
+-- can.script
+-- Define script properties for health and an attack target
+go.property("health", 100)
+go.property("target", msg.url())
+
+function init(self)
+  -- store initial position of target.
+  -- self.target is a url referencing another object.
+  self.target_pos = go.get_position(self.target)
+  ...
+end
+
+function on_message(self, message_id, message, sender)
+  if message_id == hash("take_damage") then
+    -- decrease the health property
+    self.health = self.health - message.damage
+    if self.health <= 0 then
+      go.delete()
+    end
+  end
+end
+```
+
+Ardından, bu betikten oluşturulan her betik bileşeni örneği için özellik değerleri ayarlanabilir.
+
+![Özellikleri olan bileşen](images/script-properties/component.png)
+
+ Düzenleyicideki *Outline* görünümünde betik bileşenini seçin; özellikler, düzenleyebilmeniz için *Properties* görünümünde belirir:
+
+![Properties görünümü](images/script-properties/properties.png)
+
+Örneğe özgü yeni bir değerle geçersiz kılınan her özellik mavi renkle işaretlenir. Değeri varsayılana (betikte ayarlanan değere) döndürmek için özellik adının yanındaki sıfırlama düğmesine tıklayın.
+
+
+::: important
+Betik özellikleri proje derlenirken ayrıştırılır. Değer ifadeleri değerlendirilmez. Bu, `go.property("hp", 3+6)` gibi bir ifadenin çalışmayacağı, ancak `go.property("hp", 9)` ifadesinin çalışacağı anlamına gelir.
+:::
+
+### Metin özellikleri
+
+Defold 1.13.2 sürümünden itibaren, varsayılan değer olarak verilen bir dize bir metin özelliği tanımlar. Metin özellikleri UTF-8 ve yeni satır karakterlerini destekler ve düzenleyicide çok satırlı bir alanda düzenlenir:
+
+```lua
+go.property("greeting", "Hello!\nWelcome, José!")
+
+function init(self)
+    go.set("#label", "text", self.greeting)
+end
+```
+
+Diğer betik özelliklerinde olduğu gibi metin özelliklerini de geçersiz kılmak için bir oyun nesnesindeki veya koleksiyondaki (collection) betik bileşenini seçin. Varsayılan değerlerde veya bunları geçersiz kılan değerlerde gömülü NUL karakterlerine izin verilmez.
+
+Diğer betikler, betik bileşeninin URL adresi üzerinden bir metin özelliğini okuyabilir ve yazabilir. Örneğin, yukarıdaki betiği ve bir etiket (label) bileşenini koleksiyondaki `speaker` adlı oyun nesnesine, bileşen tanımlayıcıları `script` ve `label` olacak şekilde ekleyin. Bunları başka bir betiğin `init()` işlevinden güncelleyin:
+
+```lua
+function init(self)
+    local greeting = go.get("/speaker#script", "greeting")
+    go.set("/speaker#script", "greeting", greeting .. "\nEnjoy the game!")
+    go.set("/speaker#label", "text", go.get("/speaker#script", "greeting"))
+end
+```
+
+Betik özelliğini değiştirmek, etiket bileşenini otomatik olarak güncellemez; son satır yeni değeri açıkça etiket bileşeninin `text` özelliğine kopyalar.
+
+## Betik özelliklerine erişme
+
+Tanımlanmış her betik özelliğine, betik örneği başvurusu olan `self` içinde saklanan bir üye olarak erişilebilir:
+
+```lua
+-- my_script.script
+go.property("my_property", 1)
+
+function update(self, dt)
+  -- Read and write the property
+  if self.my_property == 1 then
+      self.my_property = 3
+  end
+end
+```
+
+Kullanıcı tanımlı betik özellikleri `go.get()` ile de okunabilir ve `go.set()` ile yazılabilir. Vektörler ve kuaterniyonlar (quaternion) dahil sayısal özelliklere `go.animate()` ile animasyon uygulanabilir. Metin özellikleri okunabilir ve yazılabilir, ancak bunlara animasyon uygulanamaz:
+
+```lua
+-- another.script
+
+-- increase "my_property" in "myobject#script" by 1
+local val = go.get("myobject#my_script", "my_property")
+go.set("myobject#my_script", "my_property", val + 1)
+
+-- animate "my_property" in "myobject#my_script"
+go.animate("myobject#my_script", "my_property", go.PLAYBACK_LOOP_PINGPONG, 100, go.EASING_LINEAR, 2.0)
+```
+
+## Fabrikayla oluşturulan nesneler
+
+Oyun nesnesini oluşturmak için bir fabrika (factory) kullanıyorsanız betik özelliklerini oluşturma anında ayarlayabilirsiniz:
+
+```lua
+local props = { health = 50, target = msg.url("player") }
+local id = factory.create("#can_factory", nil, nil, props)
+
+-- Accessing factory-created script properties
+local url = msg.url(nil, id, "can")
+local can_health = go.get(url, "health")
+```
+
+`collectionfactory.create()` aracılığıyla çalışma sırasında bir oyun nesnesi hiyerarşisi oluştururken nesne tanımlayıcılarını özellik tablolarıyla eşleştirmeniz gerekir. Bunlar bir tabloda bir araya getirilir ve `create()` işlevine iletilir:
+
+```lua
+local props = {}
+props[hash("/can1")] = { health = 150 }
+props[hash("/can2")] = { health = 250, target = msg.url("player") }
+props[hash("/can3")] = { health = 200 }
+
+local ids = collectionfactory.create("#cangang_factory", nil, nil, props)
+```
+
+`factory.create()` ve `collectionfactory.create()` aracılığıyla verilen özellik değerleri, prototip dosyasında ayarlanan tüm değerlerin yanı sıra betikteki varsayılan değerleri de geçersiz kılar.
+
+Bir oyun nesnesine bağlı birden çok betik bileşeni aynı özelliği tanımlıyorsa her bileşen, `factory.create()` veya `collectionfactory.create()` işlevine verilen değerle başlatılır.
+
+
+## Kaynak özellikleri {#resource-properties}
+
+Kaynak özellikleri (resource properties), temel veri türlerine ait betik özellikleriyle aynı şekilde tanımlanır:
+
+```lua
+go.property("my_atlas", resource.atlas("/atlas.atlas"))
+go.property("my_font", resource.font("/font.font"))
+go.property("my_material", resource.material("/material.material"))
+go.property("my_texture", resource.texture("/texture.png"))
+go.property("my_tile_source", resource.tile_source("/tilesource.tilesource"))
+```
+
+Bir kaynak özelliği tanımlandığında, diğer betik özellikleri gibi *Properties* görünümünde belirir; ancak dosya/kaynak seçmeye yarayan bir alan olarak gösterilir:
+
+![Kaynak özellikleri](images/script-properties/resource-properties.png)
+
+Kaynak özelliklerine `go.get()` ile veya `self` betik örneği başvurusu üzerinden erişir ve bunları `go.set()` ile kullanırsınız:
+
+```lua
+function init(self)
+  go.set("#sprite", "image", self.my_atlas)
+  go.set("#label", "font", self.my_font)
+  go.set("#sprite", "material", self.my_material)
+  go.set("#model", "texture0", self.my_texture)
+  go.set("#tilemap", "tile_source", self.my_tile_source)
+end
+```

--- a/docs/tr/manuals/script.md
+++ b/docs/tr/manuals/script.md
@@ -1,0 +1,204 @@
+---
+title: Betiklerde oyun mantığı yazma
+brief: Bu kılavuz, betik bileşenleri kullanarak oyun mantığının nasıl ekleneceğini açıklar.
+---
+
+# Betikler
+
+Betik bileşenleri (script component), [Lua programlama dilini](/manuals/lua) kullanarak oyun mantığı oluşturmanızı sağlar.
+
+
+## Betik türleri
+
+Defold'da üç tür Lua betiği vardır ve her tür farklı Defold kütüphanelerine erişebilir.
+
+Oyun nesnesi betikleri
+: Uzantısı _.script_ şeklindedir. Bu betikler oyun nesnelerine (game object) diğer [bileşenlerle](/manuals/components) aynı şekilde eklenir ve Defold, Lua kodunu motorun yaşam döngüsü (lifecycle) işlevlerinin bir parçası olarak yürütür. Oyun nesnesi betikleri genellikle oyun nesnelerini ve bölüm yükleme, oyun kuralları gibi işlemlerle oyunu bir arada tutan mantığı denetlemek için kullanılır. Oyun nesnesi betikleri [GO](/ref/go) işlevlerine ve [GUI](/ref/gui) ile [Render](/ref/render) işlevleri dışındaki tüm Defold kütüphane işlevlerine erişebilir.
+
+
+GUI betikleri
+: Uzantısı _.gui_script_ şeklindedir. GUI bileşenleri tarafından çalıştırılır ve genellikle oyun içi bilgi göstergeleri, menüler vb. GUI öğelerini görüntülemek için gereken mantığı içerir. Defold, Lua kodunu motorun yaşam döngüsü işlevlerinin bir parçası olarak yürütür. GUI betikleri [GUI](/ref/gui) işlevlerine ve [GO](/ref/go) ile [Render](/ref/render) işlevleri dışındaki tüm Defold kütüphane işlevlerine erişebilir.
+
+
+İşleme betikleri
+: Uzantısı _.render_script_ şeklindedir. İşleme betikleri (render script), işleme hattı (rendering pipeline) tarafından çalıştırılır ve her karede uygulamanın/oyunun tüm grafiklerinden görüntü oluşturmak için gereken mantığı içerir. İşleme betiğinin oyunun yaşam döngüsünde özel bir yeri vardır. Ayrıntıları [uygulama yaşam döngüsü belgelerinde](/manuals/application-lifecycle) bulabilirsiniz. İşleme betikleri [Render](/ref/render) işlevlerine ve [GO](/ref/go) ile [GUI](/ref/gui) işlevleri dışındaki tüm Defold kütüphane işlevlerine erişebilir.
+
+
+## Betik yürütme, geri çağırımlar ve self
+
+Defold, Lua betiklerini motorun yaşam döngüsünün bir parçası olarak yürütür ve önceden tanımlanmış bir dizi geri çağırım (callback) işleviyle yaşam döngüsüne erişim sağlar. Bir oyun nesnesine betik bileşeni eklediğinizde betik, oyun nesnesinin ve bileşenlerinin yaşam döngüsünün bir parçası olur. Betik yüklendiğinde Lua bağlamında değerlendirilir; ardından motor aşağıdaki işlevleri yürütür ve geçerli betik bileşeni örneğine (instance) bir başvuruyu parametre olarak geçirir. Bileşen örneğinde durum saklamak için bu `self` başvurusunu kullanabilirsiniz.
+
+::: important
+`self`, Lua tablosu gibi davranan bir `userdata` nesnesidir; ancak üzerinde `pairs()` veya `ipairs()` ile yineleme yapamaz ve `pprint()` kullanarak içeriğini yazdıramazsınız.
+:::
+
+#### `init(self)`
+Bileşenin başlangıç işlemleri sırasında çağrılır.
+
+```lua
+function init(self)
+  -- These variables are available through the lifetime of the component instance
+  self.my_var = "something"
+  self.age = 0
+end
+```
+
+#### `final(self)`
+Bileşen silindiğinde çağrılır. Temizleme işlemleri için kullanışlıdır; örneğin çalışma sırasında oluşturduğunuz oyun nesnelerinin bileşen silindiğinde silinmesi gerekiyorsa kullanılabilir.
+
+```lua
+function final(self)
+  if self.my_var == "something" then
+      -- do some cleanup
+  end
+end
+```
+
+#### `fixed_update(self, dt)`
+Kare hızından bağımsız güncelleme. `dt` parametresi son güncellemeden beri geçen süreyi içerir. Bu işlev, karenin zamanlamasına ve sabit zaman adımlı güncellemenin sıklığına bağlı olarak `0-N` kez çağrılır. Yalnızca *game.project* dosyasında `Physics`-->`Use Fixed Timestep` etkinleştirildiğinde ve `Engine`-->`Fixed Update Frequency` değeri 0'dan büyük olduğunda çağrılır. Kararlı bir fizik simülasyonu elde etmek için fizik nesnelerini düzenli aralıklarla değiştirmek istediğinizde kullanışlıdır.
+
+```lua
+function fixed_update(self, dt)
+  msg.post("#co", "apply_force", {force = vmath.vector3(1, 0, 0), position = go.get_world_position()})
+end
+```
+
+#### `update(self, dt)`
+Her karede, tüm betiklerin `fixed_update` geri çağırımlarından sonra (Fixed Timestep etkinse) bir kez çağrılır. `dt` parametresi son kareden beri geçen süreyi içerir.
+
+```lua
+function update(self, dt)
+  self.age = self.age + dt -- increase age with the timestep
+end
+```
+
+#### `late_update(self, dt)`
+Her karede, tüm betiklerin `update` geri çağırımlarından sonra, ancak işlemeden hemen önce bir kez çağrılır. `dt` parametresi son kareden beri geçen süreyi içerir.
+
+```lua
+function late_update(self, dt)
+  go.set_position("/camera", self.final_camera_position)
+end
+```
+
+#### on_message(self, message_id, message, sender)
+Betik bileşenine [`msg.post()`](/ref/msg#msg.post) aracılığıyla ileti gönderildiğinde motor, alıcı bileşenin bu işlevini çağırır. [İleti aktarımı hakkında daha fazla bilgi edinin](/manuals/message-passing).
+
+```lua
+function on_message(self, message_id, message, sender)
+    if message_id == hash("increase_score") then
+        self.total_score = self.total_score + message.score
+    end
+end
+```
+
+#### `on_input(self, action_id, action)`
+Bu bileşen girdi odağını (input focus) aldıysa (bkz. [`acquire_input_focus`](/ref/go/#acquire_input_focus)) motor, bir girdi algılandığında bu işlevi çağırır. [Girdi işleme hakkında daha fazla bilgi edinin](/manuals/input).
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        print("Touch", action.x, action.y)
+    end
+end
+```
+
+#### `on_reload(self)`
+Bu işlev, betik düzenleyicinin çalışma sırasında yeniden yükleme (hot reload) özelliğiyle (<kbd>Edit ▸ Reload Resource</kbd>) yeniden yüklendiğinde çağrılır. Hata ayıklama, test etme ve ince ayar yapma amacıyla çok kullanışlıdır. [Çalışma sırasında yeniden yükleme hakkında daha fazla bilgi edinin](/manuals/hot-reload).
+
+```lua
+function on_reload(self)
+  print(self.age) -- print the age of this game object
+end
+```
+
+
+## Tepkisel mantık
+
+Betik bileşeni olan bir oyun nesnesi belirli bir mantığı uygular. Bu mantık çoğu zaman dış bir etkene bağlıdır. Bir düşmanın yapay zekâsı, oyuncunun kendi çevresindeki belirli bir yarıçaplı alanda bulunmasına tepki verebilir; oyuncunun etkileşimi sonucunda bir kapının kilidi çözülüp kapı açılabilir vb.
+
+`update()` işlevi, her karede çalışan bir durum makinesi (state machine) olarak tanımlanan karmaşık davranışları uygulamanızı sağlar; bazen bu uygun bir yaklaşımdır. Ancak her `update()` çağrısının bir maliyeti vardır. Bu işleve gerçekten ihtiyacınız yoksa silmeniz ve mantığınızı _tepkisel_ (reactive) olarak kurmayı denemeniz önerilir. Bir iletinin tepkiyi tetiklemesini pasif biçimde beklemek, tepki verilecek veriler için oyun dünyasını etkin biçimde sorgulamaktan daha az maliyetlidir. Ayrıca bir tasarım sorununu tepkisel olarak çözmek, çoğu zaman daha temiz ve daha kararlı bir tasarım ve uygulama ortaya çıkarır.
+
+Somut bir örneğe bakalım. Bir betik bileşeninin başlangıç işlemlerinden 2 saniye sonra bir ileti göndermesini istediğinizi varsayalım. Ardından belirli bir yanıt iletisini beklemesi ve yanıtı aldıktan 5 saniye sonra başka bir ileti göndermesi gerekir. Bunun tepkisel olmayan kodu şöyle görünebilir:
+
+```lua
+function init(self)
+    -- Counter to keep track of time.
+    self.counter = 0
+    -- We need this to keep track of our state.
+    self.state = "first"
+end
+
+function update(self, dt)
+    self.counter = self.counter + dt
+    if self.counter >= 2.0 and self.state == "first" then
+        -- send message after 2 seconds
+        msg.post("some_object", "some_message")
+        self.state = "waiting"
+    end
+    if self.counter >= 5.0 and self.state == "second" then
+        -- send message 5 seconds after we received "response"
+        msg.post("another_object", "another_message")
+        -- Nil the state so we don’t reach this state block again.
+        self.state = nil
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("response") then
+        -- “first” state done. enter next
+        self.state = "second"
+        -- zero the counter
+        self.counter = 0
+    end
+end
+```
+
+Bu oldukça basit durumda bile epey karmaşık bir mantık ortaya çıkar. Bir modüldeki eş yordamların (coroutine) yardımıyla bunu iyileştirmek mümkündür (aşağıya bakın); ancak bunun yerine mantığı tepkisel hâle getirmeyi ve yerleşik bir zamanlama mekanizması kullanmayı deneyelim.
+
+```lua
+local function send_first()
+	msg.post("some_object", "some_message")
+end
+
+function init(self)
+	-- Wait 2s then call send_first()
+	timer.delay(2, false, send_first)
+end
+
+local function send_second()
+	msg.post("another_object", "another_message")
+end
+
+function on_message(self, message_id, message, sender)
+	if message_id == hash("response") then
+		-- Wait 5s then call send_second()
+		timer.delay(5, false, send_second)
+	end
+end
+```
+
+Bu daha temizdir ve takibi daha kolaydır. Mantık içindeki değişimlerini izlemenin çoğu zaman zor olduğu ve fark edilmesi güç hatalara yol açabilecek iç durum değişkenlerinden kurtuluruz. Ayrıca `update()` işlevini tamamen kaldırırız. Böylece motor, betiğimiz yalnızca boşta beklerken bile onu saniyede 60 kez çağırmak zorunda kalmaz.
+
+
+## Ön işleme
+
+Derleme çeşidine bağlı olarak kodu koşullu biçimde dahil etmek için bir Lua ön işlemcisi (preprocessor) ve özel işaretleme kullanabilirsiniz. Örnek:
+
+```lua
+-- Use one of the following keywords: RELEASE, DEBUG or HEADLESS
+--#IF DEBUG
+local lives_num = 999
+--#ELSE 
+local lives_num = 3
+--#ENDIF
+```
+
+Ön işlemci bir derleme uzantısı olarak sunulur. Kurulumu ve kullanımı hakkında daha fazla bilgiyi [GitHub'daki uzantı sayfasında](https://github.com/defold/extension-lua-preprocessor) bulabilirsiniz.
+
+
+## Düzenleyici desteği
+
+Defold düzenleyicisi, sözdizimi renklendirme ve otomatik tamamlama özellikleriyle Lua betiklerini düzenlemeyi destekler. Defold işlev adlarını tamamlamak için *Ctrl+Space* tuşlarına basarak yazdığınız metinle eşleşen işlevlerin listesini açın.
+
+![Otomatik tamamlama](images/script/completion.png)

--- a/docs/tr/manuals/shader.md
+++ b/docs/tr/manuals/shader.md
@@ -1,0 +1,459 @@
+---
+title: Defold'da gölgelendirici programları
+brief: Bu kılavuz, köşe ve parça gölgelendiricilerini ve bunların Defold'da nasıl kullanılacağını ayrıntılı olarak açıklar.
+---
+
+# Gölgelendiriciler
+
+Gölgelendirici (shader) programları, grafiklerden görüntü oluşturan işleme (rendering) sürecinin temelindedir. Bunlar, GLSL (GL Shading Language) adı verilen C benzeri bir dilde yazılan ve grafik donanımının, temel alınan 3B veriler (köşeler) veya ekranda beliren pikseller ("parçalar") üzerinde işlemler yapmak için çalıştırdığı programlardır. Gölgelendiriciler; sprite bileşenlerini çizmek, 3B modelleri aydınlatmak, tam ekran son işleme efektleri oluşturmak ve daha pek çok şey için kullanılır.
+
+Bu kılavuz, Defold'un işleme hattının (rendering pipeline) GPU gölgelendiricileriyle nasıl etkileşim kurduğunu açıklar. İçeriğiniz için gölgelendiriciler oluşturmak üzere materyal (material) kavramını ve işleme hattının nasıl çalıştığını da anlamanız gerekir.
+
+* İşleme hattıyla ilgili ayrıntılar için [İşleme kılavuzuna](/manuals/render) bakın.
+* Materyallerle ilgili ayrıntılar için [Materyal kılavuzuna](/manuals/material) bakın.
+* Hesaplama programlarıyla ilgili ayrıntılar için [Hesaplama kılavuzuna](/manuals/compute) bakın.
+
+OpenGL ES 2.0 (OpenGL for Embedded Systems) ve OpenGL ES Shading Language belirtimlerini [Khronos OpenGL Registry](https://www.khronos.org/registry/gles/) sitesinde bulabilirsiniz.
+
+Masaüstü bilgisayarlarda, OpenGL ES 2.0'da bulunmayan özellikleri kullanarak gölgelendiriciler yazmanın mümkün olduğunu unutmayın. Ekran kartı sürücünüz, mobil cihazlarda çalışmayacak gölgelendirici kodunu sorunsuzca derleyip çalıştırabilir.
+
+
+## Kavramlar
+
+Köşe gölgelendiricisi
+: Bir köşe gölgelendiricisi (vertex shader) köşe oluşturamaz veya silemez; yalnızca bir köşenin konumunu değiştirebilir. Köşe gölgelendiricileri genellikle köşelerin konumlarını 3B dünya uzayından 2B ekran uzayına dönüştürmek için kullanılır.
+
+  Bir köşe gölgelendiricisinin girdisi, köşe verileri (`attributes` biçiminde) ve sabitlerdir (`uniforms`). Yaygın kullanılan sabitler, bir köşenin konumunu ekran uzayına dönüştürmek ve izdüşürmek için gereken matrislerdir.
+
+  Köşe gölgelendiricisinin çıktısı, köşenin hesaplanan ekran konumudur (`gl_Position`). Köşe gölgelendiricisinden parça gölgelendiricisine `varying` değişkenleri aracılığıyla veri aktarmak da mümkündür.
+
+Parça gölgelendiricisi
+: Köşe gölgelendiricisinin işi bittiğinde, oluşan temel geometrik şekillerin (primitive) her bir parçasının (veya pikselinin) rengini belirlemek parça gölgelendiricisinin (fragment shader) görevidir.
+
+  Bir parça gölgelendiricisinin girdisi, sabitler (`uniforms`) ve köşe gölgelendiricisinin ayarladığı tüm `varying` değişkenleridir.
+
+  Parça gölgelendiricisinin çıktısı, ilgili parçanın renk değeridir (`gl_FragColor`).
+
+Hesaplama gölgelendiricisi
+: Bir hesaplama gölgelendiricisi (compute shader), GPU üzerinde her tür işi gerçekleştirmek için kullanılabilen genel amaçlı bir gölgelendiricidir. Grafik hattının bir parçası değildir; hesaplama gölgelendiricileri ayrı bir yürütme bağlamında çalışır ve başka bir gölgelendiriciden gelen girdiye bağımlı değildir.
+
+  Bir hesaplama gölgelendiricisinin girdisi, sabit arabellekleri (`uniforms`), doku görüntüleri (`image2D`), örnekleyiciler (`sampler2D`) ve depolama arabellekleridir (`buffer`).
+
+  Hesaplama gölgelendiricisinin çıktısı açıkça tanımlanmaz; köşe ve parça gölgelendiricilerinden farklı olarak üretilmesi gereken belirli bir çıktı yoktur. Hesaplama gölgelendiricileri genel amaçlı olduğu için hesaplama gölgelendiricisinin ne tür bir sonuç üretmesi gerektiğini tanımlamak programcıya bağlıdır.
+
+Dünya matrisi
+: Bir modelin şeklini oluşturan köşelerin konumları, modelin başlangıç noktasına göre saklanır. Buna "model uzayı" (model space) denir. Oyun dünyası ise her köşenin konumunun, yöneliminin ve ölçeğinin dünyanın başlangıç noktasına göre ifade edildiği bir "dünya uzayıdır" (world space). Oyun motoru bunları ayrı tutarak her modeli, model bileşeninde (model component) saklanan özgün köşe değerlerini bozmadan taşıyabilir, döndürebilir ve ölçeklendirebilir.
+
+  Bir model oyun dünyasına yerleştirildiğinde, modelin yerel köşe koordinatlarının dünya koordinatlarına dönüştürülmesi gerekir. Bu dönüşüm, modelin köşelerinin oyun dünyasının koordinat sistemine doğru yerleştirilmesi için hangi öteleme (hareket), dönme ve ölçeğin uygulanması gerektiğini belirten bir *dünya dönüşüm matrisi* (world transform matrix) ile yapılır.
+
+  ![Dünya dönüşümü](images/shader/world_transform.png)
+
+Görünüm ve izdüşüm matrisi
+: Oyun dünyasındaki köşeleri ekrana yerleştirmek için önce her matrisin 3B koordinatları kameraya göre koordinatlara dönüştürülür. Bu, bir _görünüm matrisi_ (view matrix) ile yapılır. İkinci olarak, köşeler bir _izdüşüm matrisi_ (projection matrix) ile 2B ekran uzayına izdüşürülür:
+
+  ![İzdüşüm](images/shader/projection.png)
+
+Öznitelikler
+: Tek bir köşeyle ilişkili değer. Öznitelikler (attributes) motordan gölgelendiriciye aktarılır; bir özniteliğe erişmek isterseniz onu gölgelendirici programınızda bildirmeniz yeterlidir. Farklı bileşen türlerinin farklı öznitelik kümeleri vardır:
+  - Sprite bileşeninde `position` ve `texcoord0` bulunur.
+  - Tilegrid bileşeninde `position` ve `texcoord0` bulunur.
+  - GUI düğümünde `position`, `textcoord0` ve `color` bulunur.
+  - ParticleFX bileşeninde `position`, `texcoord0` ve `color` bulunur.
+  - Model bileşeninde `position`, `texcoord0` ve `normal` bulunur.
+  - Yazı tipinde `position`, `texcoord0`, `face_color`, `outline_color` ve `shadow_color` bulunur.
+
+Sabitler
+: Gölgelendirici sabitleri, işleme çizim çağrısı boyunca sabit kalır. Sabitler, materyal dosyasındaki *Constants* bölümlerine eklenir ve ardından gölgelendirici programında `uniform` olarak bildirilir. Örnekleyici uniform değişkenleri, materyalin *Samplers* bölümüne eklenir ve ardından gölgelendirici programında `uniform` olarak bildirilir. Bir köşe gölgelendiricisinde köşe dönüşümlerini gerçekleştirmek için gereken matrisler sabit olarak sunulur:
+
+  - `CONSTANT_TYPE_WORLD`, bir nesnenin yerel koordinat uzayından dünya uzayına eşleyen *dünya matrisidir*.
+  - `CONSTANT_TYPE_VIEW`, dünya uzayından kamera uzayına eşleyen *görünüm matrisidir*.
+  - `CONSTANT_TYPE_PROJECTION`, kamera uzayından ekran uzayına eşleyen *izdüşüm matrisidir*.
+  - `CONSTANT_TYPE_WORLDVIEW`, `CONSTANT_TYPE_VIEWPROJ` ve `CONSTANT_TYPE_WORLDVIEWPROJ`, ilgili birleşik matrisleri sağlar.
+  - `CONSTANT_TYPE_WORLD_INVERSE`, `CONSTANT_TYPE_VIEW_INVERSE`, `CONSTANT_TYPE_PROJECTION_INVERSE`, `CONSTANT_TYPE_VIEWPROJ_INVERSE`, `CONSTANT_TYPE_WORLDVIEW_INVERSE` ve `CONSTANT_TYPE_WORLDVIEWPROJ_INVERSE`, gölgelendiricinin bunları hesaplamasına gerek kalmadan ters matrisleri sağlar.
+  - `CONSTANT_TYPE_TIME`, motorun sağladığı bir `vec4` değeridir: `.x` içinde motorun başlangıcından bu yana geçen süre, `.y` içinde kare zaman farkı, `.z` ve `.w` içinde ise sıfır bulunur.
+  - `CONSTANT_TYPE_USER`, istediğiniz gibi kullanabileceğiniz `vec4` türünde bir sabittir.
+
+  [Materyal kılavuzu](/manuals/material), sabitlerin nasıl belirtileceğini açıklar.
+
+Örnekleyiciler
+: Gölgelendiriciler, *örnekleyici* (sampler) türünde uniform değişkenleri bildirebilir. Örnekleyiciler bir görüntü kaynağından değer okumak için kullanılır:
+
+  - `sampler2D`, 2B görüntü dokusundan örnekleme yapar.
+  - `sampler2DArray`, 2B görüntü dizisi dokusundan örnekleme yapar. Bu, çoğunlukla sayfalı atlaslar için kullanılır.
+  - `samplerCube`, 6 görüntüden oluşan küp haritası dokusundan örnekleme yapar.
+  - `image2D`, doku verilerini bir görüntü nesnesine yükler (ve gerektiğinde kaydeder). Bu, çoğunlukla hesaplama gölgelendiricilerinde depolama için kullanılır.
+
+  Bir örnekleyiciyi yalnızca GLSL standart kütüphanesinin doku arama işlevlerinde kullanabilirsiniz. [Materyal kılavuzu](/manuals/material), örnekleyici ayarlarının nasıl belirtileceğini açıklar.
+
+UV koordinatları
+: Bir köşeyle bir 2B koordinat ilişkilendirilir ve bu koordinat 2B dokudaki bir noktaya eşlenir. Böylece dokunun bir kısmı veya tamamı, bir köşe kümesinin tanımladığı şekle boyanabilir.
+
+  ![UV koordinatları](images/shader/uv_map.png)
+
+  UV haritası genellikle 3B modelleme programında oluşturulur ve örgüde (mesh) saklanır. Her köşenin doku koordinatları, köşe gölgelendiricisine bir öznitelik olarak sağlanır. Ardından her parçanın UV koordinatını köşe değerlerinden ara değerleme (interpolation) yoluyla bulmak için bir `varying` değişkeni kullanılır.
+
+Varying değişkenleri
+: `Varying` türündeki değişkenler, köşe aşaması ile parça aşaması arasında bilgi aktarmak için kullanılır.
+
+  1. Köşe gölgelendiricisinde her köşe için bir varying değişkeni ayarlanır.
+  2. Rasterleştirme (rasterization) sırasında, işlenen temel geometrik şeklin her parçası için bu değerin ara değerlemesi yapılır. Parçanın şeklin köşelerine olan uzaklığı, ara değerlenmiş değeri belirler.
+  3. Değişken, parça gölgelendiricisinin her çağrısı için ayarlanır ve parça hesaplamalarında kullanılabilir.
+
+  ![Varying ara değerlemesi](images/shader/varying_vertex.png)
+
+  Örneğin, bir üçgenin her köşesinde bir `varying` değişkenini `vec3` RGB renk değerine ayarlamak, renklerin şeklin tamamı boyunca ara değerlenmesini sağlar. Benzer şekilde, bir dikdörtgenin her köşesinde doku haritası arama koordinatlarını (veya *UV koordinatlarını*) ayarlamak, parça gölgelendiricisinin şeklin tüm alanı için doku renk değerlerini aramasını sağlar.
+
+  ![Varying ara değerlemesi](images/shader/varying.png)
+
+## Modern GLSL gölgelendiricileri yazma
+
+Defold motoru birden çok platformu ve grafik API'sini desteklediği için geliştiricilerin her yerde çalışan gölgelendiriciler yazması basit olmalıdır. Varlık işleme hattı bunu başlıca iki yolla sağlar (bunlar bundan sonra gölgelendirici hatları, yani `shader pipelines` olarak anılacaktır):
+
+1. Gölgelendiricilerin ES2 uyumlu GLSL koduyla yazıldığı eski hat.
+2. Gölgelendiricilerin SPIR-v uyumlu GLSL koduyla yazıldığı modern hat.
+
+Defold 1.9.2'den itibaren yeni hattı kullanan gölgelendiriciler yazmanız önerilir; bunu sağlamak için çoğu gölgelendiricinin en az sürüm 140 (OpenGL 3.1) ile yazılmış gölgelendiricilere dönüştürülmesi gerekir. Bir gölgelendiriciyi dönüştürmek için şu gereksinimlerin karşılandığından emin olun:
+
+### Sürüm bildirimi
+Gölgelendiricinin en üstüne en az #version 140 yerleştirin:
+
+```glsl
+#version 140
+```
+
+Proje derleme sürecinde gölgelendirici hattı bu şekilde seçilir; bu nedenle eski gölgelendiricileri kullanmaya devam edebilirsiniz. Sürüm belirten bir önişlemci yönergesi bulunmazsa Defold eski hattı kullanır.
+
+### Öznitelikler
+Köşe gölgelendiricilerinde `attribute` anahtar sözcüğünü `in` ile değiştirin:
+
+```glsl
+// instead of:
+// attribute vec4 position;
+// do:
+in vec4 position;
+```
+
+Not: Parça gölgelendiricileri (ve hesaplama gölgelendiricileri) köşe girdisi almaz.
+
+### Varying değişkenleri
+Köşe gölgelendiricilerinde varying değişkenlerinin önüne `out` eklenmelidir. Parça gölgelendiricilerinde varying değişkenleri `in` olur:
+
+```glsl
+// In a vertex shader, instead of:
+// varying vec4 var_color;
+// do:
+out vec4 var_color;
+
+// In a fragment shader, instead of:
+// varying vec4 var_color;
+// do:
+in vec4 var_color;
+```
+
+### Uniform değişkenleri (Defold'da sabitler olarak adlandırılır)
+
+Opak (opaque) uniform türleri (örnekleyiciler, görüntüler, atomik türler, SSBO'lar) için herhangi bir dönüşüm gerekmez; bunları bugün olduğu gibi kullanabilirsiniz:
+
+```glsl
+uniform sampler2D my_texture;
+uniform image2D my_image;
+```
+
+Opak olmayan uniform türlerini bir uniform bloğuna (`uniform block`) yerleştirmeniz gerekir. Uniform bloğu, uniform değişkenlerinden oluşan bir kümedir ve `uniform` anahtar sözcüğüyle bildirilir:
+
+```glsl
+uniform vertex_inputs
+{
+    mat4 mtx_world;
+    mat4 mtx_proj;
+    mat4 mtx_view;
+    mat4 mtx_normal;
+    ...
+};
+
+void main()
+{
+    // Individual members of the uniform block can be used as-is
+    gl_Position = mtx_proj * mtx_view * mtx_world * vec4(position, 1.0);
+}
+```
+
+Uniform bloğundaki tüm üyeler, materyallere ve bileşenlere ayrı sabitler olarak sunulur. İşleme sabit arabelleklerini veya `go.set` ve `go.get` işlevlerini kullanmak için herhangi bir dönüşüm gerekmez.
+
+### Yerleşik değişkenler
+
+Parça gölgelendiricilerinde, sürüm 140'tan itibaren `gl_FragColor` kullanımı önerilmez. Bunun yerine `out` kullanın:
+
+```glsl
+// instead of:
+// gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+// do:
+out vec4 color_out;
+
+void main()
+{
+    color_out = vec4(1.0, 0.0, 0.0, 1.0);
+}
+```
+
+### Doku işlevleri
+
+`texture2D` ve `texture2DArray` gibi belirli doku örnekleme işlevleri artık yoktur. Bunların yerine yalnızca `texture` işlevini kullanın:
+
+```glsl
+uniform sampler2D my_texture;
+uniform sampler2DArray my_texture_array;
+
+// instead of:
+// vec4 sampler_2d = texture2D(my_texture, uv);
+// vec4 sampler_2d_array = texture2DArray(my_texture_array, vec3(uv, slice));
+// do:
+vec4 sampler_2d = texture(my_texture, uv);
+vec4 sampler_2d_array = texture(my_texture_array, vec3(uv, slice));
+```
+
+### Hassasiyet {#precision}
+
+Defold, gölgelendiricileri GLSL ES için çapraz derlerken genel varsayılan hassasiyet niteleyicileri oluşturur. Varsayılanlar, kayan noktalı değerler için `mediump` ve tamsayılar için `highp` değerleridir. Bunlar **GLSL ES Default Precision Float** (`shader.glsl_es_default_precision_float`) ve **GLSL ES Default Precision Int** (`shader.glsl_es_default_precision_int`) [proje ayarlarıyla](/manuals/project-settings/#shader) değiştirilebilir; her ikisi de `mediump` veya `highp` değerini kabul eder.
+
+Bir değişken, girdi veya çıktı üzerindeki açık niteleyici, oluşturulan genel varsayılan değere göre önceliklidir. OpenGL ES 2.0 ve WebGL 1.0 parça gölgelendiricilerinde `highp`, her cihazda desteklenmez. Genel varsayılan olarak `highp` seçildiğinde Defold bunu `GL_FRAGMENT_PRECISION_HIGH` ile korur ve desteklemeyen cihazlarda `mediump` değerine geri döner.
+
+### Hepsini bir araya getirme
+
+Tüm bu kuralların uygulandığı son bir örnek olarak, yeni biçime dönüştürülmüş yerleşik sprite gölgelendiricileri aşağıdadır:
+
+```glsl
+#version 140
+
+uniform vx_uniforms
+{
+    mat4 view_proj;
+};
+
+// positions are in world space
+in vec4 position;
+in vec2 texcoord0;
+
+out vec2 var_texcoord0;
+
+void main()
+{
+    gl_Position = view_proj * vec4(position.xyz, 1.0);
+    var_texcoord0 = texcoord0;
+}
+```
+
+```glsl
+#version 140
+
+in vec2 var_texcoord0;
+
+out vec4 color_out;
+
+uniform sampler2D texture_sampler;
+
+uniform fs_uniforms
+{
+    vec4 tint;
+};
+
+void main()
+{
+    // Premultiply alpha since all runtime textures already are
+    vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
+    color_out = texture(texture_sampler, var_texcoord0.xy) * tint_pm;
+}
+
+```
+
+## Gölgelendiricilere kod parçaları dahil etme
+
+Defold'daki gölgelendiriciler, proje içindeki `.glsl` uzantılı dosyalardan kaynak kod dahil etmeyi destekler. Bir gölgelendiriciden glsl dosyası dahil etmek için `#include` pragmasını çift tırnak veya ayraçlarla kullanın. Dahil etme yolları, projeye veya dosyayı dahil eden dosyaya göreli olmalıdır:
+
+```glsl
+// In file /main/my-shader.fp
+
+// Absolute path
+#include "/main/my-snippet.glsl"
+// The file is in the same folder
+#include "my-snippet.glsl"
+// The file is in a sub-folder on the same level as 'my-shader'
+#include "sub-folder/my-snippet.glsl"
+// The file is in a sub-folder on the parent directory, i.e /some-other-folder/my-snippet.glsl
+#include "../some-other-folder/my-snippet.glsl"
+// The file is on the parent directory, i.e /root-level-snippet.glsl
+#include "../root-level-snippet.glsl"
+```
+
+Dahil edilen dosyaların nasıl bulunacağıyla ilgili dikkat edilmesi gereken bazı noktalar vardır:
+
+  - Dosyalar projeye göreli olmalıdır; yani yalnızca proje içindeki dosyaları dahil edebilirsiniz. Mutlak yolların başında `/` bulunmalıdır
+  - Dosyanın herhangi bir yerine kod dahil edebilirsiniz, ancak bir dosyayı bir deyimin içine satır içi olarak dahil edemezsiniz. Örneğin, `const float #include "my-float-name.glsl" = 1.0` çalışmaz
+
+### Başlık koruyucuları
+
+Kod parçaları da başka `.glsl` dosyalarını dahil edebilir; bu, sonunda üretilen gölgelendiricinin aynı kodu birkaç kez içerebileceği anlamına gelir. Dosyaların içeriğine bağlı olarak aynı sembollerin birden fazla kez bildirilmesi nedeniyle kod derleme sorunlarıyla karşılaşabilirsiniz. Bunu önlemek için birçok programlama dilinde yaygın bir kavram olan *başlık koruyucularını* (header guards) kullanabilirsiniz. Örnek:
+
+```glsl
+// In my-shader.vs
+#include "math-functions.glsl"
+#include "pi.glsl"
+
+// In math-functions.glsl
+#include "pi.glsl"
+
+// In pi.glsl
+const float PI = 3.14159265359;
+```
+
+Bu örnekte `PI` sabiti iki kez tanımlanır; bu da projeyi çalıştırırken derleyici hatalarına neden olur. Bunun yerine içeriği başlık koruyucularıyla korumanız önerilir:
+
+```glsl
+// In pi.glsl
+#ifndef PI_GLSL_H
+#define PI_GLSL_H
+
+const float PI = 3.14159265359;
+
+#endif // PI_GLSL_H
+```
+
+`pi.glsl` dosyasındaki kod, `my-shader.vs` içinde iki kez açımlanır; ancak başlık koruyucularıyla çevrelediğiniz için PI sembolü yalnızca bir kez tanımlanır ve gölgelendirici başarıyla derlenir.
+
+Ancak kullanım durumuna bağlı olarak bu her zaman kesinlikle gerekli değildir. Kodu bir işlevin içinde veya değerlerin gölgelendirici kodunun genelinde erişilebilir olmasına gerek olmayan başka bir yerde yerel olarak yeniden kullanmak istiyorsanız, büyük olasılıkla başlık koruyucularını kullanmamanız önerilir. Örnek:
+
+```glsl
+// In red-color.glsl
+vec3 my_red_color = vec3(1.0, 0.0, 0.0);
+
+// In my-shader.fp
+vec3 get_red_color()
+{
+  #include "red-color.glsl"
+  return my_red_color;
+}
+
+vec3 get_red_color_inverted()
+{
+  #include "red-color.glsl"
+  return 1.0 - my_red_color;
+}
+```
+
+## Düzenleyiciye özgü gölgelendirici kodu
+
+Gölgelendiriciler Defold düzenleyicisinin görünüm alanında işlendiğinde `EDITOR` önişlemci tanımı kullanılabilir. Bu, düzenleyicide çalışırken asıl oyun motorunda çalıştığından farklı davranan gölgelendirici kodu yazmanızı sağlar.
+
+Bu, özellikle şu amaçlar için kullanışlıdır:
+  - Yalnızca düzenleyicide görünmesi gereken hata ayıklama görselleştirmeleri eklemek.
+  - Tel kafes modları veya materyal önizlemeleri gibi düzenleyiciye özgü özellikler uygulamak.
+  - Düzenleyicinin görünüm alanında düzgün çalışmayabilecek materyaller için yedek işleme sağlamak.
+
+Yalnızca düzenleyicide çalışması gereken kodu koşullu olarak derlemek için `#ifdef EDITOR` önişlemci yönergesini kullanın:
+
+```glsl
+#ifdef EDITOR
+    // This code will only execute when the shader is rendered in the Defold Editor
+    color_out = vec4(1.0, 0.0, 1.0, 1.0); // Magenta color for editor preview
+#else
+    // This code will execute when running in the game
+    color_out = texture(texture_sampler, var_texcoord0) * tint_pm;
+#endif
+```
+
+## İşleme süreci
+
+Oyununuz için oluşturduğunuz veriler, ekrana ulaşmadan önce bir dizi adımdan geçer:
+
+![İşleme hattı](images/shader/pipeline.png)
+
+Tüm görsel bileşenler (sprite bileşenleri, GUI düğümleri, parçacık efektleri veya modeller), 3B dünyada bileşenin şeklini tanımlayan noktalar olan köşelerden oluşur. Bunun iyi yanı, şekli herhangi bir açıdan ve uzaklıktan görüntülemenin mümkün olmasıdır. Köşe gölgelendirici programının görevi, tek bir köşeyi alıp görünüm alanındaki bir konuma dönüştürerek şeklin ekranda belirmesini sağlamaktır. 4 köşeli bir şekil için köşe gölgelendirici programı, her biri paralel olmak üzere 4 kez çalışır.
+
+![Köşe gölgelendiricisi](images/shader/vertex_shader.png)
+
+Programın girdisi köşe konumu (ve köşeyle ilişkili diğer öznitelik verileri), çıktısı ise yeni bir köşe konumu (`gl_Position`) ve her parça için ara değerlenmesi gereken tüm `varying` değişkenleridir.
+
+En basit köşe gölgelendirici programı, çıktı konumunu yalnızca sıfır koordinatlı bir köşeye ayarlar (bu pek kullanışlı değildir):
+
+```glsl
+void main()
+{
+    gl_Position = vec4(0.0,0.0,0.0,1.0);
+}
+```
+
+Daha kapsamlı bir örnek, yerleşik sprite köşe gölgelendiricisidir:
+
+```glsl
+-- sprite.vp
+uniform mediump mat4 view_proj;             // [1]
+
+attribute mediump vec4 position;            // [2]
+attribute mediump vec2 texcoord0;
+
+varying mediump vec2 var_texcoord0;         // [3]
+
+void main()
+{
+  gl_Position = view_proj * vec4(position.xyz, 1.0);    // [4]
+  var_texcoord0 = texcoord0;                            // [5]
+}
+```
+1. Görünüm ve izdüşüm matrislerinin çarpımını içeren bir uniform (sabit).
+2. Sprite köşesinin öznitelikleri. `position` zaten dünya uzayına dönüştürülmüştür. `texcoord0`, köşenin UV koordinatını içerir.
+3. Bir varying çıktı değişkeni bildirin. Bu değişken, her köşe için ayarlanan değerler arasında her parça için ara değerlenir ve parça gölgelendiricisine gönderilir.
+4. `gl_Position`, geçerli köşenin izdüşüm uzayındaki çıktı konumuna ayarlanır. Bu değerin 4 bileşeni vardır: `x`, `y`, `z` ve `w`. `w` bileşeni, perspektife uygun ara değerlemeyi hesaplamak için kullanılır. Herhangi bir dönüşüm matrisi uygulanmadan önce bu değer normalde her köşe için 1,0'dır.
+5. Bu köşe konumu için varying UV koordinatını ayarlayın. Rasterleştirmeden sonra her parça için ara değerlenir ve parça gölgelendiricisine gönderilir.
+
+
+
+
+Köşe gölgelendirmesinden sonra bileşenin ekrandaki şekli belirlenir: temel geometrik şekiller üretilir ve rasterleştirilir; yani grafik donanımı her şekli *parçalara* veya piksellere böler. Ardından parça gölgelendirici programını her parça için bir kez çalıştırır. Ekranda 16x24 piksel boyutundaki bir görüntü için program, her biri paralel olmak üzere 384 kez çalışır.
+
+![Parça gölgelendiricisi](images/shader/fragment_shader.png)
+
+Programın girdisi, işleme hattının ve köşe gölgelendiricisinin gönderdiği verilerdir; genellikle parçanın *UV koordinatları*, renk çarpanları vb. Çıktı, pikselin son rengidir (`gl_FragColor`).
+
+En basit parça gölgelendirici programı, her pikselin rengini yalnızca siyaha ayarlar (yine pek kullanışlı bir program değildir):
+
+```glsl
+void main()
+{
+    gl_FragColor = vec4(0.0,0.0,0.0,1.0);
+}
+```
+
+Yine daha kapsamlı bir örnek, yerleşik sprite parça gölgelendiricisidir:
+
+```glsl
+// sprite.fp
+varying mediump vec2 var_texcoord0;             // [1]
+
+uniform lowp sampler2D DIFFUSE_TEXTURE;         // [2]
+uniform lowp vec4 tint;                         // [3]
+
+void main()
+{
+  lowp vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);          // [4]
+  lowp vec4 diff = texture2D(DIFFUSE_TEXTURE, var_texcoord0.xy);// [5]
+  gl_FragColor = diff * tint_pm;                                // [6]
+}
+```
+1. Varying doku koordinatı değişkeni bildirilir. Bu değişkenin değeri, şeklin her köşesi için ayarlanan değerler arasında her parça için ara değerlenir.
+2. Bir `sampler2D` uniform değişkeni bildirilir. Örnekleyici, sprite bileşeninin doğru şekilde dokuyla kaplanabilmesi için ara değerlenmiş doku koordinatlarıyla birlikte doku araması yapmak üzere kullanılır. Bu bir sprite bileşeni olduğundan motor, bu örnekleyiciyi sprite bileşeninin *Image* özelliğinde ayarlanan görüntüye atar.
+3. Materyalde `CONSTANT_TYPE_USER` türünde bir sabit tanımlanır ve `uniform` olarak bildirilir. Değeri, sprite bileşeninin renk çarpanıyla renklendirilmesini sağlamak için kullanılır. Varsayılan değer saf beyazdır.
+4. Çalışma zamanındaki tüm dokular zaten önceden çarpılmış alfa içerdiği için renk çarpanının renk değeri alfa değeriyle önceden çarpılır.
+5. Ara değerlenmiş koordinatta dokudan örnekleme yapın ve örneklenen değeri döndürün.
+6. `gl_FragColor`, parçanın çıktı rengine ayarlanır: dokudaki dağınık renk, renk çarpanı değeriyle çarpılır.
+
+Elde edilen parça değeri daha sonra testlerden geçer. Yaygın bir test olan *derinlik testinde* (depth test), parçanın derinlik değeri, test edilen pikselin derinlik arabelleği değeriyle karşılaştırılır. Teste bağlı olarak parça atılabilir veya derinlik arabelleğine yeni bir değer yazılır. Bu testin yaygın kullanımlarından biri, kameraya daha yakın grafiklerin daha gerideki grafikleri örtmesini sağlamaktır.
+
+Test, parçanın kare arabelleğine yazılması gerektiği sonucuna varırsa parça, arabellekte zaten bulunan piksel verileriyle *harmanlanır*. İşleme betiğinde (render script) ayarlanan harmanlama parametreleri, kaynak rengin (parça gölgelendiricisinin yazdığı değer) ve hedef rengin (kare arabelleğindeki görüntünün rengi) çeşitli şekillerde birleştirilmesini sağlar. Harmanlamanın yaygın kullanımlarından biri, saydam nesnelerin işlenmesini sağlamaktır.
+
+## İleri okuma
+
+- [Shadertoy](https://www.shadertoy.com), kullanıcıların katkıda bulunduğu çok sayıda gölgelendirici içerir. Çeşitli gölgelendirme tekniklerini öğrenebileceğiniz harika bir ilham kaynağıdır. Sitede sergilenen gölgelendiricilerin birçoğu çok az çalışmayla Defold'a taşınabilir. [Shadertoy öğreticisi](https://www.defold.com/tutorials/shadertoy/), mevcut bir gölgelendiriciyi Defold'a dönüştürme adımlarını anlatır.
+
+- [Renk derecelendirme öğreticisi](https://www.defold.com/tutorials/grading/), derecelendirme için renk arama tablosu dokularını kullanarak tam ekran renk derecelendirme efektinin nasıl oluşturulacağını gösterir.
+
+- [The Book of Shaders](https://thebookofshaders.com/00/), gölgelendiricileri nasıl kullanıp projelerinize dahil edeceğinizi öğreterek projelerinizin performansını ve grafik kalitesini artırmanıza yardımcı olur.

--- a/docs/tr/manuals/socket-connections.md
+++ b/docs/tr/manuals/socket-connections.md
@@ -1,0 +1,22 @@
+---
+title: Soket bağlantıları
+brief: Bu kılavuz, soket bağlantılarının nasıl oluşturulduğunu açıklar.
+---
+
+## Soket bağlantıları
+
+Defold, TCP ve UDP soket (socket) bağlantıları oluşturmak için [LuaSocket kütüphanesini](https://lunarmodules.github.io/luasocket/) içerir. Aşağıdaki örnek, bir soket bağlantısının nasıl oluşturulduğunu, nasıl veri gönderildiğini ve yanıtın nasıl okunduğunu gösterir:
+
+```Lua
+local client = socket.tcp()
+client:connect("127.0.0.1", 8123)
+client:settimeout(0)
+client:send("foobar")
+local response = client:receive("*l")
+```
+
+Bu kod bir TCP soketi oluşturur ve onu 127.0.0.1 (localhost) IP adresindeki 8123 bağlantı noktasına bağlar. Soketin yürütmeyi engellememesi (non-blocking) için zaman aşımını 0 olarak ayarlar ve soket üzerinden "foobar" dizesini gönderir. Ayrıca soketten bir satırlık veri (yeni satır karakteriyle biten baytlar) okur. Yukarıdaki örnekte hiçbir hata işleme mekanizması bulunmadığını unutmayın.
+
+### API başvurusu ve örnekler
+
+LuaSocket üzerinden sunulan işlevler hakkında daha fazla bilgi edinmek için [API başvurusuna](/ref/socket/) bakın. [Resmî LuaSocket belgelerinde](https://lunarmodules.github.io/luasocket/) de kütüphanenin nasıl kullanılacağına dair birçok örnek bulunur. [DefNet kütüphanesinde](https://github.com/britzl/defnet/) de bazı örnekler ve yardımcı modüller vardır.

--- a/docs/tr/manuals/sony-playstation.md
+++ b/docs/tr/manuals/sony-playstation.md
@@ -1,0 +1,23 @@
+---
+title: PlayStation®4 ve PlayStation®5 için Defold ile geliştirme
+brief: Bu kılavuzda PlayStation®4 ve PlayStation®5 erişiminin nasıl alınacağı açıklanır
+---
+
+# PlayStation®4 ve PlayStation®5 konsolları için oyun geliştirme 
+Lisans kısıtlamaları nedeniyle, PS4 ve PS5 üzerinde geliştirmeyi destekleyen Defold sürümlerine erişim, Defold'un standart sürümüne dahil değildir. PS4 ve PS5 için oyun geliştirme desteği sunan Defold sürümlerine erişebilmek için ilgili platformda lisanslı oyun geliştiricisi olarak kayıtlı olmanız gerekir.
+
+## PS4 ve PS5 için oyun geliştiricisi olarak kayıt olma
+PS4™ ve PS5™ için oyun geliştirmek üzere [PlayStation™ Partners sayfasından](https://register.playstation.net/partnership) oyun geliştiricisi olarak kayıt olabilirsiniz
+
+Sony tarafından onaylandığınızda Playstation 5 DevNet ve/veya Playstation 4 DevNet erişimi elde edersiniz. Development > Tools & Middleware > Tools & Middleware directory > Defold yolunu izleyin. 'Confirm Status' düğmesine tıklayın.
+
+## Defold'da PS4™ ve PS5™ erişimi 
+PS4™ ve PS5™ için lisanslı geliştirici olduğunuzun onayını aldıktan sonra size aşağıdakilere erişim sağlayacağız:
+
+* Konsola özgü API tümleştirmeleri içeren PS4™ ve PS5™ eklentisinin (extension) kaynak koduna erişim.
+* Defold oyun motorunun PS4™ ve PS5™ destekli sürümünün kaynak koduna erişim yalnızca PS5™ lisanslı oyun geliştiricilerine sağlanacaktır. Oyunları derlemek için kaynak koduna erişimin gerekli olmadığını, ancak motorun çekirdeğine kaynak kod katkısında bulunmak istemeniz durumunda erişim sağladığımızı unutmayın.
+* PS4™ ve PS5™ platformları için dağıtım paketi oluşturma desteği sunan [komut satırı aracı](/manuals/bob). Defold düzenleyicisinden paketleme desteklenmez.
+* PS4™ ve PS5™ platformlarına özgü destek alabileceğiniz forum.
+
+## Sık sorulan sorular
+:[Consoles FAQ](../shared/consoles-faq.md)

--- a/docs/tr/manuals/sound-streaming.md
+++ b/docs/tr/manuals/sound-streaming.md
@@ -1,0 +1,137 @@
+---
+title: Defold'da akış yoluyla ses oynatma
+brief: Bu kılavuz, seslerin Defold oyun motoruna akış yoluyla nasıl aktarılacağını açıklar
+---
+
+# Akış yoluyla ses oynatma
+
+Varsayılan davranış ses verisini bütünüyle yüklemek olsa da, veriyi kullanılmadan önce parçalar hâlinde yüklemek de yararlı olabilir. Bu yöntem genellikle "akış" (streaming) olarak adlandırılır.
+
+Akış yoluyla ses oynatmanın bir yararı, çalışma sırasında daha az belleğe ihtiyaç duyulmasıdır. Bir diğer yararı ise, örneğin bir http URL adresinden içerik akışı yapıyorsanız içeriği istediğiniz zaman güncelleyebilmeniz ve ilk indirme işleminden de kaçınabilmenizdir.
+
+### Örnek
+
+Bu kurulumu gösteren bir örnek proje bulunmaktadır: [https://github.com/defold/example-sound-streaming](https://github.com/defold/example-sound-streaming)
+
+## Akış yoluyla ses oynatmayı etkinleştirme
+
+### Kolay yol
+
+Akış yoluyla ses oynatmanın en basit yolu, *game.project* dosyasındaki [`sound.stream_enabled` ayarını](https://defold.com/manuals/project-settings/#stream-enabled) etkinleştirmektir. Bu seçenek etkinleştirildiğinde motor, sesleri akış yoluyla yüklemeye başlar.
+
+Not: Aynı anda çok sayıda ses dosyası yüklüyse `sound.stream_cache_size` değerini artırmanız gerekebilir (aşağıya bakın).
+
+### Çalışma zamanı kaynakları
+
+Yeni bir ses verisi kaynağı (resource) oluşturup bunu bir ses bileşenine (component) de atayabilirsiniz.
+
+Bunun için:
+* Ses dosyası verisinin ilk bölümünü yükleyin
+    * Not: Bu, ogg/wav üstbilgisini de içeren ham ses dosyasıdır
+* [`resource.create_sound_data()`](/ref/resource/#resource.create_sound_data) işlevini çağırarak yeni bir ses verisi kaynağı oluşturun.
+* [`go.set()`](/ref/go#go.set) işlevini kullanarak yeni ses verisi kaynağını ses bileşenine atayın
+
+Aşağıda, ses dosyasının ilk bölümünü almak için bir `http.request()` çağrısı kullanan örnek projeden bir bölüm yer alıyor.
+
+::: sidenote
+Gerçek bir akış için web sunucusunun [HTTP aralık isteklerini](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests) yerine getirmesi ve `206` durum kodunu döndürmesi gerekir. Sunucu `Range` üstbilgisini yok sayıp `200` durum kodunu döndürürse aşağıdaki örnek, bunun yerine yanıtın tamamından akış kullanmayan normal bir kaynak oluşturur.
+:::
+
+```lua
+local function play_sound(self, hash)
+    go.set(self.component, "sound", hash) -- override the resource data on the component
+    sound.play(self.component)            -- start playing the sound
+end
+
+local function parse_content_range(value)
+    if not value then
+        return nil
+    end
+    local rstart, rend, filesize = value:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
+    return tonumber(rstart), tonumber(rend), tonumber(filesize)
+end
+
+-- Callback for the http response.
+local function http_result(self, _id, response)
+    if response.status ~= 200 and response.status ~= 206 then
+        return
+    end
+
+    local options = {
+        data = response.response,
+    }
+
+    if response.status == 206 then
+        local rstart, _, filesize = parse_content_range(response.headers["content-range"])
+        if rstart ~= 0 or not filesize then
+            print("Invalid Content-Range response")
+            return
+        end
+
+        -- A partial resource enables streaming. filesize is the size of the
+        -- complete file, not only the returned range.
+        if #response.response < filesize then
+            options.filesize = filesize
+            options.partial = true
+        end
+    end
+
+    local relative_path = self.filename
+    print("Creating resource", relative_path)
+    local resource_hash = resource.create_sound_data(relative_path, options)
+    play_sound(self, resource_hash)
+end
+
+local function load_web_sound(base_url, relative_path)
+    local url = base_url .. "/" .. relative_path
+    local headers = {}
+    headers['Range'] = string.format("bytes=%d-%d", 0, 16384-1)
+
+    http.request(url, "GET", http_result, headers, nil, { ignore_cache = true })
+end
+```
+
+## Kaynak sağlayıcıları
+
+Ses dosyasının ilk parçasını yüklemek için başka yöntemler de kullanabilirsiniz. Unutulmaması gereken önemli nokta, kalan parçaların kaynak sisteminden ve onun kaynak sağlayıcılarından yüklendiğidir. Bu örnekte, [liveupdate.add_mount()](/ref/liveupdate/#liveupdate.add_mount) işlevini çağırıp bir Live Update bağlama noktası (mount) ekleyerek yeni bir (http) dosya sağlayıcısı ekliyoruz.
+
+Çalışan bir örneği [https://github.com/defold/example-sound-streaming](https://github.com/defold/example-sound-streaming) adresinde bulabilirsiniz.
+
+```lua
+-- See http_result() from above example
+
+local function load_web_sound(base_url, relative_path)
+    local url = base_url .. "/" .. relative_path
+    local headers = {}
+    -- Request the initial part of the file
+    headers['Range'] = string.format("bytes=%d-%d", 0, 16384-1)
+
+    http.request(url, "GET", http_result, headers, nil, { ignore_cache = true })
+end
+
+function init(self)
+    self.base_url = "http://my.server.com"
+    self.filename = "/path/to/sound.ogg"
+
+    liveupdate.add_mount("webmount", self.base_url, 100, function (_self, _name, _uri, _result)
+                    -- once the mount is ready, we can start our request for downloading the first chunk
+                    load_web_sound(self.base_url, self.filename)
+                end)
+end
+
+function final(self)
+    liveupdate.remove_mount("webmount")
+end
+```
+
+## Ses parçası önbelleği
+
+Seslerin çalışma sırasında tükettiği bellek miktarı, *game.project* dosyasındaki [`sound.stream_cache_size` ayarıyla](https://defold.com/manuals/project-settings/#stream-cache-size) denetlenir. Yüklenen ses verisi hiçbir zaman bu sınırı aşmaz.
+
+Her ses dosyasının ilk parçası önbellekten çıkarılamaz ve kaynaklar yüklü olduğu sürece önbellekte yer kaplar. İlk parçanın boyutu, *game.project* dosyasındaki [`sound.stream_preload_size` ayarıyla](https://defold.com/manuals/project-settings/#stream-preload-size) denetlenir.
+
+*game.project* dosyasındaki [`sound.stream_chunk_size` ayarını](https://defold.com/manuals/project-settings/#stream-chunk-size) değiştirerek her ses parçasının boyutunu da denetleyebilirsiniz. Aynı anda çok sayıda ses dosyası yüklüyse bu, ses önbelleğinin boyutunu daha da küçültmenize yardımcı olabilir. Ses parçası boyutundan küçük ses dosyaları akış yoluyla yüklenmez ve yeni bir parça önbelleğe sığmazsa en eski parça önbellekten çıkarılır
+
+::: important
+Ses parçası önbelleğinin toplam boyutunun, yüklü ses dosyası sayısı ile akış parçası boyutunun çarpımından büyük olması önerilir. Aksi takdirde her karede yeni parçaların önbellekten çıkarılması riski oluşur ve sesler düzgün oynatılmaz
+:::

--- a/docs/tr/manuals/sound.md
+++ b/docs/tr/manuals/sound.md
@@ -1,0 +1,220 @@
+---
+title: Defold'da ses
+brief: Bu kılavuz, sesleri Defold projenize nasıl ekleyeceğinizi, oynatacağınızı ve kontrol edeceğinizi açıklar.
+---
+
+# Ses
+
+Defold'un ses sistemi basit ama güçlüdür. Bilmeniz gereken yalnızca iki kavram vardır:
+
+Ses bileşenleri
+: Bu bileşenler (sound component), oynatılacak asıl sesi içerir ve bu sesi oynatabilir.
+
+Ses grupları
+: Her ses bileşeni bir _gruba_ (sound group) ait olacak şekilde atanabilir. Gruplar, birbiriyle ilişkili sesleri anlaşılır bir şekilde yönetmenin kolay bir yolunu sunar. Örneğin, bir `sound_fx` grubu oluşturulabilir ve bu gruba ait herhangi bir ses, basit bir işlev çağrısıyla kısılabilir.
+
+## Ses bileşeni oluşturma
+
+Ses bileşenlerinin örnekleri yalnızca bir oyun nesnesi (game object) içinde yerinde oluşturulabilir. Yeni bir oyun nesnesi oluşturun, üzerine sağ tıklayıp <kbd>Add Component ▸ Sound</kbd> seçeneğini seçin ve *OK* düğmesine basın.
+
+![Bileşen seçme](images/sound/sound_add_component.jpg)
+
+Oluşturulan bileşenin ayarlanması gereken bir dizi özelliği vardır:
+
+![Bileşen seçme](images/sound/sound_properties.png)
+
+*Sound*
+: Projenizdeki bir ses dosyasına ayarlamanız önerilir. Dosyanın _Wave_, _Ogg Vorbis_ veya _Ogg Opus_ biçiminde olması önerilir. Defold, 8 bit ve 16 bit PCM Wave dosyalarını destekler. Ogg Opus oynatma isteğe bağlıdır ve [App Manifest](/manuals/app-manifest/#sound) içinde **Include Sound Decoder: Opus** seçeneğini gerektirir; Opus kod çözücüsü varsayılan olarak dahil edilmez.
+
+*Looping*
+: İşaretlendiğinde ses, _Loopcount_ kez veya açıkça durdurulana kadar oynatılır.
+
+*Loopcount*
+: Döngüde oynatılan bir sesin durmadan önce kaç kez oynatılacağıdır (0, sesin açıkça durdurulana kadar döngüde oynatılacağı anlamına gelir).
+
+*Group*
+: Sesin ait olacağı ses grubunun adıdır. Bu özellik boş bırakılırsa ses, yerleşik `master` grubuna atanır.
+
+*Gain*
+: Sesin kazancını (gain) doğrudan bileşen üzerinde ayarlayabilirsiniz. Böylece ses programınıza dönüp yeniden dışa aktarmadan sesin kazancını kolayca düzenleyebilirsiniz. Kazancın nasıl hesaplandığına ilişkin ayrıntılar için aşağıya bakın.
+
+*Pan*
+: Sesin stereo konumu (pan) değerini doğrudan bileşen üzerinde ayarlayabilirsiniz. Stereo konumunun -1 (sola -45 derece) ile 1 (sağa 45 derece) arasında bir değer olması gerekir.
+
+*Speed*
+: Sesin hız değerini doğrudan bileşen üzerinde ayarlayabilirsiniz. 1.0 değeri normal hız, 0.5 yarı hız, 2.0 ise iki kat hızdır.
+
+
+## Sesi oynatma
+
+Bir ses bileşenini doğru şekilde ayarladığınızda, [`sound.play()`](/ref/sound/#sound.play:url-[play_properties]-[complete_function]) işlevini çağırarak sesini oynatmasını sağlayabilirsiniz:
+
+```lua
+sound.play("go#sound", {delay = 1, gain = 0.5, pan = -1.0, speed = 1.25})
+```
+
+::: sidenote
+Ses bileşeninin ait olduğu oyun nesnesi silinse bile ses oynatılmaya devam eder. Sesi durdurmak için [`sound.stop()`](/ref/sound/#sound.stop:url) işlevini çağırabilirsiniz (aşağıya bakın).
+:::
+Bileşene gönderilen her ileti, kullanılabilir ses arabelleği dolana ve motor konsola hatalar yazdırana kadar sesin başka bir örneğini oynatmasına neden olur. Ses oynatma aralığını sınırlayan (gating) ve sesleri gruplayan bir mekanizma uygulamanız önerilir.
+
+## Sesi durdurma
+
+Bir sesin oynatılmasını durdurmak istiyorsanız [`sound.stop()`](/ref/sound/#sound.stop:url) işlevini çağırabilirsiniz:
+
+```lua
+sound.stop("go#sound")
+```
+
+## Kazanç
+
+![Kazanç](images/sound/sound_gain.png)
+
+Ses sisteminde 4 kazanç düzeyi vardır:
+
+- Ses bileşeninde ayarlanan kazanç.
+- Sesi `sound.play()` çağrısıyla başlatırken veya oynatılan ses örneğinin (voice) kazancını `sound.set_gain()` çağrısıyla değiştirirken ayarlanan kazanç.
+- Grupta bir [`sound.set_group_gain()`](/ref/sound#sound.set_group_gain) işlev çağrısıyla ayarlanan kazanç.
+- `master` grubunda ayarlanan kazanç. Bu değer, `sound.set_group_gain(hash("master"), gain)` ile değiştirilebilir.
+
+[Sound proje ayarlarında](/manuals/project-settings/#sound) **Use Linear Gain** etkin olduğunda (varsayılan durum), çıkış kazancı bu dört kazancın çarpımının sonucudur. `1.0` kazancı, birim kazançtır (0 dB). Doğrusal kazanç devre dışı bırakıldığında Defold, sesleri karıştırırken doğrusal olmayan bir eğri uygular; bu nedenle aşağıdaki dört değerin doğrudan çarpımı ve desibele dönüştürülmesi, oluşan çıkış seviyesini açıklamaz.
+
+## Ses grupları
+
+Ses grubu adı belirtilen her ses bileşeni, o ada sahip bir ses grubuna yerleştirilir. Bir grup belirtmezseniz ses, `master` grubuna atanır. Ses bileşeninin grubunu açıkça `master` olarak da ayarlayabilirsiniz; bunun etkisi aynıdır.
+
+Kullanılabilir tüm grupları ve dize biçimindeki adlarını almak, kazancı almak ve ayarlamak, RMS (bkz. http://en.wikipedia.org/wiki/Root_mean_square) ve tepe kazanç değerlerini almak için birkaç işlev vardır. Hedef cihazın müzik çalarının çalışıp çalışmadığını sınamanızı sağlayan bir işlev de vardır:
+
+```lua
+-- If sound playing on this iPhone/Android device, silence everything
+if sound.is_music_playing() then
+    for i, group_hash in ipairs(sound.get_groups()) do
+        sound.set_group_gain(group_hash, 0)
+    end
+end
+```
+
+Gruplar bir karma (hash) değeriyle tanımlanır. Dize biçimindeki ad, [`sound.get_group_name()`](/ref/sound#sound.get_group_name) ile alınabilir. Bu işlev, örneğin grup seviyelerini sınamak için kullanılan bir mikser gibi geliştirme araçlarında grup adlarını göstermek için kullanılabilir.
+
+![Ses grubu mikseri](images/sound/sound_mixer.png)
+
+::: important
+Yayıma yönelik derlemelerde bulunmadığından, bir ses grubunun dize değerine dayanan kod yazmanız önerilmez.
+:::
+
+**Use Linear Gain** etkinken, pozitif bir kazanç değerini standart formülle desibele dönüştürün:
+
+```math
+db = 20 \times \log \left( gain \right)
+```
+
+```lua
+for i, group_hash in ipairs(sound.get_groups()) do
+    -- The name string is only available in debug. Returns "unknown_*" in release.
+    local name = sound.get_group_name(group_hash)
+    local gain = sound.get_group_gain(group_hash)
+
+    -- Convert to decibel.
+    local db = 20 * math.log10(gain)
+
+    -- Get RMS (gain Root Mean Square). Left and right channel separately.
+    local left_rms, right_rms = sound.get_rms(group_hash, 2048 / 65536.0)
+    left_rmsdb = 20 * math.log10(left_rms)
+    right_rmsdb = 20 * math.log10(right_rms)
+
+    -- Get gain peak. Left and right separately.
+    left_peak, right_peak = sound.get_peak(group_hash, 2048 * 10 / 65536.0)
+    left_peakdb = 20 * math.log10(left_peak)
+    right_peakdb = 20 * math.log10(right_peak)
+end
+
+-- Set the master gain to +6 dB (math.pow(10, 6/20)).
+sound.set_group_gain("master", 1.995)
+```
+
+Defold 1.10.2, ses mikserinde uzun süredir var olan yaklaşık 3 dB'lik zayıflamayı düzeltti. Eski bir projenin ses karışımı bu zayıflamayı telafi edecek şekilde ayarlanmışsa ve yükseltme sonrasında daha yüksek ses veriyorsa, genel **Sound ▸ Gain** ayarını veya etkilenen grup kazançlarını yeniden ayarlayın.
+
+## Ses oynatma aralığını sınırlama
+
+Oyununuz bir olay gerçekleştiğinde aynı sesi oynatıyorsa ve bu olay sık tetikleniyorsa, aynı sesi neredeyse aynı anda iki veya daha fazla kez oynatma riski vardır. Bu durumda sesler arasında _faz kayması_ (phase shift) oluşur ve bu da oldukça belirgin ses kusurlarına yol açabilir.
+
+![Faz kayması](images/sound/sound_phase_shift.png)
+
+Bu sorunu çözmenin en kolay yolu, ses iletilerini filtreleyen ve belirlenen bir zaman aralığında aynı sesin birden fazla kez oynatılmasına izin vermeyen bir geçit (gate) oluşturmaktır:
+
+```lua
+-- Don't allow the same sound to be played within "gate_time" interval.
+local gate_time = 0.3
+
+function init(self)
+    -- Store played sound timers in a table and count down each frame until they have been
+    -- in the table for "gate_time" seconds. Then remove them.
+    self.sounds = {}
+end
+
+function update(self, dt)
+    -- Count down the stored timers
+    for k,_ in pairs(self.sounds) do
+        self.sounds[k] = self.sounds[k] - dt
+        if self.sounds[k] < 0 then
+            self.sounds[k] = nil
+        end
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("play_gated_sound") then
+        -- Only play sounds that are not currently in the gating table.
+        if self.sounds[message.soundcomponent] == nil then
+            -- Store sound timer in table
+            self.sounds[message.soundcomponent] = gate_time
+            -- Play the sound
+            sound.play(message.soundcomponent, { gain = message.gain })
+        else
+            -- An attempt to play a sound was gated
+            print("gated " .. message.soundcomponent)
+        end
+    end
+end
+```
+
+Geçidi kullanmak için ona bir `play_gated_sound` iletisi gönderip hedef ses bileşenini ve ses kazancını belirtmeniz yeterlidir. Geçit açıksa hedef ses bileşeniyle `sound.play()` işlevini çağırır:
+
+```lua
+msg.post("/sound_gate#script", "play_gated_sound", { soundcomponent = "/sounds#explosion1", gain = 1.0 })
+```
+
+::: important
+Geçidin `play_sound` iletilerini dinlemesi işe yaramaz; bu ad Defold motoru tarafından ayrılmıştır. Ayrılmış ileti adlarını kullanırsanız beklenmedik davranışlarla karşılaşırsınız.
+:::
+
+
+## Çalışma sırasında değiştirme
+Sesleri çalışma sırasında çeşitli özellikler aracılığıyla değiştirebilirsiniz (kullanım için [API belgelerine](/ref/sound/) bakın). Aşağıdaki özellikler `go.get()` ve `go.set()` kullanılarak değiştirilebilir:
+
+`gain`
+: Ses bileşeninin kazancıdır (`number`).
+
+`pan`
+: Ses bileşeninin stereo konumudur (`number`). Stereo konumunun -1 (sola -45 derece) ile 1 (sağa 45 derece) arasında bir değer olması gerekir.
+
+`speed`
+: Ses bileşeninin hızıdır (`number`). 1.0 değeri normal hız, 0.5 yarı hız, 2.0 ise iki kat hızdır.
+
+`sound`
+: Sesin kaynak yoludur (`hash`). Kaynak yolunu kullanarak sesi `resource.set_sound(path, buffer)` ile değiştirebilirsiniz. Örnek:
+
+```lua
+local boom = sys.load_resource("/sounds/boom.wav")
+local path = go.get("#sound", "sound")
+resource.set_sound(path, boom)
+```
+
+
+## Proje yapılandırması
+
+*game.project* dosyasında ses bileşenleriyle ilgili birkaç [proje ayarı](/manuals/project-settings#sound) bulunur.
+
+## Akış yoluyla ses oynatma
+
+[Akış yoluyla ses oynatma](/manuals/sound-streaming) desteği sağlamak da mümkündür

--- a/docs/tr/manuals/spine.md
+++ b/docs/tr/manuals/spine.md
@@ -1,0 +1,6 @@
+---
+title: Defold'da Spine kemik animasyonu
+brief: Bu kılavuz, Spine animasyonlarının _Spine_ uygulamasından Defold'a nasıl aktarılacağını açıklar.
+---
+
+[Bu kılavuz taşındı](/extension-spine)

--- a/docs/tr/manuals/spinemodel.md
+++ b/docs/tr/manuals/spinemodel.md
@@ -1,0 +1,6 @@
+---
+title: Defold'da Spine model bileşenleri
+brief: Bu kılavuz, Defold'da Spine model bileşenlerinin (Spine model components) nasıl oluşturulacağını açıklar.
+---
+
+[Bu kılavuz taşındı](/extension-spine)

--- a/docs/tr/manuals/sprite.md
+++ b/docs/tr/manuals/sprite.md
@@ -1,0 +1,133 @@
+---
+title: 2B görüntüleri gösterme
+brief: Bu kılavuz, sprite bileşeniyle 2B görüntülerin ve animasyonların nasıl gösterileceğini açıklar.
+---
+
+# Sprite bileşenleri
+
+Sprite bileşeni (sprite component), ekranda gösterilen basit bir görüntü veya kare dizisi animasyonudur (flipbook animation).
+
+![sprite bileşeni](images/graphics/sprite.png)
+
+Sprite bileşeni, grafikleri için bir [atlas](/manuals/atlas) veya [karo kaynağı](/manuals/tilesource) (tile source) kullanabilir.
+
+## Sprite özellikleri
+
+*Id*, *Position* ve *Rotation* özelliklerine ek olarak bileşene özgü şu özellikler bulunur:
+
+*Image*
+: Gölgelendiricide (shader) tek bir örnekleyici (sampler) varsa bu alan `Image` olarak adlandırılır. Aksi halde her yuva, materyaldeki doku örnekleyicisinin adını alır.
+Her yuva, o doku örnekleyicisinde sprite bileşeni için kullanılacak atlas veya karo kaynağını belirtir.
+
+*Default Animation*
+: Sprite bileşeninde kullanılacak animasyon. Animasyon bilgisi ilk atlastan veya karo kaynağından alınır.
+
+*Material*
+: Sprite bileşenini işlemek (rendering) için kullanılacak materyal.
+
+*Blend Mode*
+: Sprite bileşenini işlerken kullanılacak harmanlama modu (blend mode).
+
+*Size Mode*
+: `Automatic` olarak ayarlanırsa düzenleyici sprite bileşeninin boyutunu ayarlar. `Manual` olarak ayarlanırsa boyutu kendiniz belirleyebilirsiniz.
+
+*Slice 9*
+: Sprite bileşeni yeniden boyutlandırıldığında dokusunun kenarlarındaki piksel boyutunu korumak için ayarlayın.
+
+:[Slice-9](../shared/slice-9-texturing.md)
+
+### Harmanlama modları
+:[blend-modes](../shared/blend-modes.md)
+
+## Çalışma sırasında değiştirme
+
+Sprite bileşenlerini çalışma sırasında çeşitli işlevler ve özellikler aracılığıyla değiştirebilirsiniz (kullanım için [API belgelerine](/ref/sprite/) bakın). İşlevler:
+
+* `sprite.play_flipbook()` - Sprite bileşeninde bir animasyon oynatır.
+* `sprite.set_hflip()` ve `sprite.set_vflip()` - Sprite animasyonunun yatay ve dikey çevirme durumunu ayarlar.
+
+Sprite bileşeninin ayrıca `go.get()` ve `go.set()` kullanılarak değiştirilebilen çeşitli özellikleri vardır:
+
+`cursor`
+: Normalleştirilmiş animasyon imleci (`number`).
+
+`image`
+: Sprite görüntüsü (`hash`). Bunu, bir atlas veya karo kaynağına başvuran kaynak özelliği ve `go.set()` kullanarak değiştirebilirsiniz. Bir örnek için [API başvurusuna](/ref/sprite/#image) bakın.
+
+`material`
+: Sprite materyali (`hash`). Bunu, bir materyal kaynak özelliği ve `go.set()` kullanarak değiştirebilirsiniz. Bir örnek için [API başvurusuna](/ref/sprite/#material) bakın.
+
+`playback_rate`
+: Animasyonun oynatma hızı (`number`).
+
+`scale`
+: Sprite bileşeninin her eksende farklı olabilen ölçeği (`vector3`).
+
+`size`
+: Sprite bileşeninin boyutu (`vector3`). Yalnızca sprite bileşeninin `Size Mode` özelliği `Manual` olarak ayarlanmışsa değiştirilebilir.
+
+## Materyal sabitleri
+
+{% include shared/material-constants.md component='sprite' variable='tint' %}
+
+`tint`
+: Sprite bileşeninin renk çarpanı (tint) (`vector4`). `vector4`, renk çarpanını temsil etmek için kullanılır; `x`, `y`, `z` ve `w` sırasıyla kırmızı, yeşil, mavi ve alfa çarpanlarına karşılık gelir.
+
+## Materyal öznitelikleri
+
+Sprite bileşeni, o anda atanmış materyalin köşe özniteliklerini (vertex attributes) geçersiz kılabilir; bu öznitelikler bileşenden köşe gölgelendiricisine iletilir (daha fazla bilgi için [Materyal kılavuzuna](/manuals/material/#attributes) bakın).
+
+Materyalde belirtilen öznitelikler, özellik denetleyicisinde normal özellikler olarak görünür ve her sprite bileşeninde ayrı ayrı ayarlanabilir. Özniteliklerden herhangi biri geçersiz kılınırsa, geçersiz kılınmış bir özellik olarak görünür ve diskteki sprite dosyasında saklanır:
+
+![sprite öznitelikleri](../images/graphics/sprite-attributes.png)
+
+## Proje yapılandırması
+
+*game.project* dosyasında sprite bileşenleriyle ilgili birkaç [proje ayarı](/manuals/project-settings#sprite) bulunur.
+
+## Çok dokulu sprite bileşenleri {#multi-textured-sprites}
+
+Bir sprite bileşeni birden fazla doku kullandığında dikkat edilmesi gereken bazı noktalar vardır.
+
+### Animasyonlar
+
+Animasyon verileri (fps, kare adları) şu anda ilk dokudan alınır. Buna "belirleyici animasyon" (driving animation) diyeceğiz.
+
+Belirleyici animasyonun görüntü tanımlayıcıları, başka bir dokudaki görüntüleri bulmak için kullanılır.
+Bu nedenle, kare tanımlayıcılarının dokular arasında eşleştiğinden emin olmak önemlidir.
+
+Örneğin, `diffuse.atlas` dosyanızda şöyle bir `run` animasyonu varsa:
+
+```
+run:
+    /main/images/hero_run_color_1.png
+    /main/images/hero_run_color_2.png
+    ...
+```
+
+Kare tanımlayıcıları `run/hero_run_color_1` biçiminde olur; bu tanımlayıcının, örneğin şu `normal.atlas` dosyasında bulunması pek olası değildir:
+
+```
+run:
+    /main/images/hero_run_normal_1.png
+    /main/images/hero_run_normal_2.png
+    ...
+```
+
+Bu nedenle, bunları yeniden adlandırmak için [atlastaki](/manuals/material/) `Rename patterns` alanını kullanırız.
+İlgili atlaslarda `_color=` ve `_normal=` değerlerini ayarladığınızda her iki atlasta da şu kare adlarını elde edersiniz:
+
+```
+run/hero_run_1
+run/hero_run_2
+...
+```
+
+### UV koordinatları
+
+UV koordinatları ilk dokudan alınır. Yalnızca bir köşe kümesi bulunduğundan, ikincil dokularda daha fazla UV koordinatı veya farklı bir şekil varsa
+zaten iyi bir eşleşme garanti edemeyiz.
+
+Bu noktaya dikkat etmek önemlidir; görüntülerin yeterince benzer şekillere sahip olduğundan emin olun, aksi takdirde doku taşması (texture bleeding) yaşayabilirsiniz.
+
+Her dokudaki görüntülerin boyutları farklı olabilir.

--- a/docs/tr/manuals/texture-filtering.md
+++ b/docs/tr/manuals/texture-filtering.md
@@ -1,0 +1,34 @@
+---
+title: Doku filtreleme
+brief: Bu kılavuz, grafiklerin işlenmesi (rendering) sırasında doku filtreleme için kullanılabilen seçenekleri açıklar.
+---
+
+# Doku filtreleme ve örnekleme
+
+Doku filtreleme (texture filtering), bir _teksel_ (texel; dokudaki bir piksel) ekran pikseliyle tam olarak hizalanmadığında ortaya çıkan görsel sonucu belirler. Bu durum, dokuyu içeren bir grafik öğesini bir pikselden daha az hareket ettirdiğinizde ortaya çıkar. Aşağıdaki filtreleme yöntemleri kullanılabilir:
+
+En yakın komşu (Nearest)
+: Ekran pikselini renklendirmek için en yakın teksel seçilir. Dokularınızdaki piksellerle ekranda gördüğünüz pikseller arasında tam olarak bire bir eşleme istiyorsanız bu örnekleme (sampling) yöntemini seçin. En yakın komşu filtrelemede her şey hareket ederken pikselden piksele atlar. Sprite bileşeni yavaş hareket ediyorsa bu, titrek görünebilir.
+
+Doğrusal (Linear)
+: Ekran pikseli renklendirilmeden önce teksel ile komşularının renklerinin ortalaması alınır. Bu, yavaş ve sürekli hareketlerde akıcı bir görünüm sağlar; çünkü sprite bileşeninin rengi, pikselleri tamamen renklendirmeden önce onlara yayılmaya başlar. Böylece sprite bileşenini bir tam pikselden daha az hareket ettirmek mümkün olur.
+
+Hangi filtrelemenin kullanılacağını belirleyen ayar, [Proje ayarları](/manuals/project-settings/#graphics) dosyasında saklanır. İki ayar vardır:
+
+default_texture_min_filter
+: Küçültme filtrelemesi, teksel ekran pikselinden daha küçük olduğunda uygulanır.
+
+default_texture_mag_filter
+: Büyütme filtrelemesi, teksel ekran pikselinden daha büyük olduğunda uygulanır.
+
+Her iki ayar da `linear`, `nearest`, `nearest_mipmap_nearest`, `nearest_mipmap_linear`, `linear_mipmap_nearest` veya `linear_mipmap_linear` değerlerini kabul eder. Örneğin:
+
+```ini
+[graphics]
+default_texture_min_filter = nearest
+default_texture_mag_filter = nearest
+```
+
+Hiçbir değer belirtmezseniz her ikisi de varsayılan olarak `linear` değerine ayarlanır.
+
+*game.project* dosyasındaki ayarın varsayılan örnekleyicilerde (sampler) kullanıldığını unutmayın. Özel bir materyalde (material) örnekleyiciler tanımlarsanız her örnekleyici için filtreleme yöntemini ayrı ayrı ayarlayabilirsiniz. Ayrıntılar için [Materyaller kılavuzuna](/manuals/material/) bakın.

--- a/docs/tr/manuals/texture-profiles.md
+++ b/docs/tr/manuals/texture-profiles.md
@@ -1,0 +1,268 @@
+---
+title: Defold'da doku profilleri
+brief:  Defold, otomatik doku işlemeyi ve görüntü verilerinin sıkıştırılmasını destekler. Bu kılavuz, kullanılabilen işlevleri açıklar.
+---
+
+# Doku profilleri
+
+Defold, otomatik doku (texture) işlemeyi ve görüntü verilerinin sıkıştırılmasını destekler (*atlaslarda (Atlas)*, *karo kaynaklarında (Tile sources)*, *küp haritalarında (Cubemaps)* ve modeller, GUI vb. için kullanılan bağımsız dokularda).
+
+İki sıkıştırma türü vardır: yazılımla görüntü sıkıştırma ve donanımla doku sıkıştırma.
+
+1. Yazılımla sıkıştırma (PNG ve JPEG gibi), görüntü kaynaklarının depolama boyutunu azaltır. Bu da son dağıtım paketinin boyutunu küçültür. Ancak görüntü dosyalarının belleğe okunurken açılması gerekir; bu nedenle bir görüntü diskte küçük olsa bile bellekte çok yer kaplayabilir.
+
+2. Donanımla doku sıkıştırma da görüntü kaynaklarının depolama boyutunu azaltır. Ancak yazılımla sıkıştırmadan farklı olarak, dokuların bellekte kapladığı alanı da azaltır. Bunun nedeni, grafik donanımının sıkıştırılmış dokuları önce açmak zorunda kalmadan doğrudan işleyebilmesidir.
+
+Dokuların işlenmesi, belirli bir doku profili (texture profile) üzerinden yapılandırılır. Bu dosyada, belirli bir platform için dağıtım paketleri oluşturulurken hangi sıkıştırılmış biçimlerin ve türün kullanılması gerektiğini belirten _profiller_ oluşturursunuz. Ardından _profiller_, eşleşen dosya _yol desenleriyle_ ilişkilendirilir; böylece projenizdeki hangi dosyaların sıkıştırılacağını ve bunun tam olarak nasıl yapılacağını ayrıntılı olarak kontrol edebilirsiniz.
+
+Kullanılabilen tüm donanımla doku sıkıştırma yöntemleri kayıplı olduğundan, doku verilerinizde görüntü kusurları oluşur. Bu kusurlar, kaynak malzemenizin görünümüne ve kullanılan sıkıştırma yöntemine büyük ölçüde bağlıdır. En iyi sonuçları elde etmek için kaynak malzemenizi test etmeniz ve denemeler yapmanız önerilir. Burada Google'dan yardım alabilirsiniz.
+
+Dağıtım paketi arşivlerindeki son doku verilerine (sıkıştırılmış veya ham) hangi yazılımla görüntü sıkıştırma yönteminin uygulanacağını seçebilirsiniz. Defold, [Basis Universal](https://github.com/BinomialLLC/basis_universal) ve [ASTC](https://www.khronos.org/opengl/wiki/ASTC_Texture_Compression) sıkıştırma biçimlerini destekler.
+
+::: sidenote
+Sıkıştırma, yoğun kaynak kullanan ve zaman alan bir işlemdir. Sıkıştırılacak doku görüntülerinin sayısına, seçilen doku biçimlerine ve yazılımla sıkıştırma türüne bağlı olarak _çok_ uzun proje derleme sürelerine yol açabilir.
+:::
+
+### Basis Universal
+
+Basis Universal (kısaca BasisU), görüntüyü bir ara biçime sıkıştırır. Bu biçim, çalışma sırasında geçerli cihazın GPU'suna uygun bir donanım biçimine dönüştürülür. Basis Universal biçimi, yüksek kaliteli ancak kayıplı bir biçimdir.
+Oyun arşivinde saklanan dosyaların boyutunu daha da küçültmek için tüm görüntüler ayrıca LZ4 kullanılarak sıkıştırılır.
+
+### ASTC
+
+ASTC, ARM tarafından geliştirilmiş ve Khronos Group tarafından standartlaştırılmış esnek ve verimli bir doku sıkıştırma biçimidir. Çok çeşitli blok boyutları ve bit hızları sunarak geliştiricilerin görüntü kalitesiyle bellek kullanımını etkili biçimde dengelemesini sağlar. ASTC, 4×4 ile 12×12 teksel (texel) arasında değişen çeşitli blok boyutlarını destekler; bunlar teksel başına 8 bitten 0,89 bite kadar değişen bit hızlarına karşılık gelir. Bu esneklik, doku kalitesiyle depolama gereksinimleri arasındaki dengenin ayrıntılı olarak kontrol edilmesini sağlar.
+
+ASTC, 4×4 ile 12×12 teksel arasında değişen çeşitli blok boyutlarını destekler; bunlar teksel başına 8 bitten 0,89 bite kadar değişen bit hızlarına karşılık gelir. Bu esneklik, doku kalitesiyle depolama gereksinimleri arasındaki dengenin ayrıntılı olarak kontrol edilmesini sağlar. Aşağıdaki tabloda desteklenen blok boyutları ve bunlara karşılık gelen bit hızları gösterilmektedir:
+
+| Blok boyutu (genişlik x yükseklik) | Piksel başına bit |
+| --------------------------- | -------------- |
+| 4x4                         | 8.00           |
+| 5x4                         | 6.40           |
+| 5x5                         | 5.12           |
+| 6x5                         | 4.27           |
+| 6x6                         | 3.56           |
+| 8x5                         | 3.20           |
+| 8x6                         | 2.67           |
+| 10x5                        | 2.56           |
+| 10x6                        | 2.13           |
+| 8x8                         | 2.00           |
+| 10x8                        | 1.60           |
+| 10x10                       | 1.28           |
+| 12x10                       | 1.07           |
+| 12x12                       | 0.89           |
+
+
+#### Desteklenen cihazlar
+
+ASTC çok iyi sonuçlar verse de tüm grafik kartları tarafından desteklenmez. Üreticiye göre desteklenen cihazların kısa bir listesi şöyledir:
+
+| GPU üreticisi         | Destek                                                               |
+| ------------------ | --------------------------------------------------------------------- |
+| ARM (Mali)         | OpenGL ES 3.2 veya Vulkan desteği olan tüm ARM Mali GPU'ları ASTC'yi destekler.  |
+| Qualcomm (Adreno)  | OpenGL ES 3.2 veya Vulkan desteği olan Adreno GPU'ları ASTC'yi destekler.          |
+| Apple              | A8 çipinden itibaren Apple GPU'ları ASTC'yi destekler.                            |
+| NVIDIA             | ASTC desteği çoğunlukla mobil GPU'lar içindir (ör. Tegra tabanlı çipler).     |
+| AMD (Radeon)       | Vulkan desteği olan AMD GPU'ları genellikle ASTC'yi yazılım aracılığıyla destekler.     |
+| Intel (tümleşik) | Modern Intel GPU'larında ASTC yazılım aracılığıyla desteklenir.                  |
+
+## Doku profilleri
+
+Her proje, dokuları sıkıştırırken kullanılan yapılandırmayı içeren belirli bir *.texture_profiles* dosyası içerir. Varsayılan olarak bu dosya *builtins/graphics/default.texture_profiles* dosyasıdır ve her doku kaynağını, donanımla doku sıkıştırma kullanmadan RGBA ve varsayılan ZLib dosya sıkıştırmasını kullanan bir profille eşleştiren yapılandırmaya sahiptir.
+
+Doku sıkıştırma eklemek için:
+
+- Yeni bir doku profilleri dosyası oluşturmak için <kbd>File ▸ New...</kbd> seçeneğini seçin ve *Texture Profiles* öğesini seçin. (Alternatif olarak *default.texture_profiles* dosyasını *builtins* dışındaki bir konuma kopyalayın)
+- Yeni dosya için bir ad ve konum seçin.
+- *game.project* dosyasındaki *texture_profiles* girdisini yeni dosyayı gösterecek şekilde değiştirin.
+- *.texture_profiles* dosyasını açın ve gereksinimlerinize göre yapılandırın.
+
+![Yeni profil dosyası](images/texture_profiles/texture_profiles_new_file.png)
+
+![Doku profilini ayarlama](images/texture_profiles/texture_profiles_game_project.png)
+
+Doku profillerinin kullanımını düzenleyici tercihlerinden açıp kapatabilirsiniz. <kbd>File ▸ Preferences...</kbd> seçeneğini seçin. *General* sekmesinde *Enable texture profiles* adlı bir onay kutusu bulunur.
+
+![Doku profili tercihleri](images/texture_profiles/texture_profiles_preferences.png)
+
+## Path Settings
+
+Doku profilleri dosyasının *Path Settings* bölümü, yol desenlerinin bir listesini ve yolla eşleşen kaynaklar işlenirken hangi *profile* değerinin kullanılacağını içerir. Yollar, "Ant Glob" desenleri olarak ifade edilir (ayrıntılar için [belgelere](http://ant.apache.org/manual/dirtasks.html#patterns) bakın). Desenler şu joker karakterlerle ifade edilebilir:
+
+`*`
+: Sıfır veya daha fazla karakterle eşleşir. Örneğin `sprite*.png`, *`sprite.png`*, *`sprite1.png`* ve *`sprite_with_a_long_name.png`* dosyalarıyla eşleşir.
+
+`?`
+: Tam olarak bir karakterle eşleşir. Örneğin: `sprite?.png`, *sprite1.png* ve *`spriteA.png`* dosyalarıyla eşleşir ancak *`sprite.png`* veya *`sprite_with_a_long_name.png`* ile eşleşmez.
+
+`**`
+: Tam bir dizin ağacıyla veya---bir dizinin adı olarak kullanıldığında---sıfır veya daha fazla dizinle eşleşir. Örneğin: `/gui/**`, */gui* dizinindeki ve tüm alt dizinlerindeki bütün dosyalarla eşleşir.
+
+![Yollar](images/texture_profiles/texture_profiles_paths.png)
+
+Bu örnekte iki yol deseni ve bunlara karşılık gelen profiller bulunur.
+
+`/gui/**/*.atlas`
+: *`/gui`* dizinindeki veya alt dizinlerinden herhangi birindeki tüm *.atlas* dosyaları "gui_atlas" profiline göre işlenir.
+
+`/**/*.atlas`
+: Projenin herhangi bir yerindeki tüm *.atlas* dosyaları "atlas" profiline göre işlenir.
+
+Daha genel yolun en sona yerleştirildiğine dikkat edin. Eşleştirme algoritması yukarıdan aşağıya çalışır. Kaynak yoluyla eşleşen ilk girdi kullanılır. Listenin daha aşağısındaki eşleşen bir yol ifadesi hiçbir zaman ilk eşleşmeyi geçersiz kılmaz. Yollar ters sırada yerleştirilmiş olsaydı, *`/gui`* dizinindekiler dahil her atlas "atlas" profiliyle işlenirdi.
+
+Profil dosyasındaki hiçbir yolla _eşleşmeyen_ doku kaynakları derlenir ve 2'nin en yakın kuvvetine ölçeklenir; bunun dışında değiştirilmeden bırakılır.
+
+## Profiller
+
+Doku profilleri dosyasının *profiles* bölümü, adlandırılmış profillerin bir listesini içerir. Her profil bir veya daha fazla *platforms* öğesi içerir ve her platform bir özellik listesiyle tanımlanır.
+
+![Profiller](images/texture_profiles/texture_profiles_profiles.png)
+
+*Platforms*
+: Eşleşen bir platform belirtir. `OS_ID_GENERIC` tüm platformlarla, `OS_ID_WINDOWS` Windows hedefli dağıtım paketleriyle, `OS_ID_IOS` iOS dağıtım paketleriyle eşleşir; diğerleri de aynı şekilde çalışır. `OS_ID_GENERIC` belirtilirse tüm platformlar için dahil edileceğine dikkat edin.
+
+::: important
+İki [yol ayarı](#path-settings) aynı dosyayla eşleşirse ve yol farklı platformlara sahip farklı profiller kullanıyorsa **her iki** profil de kullanılır ve **iki** doku oluşturulur.
+:::
+
+*Formats*
+: Oluşturulacak bir veya daha fazla doku biçimi. Birden fazla biçim belirtilirse her biçim için dokular oluşturulur ve dağıtım paketine dahil edilir. Motor, çalıştığı platformun desteklediği bir biçimdeki dokuları seçer.
+
+*Mipmaps*
+: İşaretliyse platform için mipmap yapıları oluşturulur. Varsayılan olarak işaretli değildir.
+
+*Premultiply alpha*
+: İşaretliyse doku verileri alfa değeriyle önceden çarpılır. Varsayılan olarak işaretlidir.
+
+*Max Texture Size*
+: Sıfırdan farklı bir değere ayarlanırsa dokuların piksel boyutu belirtilen sayıyla sınırlandırılır. Genişliği veya yüksekliği belirtilen değerden büyük olan tüm dokular küçültülür.
+
+Bir profile eklenen her *Formats* öğesi şu özelliklere sahiptir:
+
+*Format*
+: Doku kodlanırken kullanılacak biçim. Kullanılabilen tüm doku biçimleri için aşağıya bakın.
+
+*Compressor*
+: Doku kodlanırken kullanılacak sıkıştırıcı.
+
+*Compressor Preset*
+: Ortaya çıkan sıkıştırılmış görüntüyü kodlamak için kullanılacak sıkıştırma hazır ayarını seçer. Her sıkıştırıcı hazır ayarı sıkıştırıcıya özgüdür ve ayarları sıkıştırıcının kendisine bağlıdır. Bu ayarları basitleştirmek için mevcut sıkıştırma hazır ayarları dört düzeyde sunulur:
+
+| Hazır ayar    | Not                                          |
+| --------- | --------------------------------------------- |
+| `LOW`     | En hızlı sıkıştırma. Düşük görüntü kalitesi        |
+| `MEDIUM`  | Varsayılan sıkıştırma. En iyi görüntü kalitesi       |
+| `HIGH`    | En yavaş sıkıştırma. Daha küçük dosya boyutu        |
+| `HIGHEST` | Yavaş sıkıştırma. En küçük dosya boyutu          |
+
+`uncompressed` sıkıştırıcısının yalnızca `uncompressed` adlı bir hazır ayarı vardır; bu, dokulara sıkıştırma uygulanmayacağı anlamına gelir.
+Kullanılabilen sıkıştırıcıların listesi için [Sıkıştırıcılar](#compressors) bölümüne bakın.
+
+## Doku biçimleri
+
+Grafik donanımı dokuları, farklı kanal sayıları ve bit derinlikleriyle sıkıştırılmamış veya *kayıplı* sıkıştırılmış verilere dönüştürülebilir. Donanımla sıkıştırmanın sabit olması, görüntünün içeriğinden bağımsız olarak ortaya çıkan görüntünün sabit bir boyutta olacağı anlamına gelir. Bu nedenle sıkıştırma sırasındaki kalite kaybı, özgün dokunun içeriğine bağlıdır.
+
+Basis Universal sıkıştırmasının başka bir biçime dönüştürülmesi cihazın GPU yeteneklerine bağlı olduğundan, Basis Universal sıkıştırmasıyla kullanılması önerilen biçimler şu genel biçimlerdir:
+`TEXTURE_FORMAT_RGB`, `TEXTURE_FORMAT_RGBA`, `TEXTURE_FORMAT_RGB_16BPP`, `TEXTURE_FORMAT_RGBA_16BPP`, `TEXTURE_FORMAT_LUMINANCE` ve `TEXTURE_FORMAT_LUMINANCE_ALPHA`.
+
+Basis Universal biçim dönüştürücüsü, `ASTC4x4`, `BCx`, `ETC2`, `ETC1` ve `PVRTC1` gibi birçok çıktı biçimini destekler.
+
+Aşağıdaki kayıplı sıkıştırma biçimleri şu anda desteklenmektedir:
+
+| Biçim                            | Sıkıştırma | Ayrıntılar  |
+| --------------------------------- | ----------- | -------------------------------- |
+| `TEXTURE_FORMAT_RGB`              | yok        | 3 kanallı renk. Alfa atılır |
+| `TEXTURE_FORMAT_RGBA`             | yok        | 3 kanallı renk ve tam alfa.    |
+| `TEXTURE_FORMAT_RGB_16BPP`        | yok        | 3 kanallı renk. 5+6+5 bit. |
+| `TEXTURE_FORMAT_RGBA_16BPP`       | yok        | 3 kanallı renk ve tam alfa. 4+4+4+4 bit. |
+| `TEXTURE_FORMAT_LUMINANCE`        | yok        | 1 kanallı gri tonlama, alfa yok. RGB kanalları çarpılarak tek kanala dönüştürülür. Alfa atılır. |
+| `TEXTURE_FORMAT_LUMINANCE_ALPHA`  | yok        | 1 kanallı gri tonlama ve tam alfa. RGB kanalları çarpılarak tek kanala dönüştürülür. |
+
+ASTC için kanal sayısı her zaman 4'tür (RGB + alfa) ve blok sıkıştırmasının boyutunu biçimin kendisi belirler.
+Bu biçimlerin yalnızca bir ASTC sıkıştırıcısıyla uyumlu olduğunu unutmayın; diğer tüm birleşimler derleme hatasına yol açar.
+
+`TEXTURE_FORMAT_RGBA_ASTC_4X4`
+`TEXTURE_FORMAT_RGBA_ASTC_5X4`
+`TEXTURE_FORMAT_RGBA_ASTC_5X5`
+`TEXTURE_FORMAT_RGBA_ASTC_6X5`
+`TEXTURE_FORMAT_RGBA_ASTC_6X6`
+`TEXTURE_FORMAT_RGBA_ASTC_8X5`
+`TEXTURE_FORMAT_RGBA_ASTC_8X6`
+`TEXTURE_FORMAT_RGBA_ASTC_8X8`
+`TEXTURE_FORMAT_RGBA_ASTC_10X5`
+`TEXTURE_FORMAT_RGBA_ASTC_10X6`
+`TEXTURE_FORMAT_RGBA_ASTC_10X8`
+`TEXTURE_FORMAT_RGBA_ASTC_10X10`
+`TEXTURE_FORMAT_RGBA_ASTC_12X10`
+`TEXTURE_FORMAT_RGBA_ASTC_12X12`
+
+
+## Sıkıştırıcılar {#compressors}
+
+Aşağıdaki doku sıkıştırıcıları varsayılan olarak desteklenir. Doku dosyası belleğe yüklendiğinde verilerin sıkıştırması açılır.
+
+| Ad                              | Biçimler                   | Not                                                                                          |
+| --------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------- |
+| `Uncompressed`                    | Tüm biçimler               | Sıkıştırma uygulanmaz. Varsayılan.                                                      |
+| `BasisU`                          | Tüm RGB/RGBA biçimleri      | Basis Universal yüksek kaliteli, kayıplı sıkıştırma. Daha düşük kalite düzeyi, daha küçük boyut sağlar. |
+| `ASTC`                            | Tüm ASTC biçimleri          | ASTC kayıplı sıkıştırma. Daha düşük kalite düzeyi, daha küçük boyut sağlar.                          |
+
+::: sidenote
+Defold, doku sıkıştırma hattında kurulabilir sıkıştırıcıları destekler. Bu, WEBP veya tamamen özel bir yöntem gibi bir doku sıkıştırma algoritmasının bir eklenti içinde uygulanmasını mümkün kılar.
+:::
+
+## Örnek görüntü
+
+Çıktının daha iyi anlaşılması için aşağıda bir örnek verilmiştir.
+Görüntü kalitesinin, sıkıştırma süresinin ve sıkıştırılmış boyutun her zaman girdi görüntüsüne bağlı olduğunu ve değişebileceğini unutmayın.
+
+Temel görüntü (1024x512):
+![Yeni profil dosyası](images/texture_profiles/kodim03_pow2.png)
+
+### Sıkıştırma süreleri
+
+| Hazır ayar    | Sıkıştırma süresi | Göreli süre |
+| --------- | ---------------- | ------------- |
+| `LOW`     | 0m0.143s         | 0.5x            |
+| `MEDIUM`  | 0m0.294s         | 1.0x            |
+| `HIGH`    | 0m1.764s         | 6.0x            |
+| `HIGHEST` | 0m1.109s         | 3.8x            |
+
+### Sinyal kaybı
+
+Karşılaştırma, `basisu` aracı kullanılarak (PSNR ölçülerek) yapılır.
+100 dB, sinyal kaybı olmadığı anlamına gelir (yani özgün görüntüyle aynıdır).
+
+| Hazır ayar    | Sinyal                                           |
+| --------- | ------------------------------------------------ |
+| `LOW`     | Max:  34 Mean: 0.470 RMS: 1.088 PSNR: 47.399 dB |
+| `MEDIUM`  | Max:  35 Mean: 0.439 RMS: 1.061 PSNR: 47.620 dB |
+| `HIGH`    | Max:  37 Mean: 0.898 RMS: 1.606 PSNR: 44.018 dB |
+| `HIGHEST` | Max:  51 Mean: 1.298 RMS: 2.478 PSNR: 40.249 dB |
+
+### Sıkıştırılmış dosya boyutları
+
+Özgün dosya boyutu 1572882 bayttır.
+
+| Hazır ayar    | Dosya boyutları | Oran   |
+| --------- | ---------- | ------- |
+| `LOW`     | 357225     | 22.71 %  |
+| `MEDIUM`  | 365548     | 23.24 %  |
+| `HIGH`    | 277186     | 17.62 %  |
+| `HIGHEST` | 254380     | 16.17 %  |
+
+
+### Görüntü kalitesi
+
+Ortaya çıkan görüntüler aşağıdadır (`basisu` aracı kullanılarak ASTC kodlamasından elde edilmiştir).
+
+`LOW`
+![düşük sıkıştırma hazır ayarı](images/texture_profiles/kodim03_pow2.fast.png)
+
+`MEDIUM`
+![orta sıkıştırma hazır ayarı](images/texture_profiles/kodim03_pow2.normal.png)
+
+`HIGH`
+![yüksek sıkıştırma hazır ayarı](images/texture_profiles/kodim03_pow2.high.png)
+
+`HIGHEST`
+![en iyi sıkıştırma hazır ayarı](images/texture_profiles/kodim03_pow2.best.png)

--- a/docs/tr/manuals/tilemap.md
+++ b/docs/tr/manuals/tilemap.md
@@ -1,0 +1,119 @@
+---
+title: Defold karo haritası kılavuzu
+brief: Bu kılavuz Defold'un karo haritası desteğini ayrıntılarıyla açıklar.
+---
+
+# Karo haritası
+
+*Karo haritası* (Tile Map), bir *karo kaynağındaki* (Tile Source) karoları geniş bir ızgara alanına yerleştirmenizi veya boyamanızı sağlayan bir bileşendir (component). Karo haritaları genellikle oyun bölümlerinin ortamlarını oluşturmak için kullanılır. Ayrıca, çarpışma algılama ve fizik simülasyonu için haritalarınızda karo kaynağının *çarpışma şekillerini* (Collision Shapes) kullanabilirsiniz ([örnek](/examples/tilemap/collisions/)).
+
+Bir karo haritası oluşturmadan önce bir karo kaynağı oluşturmanız gerekir. Karo kaynağının nasıl oluşturulduğunu öğrenmek için [Karo kaynağı kılavuzuna](/manuals/tilesource) bakın.
+
+## Karo haritası oluşturma
+
+Yeni bir karo haritası oluşturmak için:
+
+- *Assets* tarayıcısında bir konuma <kbd>sağ tıklayın</kbd>, ardından <kbd>New... ▸ Tile Map</kbd> seçeneğini seçin).
+- Dosyaya bir ad verin.
+- Yeni karo haritası otomatik olarak karo haritası düzenleyicisinde açılır.
+
+  ![Yeni karo haritası](images/tilemap/tilemap.png)
+
+- *Tile Source* özelliğini hazırladığınız bir karo kaynağı dosyasına ayarlayın.
+
+Karo haritanıza karolar boyamak için:
+
+1. *Outline* görünümünde üzerine boyama yapacağınız bir *Layer* katmanı seçin veya oluşturun.
+2. Fırça olarak kullanılacak bir karo seçin (karo paletini göstermek için <kbd>Space</kbd> tuşuna basın) veya birden fazla karodan oluşan dikdörtgen bir fırça oluşturmak için palette tıklayıp sürükleyerek birkaç karo seçin.
+
+   ![Palet](images/tilemap/palette.png)
+
+3. Seçili fırçayla boyayın. Bir karoyu silmek için boş bir karo seçip fırça olarak kullanın veya silgiyi seçin (<kbd>Edit ▸ Select Eraser</kbd>).
+
+   ![Karoları boyama](images/tilemap/paint_tiles.png)
+
+Karoları doğrudan bir katmandan alabilir ve seçimi fırça olarak kullanabilirsiniz. <kbd>Shift</kbd> tuşunu basılı tutup bir karoya tıklayarak onu geçerli fırça olarak seçin. <kbd>Shift</kbd> tuşunu basılı tutarken tıklayıp sürükleyerek daha büyük bir fırça olarak kullanılacak bir karo bloğu da seçebilirsiniz. Benzer şekilde, <kbd>Shift+Ctrl</kbd> tuşlarını basılı tutarak karoları kesebilir veya <kbd>Shift+Alt</kbd> tuşlarını basılı tutarak silebilirsiniz.
+
+Fırçayı saat yönünde döndürmek için <kbd>Z</kbd> tuşunu kullanın. Fırçayı yatay çevirmek için <kbd>X</kbd>, dikey çevirmek için <kbd>Y</kbd> tuşunu kullanın.
+
+![Karoları seçme](images/tilemap/pick_tiles.png)
+
+## Oyununuza karo haritası ekleme
+
+Oyununuza bir karo haritası eklemek için:
+
+1. Karo haritası bileşenini barındıracak bir oyun nesnesi (game object) oluşturun. Oyun nesnesi bir dosyada bulunabilir veya doğrudan bir koleksiyonda (collection) oluşturulabilir.
+2. Oyun nesnesinin köküne sağ tıklayın ve <kbd>Add Component File</kbd> seçeneğini seçin.
+3. Karo haritası dosyasını seçin.
+
+![Karo haritasını kullanma](images/tilemap/use_tilemap.png)
+
+## Çalışma sırasında değiştirme
+
+Karo haritalarını çalışma sırasında çeşitli işlevler ve özellikler aracılığıyla değiştirebilirsiniz (kullanım için [API belgelerine](/ref/tilemap/) bakın).
+
+### Betikten karoları değiştirme
+
+Oyununuz çalışırken bir karo haritasının içeriğini dinamik olarak okuyabilir ve yazabilirsiniz. Bunun için [`tilemap.get_tile()`](/ref/tilemap/#tilemap.get_tile) ve [`tilemap.set_tile()`](/ref/tilemap/#tilemap.set_tile) işlevlerini kullanın:
+
+```lua
+local tile = tilemap.get_tile("/level#map", "ground", x, y)
+
+if tile == 2 then
+    -- Replace grass-tile (2) with dangerous hole tile (number 4).
+    tilemap.set_tile("/level#map", "ground", x, y, 4)
+end
+```
+
+## Karo haritası özellikleri
+
+*Id*, *Position*, *Rotation* ve *Scale* özelliklerinin yanı sıra bileşene özgü şu özellikler bulunur:
+
+*Tile Source*
+: Karo haritası için kullanılacak karo kaynağı.
+
+*Material*
+: Karo haritasının işlenmesinde (rendering), yani görüntüsünün oluşturulmasında kullanılacak materyal (material).
+
+*Blend Mode*
+: Karo haritası işlenirken kullanılacak harmanlama modu (blend mode).
+
+### Harmanlama modları
+:[blend-modes](../shared/blend-modes.md)
+
+### Özellikleri değiştirme
+
+Karo haritası, `go.get()` ve `go.set()` kullanılarak değiştirilebilen çeşitli özelliklere sahiptir:
+
+`tile_source`
+: Karo haritasının karo kaynağı (`hash`). Bunu bir karo kaynağına başvuran kaynak özelliği ve `go.set()` kullanarak değiştirebilirsiniz. Örnek için [API başvurusuna](/ref/tilemap/#tile_source) bakın.
+
+`material`
+: Karo haritasının materyali (`hash`). Bunu bir materyale başvuran kaynak özelliği ve `go.set()` kullanarak değiştirebilirsiniz. Örnek için [API başvurusuna](/ref/tilemap/#material) bakın.
+
+### Materyal sabitleri
+
+{% include shared/material-constants.md component='tilemap' variable='tint' %}
+
+`tint`
+: Karo haritasının renk çarpanı (tint) (`vector4`). Renk çarpanını temsil etmek için `vector4` kullanılır; x, y, z ve w sırasıyla kırmızı, yeşil, mavi ve alfa çarpanlarına karşılık gelir.
+
+## Proje yapılandırması
+
+*game.project* dosyasında karo haritalarıyla ilgili birkaç [proje ayarı](/manuals/project-settings#tilemap) bulunur.
+
+## Harici araçlar
+
+Doğrudan Defold karo haritalarına dışa aktarabilen harici harita/bölüm düzenleyicileri vardır:
+
+### Tiled
+
+[Tiled](https://www.mapeditor.org/), dik açılı, izometrik ve altıgen haritalar için tanınan ve yaygın olarak kullanılan bir harita düzenleyicisidir. Tiled çok çeşitli özellikleri destekler ve [doğrudan Defold'a dışa aktarabilir](https://doc.mapeditor.org/en/stable/manual/export-defold/). Karo haritası verilerinin ve ek üst verilerin nasıl dışa aktarılacağı hakkında daha fazla bilgi için [Defold kullanıcısı "goeshard" tarafından yazılan bu blog yazısını](https://goeshard.org/2025/01/01/using-tiled-object-layers-with-defold-tilemaps/) okuyun.
+
+
+### Tilesetter
+
+[Tilesetter](https://www.tilesetter.org/docs/exporting#defold), basit temel karolardan otomatik olarak eksiksiz karo kümeleri oluşturmak için kullanılabilir ve doğrudan Defold'a dışa aktarabilen bir harita düzenleyicisine sahiptir.
+
+
+

--- a/docs/tr/manuals/tilesource.md
+++ b/docs/tr/manuals/tilesource.md
@@ -1,0 +1,100 @@
+---
+title: Defold karo kaynağı kılavuzu
+brief: Bu kılavuz, karo kaynağının nasıl kullanılacağını ve oluşturulacağını açıklar.
+---
+
+# Karo kaynağı
+
+Bir *karo kaynağı (Tile Source)*, bir [karo haritası bileşeni (Tilemap component)](/manuals/tilemap) tarafından ızgara şeklinde bir alana karolar çizmek için kullanılabilir ya da bir [sprite bileşeninin](/manuals/sprite) veya [parçacık efekti bileşeninin (Particle Effect component)](/manuals/particlefx) grafik kaynağı olarak kullanılabilir. Karo kaynağındaki *çarpışma şekillerini (Collision Shapes)* de bir karo haritasında [çarpışma algılama ve fizik simülasyonu](/manuals/physics) için kullanabilirsiniz ([örnek](/examples/tilemap/collisions/)).
+
+## Karo kaynağı oluşturma
+
+Tüm karoları içeren bir görüntüye ihtiyacınız vardır. Her karo tam olarak aynı boyutlarda olmalı ve bir ızgaraya yerleştirilmelidir. Defold, karolar arasında _aralık_ ve her karonun çevresinde _kenar boşluğu_ kullanımını destekler.
+
+![Karo görüntüsü](images/tilemap/small_map.png)
+
+Kaynak görüntüyü oluşturduktan sonra bir karo kaynağı oluşturabilirsiniz:
+
+- Görüntüyü *Assets* tarayıcısındaki bir proje konumuna sürükleyerek projenize içe aktarın.
+- Yeni bir karo kaynağı dosyası oluşturun (*Assets* tarayıcısındaki bir konuma <kbd>sağ tıklayın</kbd>, ardından <kbd>New... ▸ Tile Source</kbd> seçeneğini seçin).
+- Yeni dosyaya bir ad verin.
+- Dosya artık karo kaynağı düzenleyicisinde açılır.
+- *Image* özelliğinin yanındaki göz atma düğmesine tıklayın ve görüntünüzü seçin. Görüntünün artık düzenleyicide gösterilmesi gerekir.
+- *Properties* panelindeki özellikleri kaynak görüntüyle eşleşecek şekilde ayarlayın. Her şey doğru olduğunda karolar tam olarak hizalanır.
+
+![Karo kaynağı oluşturma](images/tilemap/tilesource.png)
+
+Size
+: Kaynak görüntünün boyutu.
+
+Tile Width
+: Her karonun genişliği.
+
+Tile Height
+: Her karonun yüksekliği.
+
+Tile Margin
+: Her karoyu çevreleyen piksel sayısı (yukarıdaki görüntüde turuncu).
+
+Tile Spacing
+: Karoların arasındaki piksel sayısı (yukarıdaki görüntüde mavi).
+
+Inner Padding
+: Oyun çalıştırıldığında kullanılan sonuç dokusunda karonun çevresine otomatik olarak kaç boş piksel ekleneceğini belirtir.
+
+Extrude Border
+: Oyun çalıştırıldığında kullanılan sonuç dokusunda kenar piksellerinin karonun çevresinde otomatik olarak kaç kez çoğaltılacağını belirtir.
+
+Collision
+: Karolar için otomatik olarak çarpışma şekilleri oluşturmakta kullanılacak görüntüyü belirtir.
+
+## Karo kaynağında kare dizisi animasyonları
+
+Bir karo kaynağında kare dizisi animasyonu (flip-book animation) tanımlamak için animasyon karelerini oluşturan karolar, soldan sağa uzanan bir dizide yan yana yer almalıdır. Dizi bir satırdan sonraki satıra devam edebilir. Yeni oluşturulan tüm karo kaynaklarında "`anim`" adlı varsayılan bir animasyon bulunur. *Outline* görünümünde karo kaynağının kök öğesine <kbd>sağ tıklayıp</kbd> <kbd>Add ▸ Animation</kbd> seçeneğini seçerek yeni animasyonlar ekleyebilirsiniz.
+
+Bir animasyon seçildiğinde animasyonun *Properties* paneli gösterilir.
+
+![Karo kaynağı animasyonu](images/tilemap/animation.png)
+
+Id
+: Animasyonun kimliği. Karo kaynağı içinde benzersiz olmalıdır.
+
+Start Tile
+: Animasyonun ilk karosu. Numaralandırma sol üst köşede 1'den başlar ve satır satır sağa doğru ilerleyerek sağ alt köşeye kadar devam eder.
+
+End Tile
+: Animasyonun son karosu.
+
+Playback
+: Animasyonun nasıl oynatılacağını belirtir:
+
+  - `None` animasyonu hiç oynatmaz, ilk görüntü gösterilir.
+  - `Once Forward` animasyonu ilk görüntüden son görüntüye kadar bir kez oynatır.
+  - `Once Backward` animasyonu son görüntüden ilk görüntüye kadar bir kez oynatır.
+  - `Once Ping Pong` animasyonu ilk görüntüden son görüntüye kadar ve ardından tekrar ilk görüntüye dönerek bir kez oynatır.
+  - `Loop Forward` animasyonu ilk görüntüden son görüntüye kadar sürekli tekrarlar.
+  - `Loop Backward` animasyonu son görüntüden ilk görüntüye kadar sürekli tekrarlar.
+  - `Loop Ping Pong` animasyonu ilk görüntüden son görüntüye kadar ve ardından tekrar ilk görüntüye dönerek sürekli tekrarlar.
+
+Fps
+: Animasyonun saniyedeki kare sayısı (FPS) olarak ifade edilen oynatma hızı.
+
+Flip horizontal
+: Animasyonu yatay olarak çevirir.
+
+Flip vertical
+: Animasyonu dikey olarak çevirir.
+
+## Karo kaynağı çarpışma şekilleri {#tile-source-collision-shapes}
+
+Defold, her karo için _dışbükey_ bir şekil oluşturmak üzere *Collision* özelliğinde belirtilen bir görüntüyü kullanır. Şekil, karonun renk bilgisi içeren, yani %100 saydam olmayan kısmının dış hatlarını izler.
+
+Çarpışmalar için asıl grafikleri içeren görüntüyü kullanmak çoğu zaman mantıklıdır, ancak görsellerden farklı çarpışma şekilleri istiyorsanız ayrı bir görüntü belirtebilirsiniz. Bir çarpışma görüntüsü belirttiğinizde önizleme, oluşturulan çarpışma şekillerini gösteren dış hatları her karo üzerinde gösterecek şekilde güncellenir.
+
+Karo kaynağının *Outline* görünümü, karo kaynağına eklediğiniz çarpışma gruplarını listeler. Yeni karo kaynağı dosyalarına "default" adlı bir çarpışma grubu eklenir. *Outline* görünümünde karo kaynağının kök öğesine <kbd>sağ tıklayıp</kbd> <kbd>Add ▸ Collision Group</kbd> seçeneğini seçerek yeni gruplar ekleyebilirsiniz.
+
+Belirli bir gruba ait olması gereken karo şekillerini seçmek için *Outline* görünümünde grubu seçin, ardından gruba atamak istediğiniz her karoya tıklayın. Karonun ve şeklin dış hatları grubun rengiyle renklendirilir. Renk, düzenleyicide gruba otomatik olarak atanır.
+
+![Çarpışma şekilleri](images/tilemap/collision.png)
+
+Bir karoyu çarpışma grubundan çıkarmak için *Outline* görünümünde karo kaynağının kök öğesini seçin, ardından karoya tıklayın.

--- a/docs/tr/manuals/unity.md
+++ b/docs/tr/manuals/unity.md
@@ -1,0 +1,680 @@
+---
+title: Unity kullanıcıları için Defold
+brief: Bu kılavuz, Unity deneyiminiz varsa Defold'a hızla geçmenize yardımcı olur. Unity'de kullanılan bazı temel kavramları ele alır ve bunlara karşılık gelen Defold araçlarını ve yöntemlerini açıklar.
+---
+
+# Unity kullanıcıları için Defold
+
+Unity deneyiminiz varsa bu kılavuz, Defold'da kısa sürede verimli çalışmaya başlamanıza yardımcı olur. Temel noktalara odaklanır ve daha ayrıntılı bilgi gerektiğinde sizi resmî Defold kılavuzlarına yönlendirir.
+
+## Giriş
+
+Defold, Windows, Linux ve macOS için bir düzenleyici sunan, tamamen ücretsiz ve gerçekten platformlar arası bir 3B oyun motorudur. Kaynak kodunun tamamı [GitHub](https://github.com/defold/defold/) üzerinde bulunur.
+
+Defold, düşük donanımlı cihazlarda bile performansa odaklanır. Oynanış etkileşimlerinin çoğunun kod ve ileti aktarımı yoluyla yönetildiği küçük bir bileşen (component) modeli kullanır.
+
+Defold, Unity'den çok daha küçüktür. Boş bir projeyle motor boyutu tüm platformlarda 1-3 MB arasındadır. Motorun ek bölümlerini çıkarabilir ve oyun içeriğinin bir kısmını daha sonra ayrı olarak indirmek üzere [Live Update](/manuals/live-update) kapsamına taşıyabilirsiniz. Boyut karşılaştırması ve Defold'u seçmek için diğer nedenler [Neden Defold web sayfasında](https://defold.com/why/) açıklanmıştır.
+
+Defold'u ihtiyaçlarınıza göre özelleştirmek için aşağıdakileri kendiniz yazabilir veya mevcut olanları kullanabilirsiniz:
+
+1. Aralarından seçim yapabileceğiniz birkaç arka uca (OpenGL, Vulkan vb.) sahip, görüntü oluşturan ve tamamen betiklerle yönetilebilen bir işleme (rendering) hattı (işleme betiği + materyaller/gölgelendiriciler).
+2. Yerel kod eklentileri (Native Extensions) olarak kod ve bileşenler (C++/C#).
+3. Düzenleyiciyi özelleştirmek için düzenleyici betikleri ve kullanıcı arayüzü (UI) denetimleri.
+3. Kaynak kodunun tamamı ve bir derleme hattı sunulduğu için motorun ve düzenleyicinin değiştirilmiş bir derlemesi.
+
+Ayrıca Game From Scratch'in [Unity geliştiricileri için Defold](https://www.youtube.com/watch?v=-3CzCbd4QZ0) videosuna göz atmanızı öneririz.
+
+---
+
+## Kurulum
+
+1. İşletim sisteminiz için Defold'u indirin.
+2. Arşivi çıkarın ve başlatın.
+
+Hepsi bu kadar. Bir merkez uygulaması, ek SDK, araç zincirleri veya platform paketleri kurmanız gerekmez. Bu nedenle Defold'un kurulum gerektirmediğini söylüyoruz.
+
+Daha fazla ayrıntıya ihtiyacınız varsa bu kısa [Kurulum kılavuzunu](/manuals/install/) okuyun.
+
+### Sürümler
+
+Defold sık güncellenir ve bir "LTS" sürüm kolu yoktur. Her zaman en yeni sürümü kullanmanızı öneririz. Yeni sürümler düzenli olarak, genellikle aylık ve yaklaşık iki haftalık herkese açık beta sürecinin ardından yayımlanır. Defold'u doğrudan düzenleyiciden güncelleyebilirsiniz.
+
+---
+
+## Karşılama ekranı
+
+Defold sizi Unity Hub'a benzer bir karşılama ekranıyla karşılar; buradan son projeleri açabilirsiniz:
+
+![Karşılama ekranlarının karşılaştırması](images/unity/unity_defold_start.png)
+
+Veya aşağıdakilerden yeni bir proje başlatabilirsiniz:
+- `Templates` - belirli bir platform veya tür için daha hızlı başlangıç yapmanızı sağlayan temel boş projeler,
+- `Tutorials` - ilk adımlarınızı atmanıza yardımcı olan yönlendirmeli öğrenme turları,
+- `Samples` - resmî veya topluluğun katkıda bulunduğu kullanım senaryoları ve örnekler,
+
+![Karşılama ekranındaki şablonların karşılaştırması](images/unity/unity_defold_templates.png)
+
+İlk projenizi oluşturduğunuzda ve/veya açtığınızda proje Defold düzenleyicisinde açılır.
+
+## Merhaba dünya
+
+Bu bölüm, Defold'da hızla bir şeyler ortaya çıkarmanın kısa bir yoludur. Adımları izleyin, ardından kılavuzun geri kalanını okumaya dönün.
+
+1. `Templates` bölümünden boş bir proje seçin, `Title` alanında adlandırın, konum seçin ve `Create New Project` düğmesine tıklayarak oluşturun. Proje Defold düzenleyicisinde açılır.
+![Merhaba dünya, 1. adım](images/unity/helloworld_1.png)
+2. Sol taraftaki `Assets` bölmesinde `main` klasörünü açın ve `main.collection` dosyasını açmak için dosyaya çift tıklayın.
+3. Sağ taraftaki `Outline` bölmesinde `Collection` öğesine sağ tıklayın ve `Add Game Object` seçeneğini seçin.
+![Merhaba dünya, 2. adım](images/unity/helloworld_2.png)
+4. Oluşturulan `go` oyun nesnesine sağ tıklayın ve `Add Component`, ardından `Label` seçeneğini seçin.
+![Merhaba dünya, 3. adım](images/unity/helloworld_3.png)
+5. Aşağıda, sol taraftaki `Properties` bölmesinde `Text` özelliğine bir şey yazın.
+6. Ortadaki ana sahne görünümünde etiketi sürükleyip taşıyarak yaklaşık `(480,320,0)` konumuna bırakın veya `Properties` içindeki `Position` değerini değiştirin.
+![Merhaba dünya, 4. adım](images/unity/helloworld_4.png)
+7. Etiketin konumunu değiştirdikten sonra `File` -> `Save All` seçeneğine tıklayarak veya <kbd>Ctrl</kbd>+<kbd>S</kbd> (Mac'te <kbd>Cmd</kbd>+<kbd>S</kbd>) kısayolunu kullanarak projeyi kaydedin.
+8. `Project` -> `Build` seçeneğine tıklayarak veya <kbd>Ctrl</kbd>+<kbd>B</kbd> (Mac'te <kbd>Cmd</kbd>+<kbd>B</kbd>) kısayolunu kullanarak projenizi derleyin.
+![Merhaba dünya, 5. adım](images/unity/helloworld_5.png)
+
+Defold'da ilk projenizi derlediniz; metninizi pencerede görmeniz gerekir. Oyun nesnesi (game object) ve bileşen kavramları size tanıdık gelmelidir. Koleksiyonlar, Outline görünümü, özellikler ve etiketi neden biraz sağ üste taşımamız gerektiği aşağıda açıklanmıştır.
+
+---
+
+## Defold düzenleyicisine genel bakış
+
+Burada Defold düzenleyicisini, bir Unity kullanıcısının ilk başta bilmek isteyebileceği noktalar üzerinden tanıtacağız; ancak sonrasında [Düzenleyiciye genel bakış kılavuzunun](/manuals/editor) tamamına göz atmanızı öneririz.
+
+### Düzenleyicilerin karşılaştırması
+
+Unity ile Defold arasında ilk fark edeceğiniz şey varsayılan düzenleyici yerleşimidir. Burada Unity düzenleyicisini, Defold'un varsayılan yerleşimine uyacak şekilde biraz değiştirilmiş bir yerleşimle gösteriyoruz. Unity sekmelerini daha rahat tanıyabileceğiniz için ana bölmeleri görsel olarak daha kolay karşılaştırmanız amacıyla düzenleyiciler yan yana yerleştirilmiştir.
+
+![Düzenleyicilerin karşılaştırması](images/unity/defold_unity_editor.png)
+
+Defold düzenleyicisi varsayılan olarak 2B ortografik önizlemeyle açılır. Bir 3B proje üzerinde çalışacaksanız veya yalnızca Unity'ye daha yakın bir deneyim istiyorsanız --- araç çubuğundaki `2D` seçeneğinin işaretini kaldırarak 2B'den 3B'ye geçmenizi ve `Perspective` seçeneğini işaretleyerek kamera izdüşümünü perspektif olarak değiştirmenizi öneririz:
+
+![Defold araç çubuğu](images/unity/defold_2d.png)
+
+Araç çubuğundaki `Grid Settings` ayarlarını da Unity'deki gibi `Y` düzlemini kullanacak şekilde değiştirebilirsiniz:
+
+![Defold 3B ayarları](images/unity/defold_3d.png)
+
+### Defold bölmelerine genel bakış
+
+Defold düzenleyicisi 6 ana bölmeye ayrılır.
+
+![Düzenleyici 2](images/editor/editor_overview.png)
+
+Aşağıda Defold'daki adlandırmaların ve işlevsel farkların karşılaştırması yer alır:
+
+| Defold | Unity | Farklar |
+|---|---|---|
+| 1. Assets | Project (Assets Browser) | Defold'da Assets bölmesi sola sabitlenmiştir. Defold herhangi bir `meta` dosyası oluşturmaz. |
+| 2. Main Editor | Scene View | Defold düzenleyicisi bağlama duyarlıdır (farklı dosya türleri için farklı düzenleyiciler kullanılır); Unity ise ayrı, belirli bir işe özel pencereler kullanır (ör. Animator, Shader Graph). Defold'da yerleşik bir kod düzenleyicisi de bulunur. |
+| 3. Outline | Hierarchy | Defold, genel bir hiyerarşi yerine yalnızca o anda açık olan dosyayı veya seçili öğeyi (oyun nesnesi veya bileşen) yansıtır. |
+| 4. Properties | Inspector | Defold, oyun nesnesindeki tüm bileşenlerin özelliklerini değil, yalnızca Outline içindeki **geçerli seçimin** özelliklerini gösterir. |
+| 5. Tools | Console | Defold, Console, Curve Editor, Build Errors, Search Results, Breakpoints ve Debugger gibi sekmelerde araçlar sunar. |
+| 6. Changed Files | Unity Version Control (Plastic) | Defold'da Git projenize tümleştirildiğinde değişen dosyalar burada gösterilir. Git'i harici olarak kullanmaya devam edebilirsiniz. |
+
+Düzenleyiciyle ilgili diğer yararlı adlandırmalar:
+
+| Defold | Unity | Farklar |
+|---|---|---|
+| Game Build | Game Preview | Motorla derlenmiş ve çalışmakta olan oyunu gösterir. Defold, Unity 6+ Multiplayer Play Mode özelliğine benzer şekilde, düzenleyiciden oyunun birden çok örneğini (instance) çalıştırabilir. Defold'da oyun her zaman ayrı bir pencerede çalışır ve düzenleyiciye sabitlenmez. Defold ayrıca Unity Remote'a benzer şekilde oyunu harici bir cihazda (ör. cep telefonu) çalıştırabilir. |
+| Tabs | Tabs | Defold, Main Editor görünümündeki iki bölmede yan yana düzenlemeye izin verir. Sekmeler ve bölmeler tek bir düzenleyici penceresinin içine sabitlenmiştir; bölmelerin görünürlüğü değiştirilebilir (<kbd>F6</kbd>, <kbd>F7</kbd>, <kbd>F8</kbd>) ve boyutları ayarlanabilir. |
+| Toolbar | Toolbar / Scene View Options | Dönüşüm araçları ancak daha yeni Unity sürümlerinde, Defold'dakine benzer şekilde Scene görünümüne taşınmıştır. |
+| Console | Console | Defold Console ayrılarak bağımsız bir pencereye taşınamaz. Defold'daki derleme hataları ayrı bir `Build Errors` sekmesinde görünür. |
+| Build Errors | Console içindeki kod derleme hataları | Lua betikleri yorumlandığı için kod derleme hatası oluşmaz. Ancak projeniz derlenir ve derleme sırasında bazı hatalar ortaya çıkabilir. Defold ayrıca betiklerin statik analizi için bir Lua Language Server kullanır. |
+| Search Results | Search / Project Search | Defold'da türe ve etikete göre filtreleme bulunmaz. |
+| Curve Editor | Unity Curve Editor | Defold Curve Editor yalnızca parçacık efekti özelliklerinin eğrilerini düzenlemeye izin verir. |
+| [Hata ayıklayıcı](/manuals/debugging/) | Visual Studio Debugger | Hata ayıklayıcı, Defold'a en baştan tamamen tümleştirilmiştir. Kesme noktalarını izlemek, etkinleştirmek ve devre dışı bırakmak için ek bir sekme bulunur. |
+
+---
+
+## Temel kavramlar
+
+Yeterince genel bakarsanız çoğu oyun motorunun temel kavramları birbirine çok benzer. Geliştiricilerin yapı taşlarını bir araya getirir gibi daha kolay oyun yapmasına yardımcı olmayı amaçlarlar ve karmaşık, platforma özgü işleri kendileri yürütürler.
+
+### Yapı taşları
+
+Defold yalnızca birkaç temel yapı taşıyla çalışır:
+
+![Yapı taşları](images/unity/blocks.png)
+
+Daha fazla ayrıntı için [Defold yapı taşları](/manuals/building-blocks/) hakkındaki kılavuzun tamamına göz atın.
+
+### Oyun nesneleri 
+Defold, Unity'ye benzer şekilde **"oyun nesneleri"** kullanır. Her iki motorda da oyun nesneleri, bir tanımlayıcıya sahip veri kapsayıcılarıdır ve hepsinin konum, dönme ve ölçekten oluşan dönüşümleri vardır; ancak Defold'da dönüşüm ayrı bir bileşen olmak yerine yerleşiktir.
+
+Oyun nesneleri arasında üst-alt nesne ilişkileri oluşturabilirsiniz. Defold'da bu yalnızca düzenleyicide bir "koleksiyon" (collection, aşağıda açıklanmıştır) içinde veya betikte dinamik olarak yapılabilir. Oyun nesneleri, Unity'deki gibi başka oyun nesnelerini iç içe nesneler olarak barındıramaz.
+
+### Bileşenler
+Her iki motorda da oyun nesneleri **"bileşenlerle"** genişletilebilir. Defold, temel bileşenlerden oluşan küçük bir küme sunar. 2B ve 3B arasındaki ayrım Unity'dekinden daha azdır (ör. çarpıştırıcılar); bu nedenle toplam bileşen sayısı daha azdır ve Unity'deki bazı bileşenleri arayabilirsiniz.
+
+#### Davranış bileşenleri
+
+Unity'de "bileşen" genellikle bir `GameObject` nesnesine eklenen `MonoBehaviour` anlamına gelir. `MonoBehaviour` sınıfından türeterek kendi bileşenlerinizi oluşturabilir veya Light, bazı fizik öğeleri ve benzeri yerleşik bileşenleri kullanabilirsiniz.
+
+Defold'da bileşen yalnızca Unity'deki yerleşik bileşenlere karşılık gelen veya benzeri öğeleri ifade eder; ancak Defold bir betiği monobehaviour olarak ele almaz ve dinleyici olayları/geri çağırımları oluşturmak dışında bir oyun nesnesine eklemek için açıkça herhangi bir "işaretleme" gerektirmez.
+
+Özel oynanış davranışı genellikle aynı oyun nesnesine birçok ayrı betik bileşeni olarak eklenmez. Bunun yerine çoğunlukla Lua modüllerinde uygulanıp bunları barındıran tek bir `.script` tarafından kullanılır veya birçok nesneyi yöneten daha büyük bir sistem betiği tarafından ele alınır. Aşağıdaki Kod yazma bölümü bunu daha ayrıntılı açıklar.
+
+[Defold bileşenleri hakkında buradan](/manuals/components/) daha fazla bilgi edinebilirsiniz.
+
+Aşağıdaki tablo, hızlıca karşılaştırabilmeniz için benzer Unity bileşenlerini ve her Defold bileşeninin kılavuzuna bağlantıları sunar:
+
+| Defold | Unity | Farklar |
+|---|---|---|
+| [Sprite](/manuals/sprite/) | Sprite Renderer | Defold'da sprite bileşeninin renk çarpanını (renk özelliği) yalnızca kod yoluyla değiştirebilirsiniz. |
+| [Karo haritası](/manuals/tilemap/) | Tilemap / Grid | Defold'da kare ızgaraları destekleyen yerleşik bir karo haritası düzenleyicisi bulunur (ancak örneğin [altıgenler](https://github.com/selimanac/defold-hexagon/) için bir eklenti vardır) ve yerleşik otomatik karo yerleştirme kuralları yoktur. [Tiled](https://defold.com/assets/tiled/), [TileSetter](https://defold.com/assets/tilesetter/) veya [Sprite Fusion](https://defold.com/assets/spritefusion/) gibi araçlar Defold'a dışa aktarma seçenekleri sunar. |
+| [Etiket](/manuals/label/) | Text / TextMeshPro | Defold 1.13.2'den itibaren etiket bileşenleri ve GUI metin düğümleri; renkler, renk geçişleri, dış çizgiler ve animasyonlu efektler için yerleşik [zengin metin işaretlemesini](/manuals/font-richtext/) destekler. Ayrı bir [RichText eklentisi](https://defold.com/assets/richtext/) de mevcuttur. |
+| [Ses](/manuals/sound/) | AudioSource | Defold'da yalnızca genel bir ses kaynağı bulunur (uzamsal değildir). Defold için resmî bir [FMOD eklentisi](https://github.com/defold/extension-fmod) vardır. |
+| [Fabrika](/manuals/factory/) | Prefab Instantiate() | Defold'da fabrika (factory), belirli bir prototipe (prefab; yeniden kullanılabilir nesne tanımı) sahip bir bileşendir. |
+| [Koleksiyon fabrikası](/manuals/collection-factory/) | - (Doğrudan bir bileşen karşılığı yoktur) | Defold'daki bir koleksiyon fabrikası (collection factory) bileşeni, üst-alt nesne ilişkilerine sahip birden çok oyun nesnesini aynı anda oluşturabilir. |
+| [Çarpışma nesnesi](/manuals/physics-objects) | Rigidbody + Collider | Defold'da fizik nesneleri ve çarpışma şekilleri tek bir bileşende birleştirilmiştir. |
+| [Çarpışma şekilleri](/manuals/physics-shapes/)  | BoxCollider / SphereCollider / CapsuleCollider | Defold'da şekiller (kutu, küre, kapsül) çarpışma nesnesi bileşeninin içinde yapılandırılır. Her ikisi de karo haritalarından ve dışbükey kabuk verilerinden alınan çarpışma şekillerini destekler. |
+| [Kamera](/manuals/camera/) | Camera | Unity'deki kamera daha fazla yerleşik işleme ve son işleme ayarına sahipken Defold bu ayarların işleme betiği üzerinden kullanıcı tarafından özelleştirilerek yönetilmesini sağlar. |
+| [GUI](/manuals/gui/) | UI Toolkit / Unity UI / uGUI Canvas | Defold GUI, eksiksiz kullanıcı arayüzleri ve şablonlar oluşturmak için güçlü bir bileşendir. Unity'de buna karşılık gelen tek bir kullanıcı arayüzü bileşeni yerine birden çok kullanıcı arayüzü çatısı bulunur. Defold'da [Eklenti](https://github.com/britzl/extension-imgui) için de bir eklenti vardır. |
+| [GUI betiği](/manuals/gui-script/) | Unity UI / uGUI betikleri | Defold GUI, özel `gui` API'sini kullanan GUI betikleri üzerinden yönetilebilir. |
+| [Model](/manuals/model/) | MeshRenderer + Material | Defold'da bir model bileşeni; bir 3B model dosyasını, dokuları ve gölgelendiricilere sahip bir materyali bir araya getirir. |
+| [Örgü](/manuals/mesh/) | MeshRenderer / MeshFilter / Procedural Mesh | Defold'da örgü (mesh), bir köşe kümesini kod yoluyla yönetmek için kullanılan bir bileşendir. Defold model bileşenine benzer, ancak daha da düşük düzeylidir. |
+| [ParticleFX](/manuals/particlefx/) | Particle System | Defold'un parçacık düzenleyicisi birçok özelliğe sahip 2B/3B parçacık efektlerini destekler ve Curve Editor içindeki eğrileri kullanarak bunlara zaman içinde animasyon uygulamanızı sağlar. Trails veya Collisions özellikleri yoktur. |
+| [Betik](/manuals/script/) | Script | Programlama farkları hakkında daha fazla ayrıntı aşağıda açıklanmıştır. |
+
+#### Eklentiler ve özel bileşenler
+
+Defold ayrıca eklentiler üzerinden sunulan resmî [Spine](/extension-spine/) ve [Rive](/extension-rive/) bileşenlerine sahiptir.
+
+Yerel kod eklentilerini kullanarak kendi [özel bileşenlerinizi](https://github.com/defold/extension-simpledata) de oluşturabilirsiniz; örneğin topluluk tarafından oluşturulan bu [Nesne ara değerleme bileşeni](https://github.com/indiesoftby/defold-object-interpolation) gibi.
+
+Bazı Unity bileşenlerinin Defold'da hazır bir karşılığı yoktur; örneğin Audio Listener, Light, Terrain, LineRenderer, TrailRenderer, Cloth veya Animator. Ancak bu işlevlerin tamamı betiklerde uygulanabilir ve hâlihazırda mevcut çözümler vardır: örneğin farklı aydınlatma hatları, isteğe göre örgüler (arazi dahil) üretmek için örgü bileşeni veya özelleştirilebilir iz efektleri için [Hyper Trails](https://defold.com/assets/hypertrails/). Defold gelecekte ışıklar gibi yeni yerleşik bileşenler de ekleyebilir.
+
+### Kaynaklar
+
+Unity'ye benzer şekilde bazı bileşenler **"kaynaklara" (resources)** ihtiyaç duyar; örneğin sprite ve model bileşenlerinin dokulara ihtiyacı vardır. Bunlardan birkaçı aşağıdaki tabloda karşılaştırılmıştır:
+
+| Defold | Unity | Farklar |
+|---|---|---|
+| [Atlas](/manuals/atlas/) | Sprite Atlas / Texture2D | Defold'da bir [Texture Packer eklentisi](https://defold.com/extension-texturepacker/) de bulunur. |
+| [Karo kaynağı](/manuals/tilesource/) | Tile Palette + Asset | Defold'da bir karo kaynağı, karo haritalarının yanı sıra sprite bileşenleri veya parçacıklar için de doku olarak kullanılabilir. |
+| [Yazı tipi](/manuals/font/) | Font | Unity'deki Text/TextMeshPro'ya benzer şekilde, Defold etiket bileşeni veya GUI içindeki metin düğümleri tarafından kullanılır. |
+| [Materyal](/manuals/material/) | Material | Defold'da gölgelendiriciler köşe programı ve parça programı olarak adlandırılır. |
+
+### Koleksiyon ve sahne karşılaştırması
+
+Defold'da oyun nesneleri ve bileşenler, Unity prefabları gibi ayrı dosyalara yerleştirilebilir veya onları bir araya getiren bir **"koleksiyon"** dosyasında tanımlanabilir.
+
+Defold'da bir koleksiyon temelde statik bir sahne açıklaması içeren metin dosyasıdır. Bir çalışma zamanı nesnesi **değildir**. Yalnızca oyunda hangi oyun nesnelerinin örneklerinin oluşturulacağını ve bu nesneler arasındaki üst-alt nesne ilişkilerinin nasıl kurulacağını tanımlar.
+
+#### Oyun dünyaları
+
+Unity sahneleri varsayılan olarak aynı genel oyun durumunu ve fizik simülasyonunu, dolayısıyla aynı *dünyayı* (*oyun dünyasını*) paylaşır. Defold'da iki seçeneğiniz vardır:
+1. Prefablarda olduğu gibi, tek bir oyun nesnesi dosyasından `Factory` aracılığıyla veya bir koleksiyon dosyasından `Collection Factory` aracılığıyla, örneği zaten oluşturulmuş belirli bir *dünyada* oyun nesnelerinin örneklerini oluşturmak.
+2. Başlangıçta yüklenen bir koleksiyon veya bir koleksiyon vekili (collection proxy) olan `Collection Proxy` bileşeni aracılığıyla, kendi oyun nesnelerine, fizik dünyasına, motor işlemlerine ve adresleme ad alanına sahip ayrı bir oyun *dünyasını* çalışma sırasında oluşturmak.
+
+Fabrika ve vekil bileşenleri aşağıda ayrıca açıklanmıştır.
+Koleksiyonlar hakkında daha fazla bilgi için [Yapı taşları kılavuzunu](/manuals/building-blocks/#collections) okuyun.
+
+---
+
+## Proje kaynakları ve varlıkları
+
+Unity ve Defold, oyun içeriğini proje dizininde saklar; ancak varlıkların (asset) nasıl izlendiği ve hazırlandığı konusunda farklılık gösterir.
+
+### Varlıklar
+
+Unity varlıkları `Assets/` içinde tutar ve `.meta` dosyaları oluşturur. Defold'da meta dosyaları yoktur. Defold'daki proje, diskte olduğu hâliyle klasör yapınızdan ibarettir ve `Assets` bölmesi her zaman bu yapıyı yansıtır.
+
+### Kaynak biçimleri
+
+Unity varlıkları içe aktarır ve arka planda başka biçimlere dönüştürür. Defold'da doğrudan kaynaklarla (`.png`, `.gltf`, `.wav`, `.ogg` vb.) çalışır ve bunları `Components` öğelerine atarsınız.
+
+Unity tek bir görüntüyü Sprite olarak kullanabilir. Defold'da görüntüler doğrudan model/örgü bileşenlerinde kullanılabilir; ancak sprite/GUI/karo haritası/parçacık bileşenleri bir atlas (paketlenmiş dokular) veya karo kaynağı (ızgara tabanlı karolar) gerektirir.
+
+Defold kaynaklarının çoğu metin olarak saklanır; bu da sürüm kontrolüne uygundur.
+
+### Kütüphane önbelleği
+
+Unity, içe aktarılan varlıklar için bir `Library/` klasörü oluşturur. Defold'da böyle bir dizin yoktur; varlıklar derleme sırasında işlenir ve çıktılar derleme klasöründe (ve isteğe bağlı yerel/uzak derleme önbelleklerinde) önbelleğe alınır.
+
+---
+
+## Kod yazma
+
+`MonoBehaviour` betiklerinin Defold'daki karşılığı bir betik bileşenidir; ancak bilinmesi gereken bazı farklar vardır.
+
+### Lua
+
+Defold betikleri, dinamik türlere sahip ve birden çok programlama paradigmasını destekleyen [Lua](https://www.lua.org/) dilinde yazılır.
+
+Birkaç Lua betiği türü vardır: `*.script`, `*.gui_script`, `*.render_script`, `*.editor_script` ve `*.lua` modülleri.
+
+### Teal
+
+Defold, Lua'nın statik türlere sahip bir lehçesi olan [Teal](https://teal-language.org/) gibi Lua kodu üreten kaynak kod dönüştürücülerinin kullanımını destekler; ancak bu işlev daha sınırlıdır ve ek kurulum gerektirir. Ayrıntılar [Teal eklenti deposunda](https://github.com/defold/extension-teal) bulunur.
+
+### C++/C# yerel kod eklentileri
+
+Defold'da yerel kod eklentileri, hedef platforma bağlı olarak başka birkaç dilde yazılabilir: C, C++, C#, Objective-C, Java veya JS. C# diline çok hâkimseniz oyun mantığınızın çoğunu bir C# eklentisinde yapılandırıp yalnızca küçük bir Lua başlangıç betiğinden çağırmak teknik olarak mümkündür; ancak bu, ileri düzey API bilgisi gerektirir ve yeni başlayanlara önerilmez.
+
+Eklentiler hakkında daha fazla bilgi için [Defold yerel kod eklentileri kılavuzunu](/manuals/extensions/) okuyun.
+
+
+### MonoBehaviour betiklerinden Lua modüllerine
+
+Unity açık bir betik yazma modeline sahiptir. `MonoBehaviour` düzenleyicide davranış eklemenin başlıca yolu olduğu için birçok Unity projesi, önemli her GameObject için denetleyici tarzında bir betikle başlar: `PlayerController`, `EnemyController`, `BulletController`, `GameManager`, `EnemyManager` vb.
+
+Defold, varsayılan mimarisi konusunda daha belirli bir yaklaşım benimser. Bir oyun nesnesinin bir `.script` dosyası olabilir; ancak her oyun nesnesi için betik oluşturmanız nadiren gerekir. Çünkü Defold'un güçlü adresleme ve ileti aktarımı sayesinde Defold'daki tek bir betik, kendilerine ait hiçbir betikleri olmasa bile yüzlerce veya binlerce başka nesneyi ve bunların bileşenlerini yönetebilir. Her oyun nesnesine karşılık bir betik oluşturmak nadiren gereklidir ve yarardan çok zarar getiren karmaşıklığa yol açabilir.
+
+Yeniden kullanılabilir oynanış davranışı için Unity geliştiricileri sıkça bileşime (composition) yönelir: aynı GameObject nesnesine eklenen `Health.cs`, `Attack.cs` veya `EnemyFinder.cs` gibi daha küçük `MonoBehaviour` betikleri kullanırlar. Defold'da genellikle eklenmiş tek bir `.script` dosyasını barındırıcı veya koordinatör olarak tutar, yeniden kullanılabilir mantığı da normal Lua modüllerine yerleştirirsiniz.
+
+Unity'de bu bileşim şöyle görünebilir:
+
+```text
+Player
+├── PlayerMovement.cs
+├── PlayerAttack.cs
+├── EnemyFinder.cs
+└── Health.cs
+```
+
+Defold'da aynı sorumluluklar genellikle eklenmiş tek bir betik ile yeniden kullanılabilir modüller arasında paylaştırılır:
+
+```text
+player.go
+├── sprite
+├── collisionobject
+└── player.script
+
+modules/
+├── player_movement.lua
+├── player_attack.lua
+├── enemy_finder.lua
+└── health.lua
+```
+
+Eklenmiş `.script`, barındırıcı veya koordinatör hâline gelir. Lua modülleri, Unity'deki küçük `MonoBehaviour` betiklerinin çoğunlukla tek bir sorumluluk içermesine benzer şekilde yeniden kullanılabilir mantık içerir.
+
+```lua
+local movement = require "modules.player_movement"
+local attack = require "modules.player_attack"
+local finder = require "modules.enemy_finder"
+local health = require "modules.health"
+
+function init(self)
+    self.movement = movement.new(self)
+    self.attack = attack.new(self)
+    self.finder = finder.new(self)
+    self.health = health.new(self)
+end
+
+function update(self, dt)
+    self.movement:update(dt)
+    self.attack:update(dt)
+    self.finder:update(dt)
+end
+
+function on_message(self, message_id, message, sender)
+    self.health:on_message(message_id, message, sender)
+    self.attack:on_message(message_id, message, sender)
+end
+```
+
+Önemli fark, Defold'un modüler mimariyi engellemesi değildir; bileşimin nerede yapıldığı ve oynanış kodunun nasıl iletişim kurduğudur:
+
+| Unity | Defold |
+|---|---|
+| Inspector içinde birkaç `MonoBehaviour` betiği ekleyin | Bir `.script` ekleyin ve Lua modüllerini kodda bir araya getirin |
+| Davranışları bağlamak için `GetComponent<T>()` veya serileştirilmiş alanları kullanın | Modül örneklerini `self` üzerinde saklayın ve nesneler arasında adresler/iletiler kullanın |
+| Her bileşen kendi yaşam döngüsü yöntemlerine sahip olabilir | Barındırıcı betik `init()`, `update()`, `on_message()`, `final()` vb. çağrıları yönlendirir |
+| Birçok mimari tarz mümkündür | İleti odaklı, açıkça kodda yapılan bileşim yaygın uygulamadır |
+
+Özellikle Inspector içinde bileşenler ekleyerek davranış yapılandırmaya alışkınsanız bu yaklaşım başta alışılmadık gelebilir. Unity'de görsel olarak yapılandırabileceğiniz birçok şey Defold'da kod üzerinden oluşturulabilir, bağlanabilir, etkinleştirilebilir, devre dışı bırakılabilir veya güncellenebilir. Defold'un ileti sistemi mantığın birbirinden ayrılmasına yardımcı olur: gönderen bir adrese veri gönderir, alıcı ise bu veriyle ne yapacağına karar verir.
+
+Bu yaklaşım önerilse de zorunlu değildir; oyun nesnesi başına birden çok betik eklemek veya nesne yönelimli programlama tarzına yaklaşmak dahil, betiklerinizi istediğiniz gibi yazabilirsiniz. Hatta bu konuda size yardımcı olacak kütüphaneler de vardır ([defold-oop](https://github.com/xiyoo0812/defold-oop) veya [lua-class](https://github.com/d954mas/lua-class)).
+
+Mermiler, düşmanlar, parçacıklar, karolar veya basit etkileşimli öğeler gibi aynı türden çok sayıda nesne için her nesneye ayrı bir betik vermek yerine bunları bir sistem ya da yönetici betiğinden yönetmek çoğunlukla daha iyidir. Bir nesnenin kendine ait anlamlı durumu ve davranışı varsa nesne başına betik kullanın. Yeniden kullanılabilir mantık istediğinizde modülleri kullanın. Tek bir betik birçok nesneyi verimli şekilde yönetebiliyorsa sistem betiklerini kullanın.
+
+Birden çok birimi yönetmek için Defold betik özelliklerinin, fabrikaların, adreslemenin ve iletilerin nasıl kullanılacağını gösteren bir örneği [burada](https://defold.com/examples/factory/spawn_manager/) bulabilirsiniz.
+
+Kod yazma hakkında yararlı kılavuzlar:
+- [Betik kılavuzu](/manuals/script/)
+- [Kod yazma](/manuals/writing-code/)
+- [Hata ayıklama](/manuals/debugging/)
+
+
+### Yerleşik kod düzenleyicisi
+
+Defold düzenleyicisi; kod tamamlama, sözdizimi vurgulama, belgelere hızlı erişim, statik kod denetimi ve yerleşik hata ayıklayıcı sunan bir kod düzenleyicisi içerir.
+
+![Defold kod düzenleyicisi](/images/editor/code-editor.png)
+
+### VS Code ve diğer düzenleyiciler
+
+İsterseniz kendi harici düzenleyicinizi kullanmaya devam edebilirsiniz. Tüm Defold bileşenleri ve ilgili dosyalar metin tabanlı olduğundan bunları herhangi bir metin düzenleyicisiyle düzenleyebilirsiniz; ancak Protobuf tabanlı oldukları için doğru biçimlendirmeye ve öğe yapısına uymanız gerekir.
+
+VS Code'a alışkınsanız ve oyununuzun kodunu yazmak için onu kullanmak istiyorsanız Visual Studio Marketplace üzerinden [Defold Kit](https://marketplace.visualstudio.com/items?itemName=astronachos.defold) veya [Defold Buddy](https://marketplace.visualstudio.com/items?itemName=mikatuo.vscode-defold-ide) kurmanızı öneririz.
+
+Defold düzenleyicisinin tercihlerini, metin dosyalarını varsayılan olarak VS Code'da (veya başka bir harici düzenleyicide) açacak şekilde de yapılandırabilirsiniz. Ayrıntılar için [Düzenleyici tercihleri](/manuals/editor-preferences/) bölümüne bakın.
+
+### Gölgelendiriciler - GLSL
+
+Defold, Unity'ye benzer şekilde `Vertex Programs` ve `Fragment Programs` gölgelendiricileri için GLSL (OpenGL Shading Language) kullanır. Defold, Unity gibi bir Shader Graph sunmasa da (bu bir dezavantaj olabilir) kod yazarak eşdeğer gölgelendiriciler oluşturabilirsiniz.
+
+Gölgelendiriciler hakkında daha fazla bilgi için [Gölgelendiriciler kılavuzunu](/manuals/shader) okuyun.
+
+#### Materyaller
+
+Defold, `.fp` ve `.vp` gölgelendiricilerini, örnekleyicileri (dokuları) ve Vertex Attributes veya Constants gibi diğer öğeleri birbirine bağlayan bir `Material` kavramı kullanır.
+
+Materyaller hakkında daha fazla bilgi için [Materyaller kılavuzunu](/manuals/material) okuyun.
+
+---
+
+## İleti sistemi
+
+Defold'da nesneler birbirlerine doğrudan başvuru tutmaz. `GetComponent`, betikler arasında nesneler arası yöntem çağrıları veya Unity'deki gibi genel sahne erişimi yoktur.
+
+Bunun yerine betikler ileti aktarımı yoluyla iletişim kurar: yöntem çağırmak veya bileşenlere doğrudan erişmek yerine diğer betiklere iletiler gönderirsiniz. Bu nesnelerin iletilerle ne yapacağı kendilerine bağlıdır.
+
+Bu yaklaşım başta yabancı gelebilir; ancak gevşek bağlılığı teşvik eder ve sıkı karşılıklı bağımlılıkları azaltır.
+
+
+### İleti gönderme
+
+Unity'de iletişim genellikle şöyle görünür:
+
+```c#
+var enemy = GameObject.Find("Enemy");
+enemy.GetComponent<EnemyAI>().TakeDamage(10);
+```
+
+Yani nesneler birbirlerine doğrudan başvurabilir ve diğer betiklerdeki yöntemleri çağırabilir. Her şey ortak bir sahne uzayında bulunur.
+
+Defold'da bir betikten başka bir betiğe (veya başka bir bileşene) ileti gönderirsiniz:
+
+```lua
+msg.post("#my_component", "my_message", { my_name = "Defold" })
+```
+
+Ve bu iletileri betikte işleyebilirsiniz:
+
+```lua
+function on_message(self, message_id, messsage)
+    if message_id == hash("my_message") then
+        print("Hello ", message.my_name)
+    end
+end
+```
+
+Şimdilik `#` ve `hash` öğelerini dikkate almayın; bunları daha sonra ele alacağız. Geri kalanı anlaşılır olmalıdır. Örneği oluşturulmuş herhangi bir oyun nesnesinin herhangi bir bileşenine (aynı betiğe bile) ileti gönderebilirsiniz.
+
+#### Betik dışındaki bileşenler
+
+Bazen `Sprite` veya `Collision` gibi bileşenlere, örneğin bunları etkinleştirmek veya devre dışı bırakmak için ileti gönderirsiniz. Bazen de `Components` öğeleri, örneğin bir çarpışma olduğunda bunu işleyebilmeniz için betiğinize ileti gönderir. Defold, motor olayları ve oynanış iletişimi için dahili olarak aynı ileti sistemini kullanır. 
+
+Adresleme ve kullanım kuralları farklı olsa da ileti sistemi Unity'nin SendMessage veya olay sistemlerine bir ölçüde benzer.
+
+Daha fazla ayrıntı için [İleti aktarımı kılavuzunu](/manuals/message-passing/) okuyabilirsiniz.
+
+### Adresleme
+
+Defold'da nesneler ve bileşenler, URL olarak bilinen adreslerle tanımlanır.
+
+Örneği oluşturulmuş her nesne ve bileşenin kendine ait benzersiz bir adresi vardır; bunları bulmak için bir sahne grafında gezinmeniz gerekmez. Bu, adreslemeyi açık ve doğrudan hâle getirir.
+
+Defold'da basit bir URL şöyle görünebilir:
+```lua
+"/player"
+```
+
+Bu, *kavramsal olarak* şuna benzer:
+```c#
+GameObject.Find("player")
+```
+
+Şimdi adreslerde neden `"/"` veya `"#"` kullanıldığını açıklama zamanı.
+
+Defold URL adresi ([URL](https://en.wikipedia.org/wiki/URL) yapısına benzer şekilde) üç bölümden oluşur:
+
+```yaml
+socket: /path #fragment
+```
+
+Veya Defold adlandırmasına daha yakın biçimde açıklarsak:
+
+```yaml
+collection: /gameobject #component 
+```
+Yukarıdaki açıklamalara yalnızca bu 3 bölümü görsel olarak ayırmak için boşluklar eklenmiştir.
+
+Basitçe ifade etmek gerekirse:
+1. `collection:`, sonunda `:` bulunacak şekilde koleksiyon bağlamını tanımlar.
+2. `/path`, tanımlayıcıdan önce `/` gelecek şekilde oyun nesnesini tanımlar.
+3. `#fragment`, tanımlayıcıdan önce `#` gelecek şekilde o nesne üzerindeki belirli bileşeni (betik, sprite veya çarpışma bileşeni gibi) tanımlar.
+
+#### Statik adres
+
+Bu tanımlayıcılar her öğe oluşturulduğunda belirlenir ve üst-alt nesne ilişkilerini değiştirseniz bile hiçbir zaman değişmez. Bunları dosyalardaki `Id` özelliğinde ayarlayabilir veya çalışma sırasında örnek oluştururken yapılan `factory.create` ya da `collectionfactory.create` çağrılarından alabilirsiniz.
+
+#### Göreli adresleme
+
+Her zaman tam bir URL kullanmanız gerekmez.
+
+Aynı koleksiyon (aynı *dünya*) içinde ileti gönderiyorsanız soket bölümünü atlayabilirsiniz:
+
+```yaml
+/gameobject #component
+```
+Aynı oyun nesnesi içindeki bir bileşene gönderiyorsanız oyun nesnesi bölümünü de atlayabilirsiniz:
+
+```yaml
+#component
+```
+
+İki yararlı kısa gösterim şunlardır:
+- Bu *betik* bileşenine göndermek için `#`
+- Bu *oyun nesnesindeki* tüm bileşenlere göndermek için `.`
+
+Göreli adresleme ve kısa gösterimler, tam yollar belirtmeden farklı bağlamlarda ve oyun nesnelerinde yeniden kullanılabilen URL adresleri yazmanızı sağlar.
+
+### GUI ve işleme sistemine ileti gönderme
+
+Defold GUI dünyasını oyun nesnesi dünyasından ayırdığı için oyun nesnelerinin `.scripts` dosyalarından `.gui_scripts` dosyalarına da ileti gönderebilirsiniz.
+
+Ayrıca `@` ile başlayan bir tanımlayıcı kullanarak özel sistem ad alanlarına ileti gönderebilirsiniz. Örneğin işleme sistemine `@render`: üzerinden erişebilir ve bunu, varsayılan işleme betiğinde izdüşümü değiştirmek gibi belirli yerleşik işleme özelliklerini yönetmek için kullanabilirsiniz:
+
+```lua
+msg.post("@render:", "use_stretch_projection", { near = -1, far = 1 })
+```
+
+Daha fazla ayrıntıyı [Adresleme kılavuzunda](/manuals/addressing/) bulabilirsiniz.
+
+---
+
+## Prefablar ve örnekler
+
+Unity, sahnedeki herhangi bir şeyin örneğini statik veya dinamik olarak oluşturabilir; Defold da aynısını yapabilir. Unity'de bir prefab alıp `Instantiate(prefab)` çağrısını yaparsınız. Defold'da içerik örnekleri oluşturmak için 3 bileşen vardır:
+
+- `Factory` - verilen bir prototipten, yani bir `*.go` dosyasından (prefab), **tek bir oyun nesnesinin** örneğini oluşturur.
+- `Collection Factory` - verilen bir prototipten, yani bir `*.collection` dosyasından, üst-alt nesne ilişkilerine sahip **bir oyun nesnesi kümesinin** örneklerini oluşturur.
+- `Collection Proxy` - bir `*.collection` dosyasından yeni bir *dünyayı* **yükler** ve örneğini oluşturur.
+
+### Fabrika
+
+`Prototype` özelliği uygun oyun nesnesi dosyasına ayarlanmış bir `Factory` bileşeni tanımladıktan sonra çalışma sırasında nesne oluşturmak, kodda şu çağrıyı yapmak kadar basittir:
+
+```lua
+factory.create("#my_factory")
+```
+
+Bu çağrı bileşenin adresini kullanır; bu örnekte `"#my_factory"` tanımlayıcısını kullanan göreli bir yoldur.
+
+Yeni oluşturulan örneğin tanımlayıcısını döndürür; dolayısıyla bunu daha sonra kullanmanız gerekiyorsa bir değişkende saklamanız yararlı olur:
+
+```lua
+local new_instance_id = factory.create("#my_factory")
+```
+
+Defold'da nesneleri elle bir havuzda yönetmeniz gerekmediğini unutmayın; motor havuzlamayı sizin için dahili olarak yapar.
+
+Daha fazla ayrıntı için [Fabrika kılavuzuna](/manuals/factory/) göz atın. 
+
+### Koleksiyon fabrikası
+
+`Factory` ile `Collection Factory` bileşeni arasındaki fark, koleksiyon fabrikasının aynı anda **birden çok** oyun nesnesi oluşturabilmesi ve oluşturma sırasında `*.collection` dosyasında tanımlanan üst-alt nesne ilişkilerini kurabilmesidir.
+
+Unity'de böyle bir ayrım yoktur; Defold'un koleksiyon fabrikasıyla eşleşen özel bir kavram bulunmaz. En yakın benzetme, bir nesne hiyerarşisi içeren iç içe bir prefabdır.
+
+Oluşturulan tüm örneklerin tanımlayıcılarını içeren bir **tablo** döndürür:
+
+```lua
+local spawned_instances = collectionfactory.create("#my_collectionfactory")
+```
+
+Daha fazla ayrıntı için [Koleksiyon fabrikası kılavuzuna](/manuals/collection-factory/) göz atın.
+
+#### Örneklerin özel özellikleri
+
+`factory.create()` veya `collectionfactory.create()` çağrısında konum, dönme, ölçek ve betik özellikleri gibi isteğe bağlı parametreler de belirtebilirsiniz. Böylece örneğin tam olarak nasıl ve nerede ortaya çıkacağını ve nasıl davranacağını yönetebilirsiniz. Örneğin:
+
+```lua
+local scale_2d = vmath.vector3(0.5, 0.5, 1.0)
+factory.create("#my_factory", my_position, my_rotation, my_properties, scale_2d)
+```
+
+İsteğe bağlı bağımsız değişkenlerin sırası önce özellikler, ardından ölçektir. Bir 2B nesnenin yalnızca X ve Y eksenlerini ölçeklerken Z değeri açıkça `1.0` olarak ayarlanmış bir `vector3` kullanın; sayısal bir ölçek üç eksene de eşit şekilde uygulanır.
+
+#### Dinamik yükleme
+
+Hem `Factory` hem de `Collection Factory` bileşenlerinde, büyük varlıklarının yalnızca gerektiğinde belleğe alınması ve artık kullanılmadıklarında bellekten kaldırılması için bir Prototype öğesini dinamik kaynak yükleme amacıyla işaretleyebilirsiniz.
+
+Daha fazla ayrıntı için [Kaynak yönetimi kılavuzuna](/manuals/resource/) göz atın. 
+
+### Koleksiyon vekili
+
+`Collection Proxy` belirli bir `*.collection` dosyasına başvurur; ancak nesneleri (fabrikalar gibi) *geçerli dünyaya* eklemek yerine **yeni bir oyun dünyası yükler ve örneğini oluşturur**. Bu, Unity'de bir sahnenin tamamını yüklemeye bir ölçüde benzer; ancak ayrım daha katıdır.
+
+Unity'de mevcut sahnelere ek olarak bir sahneyi şöyle yükleyebilirsiniz:
+
+```c#
+SceneManager.LoadSceneAsync("Level2", LoadSceneMode.Additive);
+```
+
+Defold'da yeni koleksiyonu yalnızca `Collection Proxy` bileşenine bir ileti göndererek yüklersiniz:
+
+```lua
+msg.post("#myproxy", "load")
+```
+
+1. Vekile `"load"` iletisini (veya eş zamansız yükleme için `"async_load"`) gönderdiğinizde motor yeni bir dünya için bellek ayırır, o koleksiyondaki her şeyin örneğini orada oluşturur ve dünyayı yalıtılmış tutar.
+2. Yükleme tamamlandığında vekil, dünyanın hazır olduğunu belirten bir `"proxy_loaded"` iletisi gönderir.
+3. Ardından genellikle, yeni dünyadaki nesnelerin normal yaşam döngülerine başlaması için `"init"` ve `"enable"` iletilerini gönderirsiniz.
+
+Yüklenen dünyalar arasında iletişim kurmak için dünya adını (`collection:`, URL adresinin ilk bölümü) içeren URL adresleriyle açıkça ileti göndermeniz gerekir.
+
+Bu yalıtım, bölüm geçişlerini, mini oyunları veya büyük modüler sistemleri uygularken büyük bir avantaj sağlayabilir; çünkü istenmeyen etkileşimleri önler ve gerektiğinde güncelleme zamanlamasının ayrı olarak yönetilmesine de izin verir (ör. duraklatma veya ağır çekim için).
+
+Unity'de daha önce birden çok sahne kullanıp bunların bağımsız davranmasına ihtiyaç duyduysanız `Collection Proxy` bileşenini bu kavramı doğrudan Defold'a getirmenin bir yolu olarak düşünebilirsiniz.
+
+Daha fazla ayrıntı için [Koleksiyon vekili kılavuzuna](/manuals/collection-proxy/) göz atın.
+
+---
+
+## Uygulama yaşam döngüsü
+
+Unity'nin `Awake`, `Start`, `Update`, `FixedUpdate`, `LateUpdate`, `OnDestroy` veya `OnApplicationQuit` gibi yaşam döngüsü olaylarını biliyorsunuz.
+
+Defold'un da iyi tanımlanmış bir uygulama yaşam döngüsü vardır; ancak kavramlar ve terimler farklıdır. Defold yaşam döngüsü aşamalarını, başlangıç işlemleri sırasında, her karede ve sonlandırma işlemleri sırasında motor tarafından çağrılan bir dizi önceden tanımlanmış Lua geri çağırımı üzerinden sunar.
+
+İşte bir karşılaştırma:
+
+| Defold | Unity | Açıklama |
+|-|-|-|
+| `init()` | `Awake()` / `Start()` / `OnEnable()`| Defold'un başlangıç işlemleri için tek bir giriş noktası ve geri çağırımı vardır: init(). Her bileşen oluşturulduğunda çağrılır. |
+| `on_input` | Girdi yöntemleri | Defold, [betik için girdi odağı ayarlandığında](/manuals/input/#input-focus) girdileri alır. Güncelleme döngüsünde ilk olarak işlenir. |
+| `fixed_update()` | `FixedUpdate()` | Sabit zaman adımıyla çağrılır. Defold'da etkinleştirmek için `Use Fixed Timestep` ayarını yapmanız gerekir - [ayrıntılar](https://defold.com/manuals/project-settings/#use-fixed-timestep). 1.12.0'dan itibaren `update()` çağrısından önce çalışır. |
+| `update()` | `Update()` | Geçen süreyle birlikte kare başına bir kez çağrılır. |
+| `late_update()` | `LateUpdate()` | `update()` çağrısından sonra, kare işlenmeden hemen önce çağrılır. 1.12.0'dan itibaren mevcuttur. |
+| `on_message` | İleti alıcısı | Defold'un iletileri almak için kullandığı temel geri çağırımdır. Kuyrukta herhangi bir ileti olduğunda işlenir. |
+| `final` | `OnDisable` / `OnDestroy` / `OnApplicationQuit` | Defold, oyun nesnesi çalışma sırasında (`go.delete()` kullanılarak) silindiğinde veya dünya/koleksiyon bellekten kaldırıldığında her bileşen için, uygulama sonlandırılırken de kalan tüm nesneler için `final()` geri çağırımlarını çağırır. |
+
+::: sidenote
+Birden çok bileşenin başlangıç işlemleri/güncellemesi/kaldırılması aynı anda yapıldığında Defold'un bileşenler arasında herhangi bir yürütme sırasını garanti etmediğini unutmayın. Birbirine bağımlılığı azaltılmış tasarım önerilir.
+:::
+
+### Başlangıç işlemleri
+
+Defold'un `init()` geri çağırımını, Unity'nin `Awake()`, `Start()` ve `OnEnable()` öğelerini tek bir giriş noktasında birleştiren bir yapı olarak düşünün. Motor bu noktada her şeyi zaten hazırlamıştır ve bileşeninizin durumunu güvenle hazırlayabilirsiniz.
+
+### İletiler ne zaman işlenir?
+
+`init()` içinde ileti gönderebildiğiniz için iletiler ilk kez başlangıç işlemlerinin hemen ardından dağıtılır.
+
+İletiler daha sonra her dahili işleme döngüsünün ardından, kuyrukta bir şey olduğu her seferde işlenir; bu nedenle örneğin `on_message()` bir güncelleme döngüsünde birkaç kez bile çağrılabilir.
+
+### Güncelleme döngüsü
+
+Defold her karede bir dizi işlem yürütür: girdileri işler, iletileri dağıtır, betik ve GUI güncellemelerini tetikler, fiziği ve dönüşümleri uygular ve sonunda grafikleri işler.
+
+### Sonlandırma işlemleri
+
+Defold'da temizleme her zaman silmeye veya dünyanın bellekten kaldırılmasına bağlıdır ve bileşen başına tek çıkış kancanız `final()` geri çağırımıdır.
+
+Unity'nin modelinden ince bir farkı, bir bileşenin devre dışı bırakılması ile uygulamanın tamamının kapanması arasında ayrım olmamasıdır.
+
+### İşleme
+
+İşleme betiği (`*.render_script`), işleme hattının bir parçasıdır ve kendi `init()`, `update()` ve `on_message()` geri çağırımlarıyla yaşam döngüsüne de katılır; ancak bu geri çağırımlar işleme iş parçacığında çalışır ve oyun nesnesi ile GUI betiği mantığından ayrıdır.
+
+Daha fazla ayrıntı için [Uygulama yaşam döngüsü kılavuzunu](/manuals/application-lifecycle/) okuyun.
+
+---
+
+## GUI
+
+Defold'un GUI sistemi, UI Toolkit veya Canvas kullanan uGUI'ye benzer şekilde; menüler, üst katmanlar, iletişim kutuları ve diğer öğelerden oluşan kullanıcı arayüzlerine ayrılmış tek ve bütünlüklü bir çatıdır.
+
+GUI bir bileşendir ve oyun nesneleriyle koleksiyonlardan ayrıdır. Oyun nesneleri yerine, hiyerarşi içinde düzenlenmiş ve bir GUI betiğiyle yönetilen GUI düğümleriyle çalışırsınız.
+
+### GUI düğümleri
+
+Defold'da bir `*.gui` bileşen dosyasını açtığınızda `"GUI nodes"` öğelerini yerleştirdiğiniz bir tuval sunulur. Bunlar GUI'nin yapı taşlarıdır. Şu türlerde GUI düğümleri ekleyebilirsiniz:
+
+- Box (dokuya sahip dikdörtgen şekil)
+- Text (herhangi bir yazı tipiyle)
+- Pie (dokuya sahip, radyal dolgu sağlayan daire dilimi öğesi)
+- ParticleFX
+- Template (GUI prefabı gibi, iç içe yerleştirilmiş başka bir `.gui` dosyasının tamamı)
+- ve Spine eklentisini kullanırken Spine düğümü.
+
+### GUI betiği
+
+GUI bileşeninin GUI betikleri için özel bir özelliği vardır: bileşen başına bir `*.gui_script` dosyası atarsınız ve bu, bileşenin davranışını değiştirmenizi sağlar. Dolayısıyla normal betiklere çok benzer; ancak oyun nesnesi betiklerine yönelik olan `go.*` ad alanını kullanmaz. Bunun yerine yalnızca GUI betiklerinin (`*.gui_script`) içinde çalışan özel `gui.*` ad alanı API'sini kullanır. Bunu, Canvas kullanan Unity UI (uGUI) gibi ayrı bir sahne olarak düşünebilirsiniz.
+
+### GUI işleme
+
+GUI öğeleri, oyun kamerasından bağımsız olarak ve genellikle ekran uzayında işlenir; ancak bu davranış özel işleme hatlarında değiştirilebilir.
+
+Daha fazla ayrıntı için [GUI kılavuzunu](/manuals/gui/) okuyun.
+
+## Sorting Layers nerede?
+
+Unity'den geçerken bu konu çok sık kafa karışıklığına yol açar.
+
+GUI bileşenlerinin `Layers` özelliği vardır ve bu, Unity'deki "Sorting Layers" ile neredeyse aynı şekilde çalışır; ancak `Sprites`, `Tilemaps`, `Models` vb. diğer bileşenler için doğrudan bir karşılığı yoktur.
+
+Bunun yerine genellikle şunları birleştirirsiniz:
+- Varsayılan kamera kullanırken Z ekseni veya Camera bileşeni kullanırken derinlik üzerinden ayrıntılı sıralama.
+- Materyal etiketlerine göre neyin çizileceğini seçmek için işleme yüklemlerini kullanan işleme betiği üzerinden genel sıralama.
+
+Ancak çok sayıda etiketle Unity Sorting Layers davranışını taklit etmeniz önerilmez; çünkü Defold'da etiketler işleme düzeyinde bir mekanizmadır. Bunları aşırı kullanmak toplu çizimi bozabilir ve çizimin ek yükünü artırabilir.
+
+---
+
+## Buradan sonra nereye geçmeli?
+
+- [Defold örnekleri](/examples)
+- [Öğreticiler](/tutorials)
+- [Kılavuzlar](/manuals)
+- [API başvuru belgeleri](/ref/go)
+- [Sık sorulan sorular](/faq/faq)
+
+Sorularınız varsa veya takılırsanız [Defold Forumu](//forum.defold.com) veya [Discord](https://defold.com/discord/) yardım istemek için çok iyi yerlerdir.

--- a/docs/tr/manuals/version-control.md
+++ b/docs/tr/manuals/version-control.md
@@ -1,0 +1,22 @@
+---
+title: Sürüm kontrolü
+brief: Bu kılavuz, Defold projelerinde Git kullanımını ve düzenleyicide yerel değişikliklerin incelenmesini ele alır.
+---
+
+# Sürüm kontrolü
+
+Defold projeleri [Git](https://git-scm.com) ile iyi çalışır, ancak eşitleme düzenleyicinin dışında yapılır. Klonlamak (clone), uzak değişiklikleri almak (fetch), değişiklikleri çekmek (pull), değişiklik kaydı oluşturmak (commit), değişiklikleri göndermek (push), dallar oluşturmak ve çakışmaları çözmek için tercih ettiğiniz Git istemcisini veya komut satırını kullanın.
+
+## Değişen dosyalar
+
+Proje dizini, en az bir değişiklik kaydı bulunan bir Git çalışma ağacının (working tree) kök dizini olduğunda Defold, yoksayılmayan ve eklendiği, değiştirildiği, silindiği veya yeniden adlandırıldığı tespit edilen dosyaları düzenleyicinin *Changed Files* bölmesinde listeler. Bu girdileri, diskteki dosyaları doğrudan geçerli değişiklik kaydıyla (`HEAD`) karşılaştırarak belirler; bu nedenle bir değişikliği hazırlama alanına eklemek (staging) listeyi değiştirmez. Birleştirme çakışmalarını harici bir Git istemcisinde çözün.
+
+![değişen dosyalar](images/workflow/changed_files.png)
+
+Değiştirilmiş veya yeniden adlandırılmış dosyalardan tam olarak birini seçin ve metin farkını görüntülemek için <kbd>Diff</kbd> düğmesine tıklayın. Seçilen çalışma ağacı ve indeks (index) değişikliklerini iptal etmek için <kbd>Revert</kbd> düğmesine tıklayın. İzlenen dosyalar `HEAD` durumuna geri yüklenir; `HEAD` içinde bulunmayan dosyalar, ekleme olarak hazırlama alanına alınmış olsalar da olmasalar da silinir; yeniden adlandırmalarda ise yeni yol silinir ve eski yol geri yüklenir. Bu işlem düzenleyicide geri alınamaz; bu nedenle ihtiyaç duyabileceğiniz çalışmalar için değişiklik kaydı oluşturun veya bunları yedekleyin.
+
+## Git
+
+Git, Defold'un metin tabanlı proje dosyalarını verimli biçimde saklar. PSD veya ses prodüksiyonu dosyaları gibi sık değişen büyük ikili varlıklar (binary assets), depo geçmişinin yine de hızla büyümesine neden olabilir. Büyük çalışma dosyaları için Git LFS veya ayrı bir depolama ve yedekleme çözümü kullanmayı değerlendirin.
+
+*Changed Files* bölmesi yalnızca yerel durum, fark görüntüleme ve değişiklikleri geri alma işlemlerini sağlar. Değişiklik kayıtlarının uzak bir depoya gönderilip gönderilmediğini bilmez ve fetch, pull, commit veya push işlemlerini yapmaz. Bu işlemleri harici bir Git istemcisinde veya komut satırından gerçekleştirin. Varsayılan olarak Defold, yeniden odak kazandığında harici değişiklikleri yeniden yükler ve bölmeyi yeniler. *Load External Changes on App Focus* devre dışıysa *File ▸ Load External Changes* seçeneğini seçin.

--- a/docs/tr/manuals/websocket-connections.md
+++ b/docs/tr/manuals/websocket-connections.md
@@ -1,0 +1,5 @@
+---
+title: WebSocket bağlantıları
+brief: Bu kılavuz, WebSocket bağlantılarının nasıl kullanılacağını açıklar.
+---
+[WebSocket eklentisi kılavuzuna](/extension-websocket) taşındı.

--- a/docs/tr/manuals/webview.md
+++ b/docs/tr/manuals/webview.md
@@ -1,0 +1,6 @@
+---
+title: Defold'da WebView görünümleri
+brief: WebView görünümleri, web sayfalarını yükleyip oyunlarınızın üzerinde bir katman (overlay) olarak görüntülemenizi sağlar. Ayrıca arka planda kullanıcı tarafından sağlanan JavaScript kodunu çalıştırabilir. Bu kılavuz, Defold'un resmî WebView eklentisini, API'sini ve işlevlerini açıklar.
+---
+
+WebView belgeleri [taşındı](/extension-webview).

--- a/docs/tr/manuals/windows.md
+++ b/docs/tr/manuals/windows.md
@@ -1,0 +1,43 @@
+---
+title: Windows platformu için Defold geliştirme
+brief: Bu kılavuz, Windows'ta Defold uygulamalarının nasıl derlenip çalıştırılacağını açıklar
+---
+
+# Windows için geliştirme
+
+Windows platformu için Defold uygulamaları geliştirmek, dikkat edilmesi gereken çok az noktanın bulunduğu basit bir süreçtir.
+
+## Proje ayarları
+
+Windows'a özgü uygulama yapılandırması, *game.project* ayarlar dosyasının [Windows bölümünden](/manuals/project-settings/#windows) yapılır.
+
+## Uygulama simgesi
+
+Bir Windows oyununda kullanılan uygulama simgesinin .ico biçiminde olması gerekir. [ICOConvert](https://www.icoconverter.com/) veya [AConvert](https://www.aconvert.com/icon/png-to-ico/) gibi bir çevrimiçi araç kullanarak .png dosyasından kolayca .ico dosyası oluşturabilirsiniz. Bir görüntü yükleyin ve en azından şu simge boyutlarını kullanın: 16x16, 24x24, 32x32, 48x48, 256x256.
+
+Kaynak: [Microsoft - Windows uygulama simgesi oluşturma](https://learn.microsoft.com/en-us/windows/apps/design/style/iconography/app-icon-construction#icon-sizes-win32)
+
+### ImageMagick yazılım paketiyle yerel olarak .ico dosyası oluşturma.
+[ImageMagick](https://www.imagemagick.org/), dijital görüntüleri düzenlemek ve işlemek için kullanılan ücretsiz, açık kaynaklı bir yazılım paketidir.
+
+1. ImageMagick kurun
+  * Linux: `apt` kullanarak kurun
+```
+sudo apt install imagemagick
+```
+  * Windows: [https://imagemagick.org/script/download.php#windows](https://imagemagick.org/script/download.php#windows) adresinden indirin:
+  * macOS: `brew` kullanarak kurun:
+```
+brew install imagemagick
+```
+
+2. PNG simgenizi hazırlayın.
+3. [convert](https://www.imagemagick.org/script/convert.php) aracını kullanarak PNG dosyasını ICO biçimine dönüştürün:
+```bash
+magick icon_256x256px.png -compress None -define icon:auto-resize=256,128,96,64,48,32,24,16 favicon.ico
+```
+
+
+
+## Sık sorulan sorular
+:[Windows FAQ](../shared/windows-faq.md)

--- a/docs/tr/manuals/working-offline.md
+++ b/docs/tr/manuals/working-offline.md
@@ -1,0 +1,55 @@
+---
+title: Çevrimdışı çalışma
+brief: Bu kılavuz, bağımlılıklar ve özellikle yerel kod eklentileri içeren projelerde çevrimdışı nasıl çalışılacağını açıklar
+---
+
+# Çevrimdışı çalışma
+
+Defold çoğu durumda çalışmak için internet bağlantısı gerektirmez. Ancak internet bağlantısının gerektiği birkaç durum vardır:
+
+* Otomatik güncellemeler
+* Sorun bildirme
+* Bağımlılıkları alma
+* Yerel kod eklentilerini derleme
+
+
+## Otomatik güncellemeler
+
+Defold, yeni güncellemelerin olup olmadığını düzenli aralıklarla denetler. Defold güncelleme denetimleri [resmî indirme sitesi](https://d.defold.com) üzerinden yapılır. Bir güncelleme bulunursa otomatik olarak indirilir.
+
+İnternet bağlantısına yalnızca sınırlı sürelerle erişebiliyorsanız ve otomatik güncellemenin başlamasını beklemek istemiyorsanız, Defold'un yeni sürümlerini [resmî indirme sitesinden](https://d.defold.com) elle indirebilirsiniz.
+
+
+## Sorun bildirme
+
+Düzenleyicide bir sorun algılanırsa sorunu Defold sorun takip sistemine bildirme seçeneği sunulur. Sorun takip sistemi [GitHub'da barındırıldığından](https://www.github.com/defold/editor2-issues) sorunu bildirmek için internet bağlantısı gerekir.
+
+Çevrimdışıyken bir sorunla karşılaşırsanız, daha sonra düzenleyicinin [Help menüsündeki Report Issue seçeneğini](/manuals/getting-help/#report-a-problem-from-the-editor) kullanarak sorunu elle bildirebilirsiniz.
+
+
+## Bağımlılıkları alma
+
+Defold, geliştiricilerin [kütüphane projeleri (Library Projects)](/manuals/libraries/) adı verilen bir sistem aracılığıyla kod ve varlık paylaşmasını destekler. Kütüphaneler, internette herhangi bir yerde barındırılabilen zip dosyalarıdır. Defold kütüphane projelerini genellikle GitHub'da ve diğer çevrimiçi kaynak kod depolarında bulabilirsiniz.
+
+Bir projeye, [proje ayarlarında proje bağımlılığı olarak](/manuals/project-settings/#dependencies) bir kütüphane eklenebilir. Bağımlılıklar, proje açıldığında veya *Project* menüsünden *Fetch Libraries* seçeneği seçildiğinde indirilir/güncellenir.
+
+Çevrimdışı olarak birden fazla projede çalışmanız gerekiyorsa, bağımlılıkları önceden indirip yerel bir sunucu aracılığıyla paylaşabilirsiniz. GitHub'daki bağımlılıklar genellikle proje deposunun Releases sekmesinde bulunur:
+
+![GitHub kütüphane URL adresi](images/libraries/libraries_library_url_github.png)
+
+Python kullanarak kolayca yerel bir sunucu oluşturabilirsiniz:
+
+    python -m SimpleHTTPServer
+
+Bu komut, geçerli dizinde `localhost:8000` adresi üzerinden dosya sunan bir sunucu oluşturur. Geçerli dizin indirilmiş bağımlılıklar içeriyorsa, bunları *game.project* dosyanıza ekleyebilirsiniz:
+
+    http://localhost:8000/extension-fbinstant-4.1.1.zip
+
+
+## Yerel kod eklentilerini derleme
+
+Defold, geliştiricilerin [yerel kod eklentileri (Native Extensions)](/manuals/extensions/) adı verilen bir sistem aracılığıyla motorun işlevlerini genişletmek için yerel kod eklemesini destekler. Defold, bulut tabanlı bir derleme çözümüyle yerel kod eklentilerini hiçbir kurulum gerektirmeden kullanmaya başlamanızı sağlar.
+
+Yerel kod eklentisi içeren bir projeyi ilk kez derlediğinizde, yerel kod Defold derleme sunucularında özel bir Defold oyun motoruna derlenir ve bilgisayarınıza geri gönderilir. Özel motor projenizde önbelleğe alınır ve herhangi bir yerel kod eklentisi eklemediğiniz, kaldırmadığınız veya değiştirmediğiniz ve düzenleyiciyi güncellemediğiniz sürece sonraki derlemelerde yeniden kullanılır.
+
+Çevrimdışı çalışmanız gerekiyorsa ve projeniz yerel kod eklentileri içeriyorsa, projenizin özel motorun önbelleğe alınmış bir kopyasını içermesi için en az bir kez başarıyla derlendiğinden emin olmanız gerekir.

--- a/docs/tr/manuals/writing-code.md
+++ b/docs/tr/manuals/writing-code.md
@@ -1,0 +1,93 @@
+---
+title: Kod yazma
+brief: Bu kılavuz, Defold'da kodla nasıl çalışılacağını kısaca ele alır.
+---
+
+# Kod yazma
+
+Defold, oyun içeriğinizin büyük bir bölümünü karo haritası (tilemap) ve parçacık efekti (particle effect) düzenleyicileri gibi görsel araçlarla oluşturmanıza olanak tanısa da oyun mantığını bir kod düzenleyicisi kullanarak oluşturursunuz. Oyun mantığı [Lua programlama dili](https://www.lua.org/) ile yazılırken motorun kendisine yönelik eklentiler, hedef platformun yerel dili veya dilleri kullanılarak yazılır.
+
+## Lua kodu yazma
+
+Defold, hedef platforma bağlı olarak Lua 5.1 ve LuaJIT kullanır. Oyun mantığını yazarken Lua'nın bu belirli sürümlerinin dil belirtimine uymanız gerekir. Defold'da Lua ile çalışma hakkında daha fazla bilgi için [Defold'da Lua kılavuzumuza](/manuals/lua) bakın.
+
+## Lua'ya dönüştürülen diğer dilleri kullanma
+
+Defold, Lua kodu üreten kaynak kod dönüştürücülerin (transpiler) kullanımını destekler. Kaynak kod dönüştürücü eklentisi yüklüyken, statik olarak denetlenen Lua kodu yazmak için [Teal](https://github.com/defold/extension-teal) gibi alternatif diller kullanabilirsiniz. Bu, kısıtlamaları olan bir önizleme özelliğidir: mevcut kaynak kod dönüştürücü desteği, Defold Lua çalışma zamanı ortamında tanımlı modüller ve işlevler hakkındaki bilgileri sunmaz. Bu nedenle `go.animate` gibi Defold API'lerini kullanmak için harici tanımları kendiniz yazmanız gerekir.
+
+## Yerel kod yazma
+
+Defold, motorun kendisinin sunmadığı platforma özgü işlevlere erişmek için oyun motorunu yerel kodla (native code) genişletmenize olanak tanır. Lua'nın performansı yeterli olmadığında da yerel kod kullanabilirsiniz (yoğun kaynak gerektiren hesaplamalar, görüntü işleme vb.). Daha fazla bilgi için [yerel kod eklentileri kılavuzlarımıza](/manuals/extensions/) bakın.
+
+## Yerleşik kod düzenleyicisini kullanma
+
+Defold'un yerleşik kod düzenleyicisi, Lua dosyalarını (.lua), Defold betik dosyalarını (.script, .gui_script ve .render_script) ve düzenleyicinin doğrudan işlemediği dosya uzantılarına sahip diğer tüm dosyaları açıp düzenlemenize olanak tanır. Ayrıca düzenleyici, Lua ve betik dosyaları için sözdizimi vurgulaması sağlar.
+
+![](/images/editor/code-editor.png)
+
+### Kod tamamlama {#code-completion}
+
+Yerleşik kod düzenleyicisi, kod yazarken işlevler için kod tamamlama önerileri gösterir:
+
+![](/images/editor/codecompletion.png)
+
+<kbd>CTRL</kbd> + <kbd>Space</kbd> tuşlarına bastığınızda işlevler, bağımsız değişkenler ve dönüş değerleri hakkında ek bilgiler gösterilir:
+
+![](/images/editor/apireference.png)
+
+Birlikte gelen Lua dil sunucusu, Defold API'leri için tür açıklamaları (type annotations) içerir. Kod tamamlama, üzerine gelindiğinde gösterilen bilgiler ve tanılama işlevleri; karma değerleri (hash), URL'ler, vektörler ve kuaterniyonlar (quaternion) gibi Defold türlerini, işlev bağımsız değişkenlerini ve dönüş değerlerini tanır. Düzenleyici, oyun betikleri ve `.editor_script` dosyalarında kullanılan `editor.*` API'leri için açıklamalar sağlar. Defold kod düzenleyicisini kullanırken yerleşik API'ler için ayrı bir açıklama kütüphanesine gerek yoktur.
+
+Üçüncü taraf eklenti API'leri kendi açıklamalarına ihtiyaç duyabilir.
+
+### Kodu biçimlendirme {#formatting-code}
+
+Dil sunucusunun biçimlendiricisini çalıştırmak için <kbd>Edit ▸ Format Document/Selection</kbd> seçeneğini seçin veya <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd> tuşlarına basın. Bir seçim varsa düzenleyici seçili satırları, yoksa belgenin tamamını biçimlendirir. Biçimlendirme için ilgili biçimlendirme işlemini destekleyen bir dil sunucusu gerekir.
+
+Değiştirilmiş açık dosyaları kaydederken biçimlendirmek için <kbd>Preferences ▸ Code</kbd> bölümündeki **Format on save** seçeneğini etkinleştirin. Bu tercih varsayılan olarak devre dışıdır ve belge biçimlendirmeyi destekleyen bir dil sunucusu gerektirir. [Kod tercihlerine](/manuals/editor-preferences/#code) bakın.
+
+### Simgeye gitme
+
+Yerleşik kod düzenleyicisi, geçerli kod dosyasındaki işlevler, nesneler ve değişkenler gibi simgelerin aranabilir bir listesini gösterebilir. <kbd>View ▸ Jump to Symbol…</kbd> seçeneğini seçin veya Windows ve Linux'ta <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>O</kbd>, macOS'te ise <kbd>⌘ Cmd</kbd> + <kbd>Shift</kbd> + <kbd>O</kbd> tuşlarına basın.
+
+Simgeler arasında yaklaşık eşleşmeyle arama yapmak için yazmaya başlayın. Sonuçlar arasında ilerlemek ve düzenleyicideki konumlarını önizlemek için ok tuşlarını kullanın, ardından seçili simgeye gitmek için <kbd>Enter</kbd> tuşuna basın. İletişim kutusunu kapatıp önceki imleç ve kaydırma konumuna dönmek için <kbd>Esc</kbd> tuşuna basın.
+
+![](/images/editor/jump-to-symbol.png)
+
+### Statik kod denetimini yapılandırma {#linting-configuration}
+
+Yerleşik kod düzenleyicisi, [Luacheck](https://luacheck.readthedocs.io/en/stable/index.html) ve [Lua dil sunucusunu](https://luals.github.io/wiki/diagnostics/) kullanarak statik kod denetimi (code linting) yapar. Luacheck'i yapılandırmak için projenin kök dizininde bir `.luacheckrc` dosyası oluşturun. Kullanılabilir seçeneklerin listesi için [Luacheck yapılandırma sayfasını](https://luacheck.readthedocs.io/en/stable/config.html) okuyabilirsiniz. Defold, Luacheck yapılandırmasında aşağıdaki varsayılanları kullanır:
+
+```lua
+unused_args = false      -- don't warn on unused arguments (common for .script files)
+max_line_length = false  -- don't warn on long lines
+ignore = {
+    "611",               -- line contains only whitespace
+    "612",               -- line contains trailing whitespace
+    "614"                -- trailing whitespace in a comment
+},
+```
+
+## Harici bir kod düzenleyicisi kullanma
+
+Defold'un kod düzenleyicisi, kod yazmak için gereken temel işlevleri sağlar. Ancak daha gelişmiş kullanım durumlarında veya tercih ettiği bir kod düzenleyicisi olan ileri düzey kullanıcılar için Defold'un dosyaları harici bir düzenleyiciyle açmasını sağlamak mümkündür. [Preferences penceresinin Code sekmesinde](/manuals/editor-preferences/#code), kod düzenlerken kullanılacak harici bir düzenleyici tanımlayabilirsiniz.
+
+### Visual Studio Code - Defold Kit
+
+Defold Kit, aşağıdaki özellikleri sunan bir Visual Studio Code eklentisidir:
+
+* Önerilen eklentileri yükleme
+* Lua vurgulaması, otomatik tamamlama ve statik kod denetimi
+* İlgili ayarları çalışma alanına uygulama
+* Defold API'si için Lua açıklamaları
+* Bağımlılıklar için Lua açıklamaları
+* Derleyip başlatma
+* Kesme noktalarıyla hata ayıklama
+* Tüm platformlar için paketleme
+* Bağlı mobil cihazlarda dağıtıma alma
+
+[Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astronachos.defold) üzerinden daha fazla bilgi edinin ve Defold Kit'i yükleyin.
+
+
+## Belge yazılımları
+
+[Dash ve Zeal](https://forum.defold.com/t/defold-docset-for-dash/2417) için topluluk tarafından oluşturulmuş API başvuru belgesi paketleri mevcuttur.

--- a/docs/tr/manuals/zerobrane.md
+++ b/docs/tr/manuals/zerobrane.md
@@ -1,0 +1,99 @@
+---
+title: ZeroBrane Studio ile hata ayıklama
+brief: Bu kılavuz, Defold'daki Lua kodunda hata ayıklamak için ZeroBrane Studio'nun nasıl kullanılacağını açıklar.
+---
+
+# ZeroBrane Studio ile Lua betiklerinde hata ayıklama
+
+Defold yerleşik bir hata ayıklayıcı (debugger) içerir; ancak ücretsiz ve açık kaynaklı Lua tümleşik geliştirme ortamı (IDE) _ZeroBrane Studio_ uygulamasını haricî bir hata ayıklayıcı olarak çalıştırmak da mümkündür. Hata ayıklama özelliklerini kullanmak için ZeroBrane Studio'nun kurulu olması gerekir. Program birden çok platformu destekler ve hem macOS hem de Windows üzerinde çalışır.
+
+"ZeroBrane Studio" uygulamasını http://studio.zerobrane.com adresinden indirin
+
+## ZeroBrane yapılandırması
+
+ZeroBrane'in projenizdeki dosyaları bulabilmesi için Defold proje dizininizin konumunu belirtmeniz gerekir. Bu konumu bulmanın pratik bir yolu, Defold projenizin kök dizinindeki bir dosyada <kbd>Show in Desktop</kbd> seçeneğini kullanmaktır.
+
+1. *game.project* dosyasına sağ tıklayın
+2. <kbd>Show in Desktop</kbd> seçeneğini seçin
+
+![Show in Finder](images/zerobrane/show_in_desktop.png)
+
+## ZeroBrane'i ayarlama
+
+ZeroBrane'i ayarlamak için <kbd>Project ▸ Project Directory ▸ Choose...</kbd> seçeneğini seçin:
+
+![Ayarlama](images/zerobrane/setup.png)
+
+Bu ayar geçerli Defold proje diziniyle eşleşecek şekilde yapıldığında, ZeroBrane'de Defold projesinin dizin ağacını görebilmeniz, dosyalar arasında gezinebilmeniz ve dosyaları açabilmeniz gerekir.
+
+Önerilen ancak zorunlu olmayan diğer yapılandırma değişikliklerini belgenin ilerleyen bölümlerinde bulabilirsiniz.
+
+## Hata ayıklama sunucusunu başlatma
+
+Bir hata ayıklama oturumu başlatmadan önce ZeroBrane'in yerleşik hata ayıklama sunucusunun başlatılması gerekir. Sunucuyu başlatan menü seçeneği <kbd>Project</kbd> menüsündedir. <kbd>Project ▸ Start Debugger Server</kbd> seçeneğini seçmeniz yeterlidir:
+
+![Hata ayıklayıcıyı başlatma](images/zerobrane/startdebug.png)
+
+## Uygulamanızı hata ayıklayıcıya bağlama
+
+Hata ayıklama, Defold uygulamasının çalıştığı süre boyunca herhangi bir anda başlatılabilir; ancak işlemin Lua betiğinden (Lua script) açıkça başlatılması gerekir. Bir hata ayıklama oturumu başlatmak için kullanılan Lua kodu şöyledir:
+
+::: sidenote
+`dbg.start()` çağrıldığında oyununuz kapanıyorsa bunun nedeni ZeroBrane'in bir sorun algılayıp oyuna çıkış komutu göndermesi olabilir. Nedeni bilinmemekle birlikte, ZeroBrane hata ayıklama oturumunu başlatmak için bir dosyanın açık olmasını gerektirir; aksi takdirde şu çıktıyı verir:
+"Can't start debugging without an opened file or with the current file not being saved 'untitled.lua')."
+Bu hatayı düzeltmek için ZeroBrane'de `dbg.start()` eklediğiniz dosyayı açın.
+:::
+
+```lua
+dbg = require "builtins.scripts.mobdebug"
+dbg.start()
+```
+
+Yukarıdaki kodu uygulamaya eklediğinizde uygulama, ZeroBrane'in hata ayıklama sunucusuna (varsayılan olarak "localhost" üzerinden) bağlanır ve yürütülecek bir sonraki deyimde duraklar.
+
+```txt
+Debugger server started at localhost:8172.
+Mapped remote request for '/' to '/Users/my_user/Documents/Projects/Defold_project/'.
+Debugging session started in '/Users/my_user/Documents/Projects/Defold_project'.
+```
+
+Artık ZeroBrane'in hata ayıklama özelliklerini kullanabilirsiniz; kodda adım adım ilerleyebilir, inceleme yapabilir, kesme noktası (breakpoint) ekleyip kaldırabilir ve benzeri işlemler yapabilirsiniz.
+
+::: sidenote
+Hata ayıklama yalnızca başlatıldığı Lua bağlamı (Lua context) için etkinleştirilir. *game.project* dosyasında "shared_state" ayarını etkinleştirdiğinizde, hata ayıklamayı nerede başlattığınızdan bağımsız olarak uygulamanızın tamamında hata ayıklayabilirsiniz.
+:::
+
+![Adım adım ilerleme](images/zerobrane/code.png)
+
+Bağlantı girişimi başarısız olursa (örneğin hata ayıklama sunucusu çalışmadığı için), uygulamanız bağlantı girişiminin ardından normal şekilde çalışmaya devam eder.
+
+## Uzaktan hata ayıklama
+
+Hata ayıklama standart ağ bağlantıları (TCP) üzerinden gerçekleştiği için uzaktan hata ayıklama da yapılabilir. Bu, uygulamanız bir mobil cihazda çalışırken hata ayıklayabileceğiniz anlamına gelir.
+
+Gereken tek değişiklik, hata ayıklamayı başlatan komuttadır. Varsayılan olarak `start()` localhost adresine bağlanmayı dener; ancak uzaktan hata ayıklama için ZeroBrane'in hata ayıklama sunucusunun adresini aşağıdaki gibi elle belirtmemiz gerekir:
+
+```lua
+dbg = require "builtins.scripts.mobdebug"
+dbg.start("192.168.5.101")
+```
+
+Bu nedenle uzak cihazdan ağ bağlantısı sağlandığından ve güvenlik duvarları veya benzeri yazılımların 8172 bağlantı noktasından TCP bağlantılarına izin verdiğinden emin olmak da önemlidir. Aksi takdirde uygulama, başlatılırken hata ayıklama sunucunuza bağlanmaya çalıştığında takılı kalabilir.
+
+## Önerilen diğer ZeroBrane ayarı
+
+ZeroBrane'in hata ayıklama sırasında Lua betik dosyalarını otomatik olarak açmasını sağlayabilirsiniz. Böylece diğer kaynak dosyalardaki işlevlerin içine, dosyaları elle açmak zorunda kalmadan ilerleyebilirsiniz.
+
+İlk adım, düzenleyicinin yapılandırma dosyasına erişmektir. Dosyanın kullanıcıya özel sürümünü değiştirmeniz önerilir.
+
+- <kbd>Edit ▸ Preferences ▸ Settings: User</kbd> seçeneğini seçin
+- Yapılandırma dosyasına şunları ekleyin:
+
+  ```txt
+  - to automatically open files requested during debugging
+  editor.autoactivate = true
+  ```
+
+- ZeroBrane'i yeniden başlatın
+
+![Önerilen diğer ayarlar](images/zerobrane/otherrecommended.png)

--- a/docs/tr/shared/android-adb.md
+++ b/docs/tr/shared/android-adb.md
@@ -1,0 +1,33 @@
+`adb` komut satırı aracı, Android cihazlarıyla etkileşim kurmak için kullanılan, kullanımı kolay ve çok yönlü bir programdır. `adb` aracını Mac, Linux veya Windows için Android SDK Platform-Tools paketinin bir parçası olarak indirip kurabilirsiniz.
+
+Android SDK Platform-Tools paketini şu adresten indirin: https://developer.android.com/studio/releases/platform-tools. *adb* aracını */platform-tools/* dizininde bulabilirsiniz. Alternatif olarak, platforma özgü paketler ilgili paket yöneticileri aracılığıyla kurulabilir.
+
+Ubuntu Linux üzerinde:
+
+```
+$ sudo apt-get install android-tools-adb
+```
+
+Fedora 18/19 üzerinde:
+
+```
+$ sudo yum install android-tools
+```
+
+macOS üzerinde (Homebrew)
+
+```
+$ brew cask install android-platform-tools
+```
+
+Android cihazınızı USB aracılığıyla bilgisayarınıza bağlayıp aşağıdaki komutu çalıştırarak `adb` aracının çalıştığını doğrulayabilirsiniz:
+
+```
+$ adb devices
+List of devices attached
+31002535c90ef000    device
+```
+
+Cihazınız görünmüyorsa Android cihazında *USB debugging* seçeneğini etkinleştirdiğinizi doğrulayın. Cihazın *Settings* bölümünü açın ve *Developer options* (veya *Development*) seçeneğini bulun.
+
+![USB hata ayıklamayı etkinleştirme](images/android/usb_debugging.png)

--- a/docs/tr/shared/android-faq.md
+++ b/docs/tr/shared/android-faq.md
@@ -1,0 +1,30 @@
+#### Q: Android'de gezinme ve durum çubuklarını gizlemek mümkün mü?
+A: Evet, *game.project* dosyasının *Android* bölümündeki *immersive_mode* ayarını etkinleştirin. Bu, uygulamanızın ekranın tamamını kaplamasını ve ekrandaki tüm dokunma olaylarını yakalamasını sağlar.
+
+
+#### Q: Cihaza bir Defold oyunu kurarken neden "Failure [INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES]" hatasını alıyorum?
+A: Android, uygulamayı yeni bir sertifikayla kurmaya çalıştığınızı algılar. Hata ayıklama derlemeleri (debug build) paketlenirken her derleme geçici bir sertifikayla imzalanır. Yeni sürümü kurmadan önce eski uygulamayı kaldırın:
+
+```
+$ adb uninstall com.defold.examples
+Success
+$ adb install Defold\ examples.apk
+4826 KB/s (18774344 bytes in 3.798s)
+      pkg: /data/local/tmp/Defold examples.apk
+Success
+```
+
+
+#### Q: Belirli eklentilerle projeyi derlerken neden AndroidManifest.xml dosyasındaki çakışan özelliklerle ilgili hatalar alıyorum?
+A: Bu durum, iki veya daha fazla eklentinin (extension) aynı property etiketini farklı değerlerle içeren bir Android bildirim parçası (Android Manifest stub) sağlaması durumunda ortaya çıkabilir. Örneğin Firebase ve AdMob ile bu sorun yaşanmıştır. Derleme hatası şuna benzer:
+
+```
+SEVERE: /tmp/job4531953598647135356/upload/AndroidManifest.xml:32:13-58
+Error: Attribute property#android.adservices.AD_SERVICES_CONFIG@resource
+value=(@xml/ga_ad_services_config) from AndroidManifest.xml:32:13-58 is also
+present at AndroidManifest.xml:92:13-59 value=(@xml/gma_ad_services_config).
+Suggestion: add 'tools:replace="android:resource"' to <property> element at
+AndroidManifest.xml to override. 
+```
+
+Sorun ve geçici çözümü hakkında daha fazla bilgi için Defold hata bildirimi [#9453](https://github.com/defold/defold/issues/9453#issuecomment-2367367269) ve Google hata bildirimi [#327696048](https://issuetracker.google.com/issues/327696048?pli=1) sayfalarını okuyabilirsiniz.

--- a/docs/tr/shared/apple-privacy-manifest.md
+++ b/docs/tr/shared/apple-privacy-manifest.md
@@ -1,0 +1,8 @@
+
+## Apple gizlilik bildirimi
+
+Gizlilik bildirimi (privacy manifest), uygulamanız veya üçüncü taraf SDK tarafından toplanan veri türlerini ve kullanılan, kullanım gerekçesi bildirilmesi zorunlu API'leri kaydeden bir özellik listesidir (property list). Uygulamanız veya üçüncü taraf SDK, topladığı her veri türü ve kullandığı, kullanım gerekçesi bildirilmesi zorunlu her API kategorisi için gerekçeleri, kendi paketine dahil edilen gizlilik bildirimi dosyasına kaydetmelidir.
+
+Defold, *game.project* dosyasındaki Privacy Manifest alanı aracılığıyla varsayılan bir gizlilik bildirimi sağlar. Bir uygulama dağıtım paketi oluşturulurken gizlilik bildirimi, proje bağımlılıklarındaki tüm gizlilik bildirimleriyle birleştirilir ve uygulama dağıtım paketine eklenir.
+
+Gizlilik bildirimleri hakkında daha fazla bilgi için [Apple'ın resmî belgelerini](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files?language=objc) okuyun.

--- a/docs/tr/shared/blend-modes.md
+++ b/docs/tr/shared/blend-modes.md
@@ -1,0 +1,13 @@
+*Blend Mode* özelliği, bileşenin (component) grafiklerinin arkasındaki grafiklerle nasıl harmanlanacağını belirler. Kullanılabilir harmanlama modları (blend modes) ve hesaplanma biçimleri şunlardır:
+
+Alpha
+: Normal harmanlama: `src.a * src.rgb + (1 - src.a) * dst.rgb`
+
+Add
+: Bileşenin karşılık gelen piksellerinin renk değerleriyle arka planı aydınlatır: `src.rgb + dst.rgb`
+
+Multiply
+: Bileşenin karşılık gelen piksellerinin değerleriyle arka planı koyulaştırır: `src.rgb * dst.rgb`
+
+Screen
+: Multiply modunun tersidir. Arka planın ve bileşenin karşılık gelen piksellerinin parlaklığını artırır: `src.rgb - dst.rgb * dst.rgb`

--- a/docs/tr/shared/build-variants.md
+++ b/docs/tr/shared/build-variants.md
@@ -1,0 +1,37 @@
+## Derleme çeşitleri
+
+Bir oyunun dağıtım paketini oluştururken kullanmak istediğiniz motor türünü seçmeniz gerekir. Üç temel seçeneğiniz vardır:
+
+  * Debug
+  * Release
+  * Headless
+
+Bu farklı sürümler derleme çeşitleri (`Build variants`) olarak da adlandırılır.
+
+::: sidenote
+<kbd>Project ▸ Build</kbd> seçeneğini seçtiğinizde her zaman hata ayıklama sürümünü elde edersiniz.
+:::
+
+
+### Debug
+
+Bu tür yürütülebilir dosyalar, birkaç yararlı hata ayıklama özelliği içerdiği için genellikle oyun geliştirme sırasında kullanılır:
+
+* Profil çıkarıcı (profiler) - Performans ve kullanım sayaçlarını toplamak için kullanılır. Profil çıkarıcının nasıl kullanılacağını [Profil çıkarma kılavuzundan](/manuals/profiling/) öğrenin.
+* Günlüğe kaydetme (logging) - Günlüğe kaydetme etkinleştirildiğinde motor, sistem bilgilerini, uyarıları ve hataları günlüğe kaydeder. Motor ayrıca Lua'nın `print()` işlevinden ve `dmLogInfo()`, `dmLogError()` gibi işlevlerle günlüğe kaydeden yerel kod eklentilerinden (native extension) gelen günlükleri de çıktıya yazar. Bu günlükleri nasıl okuyacağınızı [Oyun ve sistem günlükleri kılavuzundan](https://defold.com/manuals/debugging-game-and-system-logs/) öğrenin.
+* Çalışma sırasında yeniden yükleme (hot reload) - Çalışma sırasında yeniden yükleme, geliştiricinin oyun çalışırken bir kaynağı (resource) yeniden yüklemesini sağlayan güçlü bir özelliktir. Bunu nasıl kullanacağınızı [Çalışma sırasında yeniden yükleme kılavuzundan](https://defold.com/manuals/hot-reload/) öğrenin.
+* Motor hizmetleri (engine services) - Çeşitli açık TCP bağlantı noktaları ve hizmetler aracılığıyla bir oyunun hata ayıklama sürümüne bağlanmak ve bu sürümle etkileşim kurmak mümkündür. Bu hizmetler, yukarıda sözü edilen çalışma sırasında yeniden yükleme özelliğini, uzaktan günlük erişimini ve profil çıkarıcıyı, ayrıca motorla uzaktan etkileşim kurmaya yönelik başka hizmetleri de içerir. Motor hizmetleri hakkında daha fazla bilgi için [geliştirici belgelerine](https://github.com/defold/defold/blob/dev/engine/docs/DEBUG_PORTS_AND_SERVICES.md) bakın.
+
+
+### Release
+
+Bu çeşitte hata ayıklama özellikleri devre dışıdır. Oyun, uygulama mağazasında yayımlanmaya veya başka yollarla oyuncularla paylaşılmaya hazır olduğunda bu seçeneğin seçilmesi önerilir. Bir oyunu hata ayıklama özellikleri etkin durumdayken yayımlamak çeşitli nedenlerle önerilmez:
+
+* Hata ayıklama özellikleri ikili dosyada az da olsa yer kaplar ve [yayımlanan bir oyunun ikili dosya boyutunu olabildiğince küçük tutmaya çalışmak iyi bir uygulamadır](https://defold.com/manuals/optimization/#optimize-application-size).
+* Hata ayıklama özellikleri az da olsa CPU süresi de kullanır. Kullanıcının donanımı düşük özelliklere sahipse bu durum oyunun performansını etkileyebilir. Cep telefonlarında artan CPU kullanımı, ısınmaya ve pilin tükenmesine de katkıda bulunur.
+* Hata ayıklama özellikleri, güvenlik, hile veya dolandırıcılık açısından oyuncuların görmesi amaçlanmayan oyun bilgilerini açığa çıkarabilir.
+
+
+### Headless
+
+Bu yürütülebilir dosya herhangi bir grafik veya ses olmadan çalışır. Bu, oyunun birim/duman testlerini (unit/smoke tests) bir sürekli tümleştirme (CI) sunucusunda çalıştırabileceğiniz, hatta bu dosyayı bulutta bir oyun sunucusu olarak kullanabileceğiniz anlamına gelir.

--- a/docs/tr/shared/bundle-resources.md
+++ b/docs/tr/shared/bundle-resources.md
@@ -1,0 +1,20 @@
+Dağıtım paketine eklenen kaynaklar (bundle resources), [*Bundle Resources* alanı](/manuals/project-settings/#bundle-resources) kullanılarak *game.project* dosyası üzerinden uygulamanızın dağıtım paketine dahil edilen ek dosya ve klasörlerdir.
+
+*Bundle Resources* alanı, paketleme sırasında oluşan pakete olduğu gibi kopyalanması gereken kaynak dosyalarını ve klasörlerini içeren dizinlerin virgülle ayrılmış bir listesini içermelidir. Dizinler, proje kökünden başlayan mutlak bir yolla belirtilmelidir; örneğin `/res`. Kaynak dizini, `platform` veya `architecture-platform` biçiminde adlandırılmış alt klasörler içermelidir.
+
+Desteklenen platformlar `ios`, `android`, `osx`, `win32`, `linux`, `web`, `switch` şeklindedir. Tüm platformlar için ortak kaynak dosyalarını içeren `common` adlı bir alt klasöre de izin verilir. Örnek:
+
+```
+res
+├── win32
+│   └── mywin32file.txt
+├── common
+│   └── mycommonfile.txt
+└── android
+    ├── myandroidfile.txt
+    └── res
+        └── xml
+            └── filepaths.xml
+```
+
+Uygulamanın depolandığı konumun yolunu almak için [`sys.get_application_path()`](/ref/stable/sys/#sys.get_application_path:) işlevini kullanabilirsiniz. Erişmeniz gereken dosyaların nihai mutlak yolunu oluşturmak için bu uygulama temel yolunu kullanın. Bu dosyaların mutlak yolunu elde ettikten sonra dosyalara erişmek için `io.*` ve `os.*` işlevlerini kullanabilirsiniz.

--- a/docs/tr/shared/component-max-count-optimizations.md
+++ b/docs/tr/shared/component-max-count-optimizations.md
@@ -1,0 +1,10 @@
+## Bileşen sayısı üst sınırı optimizasyonları {#component-max-count-optimizations}
+*game.project* ayar dosyası, belirli bir kaynak (resource) türünden aynı anda en fazla kaç tane bulunabileceğini belirten birçok değer içerir. Bu sayılar genellikle yüklenen her koleksiyon (collection; dünya olarak da adlandırılır) için ayrı hesaplanır. Defold motoru, oyun çalışırken dinamik bellek ayırmayı ve bellek parçalanmasını önlemek için bu üst sınır değerlerini kullanarak gereken belleği önceden ayırır.
+
+Defold'da bileşenleri (component) ve diğer kaynakları temsil etmek için kullanılan veri yapıları, mümkün olduğunca az bellek kullanacak şekilde optimize edilmiştir. Yine de gerçekten gerekenden fazla bellek ayırmamak için bu değerleri belirlerken dikkatli olunmalıdır.
+
+Bellek kullanımını daha da optimize etmek için Defold'un proje derleme süreci oyunun içeriğini analiz eder ve tam sayının kesin olarak bilinebildiği durumlarda sayı üst sınırlarını geçersiz kılarak bu sayıyı kullanır:
+
+* Bir koleksiyon hiçbir fabrika (factory) bileşeni içermiyorsa her bileşen ve oyun nesnesi (game object) için tam olarak gereken miktarda bellek ayrılır ve sayı üst sınırı değerleri yok sayılır.
+* Bir koleksiyon fabrika bileşeni içeriyorsa çalışma sırasında oluşturulan nesneler analiz edilir ve fabrikalardan oluşturulabilecek bileşenler ile oyun nesneleri için sayı üst sınırı kullanılır.
+* Bir koleksiyon, "Dynamic Prototype" seçeneği etkinleştirilmiş bir fabrika veya koleksiyon fabrikası (collection factory) içeriyorsa bu koleksiyon sayı üst sınırı değerlerini kullanır.

--- a/docs/tr/shared/components.md
+++ b/docs/tr/shared/components.md
@@ -1,0 +1,24 @@
+Bileşenler (component), oyun nesnelerine (game object) belirli bir görünüm ve/veya işlev kazandırmak için kullanılır. Bileşenlerin oyun nesnelerinin içinde bulunması gerekir ve bileşeni içeren oyun nesnesinin konumundan, dönmesinden ve ölçeğinden etkilenirler:
+
+![Bileşenler](../shared/images/components.png)
+
+Birçok bileşenin, türüne özgü ve değiştirilebilen özellikleri vardır. Ayrıca, çalışma sırasında bileşenlerle etkileşim kurmak için bileşen türüne özgü işlevler bulunur:
+
+```lua
+-- disable the can "body" sprite
+msg.post("can#body", "disable")
+
+-- play "hoohoo" sound on "bean" in 1 second
+sound.play("bean#hoohoo", { delay = 1, gain = 0.5 } )
+```
+
+Bileşenler bir oyun nesnesine ya yerinde (in-place) ya da bir bileşen dosyasına başvuru olarak eklenir:
+
+*Outline* görünümünde oyun nesnesine <kbd>sağ tıklayın</kbd> ve <kbd>Add Component</kbd> (yerinde ekleme) veya <kbd>Add Component File</kbd> (dosya başvurusu olarak ekleme) seçeneğini seçin.
+
+Çoğu durumda bileşenleri yerinde oluşturmak en mantıklısıdır, ancak aşağıdaki bileşen türlerinin, bir oyun nesnesine başvuru yoluyla eklenmeden önce ayrı kaynak dosyalarında oluşturulması gerekir:
+
+* Betik (Script)
+* GUI
+* Parçacık efekti (Particle FX)
+* Karo haritası (Tile Map)

--- a/docs/tr/shared/consoles-faq.md
+++ b/docs/tr/shared/consoles-faq.md
@@ -1,0 +1,8 @@
+#### Q: Konsollara yönelik proje derlemek için ek araçlar kurmam gerekir mi?
+
+A: Düzenleyiciyi ve komut satırı araçlarını kullanarak uygulama dağıtım paketleri (application bundles) oluşturabileceksiniz. İlgili platformlara erişim izni aldığınızda PlayStation®4, PlayStation®5 ve Nintendo Switch donanımlarında nasıl test yapacağınız hakkında size bilgi verilecektir.
+
+
+#### Q: Konsolları da hedeflemeye karar verirsem tek bir kod tabanı kullanmak yine kolay olur mu?
+
+A: Evet, standart Defold API işlevlerinin tümü konsol platformlarında da kullanılabilir. Standart işlevlere ek olarak PlayStation®4, PlayStation®5 ve Nintendo Switch'e özgü birkaç işleve de erişebileceksiniz, ancak genel olarak kodun birden çok platformda tamamen aynı kalabilmesi beklenir.

--- a/docs/tr/shared/custom-resources.md
+++ b/docs/tr/shared/custom-resources.md
@@ -1,0 +1,3 @@
+Özel kaynaklar (custom resources), [*Custom Resources* alanı](https://defold.com/manuals/project-settings/#custom-resources) üzerinden *game.project* dosyasında belirtilerek ana oyun arşivine eklenir.
+
+*Custom Resources* alanının, ana oyun arşivine dahil edilecek kaynakları virgülle ayrılmış bir liste olarak içermesi önerilir. Dizinler belirtilirse, bu dizinlerdeki tüm dosyalar ve alt dizinler özyinelemeli olarak dahil edilir. Dosyaları [`sys.load_resource()`](/ref/sys/#sys.load_resource) kullanarak okuyabilirsiniz.

--- a/docs/tr/shared/editor-faq.md
+++ b/docs/tr/shared/editor-faq.md
@@ -1,0 +1,26 @@
+#### Q: Düzenleyicinin sistem gereksinimleri nelerdir?
+A: Düzenleyici (editor), sistemde kullanılabilir belleğin %75'ine kadarını kullanır. 4 GB RAM bulunan bir bilgisayarda bunun küçük Defold projeleri için yeterli olması beklenir. Orta büyüklükteki veya büyük projeler için 6 GB veya daha fazla RAM kullanılması önerilir.
+
+
+#### Q: Defold'un beta sürümleri otomatik olarak güncelleniyor mu?
+A: Evet. Defold'un beta düzenleyicisi, kararlı sürümde olduğu gibi başlangıçta güncellemeleri kontrol eder.
+
+
+#### Q: Düzenleyiciyi başlatırken neden `java.awt.AWTError: Assistive Technology not found` hatasını alıyorum?
+A: Bu hata, [NVDA ekran okuyucusu](https://www.nvaccess.org/download/) gibi Java yardımcı teknolojileriyle ilgili sorunlardan kaynaklanır. Muhtemelen kullanıcı klasörünüzde bir `.accessibility.properties` dosyası vardır. Dosyayı kaldırın ve düzenleyiciyi yeniden başlatmayı deneyin. (Not: Herhangi bir yardımcı teknoloji kullanıyorsanız ve bu dosyanın bulunması gerekiyorsa alternatif çözümleri görüşmek için lütfen info@defold.se adresinden bizimle iletişime geçin).
+
+Bu konu [Defold forumunda burada ele alınmıştır](https://forum.defold.com/t/editor-endless-loading-windows-10-1-2-169-solved/65481/3).
+
+
+#### Q: Düzenleyiciyi başlatırken neden `sun.security.validator.ValidatorException: PKIX path building failed` hatasını alıyorum?
+A: Bu istisna, düzenleyici bir https bağlantısı kurmaya çalıştığında sunucunun sağladığı sertifika zinciri doğrulanamıyorsa ortaya çıkar.
+
+Bu hata hakkında ayrıntılı bilgi için [bu bağlantıya](https://github.com/defold/defold/blob/master/editor/README_TROUBLESHOOTING_PKIX.md) bakın.
+
+
+#### Q: Belirli işlemleri gerçekleştirirken neden `java.lang.OutOfMemoryError: Java heap space` hatasını alıyorum?
+A: Defold düzenleyicisi Java kullanılarak geliştirilmiştir ve bazı durumlarda Java'nın varsayılan bellek yapılandırması yeterli olmayabilir. Bu durumda düzenleyicinin yapılandırma dosyasını düzenleyerek daha fazla bellek ayırmasını elle yapılandırabilirsiniz. `config` adlı yapılandırma dosyası, macOS'te `Defold.app/Contents/Resources/` klasöründe bulunur. Windows'ta `Defold.exe` yürütülebilir dosyasının, Linux'ta ise `Defold` yürütülebilir dosyasının yanında bulunur. `config` dosyasını açın ve `-Xmx6gb` seçeneğini `vmargs` ile başlayan satıra ekleyin. `-Xmx6gb` eklemek, en büyük öbek (heap) boyutunu 6 gigabayt olarak ayarlar (varsayılan değer genellikle 4Gb'dir). Şuna benzer bir görünüm elde etmelisiniz:
+
+```
+vmargs = -Xmx6gb,-Dfile.encoding=UTF-8,-Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Ddefold.archive.domain=${build.archive_domain},-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false,--illegal-access=warn,--add-opens=java.base/java.lang=ALL-UNNAMED,--add-opens=java.desktop/sun.awt=ALL-UNNAMED,--add-opens=java.desktop/sun.java2d.opengl=ALL-UNNAMED,--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED
+```

--- a/docs/tr/shared/editor-versions.md
+++ b/docs/tr/shared/editor-versions.md
@@ -1,0 +1,11 @@
+## Düzenleyici 1 ve 2
+
+Şu anda beta aşamasında olan Defold düzenleyicisi 2'ye geçiş yapıyoruz. Hazırladığımız yeni belgelerin çoğu yeni düzenleyici içindir ve zamanla tüm belgeleri güncelleyeceğiz, ancak bu süreç zaman alacak. Ekran görüntülerindeki renk temasından düzenleyicinin sürümünü anlayabilirsiniz.
+
+Düzenleyici 2, hoş görünümlü, koyu bir temaya sahiptir:
+![düzenleyici 2](../shared/images/editor2.png)
+
+Düzenleyici 1, standart bir açık temaya sahiptir:
+![düzenleyici 1](../shared/images/editor1.png)
+
+Sizi [yeni düzenleyiciyi denemeye](https://www.defold.com/editor-two/) davet ediyoruz.

--- a/docs/tr/shared/graphics-api.md
+++ b/docs/tr/shared/graphics-api.md
@@ -1,0 +1,9 @@
+| Sistem   | Grafik API'si              | Not                      |
+|----------|----------------------------|--------------------------|
+| macOS    | OpenGL 3.3 veya Metal        | MoltenVK aracılığıyla Vulkan |
+| Windows  | OpenGL 3.3 veya Vulkan 1.1   |                          |
+| Linux x86-64 | OpenGL 3.3 veya Vulkan 1.1 |                        |
+| Linux ARM64  | OpenGL ES veya Vulkan 1.1   | Varsayılan EGL/GLES'tir |
+| Android  | OpenGLES 3.0 veya Vulkan 1.1 | OpenGLES 2.0'a geri dönüş |
+| iOS      | OpenGLES 3.0 veya Metal      | MoltenVK aracılığıyla Vulkan |
+| HTML5    | WebGL 2.0 veya WebGPU        | WebGL 1.0'a geri dönüş    |

--- a/docs/tr/shared/html5-faq.md
+++ b/docs/tr/shared/html5-faq.md
@@ -1,0 +1,12 @@
+#### Q: HTML5 uygulamam Chrome'da neden açılış ekranında donuyor?
+
+A: Bazı durumlarda bir oyunu tarayıcıda yerel dosya sisteminden çalıştırmak mümkün değildir. Oyunu düzenleyiciden çalıştırdığınızda oyun yerel bir web sunucusundan sunulur. Örneğin, Python'daki `SimpleHTTPServer` modülünü kullanabilirsiniz:
+
+```sh
+$ python -m SimpleHTTPServer [port]
+```
+
+
+#### Q: Oyunum yüklenirken neden "Unexpected data size" hatasıyla çöküyor?
+
+A: Bu durum genellikle Windows kullanırken bir derleme çıktısı oluşturup bunu Git'e kaydettiğinizde (commit) ortaya çıkar. Git'teki satır sonu yapılandırmanız yanlışsa Git satır sonlarını ve dolayısıyla veri boyutunu da değiştirir. Sorunu çözmek için şu yönergeleri izleyin: [https://docs.github.com/en/free-pro-team@latest/github/using-git/configuring-git-to-handle-line-endings](https://docs.github.com/en/free-pro-team@latest/github/using-git/configuring-git-to-handle-line-endings)

--- a/docs/tr/shared/install.md
+++ b/docs/tr/shared/install.md
@@ -1,0 +1,51 @@
+## İndirme
+
+macOS, Windows ve Linux (Ubuntu) için Download düğmelerinin bulunduğu [Defold indirme sayfasına](https://defold.com/download/) gidin:
+
+![düzenleyiciyi indirme](../shared/images/editor_download.png)
+
+## Kurulum
+
+macOS'ta kurulum
+: İndirilen dosya, programı içeren bir DMG disk görüntüsüdür.
+
+  1. "Defold-x86_64-macos.dmg" dosyasını bulun ve disk görüntüsünü açmak için dosyaya çift tıklayın.
+  2. "Defold" uygulamasını "Applications" klasörü bağlantısına sürükleyin.
+
+  Düzenleyiciyi başlatmak için "Applications" klasörünü açın ve "Defold" dosyasına <kbd>çift tıklayın</kbd>.
+
+  ![macOS'ta Defold](../shared/images/macos_content.png)
+
+Windows'ta kurulum
+: İndirilen dosya, çıkarılması gereken bir ZIP arşividir:
+
+  1. "Defold-x86_64-win32.zip" arşiv dosyasını bulun, klasörü <kbd>basılı tutun</kbd> (veya klasöre <kbd>sağ tıklayın</kbd>), *Extract All* seçeneğini seçin ve ardından arşivi "Defold" adlı bir klasöre çıkarmak için yönergeleri izleyin.
+  2. "Defold" klasörünü tercih ettiğiniz konuma (ör. `D:\Defold`) taşıyın. Düzenleyicinin güncellenmesini engelleyeceği için Defold'u `C:\Program Files (x86)\` veya `C:\Program Files\` konumuna taşımamanız önerilir.
+
+  Düzenleyiciyi başlatmak için "Defold" klasörünü açın ve "Defold.exe" dosyasına <kbd>çift tıklayın</kbd>.
+
+  ![Windows'ta Defold](../shared/images/windows_content.png)
+
+Linux'ta kurulum
+: İndirilen dosya, çıkarılması gereken bir ZIP arşividir:
+
+  1. Bir terminalden "Defold-x86_64-linux.zip" arşiv dosyasını bulun ve "Defold" adlı hedef dizine çıkarın.
+
+     ```bash
+     $ unzip Defold-x86_64-linux.zip -d Defold
+     ```
+
+  Düzenleyiciyi başlatmak için uygulamayı çıkardığınız dizine geçin, ardından `Defold` yürütülebilir dosyasını çalıştırın veya masaüstünde dosyaya <kbd>çift tıklayın</kbd>.
+
+  ```bash
+  $ cd Defold
+  $ ./Defold
+  ```
+
+  `Help > Create Desktop Entry` menüsünde bir masaüstü girdisi kurmak için yardımcı araç bulunur.
+
+  Düzenleyiciyi başlatırken, bir projeyi açarken veya bir Defold oyununu çalıştırırken herhangi bir sorunla karşılaşırsanız [sık sorulan soruların Linux bölümüne](/faq/faq#linux-questions) bakın.
+
+## Eski bir sürümü kurma
+
+Defold'un her beta ve kararlı sürümüne [GitHub'dan da ulaşabilirsiniz](https://github.com/defold/defold/releases).

--- a/docs/tr/shared/ios-faq.md
+++ b/docs/tr/shared/ios-faq.md
@@ -1,0 +1,16 @@
+#### Q: Ücretsiz bir Apple Developer hesabıyla Defold oyunumu kuramıyorum.
+A: Defold projenizde, mobil sağlama profilini (provisioning profile) oluştururken Xcode projesinde kullandığınız paket tanımlayıcısının (bundle identifier) aynısını kullandığınızdan emin olun.
+
+#### Q: Paketlenmiş bir uygulamanın yetkilerini (entitlements) nasıl kontrol edebilirim?
+A: [Derlenmiş bir uygulamanın yetkilerini inceleme](https://developer.apple.com/library/archive/technotes/tn2415/_index.html#//apple_ref/doc/uid/DTS40016427-CH1-APPENTITLEMENTS) bölümünden:
+
+```sh
+codesign -d --ent :- /path/to/the.app
+```
+
+#### Q: Bir sağlama profilinin yetkilerini nasıl kontrol edebilirim
+A: [Bir profilin yetkilerini inceleme](https://developer.apple.com/library/archive/technotes/tn2415/_index.html#//apple_ref/doc/uid/DTS40016427-CH1-PROFILESENTITLEMENTS) bölümünden:
+
+```sh
+security cms -D -i /path/to/iOSTeamProfile.mobileprovision
+```

--- a/docs/tr/shared/linux-faq.md
+++ b/docs/tr/shared/linux-faq.md
@@ -1,0 +1,150 @@
+#### Q: Defold düzenleyicisi 4k veya HiDPI monitörde çalıştırıldığında neden çok küçük görünüyor?
+
+A: GNOME kullanıyorsanız Defold'u çalıştırmadan önce ölçekleme katsayısını değiştirebilirsiniz. [kaynak](https://unix.stackexchange.com/a/552411)
+
+```bash
+$ gsettings set org.gnome.desktop.interface scaling-factor 2
+$ ./Defold
+```
+
+A: Özellikle kesirli bir katsayıyla büyütmek istediğinizde kullanabileceğiniz alternatif bir çözüm, `Defold/config` dosyasını değiştirip `vmargs` satırına `glass.gtk.uiScale` eklemektir: [kaynak](https://forum.defold.com/t/4k-hidpi-monitor-support-solved/64108/12?u=britzl)
+
+```
+vmargs = -Dglass.gtk.uiScale=1.5,-Dfile.encoding=UTF-8,...
+vmargs = -Dglass.gtk.uiScale=175%,-Dfile.encoding=UTF-8,...
+vmargs = -Dglass.gtk.uiScale=192dpi,-Dfile.encoding=UTF-8,...
+```
+
+Bu değer hakkında daha fazla bilgi için [Arch Linux HiDPI wiki yazısına](https://wiki.archlinux.org/title/HiDPI#JavaFX) bakın.
+
+A: KDE kullanıyorsanız `GDK_SCALE` değerini ayarlayabilirsiniz:
+
+```bash
+$ GDK_SCALE=2 ./Defold
+```
+
+#### Q: Elementary OS üzerinde fare tıklamaları neden düzenleyicinin içinden geçip altındaki öğelere ulaşıyor?
+
+A: Düzenleyiciyi şu şekilde başlatın:
+
+```bash
+$ GTK_CSD=0 ./Defold
+```
+
+
+#### Q: Defold düzenleyicisi bir koleksiyon veya oyun nesnesi açarken çöküyor ve çökme iletisinde `com.jogamp.opengl` geçiyor
+
+A: Bazı dağıtımlarda (Ubuntu 18 gibi), Defold'un kullandığı `jogamp`/`jogl` sürümü ile sistemdeki [Mesa](https://docs.mesa3d.org/) sürümü arasında bir sorun vardır. `MESA_GL_VERSION_OVERRIDE` değerini 2.1 veya daha yüksek, ancak sürücünüzün sürümünü aşmayan bir değere ayarlayarak `glGetString(GL_VERSION)` çağrıldığında bildirilen GL sürümünü değiştirebilirsiniz. Sürücünüzün desteklediği en yüksek OpenGL sürümünü `glxinfo` kullanarak kontrol edebilirsiniz:
+
+```bash
+glxinfo | grep version
+```
+
+Örnek çıktı ("OpenGL version string: x.y" satırını arayın):
+
+```
+server glx version string: 1.4
+client glx version string: 1.4
+GLX version: 1.4
+Max core profile version: 4.6
+Max compat profile version: 4.6
+Max GLES1 profile version: 1.1
+Max GLES[23] profile version: 3.2
+OpenGL core profile version string: 4.6 (Core Profile) Mesa 20.2.6
+OpenGL core profile shading language version string: 4.60
+OpenGL version string: 4.6 (Compatibility Profile) Mesa 20.2.6
+OpenGL shading language version string: 4.60
+OpenGL ES profile version string: OpenGL ES 3.2 Mesa 20.2.6
+OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
+GL_EXT_shader_implicit_conversions, GL_EXT_shader_integer_mix,
+```
+
+2.1 sürümünü veya grafik sürücünüzle eşleşen sürümü kullanın:
+
+```bash
+$ MESA_GL_VERSION_OVERRIDE=2.1 ./Defold
+```
+
+```bash
+$ MESA_GL_VERSION_OVERRIDE=4.6 ./Defold
+```
+
+
+#### Q: Defold'u başlatırken neden "`com.jogamp.opengl.GLException: Graphics configuration failed`" hatasını alıyorum?
+
+A: Bazı dağıtımlarda (örneğin Ubuntu 20.04), Defold çalıştırılırken yeni [Mesa](https://docs.mesa3d.org/) sürücüleriyle (Iris) ilgili bir sorun yaşanır. Defold'u çalıştırırken daha eski bir sürücü sürümü kullanmayı deneyebilirsiniz:
+
+```bash
+$ MESA_LOADER_DRIVER_OVERRIDE=i965 ./Defold
+```
+
+
+#### Q: Defold düzenleyicisi bir koleksiyon veya oyun nesnesi açarken çöküyor ve çökme iletisinde `libffi.so` geçiyor
+
+A: Dağıtımınızın [libffi](https://sourceware.org/libffi/) sürümü ile Defold'un gerektirdiği sürüm (6 veya 7) eşleşmiyor. `libffi.so.6` veya `libffi.so.7` dosyasının `/usr/lib/x86_64-linux-gnu` altında kurulu olduğundan emin olun. `libffi.so.7` dosyasını şu şekilde indirebilirsiniz:  
+
+```bash
+$ wget http://ftp.br.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb
+$ sudo dpkg -i libffi7_3.3-6_amd64.deb
+```
+
+Ardından Defold'u çalıştırırken bu sürümün yolunu `LD_PRELOAD` ortam değişkeninde belirtin:
+
+```bash
+$ LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libffi.so.7 ./Defold
+```
+
+
+#### Q: OpenGL sürücülerim güncelliğini yitirmiş. Defold kullanmaya devam edebilir miyim?
+
+A: Evet, yazılımla işlemeyi (software rendering) etkinleştirirseniz Defold'u kullanmanız mümkün olabilir. `LIBGL_ALWAYS_SOFTWARE` ortam değişkenini 1 yaparak yazılımla işlemeyi etkinleştirebilirsiniz:
+
+```bash
+$ LIBGL_ALWAYS_SOFTWARE=1 ./Defold
+```
+
+
+#### Q: Linux'ta çalıştırmayı denediğimde Defold oyunum neden başlamıyor?
+
+A: Düzenleyicideki konsol çıktısını kontrol edin. Şu iletiyi alıyorsanız:
+
+```
+dmengine: error while loading shared libraries: libopenal.so.1: cannot open shared object file: No such file or directory
+```
+
+*`libopenal1`* paketini kurmanız gerekir. Paket adı dağıtımlar arasında farklılık gösterir ve bazı durumlarda *`openal`* ile *`openal-dev`* veya *`openal-devel`* paketlerini kurmanız gerekebilir.
+
+```bash
+$ apt-get install libopenal-dev
+```
+
+#### Q: Üst menü neden bir şey seçemeden kapanıyor?
+
+A: Bunun nedeni büyük olasılıkla kullanılan pencere yöneticisidir (örneğin `Qtile` veya i3). Bu, [JavaFX'te bilinen bir sorundur](https://bugs.openjdk.org/browse/JDK-8251240?focusedCommentId=14362084&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14362084) ve `GDK_DISPLAY` ortam değişkenini 1 yaparak çözülebilir:¨
+
+```bash
+$ GDK_DISPLAY=1 ./Defold
+
+D=2
+
+```
+
+Veya `Defold/config` dosyasını değiştirip `vmargs` satırına `-Djdk.gtk.version=2` ekleyerek çözebilirsiniz:
+
+```
+vmargs = -Djdk.gtk.version=2,-Dfile.encoding=UTF-8,...
+```
+
+
+#### Q: Open From Disk seçeneğini seçtiğimde neden mevcut tüm dosya konumlarına göz atamıyorum?
+
+A: Defold'u [Flatpak kullanan Steam üzerinden](https://flathub.org/apps/com.valvesoftware.Steam) çalıştırıyorsanız Steam'e diğer sürücülerinize erişme izni vermeniz gerekir. Flatpak uygulamalarınızın izinlerini [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) veya benzer bir araçla değiştirebilirsiniz.
+
+
+#### Q: Web profil çıkarıcısını veya tarayıcı gerektiren diğer menü seçeneklerini neden açamıyorum?
+
+A: Büyük olasılıkla Gnome dışındaki sistemlerde tarayıcı algılanmadığı için dahili `Desktop.getDesktop().browse(new URI(url));` çağrısı başarısız oluyordur. `libgnome` kurmayı deneyin.
+
+```bash
+$ apt-get install libgnome
+```

--- a/docs/tr/shared/material-constants.md
+++ b/docs/tr/shared/material-constants.md
@@ -1,0 +1,6 @@
+
+Varsayılan {{ include.component }} materyalinde (material), [go.set()](/ref/stable/go/#go.set) veya [go.animate()](/ref/stable/go/#go.animate) kullanarak değiştirebileceğiniz aşağıdaki sabitler bulunur (daha fazla ayrıntı için [Materyal kılavuzuna](/manuals/material/#vertex-and-fragment-constants) bakın). Örnekler:
+```lua
+go.set("#{{ include.component }}", "{{ include.variable }}", vmath.vector4(1,0,0,1))
+go.animate("#{{ include.component }}", "{{ include.variable }}", go.PLAYBACK_LOOP_PINGPONG, vmath.vector4(1,0,0,1), go.EASING_LINEAR, 2)
+```

--- a/docs/tr/shared/optimization-memory-html5.md
+++ b/docs/tr/shared/optimization-memory-html5.md
@@ -1,0 +1,21 @@
+## Öbek boyutu (HTML5)
+Bir Defold HTML5 oyununun öbek boyutu (heap size), *game.project* dosyasındaki [`heap_size` alanından](/manuals/project-settings/#heap-size) yapılandırılabilir. Oyununuzun bellek kullanımını optimize ettiğinizden ve öbek boyutunu mümkün olan en küçük değere ayarladığınızdan emin olun.
+
+Küçük oyunlarda 32 MB öbek boyutuna ulaşmak mümkündür. Daha büyük oyunlarda 64–128 MB hedefleyin. Örneğin, kullanımınız 58 MB ise ve daha fazla optimizasyon yapmak mümkün değilse, üzerinde fazla düşünmeden 64 MB değerini seçebilirsiniz. Kesin bir hedef boyut yoktur; bu, oyuna bağlıdır. Yalnızca daha küçük boyutları hedefleyin; ideal olarak ikinin kuvvetlerine karşılık gelen değerlerle ilerleyin. 
+
+Geçerli öbek kullanımını kontrol etmek için oyununuzu başlatıp en fazla "kaynak tüketen" seviyeyi veya bölümü oynayarak bellek kullanımını izleyebilirsiniz:
+
+```lua
+if html5 then
+    local mem = tonumber(html5.run("HEAP8.length") / 1024 / 1024)
+    print(mem)
+end
+```
+
+Tarayıcınızın geliştirici araçlarını açıp konsola şunu da yazabilirsiniz:
+
+```js
+HEAP8.length / 1024 / 1024
+```
+
+Bellek kullanımı 32 MB düzeyinde kalıyorsa harika! Kalmıyorsa, [motorun kendisinin ve sesler ile dokular gibi büyük varlıkların boyutunu optimize etmek](/manuals/optimization-size) için belirtilen adımları izleyin.

--- a/docs/tr/shared/platforms.md
+++ b/docs/tr/shared/platforms.md
@@ -1,0 +1,3 @@
+Desteklenen platformlar `ios`, `android`, `osx`, `win32`, `linux`, `web` olarak sıralanır.
+
+Desteklenen `arc-platform` çiftleri `arm64-ios`, `arm64_sim-ios`, `armv7-android`, `arm64-android`, `x86_64-android`, `arm64-osx`, `x86_64-osx`, `x86-win32`, `x86_64-win32`, `arm64-linux`, `x86_64-linux`, `wasm-web` ve `wasm_pthread-web` olarak sıralanır.

--- a/docs/tr/shared/slice-9-texturing.md
+++ b/docs/tr/shared/slice-9-texturing.md
@@ -1,0 +1,41 @@
+## Dokuz parçalı ölçekleme ile doku kaplama
+
+GUI kutu düğümleri (box nodes) ve sprite bileşenleri (sprite components) bazen boyutları bağlama göre değişen öğeler içerir: içeriklerine uyacak şekilde yeniden boyutlandırılması gereken paneller ve iletişim kutuları ya da bir düşmanın kalan sağlığını gösterecek şekilde yeniden boyutlandırılması gereken bir sağlık çubuğu. Yeniden boyutlandırılan düğüme veya sprite bileşenine doku (texture) uyguladığınızda bu durum görsel sorunlara yol açabilir.
+
+Motor normalde dokuyu dikdörtgen sınırlarına sığacak şekilde ölçekler, ancak dokuz parçalı ölçekleme (slice-9) için kenar alanları tanımlayarak dokunun hangi bölümlerinin ölçekleneceğini sınırlayabilirsiniz:
+
+![GUI ölçekleme](../shared/images/gui_slice9_scaling.png)
+
+*Slice9* kutu düğümü, normal biçimde ölçeklenmemesi gereken sol, üst, sağ ve alt kenar boşluklarının piksel sayısını belirten 4 sayıdan oluşur:
+
+![Dokuz parçalı ölçekleme özellikleri](../shared/images/gui_slice9_properties.png)
+
+Kenar boşlukları, sol kenardan başlayarak saat yönünde ayarlanır:
+
+![Dokuz parçalı ölçekleme bölümleri](../shared/images/gui_slice9.png)
+
+- Köşe parçaları hiçbir zaman ölçeklenmez.
+- Kenar parçaları tek bir eksen boyunca ölçeklenir. Sol ve sağ kenar parçaları dikey olarak ölçeklenir. Üst ve alt kenar parçaları yatay olarak ölçeklenir.
+- Merkezdeki doku alanı gerektiği gibi yatay ve dikey olarak ölçeklenir.
+
+Yukarıda açıklanan *Slice9* doku ölçeklemesi yalnızca kutu düğümünün veya sprite bileşeninin boyutunu değiştirdiğinizde uygulanır:
+
+![GUI kutu düğümü boyutu](../shared/images/gui_slice9_size.png)
+
+![Sprite bileşeni boyutu](../shared/images/sprite_slice9_size.png)
+
+::: important
+Kutu düğümünün, sprite bileşeninin veya oyun nesnesinin (game object) ölçek parametresini değiştirirseniz düğüm veya sprite bileşeni ile doku, *Slice9* parametreleri uygulanmadan ölçeklenir.
+:::
+
+::: important
+Sprite bileşenlerinde dokuz parçalı ölçekleme ile doku kaplama kullanırken [görüntünün Sprite Trim Mode ayarı](https://defold.com/manuals/atlas/#image-properties) Off olarak ayarlanmalıdır.
+:::
+
+
+### Mipmapler ve dokuz parçalı ölçekleme
+Grafik işleyicisinde (renderer) mipmap kullanımının çalışma biçimi nedeniyle, doku parçaları ölçeklenirken bazen görüntü kusurları oluşabilir. Bu durum, parçaları özgün doku boyutunun altına _küçülttüğünüzde_ ortaya çıkar. İşleyici bu durumda parça için daha düşük çözünürlüklü bir mipmap seçer ve bu da görüntü kusurlarına neden olur.
+
+![Dokuz parçalı ölçeklemede mipmap kullanımı](../shared/images/gui_slice9_mipmap.png)
+
+Bu sorunu önlemek için dokunun ölçeklenecek parçalarının, hiçbir zaman küçültülmeyip yalnızca büyütülecek kadar küçük olduğundan emin olun.

--- a/docs/tr/shared/test.md
+++ b/docs/tr/shared/test.md
@@ -1,0 +1,5 @@
+Bu dosya, içeriği başka bir belgeye dahil etmeyi (transclusion) test etmek için kullanılabilir. Dosyanın tamamı, boşluk karakterleri korunarak olduğu gibi dahil edilir.
+
+Tüm dosya başvurularının, dosyanın eklendiği belgeye göreli olduğunu unutmayın.
+
+![ortak görüntü](../shared/images/logo.png)

--- a/docs/tr/shared/url-shorthands.md
+++ b/docs/tr/shared/url-shorthands.md
@@ -1,0 +1,17 @@
+  `.`
+  : Geçerli oyun nesnesine (game object) karşılık gelen kısa gösterim.
+
+  `#`
+  : Geçerli bileşene (component) karşılık gelen kısa gösterim.
+
+  Örneğin:
+
+  ```lua
+   -- Let this game object acquire input focus
+   msg.post(".", "acquire_input_focus")
+  ```
+
+  ```lua
+   -- Post "reset" to the current script
+   msg.post("#", "reset")
+  ```

--- a/docs/tr/shared/windows-faq.md
+++ b/docs/tr/shared/windows-faq.md
@@ -1,0 +1,27 @@
+#### Q: Dokusu olmayan GUI kutu düğümleri (box node) neden düzenleyicide saydam görünüyor, ancak projeyi derleyip çalıştırdığımda beklendiği gibi görüntüleniyor?
+
+A: Bu hata [AMD Radeon GPU kullanan bilgisayarlarda](https://github.com/defold/editor2-issues/issues/2723) meydana gelebilir. Grafik sürücülerinizi güncellediğinizden emin olun.
+
+#### Q: Bir atlası veya sahne görünümünü açarken neden `com.sun.jna.Native.open.class java.lang.Error: Access is denied` hatasını alıyorum?
+
+A: Defold'u yönetici olarak çalıştırmayı deneyin. Defold'un yürütülebilir dosyasına sağ tıklayın ve "Run as Administrator" seçeneğini seçin.
+
+#### Q: Windows'ta Intel UHD tümleşik GPU kullanırken oyunumda neden görüntü işleme (rendering) düzgün çalışmıyor (oysa HTML5 derleme çıktım çalışıyor)?
+
+A: Sürücünüzü 27.20.100.8280 veya daha yeni bir sürüme güncellediğinizden emin olun. Kontrol etmek için [Intel Driver Support Assistant](https://www.intel.com/content/www/us/en/search.html?ws=text#t=Downloads&layout=table&cf:Downloads=%5B%7B%22actualLabel%22%3A%22Graphics%22%2C%22displayLabel%22%3A%22Graphics%22%7D%2C%7B%22actualLabel%22%3A%22Intel%C2%AE%20UHD%20Graphics%20Family%22%2C%22displayLabel%22%3A%22Intel%C2%AE%20UHD%20Graphics%20Family%22%7D%2C%7B%22actualLabel%22%3A%22Intel%C2%AE%20UHD%20Graphics%20630%22%2C%22displayLabel%22%3A%22Intel%C2%AE%20UHD%20Graphics%20630%22%7D%5D) aracını kullanın. Ek bilgi için [bu forum gönderisine](https://forum.defold.com/t/sprite-game-object-is-not-rendering/69198/35?u=britzl) bakabilirsiniz.
+
+#### Q: Defold düzenleyicisi çöküyor ve günlükte `AWTError: Assistive Technology not found` görünüyor
+
+Düzenleyici çöktüğünde günlükte `Caused by: java.awt.AWTError: Assistive Technology not found: com.sun.java.accessibility.AccessBridge` ifadesi yer alıyorsa şu adımları izleyin:
+
+* `C:\Users\<username>` klasörüne gidin
+* `.accessibility.properties` adlı dosyayı standart bir metin düzenleyicisiyle açın (Notepad uygundur)
+* Yapılandırmada aşağıdaki satırları bulun:
+
+```
+assistive_technologies=com.sun.java.accessibility.AccessBridge
+screen_magnifier_present=true
+```
+
+* Bu satırların başına bir kare işareti (`#``) ekleyin
+* Dosyada yaptığınız değişiklikleri kaydedin ve Defold'u yeniden başlatın

--- a/docs/tr/translation-guidelines.txt
+++ b/docs/tr/translation-guidelines.txt
@@ -1,0 +1,286 @@
+---
+title: Defold belgeleri için Türkçe çeviri kılavuzu
+brief: Türkçe anlatım, terim seçimi, ekler, arayüz etiketleri ve teknik biçimlendirme kuralları.
+---
+
+# Defold belgeleri için Türkçe çeviri kılavuzu
+
+Bu kılavuz, Defold kılavuzları, öğreticileri, sık sorulan soruları ve ortak metin parçaları için geçerlidir. [Terim sözlüğüyle](glossary.txt) birlikte kullanın. Hazırlama ve kaynakları kontrol etme tarihi: 2026-09-12.
+
+Araştırma sırasında `docs/tr` altında çeviri dosyası yoktu. Bu belge mevcut Türkçe çevirilerin alışkanlıklarını aktarmak yerine yeni çeviriler için kurallar belirler. Kurallar, depodaki çeviri materyallerine, [README dosyasına](../../README.md), İngilizce Defold belgelerine ve resmî proje veya üretici kaynaklarına dayanır.
+
+## İncelenen çeviri materyalleri
+
+Depoda bulunan on dilin `glossary.txt` ve `translation-guidelines.txt` dosyaları, toplam yirmi dosya incelendi. Sözlüklerin konu başlıkları, terim listeleri, bağlama bağlı karşılıkları ve yönergeleri karşılaştırıldı. Tekrarlanan terimler, çoğul biçimler ve tam API adları Türkçe sözlükte kavramlara göre düzenlendi. Diğer dillerin karşılıkları Türkçeye yeniden çevrilmedi; anlam için İngilizce Defold metni esas alındı.
+
+| Dil | İncelenen dosyalar | Türkçe çalışma için katkısı |
+|---|---|---|
+| Almanca (`de`) | [Sözlük](../de/glossary.txt), [kılavuz](../de/translation-guidelines.txt) | Geniş konu kapsamı, kaynak karşılaştırması, anlam ayrımları ve teknik değerlerin korunması |
+| İspanyolca (`es`) | [Sözlük](../es/glossary.txt), [kılavuz](../es/translation-guidelines.txt) | Temel kavramlar, ilk kullanımda İngilizce karşılık, kullanıcı eylemleri ve sık sorulan sorular |
+| Fransızca (`fr`) | [Sözlük](../fr/glossary.txt), [kılavuz](../fr/translation-guidelines.txt) | Teknik dizeler, çalışma zamanı, HTTP ve otomasyon |
+| Yunanca (`gr`) | [Sözlük](../gr/glossary.txt), [kılavuz](../gr/translation-guidelines.txt) | Çok anlamlı terimler, hiyerarşiler ve eski çeviri hatalarını sürdürmeme |
+| İtalyanca (`it`) | [Sözlük](../it/glossary.txt), [kılavuz](../it/translation-guidelines.txt) | Derleme ile paketleme ayrımı, testler ve geliştirme araçları |
+| Japonca (`ja`) | [Sözlük](../ja/glossary.txt), [kılavuz](../ja/translation-guidelines.txt) | Farklı resmî kaynakları karşılaştırma ve belge setine özgü seçimleri belirtme |
+| Korece (`ko`) | [Sözlük](../ko/glossary.txt), [kılavuz](../ko/translation-guidelines.txt) | Bileşenler, kaynaklar, GUI, girdi ve grafikler |
+| Lehçe (`pl`) | [Sözlük](../pl/glossary.txt), [kılavuz](../pl/translation-guidelines.txt) | 86 bölümden birleştirilen ayrıntılı terim listesi; tekrarları kavramlara göre toplama |
+| Portekizce (`pt`) | [Sözlük](../pt/glossary.txt), [kılavuz](../pt/translation-guidelines.txt) | Platformlar, yayımlama ve açıklama terimleriyle doğrulanmış arayüz çevirilerini ayırma |
+| Ukraynaca (`uk`) | [Sözlük](../uk/glossary.txt), [kılavuz](../uk/translation-guidelines.txt) | Adresleme, iletiler, yaşam döngüsü, otomasyon ve doğrulama |
+
+Bazı kurallar birbiriyle çelişir. `es`, `ko`, `pl` ve `pt` açıklayıcı kod yorumlarının çevrilmesine izin verir; README ise kod örneklerinin ve yorumlarının korunmasını ister. Türkçe belgeler README kuralını izler. Include etiketleri ve soru-yanıt kısaltmaları konusunda da farklı uygulamalar vardır. Türkçe belgelerde include yönergeleri bütünüyle, sık sorulan sorulardaki `Q:` ve `A:` işaretleri de kaynakta olduğu gibi korunur.
+
+## Temel ilke ve kaynakların önceliği
+
+Kavramları ve işlemleri anlatan metni doğal Türkçeyle yazın. Okuyucunun ekranda bulması, yazması, kopyalaması veya çağırması gereken dizeleri aynen koruyun.
+
+1. Anlam, davranış, koşullar, kısıtlamalar, işlem sırası ve desteklenen sürümler için ilgili `docs/en` dosyasını esas alın. Önce yazının tamamını okuyun.
+2. Dosya yapısı, kod ve özel işaretleme için README ile deponun kurallarını izleyin.
+3. Türkçe terimler ve anlatım için bu kılavuzu ve `docs/tr/glossary.txt` dosyasını kullanın.
+4. Arayüz etiketlerini anlatılan ürünün sürümü, görüntüleme dili ve ekran görüntüleriyle eşleştirin.
+5. Eksik terimler için aynı alandaki resmî Türkçe belgelerden kullanım örnekleri bulun. Genel yazım sorularında Türk Dil Kurumu kaynaklarına başvurun.
+
+Diğer motorların belgeleri Türkçe kullanım için yardımcıdır; Defold davranışını değiştirmek için dayanak değildir. İngilizce kaynakta teknik bir sorun görünüyorsa bunu inceleme notu olarak kaydedin. Yalnızca Türkçe çeviriye varsayılan bir düzeltme veya yeni özellik eklemeyin.
+
+## Dil, hitap ve anlatım
+
+Türkiye Türkçesinin güncel yazımını kullanın. Dosyalar `docs/tr` altında bulunur. Türkçe karakterleri ASCII karşılıklarına dönüştürmeyin.
+
+- Okuyucuya `siz` biçiminde hitap edin; özneyi her cümlede yazmanız gerekmez. Yönergelerde `seçin`, `açın`, `ekleyin`, `kaydedin`, `sürükleyin` gibi kısa emir biçimlerini kullanın.
+- Aynı metinde `seç`, `seçin` ve `seçiniz` biçimlerini karıştırmayın. Bu belge setinde `seçin` tercih edilir.
+- Açıklamalarda özneyi gerektiğinde belirtin: `Motor kaynağı yükler`, `Düzenleyici önizlemeyi gösterir`.
+- Kısa ve doğrudan yapılar kullanın. `Değiştirebilirsiniz`, `değişiklik yapma imkânına sahipsiniz` ifadesinden daha açıktır.
+- İngilizcedeki uzun sıfat ve isim zincirlerini Türkçe tamlamalara veya ayrı cümlelere dönüştürün. Koşulları, neden-sonuç ilişkilerini ve işlem sırasını koruyun.
+- `You`, `your`, `a` ve `the` sözcüklerini her seferinde ayrı bir Türkçe sözcükle karşılamayın. `Open your project` için bağlama göre `Projeyi açın` yeterlidir.
+- Birlikte yapılan örnek için `Bu örnekte ... oluşturacağız` kullanılabilir. Defold ekibinin görüşünü anlatan `we` ifadesinde görüşün kime ait olduğunu koruyun.
+- Kaynakta olmayan `kolayca`, `elbette`, `kesinlikle` gibi vurgular eklemeyin. Açıklamanın kesinliğini veya işlemin zorluğunu değiştirmeyin.
+
+Kısa fiiller ve gereksiz resmiyetten kaçınma, [Microsoft Türkçe yerelleştirme kılavuzunun][S1] yaklaşımıyla uyumludur. Bununla birlikte Microsoft metinlerinde izin verilen pazarlama amaçlı kısaltma ve içerik çıkarma serbestliği Defold teknik belgelerine aktarılmaz.
+
+| İngilizce kaynak | Türkçe anlatım |
+|---|---|
+| Select Add Game Object. | <kbd>Add Game Object</kbd> seçeneğini seçin. |
+| You can change the position at runtime. | Konumu çalışma sırasında değiştirebilirsiniz. |
+| The editor displays the resource properties. | Düzenleyici kaynağın özelliklerini gösterir. |
+| Do not modify this value. | Bu değeri değiştirmeyin. |
+
+## Zorunluluk, öneri ve olasılık
+
+| Kaynak metindeki anlam | Türkçe anlatım |
+|---|---|
+| must / required | gerekir / zorunludur |
+| must not | yapmayın / yapılmamalıdır; açık yasak olarak |
+| should / recommended | önerilir / yapmanız önerilir |
+| should not | önerilmez / kaçınmanız önerilir |
+| can, yetenek veya yapılabilirlik | yapabilir / yapılabilir |
+| may, izin | yapabilirsiniz / yapılmasına izin verilir |
+| may / might, olasılık | olabilir / gerçekleşebilir |
+| cannot / unsupported | yapılamaz / desteklenmez |
+
+`May not` hem yasak hem de bir olayın gerçekleşmeme olasılığı olabilir; bağlama göre karar verin. `Olmayabilir` ile `olmamalıdır` aynı anlamı taşımaz. `Only`, `all`, `each`, `at least`, `at most`, `before` ve `after` gibi kapsamı veya sırayı belirleyen sözcükleri atlamayın. `En az 4` ile `4'ten fazla` farklı sınırlar tanımlar. Birim, varsayılan değer, sürüm ve sayısal hassasiyet korunmalıdır.
+
+## Terimlerin ilk kullanımı
+
+Önemli Defold kavramlarını her bağımsız yazının ilk açıklamasında Türkçe ve İngilizce olarak verin:
+
+- `oyun nesnesi (game object)`
+- `bileşen (component)`
+- `koleksiyon (collection)`
+- `başlangıç koleksiyonu (bootstrap collection)`
+- `fabrika (factory)`
+- `koleksiyon fabrikası (collection factory)`
+- `koleksiyon vekili (collection proxy)`
+- `girdi eşlemesi (input binding)`
+
+Sonraki kullanımlarda Türkçesi yeterlidir. Tam bir etiket, dosya uzantısı veya işlev adı söz konusuysa özgün biçime dönün: <kbd>Collection Factory</kbd>, `.collectionfactory`, `collectionfactory.create()`.
+
+Genel başlıkları Türkçeye çevirin. `Collections Koleksiyonlar` gibi çift başlık kullanmayın; `Koleksiyonlar` yazıp İngilizce terimi ilk paragrafta açıklayın. API veya ayar adından oluşan başlıklar özgün adlarını korur.
+
+## Resmî kaynakların karşılaştırılması
+
+Resmî sitelerdeki Türkçe metinlerde de farklı karşılıklar, çeviri kusurları ve İngilizce kalan bölümler bulunabilir. Aşağıdaki tablo kaynaklarda gözlenen kullanımı bu belge setinin seçimlerinden ayırır.
+
+| Konu | Gözlenen kullanım | Defold Türkçe belgelerindeki seçim |
+|---|---|---|
+| editor | [Godot][G1] düzenleyici, [Epic][E1] editör kullanır | Açıklamalarda `düzenleyici` |
+| node / scene / resource | [Godot][G1] düğüm, sahne ve kaynak kullanır | Bu karşılıklar kullanılır; oyun nesnesi ve koleksiyon yeniden adlandırılmaz |
+| instance / sampling | [Godot][G1] örnek ve örnekleme biçimlerini kullanır; farklı anlamlarda örnekleme görülebilir | `instance` için örnek, `instantiation` için örnek oluşturma, `sampling` için örnekleme |
+| object / component | [Epic][E1] obje ve bileşen kullanır | `oyun nesnesi` ve `bileşen`; Unreal Actor ile Defold oyun nesnesi aynı tür sayılmaz |
+| asset / resource | [Epic][E2] varlık taşıma bağlamında öğe, [Godot][G1] kaynak sistemi için kaynak kullanır | Üretim içeriği için `varlık`, Defold kaynak sistemi için `kaynak` |
+| mesh / material / texture / shader | [Epic][E2] örgü, materyal, doku ve gölgelendirici kullanır | Bu karşılıklar kullanılır; işlevleri birbirine karıştırılmaz |
+| rendering / renderer | [Godot][G1] işleme ve işleyici kullanır | Grafik bağlamında bu karşılıklar; ilk açıklamada görüntü oluşturma anlamı belirtilir |
+| layer / canvas / transparency | [Krita][K1] katman, tuval ve saydamlık kullanır | Aynı karşılıklar; ürünlerin katman davranışları ayrıca korunur |
+| opacity / blend mode | [Krita][K1] matlık ve harmanlama kipi kullanır | Bu belge setinde `opaklık` ve `harmanlama modu`; bunlar Krita etiketlerinin çevirisi olarak sunulmaz |
+| build / compile / bundle | [Visual Studio][M1] derleme ve oluşturma, [Epic][E1] derleme ve paketleme kullanır | Bütün süreç `proje derleme`, belirli aşama `kod derleme`, bağımsız çıktı hazırlama `paketleme` |
+| debugging / breakpoint | [Visual Studio][M2] hata ayıklama ve kesme noktası kullanır | Bu karşılıklar kullanılır |
+| unit test / integration test | [Microsoft .NET][M3] birim testi ve tümleştirme testi kullanır | Bu karşılıklar kullanılır |
+| request / response | [Microsoft .NET][M4] istek ve yanıt kullanır | HTTP açıklamalarında bu karşılıklar; yöntem, alan ve üstbilgi adları korunur |
+| Android App Bundle | [Android Developers][A1] biçimin adını korur | `Android App Bundle (AAB)`; bütün Defold dağıtım paketlerinin ortak adı değildir |
+
+`Sprite` gibi farklı Türkçe karşılıkları bulunan terimlerde tanınabilirlik de dikkate alınır. Bu belgelerde `sprite bileşeni` kullanılır. `Kütüphane`, `varsayılan`, `dize`, `optimizasyon` ve `yayımlama` gibi seçimler de bu belge seti içindir; başka bir ürünün doğrulanmış arayüz etiketini bu tercihlere uydurmayın.
+
+## Karıştırılmaması gereken anlamlar
+
+- Koleksiyon bir düzen ve hiyerarşi tanımıdır. Koleksiyon dosyasını, dosyaya dayalı nesne örneklerini ve yüklenen oyun dünyasını birbirinden ayırın.
+- Fabrika oyun nesneleri oluşturur. Koleksiyon fabrikası içeriği geçerli oyun dünyasında oluşturur. Koleksiyon vekili ayrı bir oyun dünyasını, buna ait fizik dünyasıyla birlikte yükler. [İngilizce koleksiyon fabrikası](../en/manuals/collection-factory.md) ve [koleksiyon vekili](../en/manuals/collection-proxy.md) belgelerindeki ayrımı izleyin.
+- Koleksiyon hiyerarşisi adresleme bağlamını, üst-alt nesne hiyerarşisi dönüşümlerin aktarılmasını belirler. Üst nesnenin değişmesi oyun nesnesinin adresini değiştirmez; [yapı taşları](../en/manuals/building-blocks.md) kılavuzuna bakın.
+- GUI düğümü bir oyun nesnesi değildir. Godot düğümü, Unreal Actor ve Defold oyun nesnesi kendi sistemlerindeki anlamlarını korur.
+- `Translation` dil bağlamında çeviri, koordinat dönüşümlerinde ötelemedir. `Rotation` dönme, `scale` ölçek, `transform` dönüşümdür.
+- `Instance` için örnek, `instantiation` için örnek oluşturma kullanın. `Sampling` doku veya ses verisinden örneklemedir. Bir kod örneğiyle bir nesne örneğini bağlamda açıkça ayırın.
+- Kare (`frame`), parça (`fragment`) ve parçacık (`particle`) ayrı kavramlardır. URL parçası ile gölgelendirici parçasını da ayırın.
+- Çalışma zamanı, çalışma zamanı ortamı ve yürütme süresi aynı şey değildir. `At runtime` için çalışma sırasında, geçen süre için yürütme süresi yazın.
+- Proje derleme, kod derleme, paketleme, başlatma ve yayımlama ayrı işlemlerdir. Türkçede build ile compile için aynı kök kullanılabildiğinden gerektiğinde kapsamı açıkça belirtin.
+- Hot reload geliştirme sırasında yeniden yüklemeyi, Live Update oyun içeriğinin güncellenmesini anlatır. Düzenleyici önizlemesiyle çalışan oyundan alınan ekran görüntüsünü birbirinin yerine kullanmayın.
+- Yükleme, başlangıç işlemleri, etkinleştirme, görünür kılma, silme, sonlandırma işlemleri ve bellekten kaldırma ayrı aşamalardır. Çeviriden yeni bir yürütme sırası çıkarmayın.
+- Geri çağırım, olay ve ileti ayrı kavramlardır. API işlevi ile aldığı ileti aynı adı taşısa bile çağrı biçimlerini birleştirmeyin.
+- HTTP erişim belirteciyle dil modelinin token birimini, derleme çıktısıyla ekrandaki görüntü kusurunu (`artifact`) bağlama göre ayırın.
+
+## Türkçe ekler, tamlamalar ve çoğullar
+
+Ekleri sözcüğün okunuşuna ve ünlü uyumuna göre seçin. [TDK kısaltma kuralları][T1] ve [noktalama kuralları][T2] genel dayanağı sağlar. Teknik dizelerin bire bir korunması gereken yerlerde cümleyi Türkçe bir yardımcı adla kurmak çoğu zaman daha açıktır.
+
+- `game.project` dosyasını açın; dosya adının içine ek eklemeyin.
+- `msg.post()` işlevini çağırın; kod gösteriminin içine Türkçe metin eklemeyin.
+- <kbd>Outline</kbd> görünümünde seçin; etiketin yazımını değiştirmeyin.
+- `position` özelliğinin değerini değiştirin; `position` yerine çevrilmiş bir anahtar yazmayın.
+
+Özel adlara gelen çekim eklerini kesme işaretiyle ayırın: `Lua'nın`, `Krita'da`. Cins adlarına gelen ekleri ayırmayın: `koleksiyonun`, `betiği`, `düğümde`, `atlaslar`. Dil adında `Türkçe`, çekimli biçimde `Türkçeye` yazın; `Türkçe'ye` kullanmayın. Kurum ve kuruluşların açık adlarına ek getirmeyle ilgili TDK istisnasını gözetin; gerekirse `Defold Foundation tarafından` gibi ek gerektirmeyen bir yapı seçin.
+
+Kısaltmaların ekleri okunuşa göre belirlenir. Okuyuşu belirsiz bir teknik kısaltmada gelişigüzel ek seçmek yerine `API çağrısı`, `URL değeri`, `GPU belleği`, `JSON verisi` gibi tamlamalar kullanın. Kısaltmaya veya ürün adına Türkçe ek getirmeniz, adın harflerini değiştirme hakkı vermez.
+
+İlk kullanımda İngilizce açıklama parantez içindeyse eki Türkçe sözcüğe getirin: `koleksiyonun (collection) içeriği`. `Koleksiyon (collection)'un` gibi yapılar kullanmayın.
+
+Türkçe isim tamlamalarının eklerini koruyun: `oyun nesnesi`, `oyun nesnesinin konumu`, `oyun nesneleri`, `girdi eşlemesi`, `koleksiyon fabrikası`, `koleksiyon fabrikaları`. Belirli sayılardan sonra gereksiz çoğul kullanmayın: `3 oyun nesnesi`, `iki bileşen`; `3 oyun nesneleri` yazmayın. İngilizce çoğul eki eklemek yerine `sprite bileşenleri` gibi doğal Türkçe yapılar kullanın.
+
+Bağlaç olan `de/da` ayrı, bulunma durumu eki bitişik yazılır: `Bu bileşen de güncellenir`, `Bu bileşende iki özellik bulunur`. Soru eki ayrıdır: `Proje hazır mı?`. `Dosyadaki` gibi sözcüklerdeki ek olan `-ki` ile bağlaç olan `ki` ayrımını koruyun. Bu kuralları tam dosya adlarına veya kod tanımlayıcılarına uygulamayın.
+
+## Büyük harfler ve Türkçe karakterler
+
+Başlıklarda cümle düzenini kullanın: `Yeni bir oyun nesnesi oluşturma`. İlk sözcük ve özel adlar dışında her sözcüğü büyük harfle başlatmayın. Metin içinde `motor`, `düzenleyici`, `koleksiyon`, `bileşen` ve `oyun nesnesi` küçük harfle yazılır.
+
+Türkçede `i` harfinin büyüğü `İ`, `ı` harfinin büyüğü `I` olur. Örneğin `girdi` → `GİRDİ`, `ışık` → `IŞIK`. Otomatik İngilizce büyük/küçük harf dönüşümü Türkçe metni bozabilir; [Microsoft kılavuzu][S1] bu ayrımı özellikle belirtir. API, dosya yolu, kod, kısaltma ve ürün adlarına Türkçe harf dönüşümü uygulamayın: `init()`, `ID`, `iOS` ve `INPUT` kaynakta nasılsa öyle kalır.
+
+`ç`, `ğ`, `ı`, `İ`, `ö`, `ş`, `ü` harflerini koruyun. `yapay zekâ`, `imkân` ve `resmî` gibi sözcükleri doğru yazın. UTF-8 kullanın; bozulmuş karakterler veya noktalı `i` üzerinde fazladan birleşen nokta bırakmayın.
+
+API, GUI, HTTP, JSON, HTML5, CPU, GPU, SDK, CI, LLM ve MCP gibi teknik kısaltmaları koruyun. Gerektiğinde ilk kullanımda açıklayın: `büyük dil modeli (LLM)`. Genel metinde `yapay zekâ` yazın; yeni bir kısaltma uydurmayın. Boyutları açıklayıcı metinde `2B` ve `3B` ile belirtin, tam adlardaki `2D` ve `3D` biçimlerini koruyun.
+
+## Arayüz, işlemler ve klavye
+
+İngilizce arayüzü veya İngilizce ekran görüntüsünü anlatan kaynakta etiketleri İngilizce koruyun. Etiketi çevirmeden çevresindeki yönergeyi Türkçeleştirin:
+
+- `<kbd>Add Game Object</kbd> seçeneğini seçin.`
+- `Oyun nesnesini <kbd>Outline</kbd> görünümünde seçin.`
+- `<kbd>Properties</kbd> panelindeki değeri değiştirin.`
+- `<kbd>Edit ▸ World Space</kbd> seçeneğini seçin.`
+
+Türkçe arayüzü açıkça anlatan bir yazıda, ilgili sürüm için gerçek ekranda veya ürünün resmî yerelleştirme dosyasında doğrulanan etiketi kullanın. Sözlükte bir Türkçe karşılık bulunması, Defold içinde aynı etiketin bulunduğunu göstermez. Başka bir motorun etiketlerini Defold etiketleri olarak kullanmayın.
+
+Ayar başvurularında kategorilerin, alanların ve değerlerin tam adlarını koruyup açıklamalarını çevirin. Örneğin `Max Nodes` adını koruyun ve açıklamada en fazla kaç düğüme izin verildiğini anlatın.
+
+Kaynağın `<kbd>` etiketlerini ve vurgularını koruyun. Yeni menü yollarında `▸` kullanın. Yalnızca çeviri yaparken kaynakta bulunan bütün `>` işaretlerini veya kalın yazımları topluca değiştirmeyin.
+
+Bir `<kbd>` etiketinin içi arayüz adı değil sıradan bir kullanıcı eylemiyse onu çevirin: `<kbd>right-click</kbd>` → `<kbd>sağ tıklayın</kbd>`, `<kbd>drag</kbd>` → `<kbd>sürükleyin</kbd>`, `<kbd>drop</kbd>` → `<kbd>bırakın</kbd>`. Kararı yalnızca etikete göre değil, metnin işlevine göre verin.
+
+`Ctrl`, `Cmd`, `Shift`, `Alt`, `Enter` gibi tuş adlarını, kısayol birleşimlerini ve işletim sistemleri arasındaki farkları koruyun. Türkçe Q veya F klavyeye göre tahminle yeni kısayol yazmayın.
+
+## Kod, API ve teknik dizeler
+
+README kuralı gereği kod bloklarını yorumlarıyla birlikte aynen koruyun. Lua, C++, gölgelendirici, JSON, YAML, INI, kabuk komutu ve konsol örnekleri buna dahildir. Girinti, boşluklar, yorumlar, dizeler ve beklenen çıktılar değiştirilmez. Türkçe açıklamayı kodun dışındaki metinde verin.
+
+Özellikle şunları koruyun:
+
+- İşlevler, ad alanları ve geri çağırımlar: `msg.post()`, `go.animate()`, `gui.get_node()`, `init()`, `on_message()`.
+- İletiler, sabitler ve alanlar: `set_parent`, `proxy_loaded`, `PLAYBACK_LOOP_PINGPONG`, `self`, `message_id`.
+- Örnek adları ve adresler: `bean`, `buddy`, `shield`, `controller`, `team_1`, `main:/manager#controller`, `@render`.
+- Dosyalar, uzantılar, yollar ve anahtarlar: `game.project`, `main.collection`, `.gui_script`, `.internal/editor.port`, `display.width`.
+- Komutlar, seçenekler ve ortam değişkenleri: `build-html5`, `--variant`, `PATH`.
+- HTTP yöntemleri, rotalar, üstbilgiler ve sonuç değerleri: `GET /ping`, `POST /eval`, `/openapi.json`, `Authorization: Bearer`, `success`, `duration_ms`.
+- Yer tutucular ve kaçış dizileri: `%s`, `%d`, `{name}`, `\n`; sözdizimlerini, sıralarını ve sayılarını değiştirmeyin.
+- Hata iletileri ve beklenen çıktılar; büyük/küçük harfleri ve noktalama işaretleri dahil.
+
+Teknik dizeleri metinde ters tırnakla gösterin. Kod içindeki düz tırnakları tipografik tırnaklara, ASCII kısa çizgiyi başka çizgi işaretlerine veya ondalık noktayı virgüle dönüştürmeyin. İngilizce kod yorumu veya konsol çıktısı çeviri eksiği değildir.
+
+## Markdown, üst veriler ve bağlantılar
+
+- YAML ön bilgilerinin sınırlarını ve anahtarlarını koruyun. Açıklayıcı `title` ve `brief` değerlerini çevirin; yolları, tanımlayıcıları ve mantıksal değerleri koruyun.
+- Başlıkların düzeylerini ve sırasını, listeleri, tabloları ve tanım listelerini koruyun. İşlem adımlarını birleştirmeyin, çıkarmayın veya yeniden sıralamayın.
+- `{#the-editor-views}` ve `<a id="example">` gibi açık bağlantı hedeflerini koruyun. Başlık çevirisiyle otomatik oluşan hedef değişiyorsa ona giden bağlantıları kontrol edin.
+- `::: sidenote`, `::: important` ve kapanış `:::` işaretlerini koruyun; aralarındaki açıklamayı çevirin.
+- `:[components](../shared/components.md)` gibi include yönergelerini etiket ve yol dahil aynen koruyun. Bunları sıradan Markdown bağlantısıyla karıştırmayın.
+- Kod çitlerini, dil etiketlerini, HTML etiketlerini, teknik öznitelikleri, sınıfları ve şablon ifadelerini koruyun.
+- Açıklayıcı bağlantı metinlerini ve görüntülerin alternatif metinlerini çevirin. API, ürün ve tam arayüz adlarını bu metinlerde de koruyun.
+- Bağlantı hedeflerini, referans kimliklerini, görüntü yollarını, dosya adlarını, sorgu parametrelerini, parçaları ve sondaki eğik çizgileri koruyun. Yollara kendiliğinden `/tr/` eklemeyin.
+- Başlık, liste, tablo ve blokların çevresinde boş satır kullanın. Vurgu işaretlerinin içine gereksiz boşluk eklemeyin: `*terim*` yazın.
+
+Örnekler:
+
+- `[Project settings](/manuals/project-settings/#debug)` → `[Proje ayarları](/manuals/project-settings/#debug)`
+- `[gui.clone()](/ref/gui/#gui.clone:node)` → aynen korunur.
+- `![Editor overview](images/introduction/editor.png)` → `![Düzenleyiciye genel bakış](images/introduction/editor.png)`
+
+## Noktalama, sayılar ve birimler
+
+Bu kurallar açıklayıcı Türkçe metin içindir. Girilecek değerler, teknik örnekler ve makine çıktıları özgün biçimlerini korur.
+
+- Nokta, virgül, iki nokta, noktalı virgül, soru ve ünlem işaretinden önce boşluk bırakmayın; cümleler arasında tek boşluk kullanın.
+- Parantezin iç kenarlarında boşluk kullanmayın. Türkçe terimle İngilizce açıklaması arasında bir boşluk bırakın: `düğüm (node)`.
+- Bu düz metin dosyalarında kesme işareti için düz `'` kullanın. Yeni metin içinde kesme biçimlerini karıştırmayın; kod ve aynen aktarılan dizeler bu tercihten etkilenmez.
+- Bir alıntı için düz çift tırnak, teknik dize için ters tırnak kullanın. İşlev çağrılarının `()` işaretlerini değiştirmeyin.
+- İngilizce birleşik sıfatların kısa çizgilerini otomatik taşımayın: `user-defined property` → `kullanıcı tanımlı özellik`.
+- Açıklayıcı metinde ondalık ayıracı virgüldür: `0,5 saniye`. Girilecek değer, kod, sürüm ve biçimi belirli çıktı noktayı korur: `0.5`, `1.2.3`, `vmath.vector3(0.5, 1, 0)`.
+- Birden çok ondalıklı koordinatı açıklarken virgülleri karıştırmayın; `(0,5; 1; 0)` gibi açık bir gösterim kullanın. Kaynakta kod biçiminde verilen koordinatı değiştirmeyin.
+- Yüzde işareti Türkçe açıklamada sayıdan önce ve boşluksuzdur: `%50`. Kodda, CSS değerinde, yer tutucuda veya arayüz değerinde `50%` aynen kalır.
+- Sayı ve birim arasında boşluk kullanın: `60 Hz`, `16 ms`, `128 MB`. Birimi çevirmeyin veya büyüklüğü kendiliğinden dönüştürmeyin; `MB` ve `MiB` aynı değildir.
+- Görüntü boyutları açıklamada `1280 × 720` yazılabilir. Bir tam değer veya dosya adındaki `1280x720` korunur.
+- Port, sürüm ve tanımlayıcı sayılarına binlik ayırıcı eklemeyin. Büyük miktarları açıklarken `10 000 oyun nesnesi` gibi boşlukla gruplama kullanabilirsiniz.
+- Tarihi açıklamada açık yazın: `12 Eylül 2026`. Makinece okunan tarihler ve üst veriler kaynak biçiminde kalır.
+
+## Ürün adları ve sık sorulan sorular
+
+`Defold`, `Defold Foundation`, `Lua`, `JavaScript`, `OpenAPI`, `GitHub`, `macOS`, `iOS`, `Spine`, `Rive` ve `Automation Bridge` adlarının resmî yazımını koruyun. Bunları okunuşlarına göre yeniden yazmayın. `LUA`, `Javascript` ve `AppStore` gibi biçimleri yeni açıklayıcı metne taşımayın.
+
+Sık sorulan sorularda İngilizce kaynağın başlık düzeylerini, sırasını ve `Q:` / `A:` işaretlerini koruyun. Soruyu, yanıtı ve genel bölüm başlıklarını çevirin:
+
+- `#### Q: Defold ücretsiz mi?`
+- `A: Evet, ...`
+- `General questions` → `Genel sorular`.
+- `Publishing games` → `Oyun yayımlama`.
+
+Ücretsiz olma, açık kaynaklı olma, kaynak koduna erişebilme ve telif ücreti gerektirmeme aynı koşullar değildir. İngilizce metindeki lisans anlamını koruyun.
+
+## Sözlüğü genişletme ve çeviriyi kontrol etme
+
+Yeni madde eklemeden önce sözlüğü İngilizce terim, çoğul biçim ve kısa çizgili varyantlarıyla arayın. Aynı anlamı gereksiz yere çoğaltmayın. Farklı anlamlar varsa koşullarını açıkça belirtin.
+
+Eksik terimin anlamını önce ilgili İngilizce Defold yazısında doğrulayın. Sonra aynı teknik bağlamı anlatan resmî Türkçe kaynağı okuyun. Yalnızca URL içinde `tr` bulunması yeterli kanıt değildir. Sayfanın Türkçe gövdesini veya resmî çeviri kataloğundaki karşılıkları kontrol edin. Terimi, anlamı, kaynak URL adresini ve kontrol tarihini kaydedin; kendi seçiminizi dış kaynakta doğrudan yazan bir terim gibi sunmayın.
+
+Bir yazıyı tamamlamadan önce:
+
+1. İçeriği İngilizce kaynakla karşılaştırın: açıklamalar, koşullar, uyarılar, adımlar ve tablo satırları eksiksiz olmalıdır.
+2. Zorunlulukları, olasılıkları, olumsuzlukları, sayıları, sınırları, birimleri ve işlem sırasını kontrol edin.
+3. Sözlük karşılıklarını, ilk kullanımda İngilizce açıklamaları, tutarlı hitabı, tamlamaları, ekleri ve `i/İ/ı/I` harflerini kontrol edin.
+4. Kod bloklarını yorumlarıyla birlikte, API adlarını, etiketleri, kısayolları ve çıktıları kaynakla karşılaştırın.
+5. Ön bilgileri, Markdown yapısını, bağlantıları, açık hedefleri, include yönergelerini ve görüntü yollarını kontrol edin. Markdown yazıları için deponun [tutarlılık denetimi araçları](../../scripts/README.md) kullanılabilir.
+6. İngilizce kalmış açıklamaları, çift başlıkları, bozulmuş karakterleri ve Git çakışma işaretlerini arayın. Bilerek korunan teknik dizeleri çeviri eksiği saymayın.
+7. Türkçe metni tek başına okuyun: okuyucu işlemi, hedef arayüz öğesini ve teknik anlamı İngilizceye geri çevirmeden anlayabilmelidir.
+
+## Kaynaklar ve araştırmanın sınırları
+
+Terim araştırması iki oyun motorunun resmî kaynaklarını ve farklı yazılım belgelerini kapsar: Godot belge çeviri kataloğu, Epic'in Unreal Engine belgeleri, Krita, Visual Studio, .NET ve Android Developers. Dil kuralları için Microsoft'un Türkçe yerelleştirme kılavuzu ile Türk Dil Kurumu kullanıldı. Kontrol tarihi: 2026-09-12.
+
+Godot için yayımlanan Türkçe web sayfasına erişilemediğinden projenin kendi deposundaki `weblate/tr.po` kataloğu okundu. Kaynak yolları `#:` satırlarıyla izlenebilen, boş veya `fuzzy` olmayan çeviriler incelendi. Bu katalog topluluk katkıları içerir ve bütün belgelerin Türkçe olarak tamamlandığını göstermez. Kaynak revizyonu bağlantıda sabitlenmiştir. Epic'in Unity karşılaştırmaları Epic kaynaklarıdır; Unity tarafından yayımlanmış Türkçe belge olarak sayılmaz. GIMP'in incelenen Türkçe adresindeki ana açıklama İngilizce kaldığı için o sayfa Türkçe terim dayanağı olarak kullanılmadı.
+
+[Microsoft kılavuzu][S1] Türkçe yerelleştirmeyi İngilizce açıklamalar ve Türkçe örneklerle ele alır; Türkçe yazılmış bir ürün kılavuzu değildir. Bu çalışma için kısa anlatım, büyük/küçük harf, kısaltma, ek, noktalama ve fiil bölümleri incelendi. Ürün arayüzünü değiştirmeye, kod örneklerini yerelleştirmeye veya kaynak içerikten bölüm çıkarmaya yönelik başka ürün kuralları bu depoya aktarılmaz.
+
+Bu dosyadaki hitap, terim tercihleri, FAQ işaretleri, noktalama tercihleri ve Defold kavramlarının Türkçe karşılıkları bu belge seti için belirlenmiştir. Resmî kaynaklar tüm seçimleri onaylayan bir Defold sözlüğü olarak sunulmaz. Kullanılan teknik kaynakların ayrıntılı listesi [terim sözlüğünde](glossary.txt) bulunur.
+
+[G1]: https://github.com/godotengine/godot-docs-l10n/blob/b8a5a2ee3186c8007ea3f88fc055fc6461ffb8a3/weblate/tr.po
+[E1]: https://dev.epicgames.com/documentation/unreal-engine/unity-to-unreal-engine-overview?lang=tr
+[E2]: https://dev.epicgames.com/documentation/unreal-engine/migrating-assets-from-unity-to-unreal-engine?lang=tr
+[K1]: https://docs.krita.org/tr/user_manual/getting_started/basic_concepts.html
+[M1]: https://learn.microsoft.com/tr-tr/visualstudio/ide/compiling-and-building-in-visual-studio?view=visualstudio
+[M2]: https://learn.microsoft.com/tr-tr/visualstudio/debugger/debugger-feature-tour?view=visualstudio
+[M3]: https://learn.microsoft.com/tr-tr/dotnet/core/testing/
+[M4]: https://learn.microsoft.com/tr-tr/dotnet/fundamentals/networking/http/httpclient
+[A1]: https://developer.android.com/guide/app-bundle?hl=tr
+[S1]: https://download.microsoft.com/download/c/7/e/c7e1f405-1a5a-418d-a56d-3a8c183cabd9/tur-tur-StyleGuide.pdf
+[T1]: https://tdk.gov.tr/icerik/yazim-kurallari/kisaltmalar/
+[T2]: https://tdk.gov.tr/icerik/yazim-kurallari/noktalama-isaretleri-aciklamalar/

--- a/docs/tr/tutorials/15-puzzle.md
+++ b/docs/tr/tutorials/15-puzzle.md
@@ -1,0 +1,394 @@
+---
+title: Defold'da 15 bulmacası oyunu oluşturma
+brief: Defold'a yeni başladıysanız bu kılavuz, Defold'un yapı taşlarından birkaçını denemenize ve betik mantığını çalıştırmanıza yardımcı olacaktır.
+---
+
+# Klasik 15 bulmacası
+
+Bu tanınmış bulmaca, 1870'lerde Amerika'da popüler oldu. Bulmacanın amacı, tahtadaki karoları yatay ve dikey olarak kaydırarak sıralamaktır. Bulmaca, karoların karıştırıldığı bir düzenden başlar.
+
+Bulmacanın en yaygın sürümünde karoların üzerinde 1--15 sayıları bulunur. Ancak karoları bir görüntünün parçaları hâline getirerek bulmacayı biraz daha zorlaştırabilirsiniz. Başlamadan önce bulmacayı çözmeyi deneyin. Boş kareye komşu bir karoyu tıklayarak boş konuma kaydırın.
+
+## Projeyi oluşturma
+
+1. Defold'u başlatın.
+2. Soldaki *New Project* seçeneğini seçin.
+3. *From Template* sekmesini seçin.
+4. *Empty Project* seçeneğini seçin
+5. Yerel sürücünüzde proje için bir konum seçin.
+6. *Create New Project* seçeneğine tıklayın.
+
+*game.project* ayarlar dosyasını açın ve oyunun boyutlarını 512⨉512 olarak ayarlayın. Bu boyutlar, kullanacağınız görüntüyle eşleşecektir.
+
+![ekran ayarları](images/15-puzzle/display_settings.png)
+
+Sonraki adım, bulmacaya uygun bir görüntü indirmektir. Kare biçiminde herhangi bir görüntü seçin, ancak 512'ye 512 piksel olacak şekilde ölçeklendirdiğinizden emin olun. Görüntü aramakla uğraşmak istemiyorsanız şunu kullanabilirsiniz:
+
+![Mona Lisa](images/15-puzzle/monalisa.png)
+
+Görüntüyü indirin, ardından projenizin *main* klasörüne sürükleyin.
+
+## Izgarayı temsil etme
+
+Defold, bulmaca tahtasını görselleştirmek için ideal olan yerleşik bir karo haritası (*Tilemap*) bileşeni (component) içerir. Karo haritaları, tek tek karoları ayarlamanıza ve okumanıza olanak tanır; bu proje için gereken de budur.
+
+Ancak karo haritasını oluşturmadan önce, karo haritasının karo görüntülerini alacağı bir karo kaynağına (*Tilesource*) ihtiyacınız vardır.
+
+*main* klasörüne <kbd>sağ tıklayın</kbd> ve <kbd>New ▸ Tile Source</kbd> seçeneğini seçin. Yeni dosyaya `monalisa.tilesource` adını verin.
+
+Karonun *Width* ve *Height* özelliklerini 128 olarak ayarlayın. Bu işlem, 512⨉512 piksellik görüntüyü 16 karoya böler. Karoları karo haritasına yerleştirdiğinizde 1--16 olarak numaralandırılırlar.
+
+![Karo kaynağı](images/15-puzzle/tilesource.png)
+
+Ardından *main* klasörüne <kbd>sağ tıklayın</kbd> ve <kbd>New ▸ Tile Map</kbd> seçeneğini seçin. Yeni dosyaya "grid.tilemap" adını verin.
+
+Defold, ızgaranın başlangıç durumunu hazırlamanızı gerektirir. Bunun için "layer1" katmanını seçin ve başlangıç noktasının hemen sağ üstüne 4⨉4 boyutunda bir karo ızgarası boyayın. Karolar için hangi değerleri ayarladığınız pek önemli değildir. Birazdan bu karoların içeriğini otomatik olarak ayarlayan kodu yazacaksınız.
+
+![Karo haritası](images/15-puzzle/tilemap.png)
+
+## Parçaları bir araya getirme
+
+*main.collection* koleksiyon (collection) dosyasını açın. *Outline* görünümündeki kök düğüme <kbd>sağ tıklayın</kbd> ve <kbd>Add Game Object</kbd> seçeneğini seçin. Yeni oyun nesnesinin (game object) *Id* özelliğini "game" olarak ayarlayın.
+
+Oyun nesnesine <kbd>sağ tıklayın</kbd> ve <kbd>Add Component File</kbd> seçeneğini seçin. *grid.tilemap* dosyasını seçin. *Id* özelliğini "tilemap" olarak ayarlayın.
+
+Oyun nesnesine <kbd>sağ tıklayın</kbd> ve <kbd>Add Component ▸ Label</kbd> seçeneğini seçin. Etiketin (label) *Id* özelliğini "done", *Text* özelliğini ise "Well done" olarak ayarlayın. Etiketi karo haritasının merkezine taşıyın.
+
+Etiketin ızgaranın üzerine çizildiğinden emin olmak için Z konumunu 1 olarak ayarlayın.
+
+![Ana koleksiyon](images/15-puzzle/main_collection.png)
+
+Ardından bulmaca mantığı için bir Lua betik (script) dosyası oluşturun: *main* klasörüne <kbd>sağ tıklayın</kbd> ve <kbd>New ▸ Script</kbd> seçeneğini seçin. Yeni dosyaya "game.script" adını verin.
+
+Sonra *main.collection* içindeki "game" adlı oyun nesnesine <kbd>sağ tıklayın</kbd> ve <kbd>Add Component File</kbd> seçeneğini seçin. *game.script* dosyasını seçin.
+
+Oyunu çalıştırın. Izgarayı çizdiğiniz hâliyle ve üzerinde "Well done" iletisini gösteren etiketi görmelisiniz.
+
+## Bulmaca mantığı
+
+Artık bütün parçalar yerli yerinde; öğreticinin geri kalanında bulmaca mantığını oluşturacağız.
+
+Betik, tahtadaki karoların karo haritasından ayrı kendi temsilini tutacaktır. Bunun nedeni, üzerinde işlem yapmayı kolaylaştırabilmemizdir. Karoları 2 boyutlu bir dizide saklamak yerine, bir Lua tablosunda tek boyutlu bir liste olarak saklayacağız. Liste, ızgaranın sol üst köşesinden başlayıp sağ alt köşesine kadar sırayla karo numaralarını içerir:
+
+```lua
+-- The completed board looks like this:
+self.board = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0}
+```
+
+Böyle bir karo listesini alıp karo haritamıza çizen kod oldukça basittir, ancak listedeki konumu x ve y konumuna dönüştürmesi gerekir:
+
+```lua
+-- Draw a table list of tiles onto a 4x4 tilemap
+local function draw(t)
+    for i=1, #t do
+        local y = 5 - math.ceil(i/4) -- <1>
+        local x = i - (math.ceil(i/4) - 1) * 4
+        tilemap.set_tile("#tilemap","layer1",x,y,t[i])
+    end
+end
+```
+1. Karo haritalarında x değeri 1 ve y değeri 1 olan karo sol alttadır. Bu nedenle y konumunun yönü tersine çevrilmelidir.
+
+Bir test `init()` işlevi oluşturarak işlevin amaçlandığı gibi çalışıp çalışmadığını denetleyebilirsiniz:
+
+```lua
+function init(self)
+    -- An inverted board, for test
+    self.board = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+    draw(self.board)
+end
+```
+
+Karolar bir Lua tablosunda liste olarak tutulduğunda sıralarını karıştırmak çok kolaydır. Kod yalnızca listedeki her öğeyi dolaşır ve her karonun yerini rastgele seçilen başka bir karoyla değiştirir:
+
+```lua
+-- Swap two items in a table list
+local function swap(t, i, j)
+    local tmp = t[i]
+    t[i] = t[j]
+    t[j] = tmp
+    return t
+end
+
+-- Randomize the order of a the elements in a table list
+local function scramble(t)
+    local n = #t
+    for i = 1, n - 1 do
+        t = swap(t, i, math.random(i, n))
+    end
+    return t
+end
+```
+
+Devam etmeden önce 15 bulmacası hakkında dikkate almanız gereken bir nokta var: karo sırasını yukarıdaki gibi rastgele belirlerseniz bulmacanın çözülmesinin *imkânsız* olma olasılığı %50'dir.
+
+Bu kötü bir haberdir, çünkü oyuncuya çözülemeyen bir bulmaca sunmayı kesinlikle istemezsiniz.
+
+Neyse ki bir düzenin çözülebilir olup olmadığını belirlemek mümkündür. Bunun nasıl yapıldığına bakalım:
+
+## Çözülebilirlik
+
+4⨉4 boyutundaki bir bulmacada bir düzenin çözülebilir olup olmadığını belirlemek için iki bilgi gerekir:
+
+1. Düzendeki "terslik" (inversion) sayısı. Bir karonun, kendisinden daha küçük numaralı başka bir karodan önce gelmesine terslik denir. Örneğin `{1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 11, 10, 13, 14, 15, 0}` listesinde 3 terslik vardır:
+
+    - 12 sayısının ardından 11 ve 10 gelir; bu da 2 terslik oluşturur.
+    - 11 sayısının ardından 10 gelir; bu da 1 terslik daha oluşturur.
+
+    (Çözülmüş bulmaca durumunda terslik sayısının sıfır olduğuna dikkat edin)
+
+2. Boş karenin bulunduğu satır (listede `0` ile gösterilir).
+
+Bu iki sayı, aşağıdaki işlevlerle hesaplanabilir:
+
+```lua
+-- Count the number of inversions in a list of tiles
+local function inversions(t)
+    local inv = 0
+    for i=1, #t do
+        for j=i+1, #t do
+            if t[i] > t[j] and t[j] ~= 0 then -- <1>
+                inv = inv + 1
+            end
+        end
+    end
+    return inv
+end
+```
+1. Boş karenin hesaba katılmadığına dikkat edin.
+
+```lua
+-- Find the x and y position of a given tile
+local function find(t, tile)
+    for i=1, #t do
+        if t[i] == tile then
+            local y = 5 - math.ceil(i/4) -- <1>
+            local x = i - (math.ceil(i/4) - 1) * 4
+            return x,y
+        end
+    end
+end
+```
+1. Alttan itibaren Y konumu.
+
+Bu iki sayıyla artık bir bulmaca durumunun çözülebilir olup olmadığını söylemek mümkündür. 4⨉4 boyutundaki bir tahta durumu şu koşullarda *çözülebilirdir*:
+
+- Boş kare *tek* numaralı bir satırdaysa (alttan sayarak 1 veya 3) ve terslik sayısı *çift* ise.
+- Boş kare *çift* numaralı bir satırdaysa (alttan sayarak 2 veya 4) ve terslik sayısı *tek* ise.
+
+## Bu nasıl çalışır?
+
+Kurallara uygun her hamle, bir parçayı boş kareyle yatay veya dikey olarak yer değiştirerek hareket ettirir.
+
+Bir parçayı yatay olarak hareket ettirmek, ne terslik sayısını ne de boş karenin bulunduğu satırın numarasını değiştirir.
+
+Ancak bir parçayı dikey olarak hareket ettirmek, terslik sayısının tek veya çift olma durumunu değiştirir (tekten çifte veya çiftten teke). Aynı şekilde boş karenin bulunduğu satırın numarasının tek veya çift olma durumunu da değiştirir.
+
+Örneğin:
+
+![bir parçayı kaydırma](images/15-puzzle/slide.png)
+
+Bu hamleyle karoların sırası şu durumdan:
+
+`{ ... 0, 11, 2, 13, 6 ... }`
+
+şu duruma değişir:
+
+`{ ... 6, 11, 2, 13, 0 ... }`
+
+Toplam terslik sayısı aşağıdaki şekilde 1 azalır:
+
+- 6 sayısı 1 terslik ekler (2 sayısı artık 6'dan sonradır)
+- 11 sayısı 1 terslik kaybeder (6 sayısı artık 11'den öncedir)
+- 13 sayısı 1 terslik kaybeder (6 sayısı artık 13'ten öncedir)
+
+Dikey bir kaydırmada terslik sayısı ±1 veya ±3 değişebilir.
+
+Dikey bir kaydırmada boş karenin satır numarası ±1 değişebilir.
+
+Bulmacanın son durumunda boş kare sağ alt köşededir (*tek* numaralı 1. satır) ve terslik sayısı *çift* bir değer olan 0'dır. Kurallara uygun her hamle, bu iki değeri ya olduğu gibi bırakır (yatay hamle) ya da tek veya çift olma durumlarını değiştirir (dikey hamle). Kurallara uygun hiçbir hamle, terslik sayısını ve boş karenin satır numarasını *tek*, *tek* veya *çift*, *çift* hâline getiremez.
+
+Dolayısıyla bu iki sayının ikisinin de tek veya ikisinin de çift olduğu bir bulmaca durumunu çözmek imkânsızdır.
+
+Çözülebilirliği denetleyen kod şöyledir:
+
+```lua
+-- Is the given table list of 4x4 tiles solvable?
+local function solvable(t)
+    local x,y = find(t, 0)
+    if y % 2 == 1 and inversions(t) % 2 == 0 then
+        return true
+    end
+    if y % 2 == 0 and inversions(t) % 2 == 1 then
+        return true
+    end
+    return false    
+end
+```
+
+## Kullanıcı girdisi
+
+Şimdi geriye yalnızca bulmacayı etkileşimli hâle getirmek kaldı.
+
+Yukarıda oluşturulan işlevleri kullanarak çalışma sırasındaki tüm hazırlıkları yapan bir `init()` işlevi oluşturun:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus") -- <1>
+    math.randomseed(socket.gettime()) -- <2>
+    self.board = scramble({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0}) -- <3>
+    while not solvable(self.board) do -- <4>
+        self.board = scramble(self.board)
+    end
+    draw(self.board) -- <5>
+    self.done = false -- <6>
+    msg.post("#done", "disable") -- <7>
+end
+```
+1. Motora bu oyun nesnesinin girdi alması gerektiğini bildirin.
+2. Rastgele sayı üretecinin başlangıç değerini belirleyin.
+3. Tahta için rastgele bir başlangıç durumu oluşturun.
+4. Durum çözülemiyorsa yeniden karıştırın.
+5. Tahtayı çizin.
+6. Kazanma durumunu izlemek için bir tamamlanma bayrağı ayarlayın.
+7. Tamamlanma iletisini gösteren etiketi devre dışı bırakın.
+
+*/input/game.input_bindings* dosyasını açın ve yeni bir *Mouse Trigger* ekleyin. Eylemin adını "press" olarak ayarlayın:
+
+![girdi](images/15-puzzle/input.png)
+
+Betiğe dönün ve bir `on_input()` işlevi oluşturun.
+
+```lua
+-- Deal with user input
+function on_input(self, action_id, action)
+    if action_id == hash("press") and action.pressed and not self.done then -- <1>
+        local x = math.ceil(action.x / 128) -- <2>
+        local y = math.ceil(action.y / 128)
+        local ex, ey = find(self.board, 0) -- <3>
+        if math.abs(x - ex) + math.abs(y - ey) == 1 then -- <4>
+            self.board = swap(self.board, (4-ey)*4+ex, (4-y)*4+x) -- <5>
+            draw(self.board) -- <6>
+        end
+        ex, ey = find(self.board, 0)
+        if inversions(self.board) == 0 and ex == 4 then -- <7>
+            self.done = true
+            msg.post("#done", "enable")
+        end
+    end
+end
+```
+1. Bir fare düğmesine basıldıysa ve oyun hâlâ sürüyorsa aşağıdakileri yapın.
+2. Kullanıcının tıkladığı karenin x ve y konumlarını hesaplayın.
+3. Boş (0) karenin geçerli konumunu bulun.
+4. Tıklanan kare, boş karenin hemen üstünde, altında, solunda veya sağındaysa aşağıdakileri yapın:
+5. Tıklanan karedeki karoyla boş karenin yerini değiştirin.
+6. Güncellenen tahtayı yeniden çizin.
+7. Tahtadaki terslik sayısı 0 ise, yani her şey doğru sıradaysa ve boş kare en sağdaki sütundaysa (terslik sayısının 0 olması için son satırda olmalıdır), bulmaca çözülmüş demektir; bu durumda aşağıdakileri yapın:
+8. Tamamlanma bayrağını ayarlayın.
+9. Tamamlanma iletisini etkinleştirin/gösterin.
+
+İşte bu kadar! İşiniz bitti, bulmaca oyunu tamamlandı!
+
+## Betiğin tamamı
+
+Başvuru için betik kodunun tamamı aşağıdadır:
+
+```lua
+local function inversions(t)
+    local inv = 0
+    for i=1, #t do
+        for j=i+1, #t do
+            if t[i] > t[j] and t[j] ~= 0 then
+                inv = inv + 1
+            end
+        end
+    end
+    return inv
+end
+
+local function find(t, tile)
+    for i=1, #t do
+        if t[i] == tile then
+            local y = 5 - math.ceil(i/4)
+            local x = i - (math.ceil(i/4) - 1) * 4
+            return x,y
+        end
+    end
+end
+
+local function solvable(t)
+    local x,y = find(t, 0)
+    if y % 2 == 1 and inversions(t) % 2 == 0 then
+        return true
+    end
+    if y % 2 == 0 and inversions(t) % 2 == 1 then
+        return true
+    end
+    return false    
+end
+
+local function scramble(t)
+    for i=1, #t do
+        local tmp = t[i]
+        local r = math.random(#t)
+        t[i] = t[r]
+        t[r] = tmp
+    end
+    return t
+end
+
+local function swap(t, i, j)
+    local tmp = t[i]
+    t[i] = t[j]
+    t[j] = tmp
+    return t
+end
+
+local function draw(t)
+    for i=1, #t do
+        local y = 5 - math.ceil(i/4)
+        local x = i - (math.ceil(i/4) - 1) * 4
+        tilemap.set_tile("#tilemap","layer1",x,y,t[i])
+    end
+end
+
+function init(self)
+    msg.post(".", "acquire_input_focus")
+    math.randomseed(socket.gettime())
+    self.board = scramble({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0})   
+    while not solvable(self.board) do
+        self.board = scramble(self.board)
+    end
+    draw(self.board)
+    self.done = false
+    msg.post("#done", "disable")
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("press") and action.pressed and not self.done then
+        local x = math.ceil(action.x / 128)
+        local y = math.ceil(action.y / 128)
+        local ex, ey = find(self.board, 0)
+        if math.abs(x - ex) + math.abs(y - ey) == 1 then
+            self.board = swap(self.board, (4-ey)*4+ex, (4-y)*4+x)
+            draw(self.board)
+        end
+        ex, ey = find(self.board, 0)
+        if inversions(self.board) == 0 and ex == 4 then
+            self.done = true
+            msg.post("#done", "enable")
+        end
+    end
+end
+
+function on_reload(self)
+    self.done = false
+    msg.post("#done", "disable")
+end
+```
+
+## Ek alıştırmalar
+
+1. 5⨉5 boyutunda bir bulmaca, ardından 6⨉5 boyutunda bir bulmaca yapın. Çözülebilirlik denetimlerinin genel durumlarda çalıştığından emin olun.
+2. Kaydırma animasyonları ekleyin. Karolar, karo haritasından ayrı olarak hareket ettirilemediği için buna bir çözüm bulmanız gerekecektir. Belki de yalnızca kayan parçayı içeren ayrı bir karo haritası kullanabilirsiniz?

--- a/docs/tr/tutorials/astronaut.md
+++ b/docs/tr/tutorials/astronaut.md
@@ -1,0 +1,34 @@
+---
+title: Üstten görünümde hareket öğreticisi
+brief: Başlangıç düzeyindeki bu öğreticide oyuncu girdilerini yakalamayı, bir karakteri hareket ettirmeyi ve canlandırmayı öğreneceksiniz. Ayrıca oyun nesneleri, bileşenler ve koleksiyonlar hakkında bilgi edineceksiniz
+github: https://github.com/defold/tutorial-astronaut
+difficulty: Beginner
+---
+
+# Üstten görünümde hareket öğreticisi
+
+Başlangıç düzeyindeki bu öğreticide Defold'da üstten görünümlü bir oyun için basit bir karakter denetleyicisi oluşturmayı öğreneceksiniz. Özel olarak hazırlanmış bir projeyle başlayacağınız için varlıklarla ve temel kurulumla uğraşmanız gerekmeyecek; oyun mekaniklerine odaklanacaksınız.
+
+Koleksiyonlar (collection), oyun nesneleri (game object), sprite bileşenleri (sprite), betikler (script), karo haritaları (tilemap), atlaslar ve kameralar dahil olmak üzere bir Defold projesinin temel yapısını keşfedeceksiniz. Karaktere yürüme animasyonları ekleyecek, oyuncu girdilerini işleyecek, Lua kullanarak oyun nesnesini hareket ettirecek, çapraz hareketi normalleştirecek ve hareket yönüne göre animasyonları değiştireceksiniz.
+
+Öğreticinin sonunda küçük bir karo haritasından oluşan bölümde hareket eden, animasyonları çalışan bir karakteriniz olacak ve WASD kontrolleri, kameranın karakteri takip etmesi veya daha büyük bir harita gibi özelliklerle projeyi daha da geliştirmeye hazır olacaksınız.
+
+## Doğrudan Defold'dan çalıştırma
+
+Öğretici, Defold düzenleyicisine entegre edilmiştir ve Defold'un karşılama ekranından kolayca erişilebilir:
+
+1. Soldaki *Create From* -> <kbd>Tutorials</kbd> seçeneğini seçin.
+2. <kbd>Top-down Movement Tutorial</kbd> seçeneğini seçin.
+3. Projeniz için *Title* alanına bir başlık yazın.
+4. *Location* alanında proje için yerel diskinizden bir konum seçin.
+5. <kbd>Create New Project</kbd> düğmesine tıklayın.
+
+![yeni proje](images/top-down-start.webp)
+
+Düzenleyici, izleyebileceğiniz öğretici metninin tamamını içeren "README" dosyasını proje kök dizininden otomatik olarak açar.
+
+![simge](images/icon-tutorial.svg){.icon} [Öğretici metninin tamamını GitHub'da da okuyabilirsiniz](https://github.com/defold/tutorial-astronaut)
+
+Bir yerde takılırsanız Defold ekibinden ve yardımsever birçok kullanıcıdan destek alabileceğiniz [Defold Forumu'na](//forum.defold.com) gidin.
+
+Defold ile keyifli çalışmalar!

--- a/docs/tr/tutorials/car.md
+++ b/docs/tr/tutorials/car.md
@@ -1,0 +1,439 @@
+---
+title: Defold ile basit bir araba oluşturma.
+brief: Defold kullanmaya yeni başladıysanız bu kılavuz düzenleyiciyi tanımanıza yardımcı olacaktır. Ayrıca temel fikirleri ve Defold'un en yaygın yapı taşlarını açıklar - oyun nesneleri, koleksiyonlar, betikler ve sprite bileşenleri.
+---
+
+# Araba oluşturma
+
+Defold kullanmaya yeni başladıysanız bu kılavuz düzenleyiciyi tanımanıza yardımcı olacaktır. Ayrıca temel fikirleri ve Defold'un en yaygın yapı taşlarını açıklar: oyun nesneleri, koleksiyonlar, betikler ve sprite bileşenleri.
+
+Boş bir projeyle başlayıp adım adım çok küçük, oynanabilir bir uygulama oluşturacağız. Sonunda Defold'un nasıl çalıştığı hakkında bir fikir edinmiş ve daha kapsamlı bir öğreticiyi izlemeye ya da doğrudan kılavuzlara geçmeye hazır olacağınızı umuyoruz.
+
+::: sidenote
+Öğretici boyunca kavramlara ve belirli işlemlerin nasıl yapıldığına ilişkin ayrıntılı açıklamalar, bu paragraf gibi işaretlenmiştir. Bu bölümlerin fazla ayrıntıya girdiğini düşünüyorsanız onları atlayabilirsiniz.
+:::
+
+## Yeni proje oluşturma
+
+![Yeni proje](images/new_empty.png)
+
+1. Defold'u başlatın.
+2. Soldaki *New Project* seçeneğini seçin.
+3. *From Template* sekmesini seçin.
+4. *Empty Project* seçeneğini seçin
+5. Proje için yerel sürücünüzde bir konum seçin.
+6. *Create New Project* düğmesine tıklayın.
+
+## Düzenleyici
+
+[Yeni bir proje](/manuals/project-setup/) oluşturup düzenleyicide açarak başlayın. *main/main.collection* dosyasına çift tıklarsanız dosya açılır:
+
+![Düzenleyiciye genel bakış](../manuals/images/editor/editor2_overview.png)
+
+Düzenleyici şu ana alanlardan oluşur:
+
+Assets bölmesi
+: Bu görünüm projenizdeki tüm dosyaları gösterir. Farklı dosya türlerinin farklı simgeleri vardır. Bir dosyayı türüne uygun düzenleyicide açmak için çift tıklayın. Salt okunur özel *builtins* klasörü tüm projelerde ortaktır ve varsayılan bir işleme betiği (render script), bir yazı tipi, çeşitli bileşenlerin işlenmesi (rendering) için materyaller ve başka yararlı öğeler içerir.
+
+Ana düzenleyici görünümü
+: Düzenlediğiniz dosyanın türüne bağlı olarak bu görünümde o türe uygun bir düzenleyici gösterilir. En yaygın kullanılanı, burada gördüğünüz Scene düzenleyicisidir. Açık olan her dosya ayrı bir sekmede gösterilir.
+
+Changed Files
+: Geçerli Git commit'ine göre yerel olarak eklenen, değiştirilen, yeniden adlandırılan veya silinen dosyaları içerir. Burada metin farklarını görüntüleyebilir ve yerel değişiklikleri geri alabilirsiniz. Uzak bir depoyla eşitlemek için harici bir Git istemcisi veya komut satırı kullanın.
+
+Outline
+: O anda düzenlenen dosyanın içeriğini hiyerarşik bir görünümde gösterir. Bu görünüm aracılığıyla nesneleri ve bileşenleri ekleyebilir, silebilir, değiştirebilir ve seçebilirsiniz.
+
+Properties
+: O anda seçili nesne veya bileşen için ayarlanmış özellikler.
+
+Console
+: Oyun çalışırken bu görünüm, oyun motorundan gelen çıktıları (günlük kayıtları, hatalar, hata ayıklama bilgileri vb.) ve betiklerinizdeki özel `print()` ve `pprint()` hata ayıklama iletilerini gösterir. Uygulamanız veya oyununuz başlamıyorsa ilk kontrol etmeniz gereken yer konsoldur. Konsolun arkasında hata bilgilerini gösteren bir dizi sekme ve parçacık efektleri oluşturulurken kullanılan bir eğri düzenleyicisi bulunur.
+
+## Oyunu çalıştırma
+
+"Empty" proje şablonu gerçekten de tamamen boştur. Yine de projeyi derleyip oyunu başlatmak için <kbd>Project ▸ Build</kbd> seçeneğini seçin.
+
+![Proje derleme](images/car/start_build_and_launch.png)
+
+Siyah bir ekran pek heyecan verici olmayabilir, ancak bu, çalışan bir Defold oyun uygulamasıdır ve onu kolayca daha ilginç bir şeye dönüştürebiliriz. Öyleyse bunu yapalım.
+
+::: sidenote
+Defold düzenleyicisi dosyalar üzerinde çalışır. *Assets bölmesinde* bir dosyaya çift tıklayarak onu uygun bir düzenleyicide açarsınız. Ardından dosyanın içeriği üzerinde çalışabilirsiniz.
+
+Bir dosyayı düzenlemeyi bitirdiğinizde onu kaydetmeniz gerekir. Ana menüden <kbd>File ▸ Save</kbd> seçeneğini seçin. Düzenleyici, kaydedilmemiş değişiklikler içeren dosyaların sekmelerindeki dosya adına bir yıldız işareti '\*' ekleyerek bunu belirtir.
+
+![Kaydedilmemiş değişiklikler içeren dosya](images/car/file_changed.png)
+:::
+
+## Arabayı birleştirme
+
+İlk yapacağımız şey yeni bir koleksiyon (collection) oluşturmak. Koleksiyon, yerleştirdiğiniz ve konumlandırdığınız oyun nesnelerini barındıran bir kapsayıcıdır. Koleksiyonlar en yaygın olarak oyun bölümleri oluşturmak için kullanılır, ancak bir arada bulunması gereken oyun nesnesi gruplarını ve/veya hiyerarşilerini yeniden kullanmanız gerektiğinde de çok yararlıdır. Koleksiyonları bir tür yeniden kullanılabilir nesne tanımı, yani prefab olarak düşünmek faydalı olabilir.
+
+*Assets bölmesindeki* *main* klasörüne tıklayın, ardından sağ tıklayıp <kbd>New ▸ Collection File</kbd> seçeneğini seçin. Ana menüden <kbd>File ▸ New ▸ Collection File</kbd> seçeneğini de seçebilirsiniz.
+
+![Yeni koleksiyon dosyası](images/car/start_new_collection.png)
+
+Yeni koleksiyon dosyasına *car.collection* adını verin ve dosyayı açın. Bu yeni, boş koleksiyonu kullanarak birkaç oyun nesnesinden küçük bir araba oluşturacağız. Oyun nesnesi (game object), oyununuzu oluşturmak için kullandığınız bileşenleri (component; sprite bileşenleri, sesler, oyun mantığı betikleri vb.) barındıran bir kapsayıcıdır. Her oyun nesnesi, oyunda id değeriyle benzersiz olarak tanımlanır. Oyun nesneleri ileti aktarımı (message passing) yoluyla birbirleriyle iletişim kurabilir; buna daha sonra değineceğiz.
+
+Ayrıca burada yaptığımız gibi bir koleksiyonun içinde yerinde bir oyun nesnesi oluşturmak da mümkündür. Bunun sonucunda kendine özgü bir nesne oluşur. Bu nesneyi kopyalayabilirsiniz, ancak her kopya ayrıdır---birini değiştirmek diğerlerini etkilemez. Yani bir oyun nesnesinin 10 kopyasını oluşturup hepsini değiştirmek istediğinizi fark ederseniz nesnenin 10 örneğinin tamamını düzenlemeniz gerekir. Bu nedenle, yerinde oluşturulan oyun nesneleri çok sayıda kopyasını oluşturmayı düşünmediğiniz nesneler için kullanılmalıdır.
+
+Buna karşılık, bir _dosyada_ saklanan oyun nesnesi bir prototip (prototype; diğer motorlarda "prefab" veya "taslak", yani "blueprint" olarak da bilinir) işlevi görür. Dosyada saklanan bir oyun nesnesinin örneklerini koleksiyona yerleştirdiğinizde her nesne _başvuru yoluyla_ yerleştirilir---yani prototipe dayalı bir klondur. Prototipi değiştirmeniz gerektiğine karar verirseniz o prototipe dayalı olarak yerleştirilen her oyun nesnesi anında güncellenir.
+
+![Araba oyun nesnesi ekleme](images/car/start_add_car_gameobject.png)
+
+*Outline* görünümünde kök "Collection" düğümünü seçin, sağ tıklayıp <kbd>Add Game Object</kbd> seçeneğini seçin. Koleksiyonda id değeri "go" olan yeni bir oyun nesnesi görünür. Bu nesneyi seçin ve *Properties* görünümünde id değerini "car" olarak ayarlayın. "car" şu ana kadar pek ilgi çekici değil. Boş; ne görsel bir temsili ne de herhangi bir mantığı var. Görsel bir temsil eklemek için bir sprite _bileşeni_ eklememiz gerekir.
+
+Bileşenler, oyun nesnelerine görsel ve işitsel varlık (grafikler, ses) ve işlevsellik (fabrikalarla (factory) çalışma sırasında nesne oluşturma, çarpışmalar, betiklerle tanımlanan davranışlar) eklemek için kullanılır. Bir bileşen kendi başına var olamaz; bir oyun nesnesinin içinde bulunmalıdır. Bileşenler genellikle oyun nesnesiyle aynı dosyada yerinde tanımlanır. Ancak bir bileşeni yeniden kullanmak istiyorsanız onu ayrı bir dosyada saklayabilir (oyun nesnelerinde olduğu gibi) ve herhangi bir oyun nesnesi dosyasına başvuru olarak ekleyebilirsiniz. Bazı bileşen türlerinin (örneğin Lua betiklerinin) ayrı bir bileşen dosyasına yerleştirilmesi ve ardından nesnelerinize başvuru olarak eklenmesi gerekir.
+
+Bileşenleri doğrudan değiştirmediğinizi unutmayın---bileşenleri barındıran oyun nesnelerini taşıyabilir, döndürebilir, ölçekleyebilir ve özelliklerine animasyon uygulayabilirsiniz.
+
+![Araba bileşeni ekleme](images/car/start_add_car_component.png)
+
+"car" oyun nesnesini seçin, sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin; ardından *Sprite* seçeneğini seçip *Ok* düğmesine tıklayın. *Outline* görünümünde sprite bileşenini seçerseniz bazı özelliklerinin ayarlanması gerektiğini görürsünüz:
+
+Image
+: Burada sprite bileşeni için bir görüntü kaynağı gerekir. *Assets bölmesinde* "main" klasörünü seçin, sağ tıklayıp <kbd>New ▸ Atlas File</kbd> seçeneğini seçerek bir atlas görüntü dosyası oluşturun. Yeni atlas dosyasına *sprites.atlas* adını verin ve atlas düzenleyicisinde açmak için çift tıklayın. Aşağıdaki iki görüntü dosyasını bilgisayarınıza kaydedin ve *Assets bölmesindeki* *main* klasörüne sürükleyin. Artık atlas düzenleyicisinde Atlas kök düğümünü seçip sağ tıklayarak <kbd>Add Images</kbd> seçeneğini seçebilirsiniz. Araba ve lastik görüntülerini atlasa ekleyip kaydedin. Artık "car" koleksiyonundaki "car" oyun nesnesinde bulunan sprite bileşeninin görüntü kaynağı olarak *sprites.atlas* dosyasını seçebilirsiniz.
+
+Oyunumuz için görüntüler:
+
+![Araba görüntüsü](images/car/start_car.png)
+![Lastik görüntüsü](images/car/start_tire.png)
+
+Bu görüntüleri atlasa ekleyin:
+
+![Sprite atlası](images/car/start_sprites_atlas.png)
+
+![Sprite özellikleri](images/car/start_sprite_properties.png)
+
+Default Animation
+: Bunu "car" olarak (veya araba görüntüsüne verdiğiniz ad neyse o adla) ayarlayın. Her sprite bileşeni, oyunda gösterildiğinde oynatılacak bir varsayılan animasyona ihtiyaç duyar. Bir atlasa görüntü eklediğinizde Defold, her görüntü dosyası için tek karelik (durağan) animasyonlar oluşturarak işinizi kolaylaştırır.
+
+## Arabayı tamamlama
+
+Koleksiyona iki oyun nesnesi daha ekleyerek devam edin. Bunlara "left_wheel" ve "right_wheel" adlarını verin ve her birine, *sprites.atlas* dosyasına eklediğimiz lastik görüntüsünü gösteren bir sprite bileşeni koyun. Ardından tekerlek oyun nesnelerini tutup "car" üzerine bırakarak onları "car" nesnesinin alt nesneleri yapın. Başka oyun nesnelerinin alt nesnesi olan oyun nesneleri, üst nesneleri hareket ettiğinde ona bağlı kalır. Ayrı ayrı da hareket ettirilebilirler, ancak tüm hareketler üst nesneye göredir. Bu, lastikler için tam istediğimiz davranıştır; çünkü onların arabaya bağlı kalmasını isteriz ve arabayı yönlendirirken onları hafifçe sola ve sağa döndürmemiz yeterlidir. Bir koleksiyon, yan yana duran, karmaşık üst-alt nesne ağaçları biçiminde düzenlenmiş veya bu iki biçimi bir arada kullanan istenen sayıda oyun nesnesi içerebilir.
+
+Lastik oyun nesnelerini seçip <kbd>Scene ▸ Move Tool</kbd> seçeneğini seçerek yerlerine taşıyın. Nesneyi uygun bir noktaya taşımak için ok tutamaçlarını veya ortadaki yeşil kareyi tutun. Son olarak lastiklerin arabanın altında çizildiğinden emin olmamız gerekir. Bunu, konumun Z bileşenini -0.5 olarak ayarlayarak yaparız. Oyundaki her görsel öğe, Z değerine göre sıralanarak arkadan öne doğru çizilir. Z değeri 0 olan bir nesne, Z değeri -0.5 olan bir nesnenin üzerine çizilir. Araba oyun nesnesinin varsayılan Z değeri 0 olduğundan lastik nesnelerinin yeni değeri onları araba görüntüsünün altına yerleştirir.
+
+![Tamamlanmış araba koleksiyonu](images/car/start_car_collection_complete.png)
+
+## Araba betiği
+
+Bulmacanın son parçası, arabayı kontrol edecek bir _betiktir_ (script). Betik, oyun nesnelerinin davranışlarını tanımlayan bir program içeren bileşendir. Betiklerle oyununuzun kurallarını ve nesnelerin çeşitli etkileşimlere (hem oyuncuyla hem de diğer nesnelerle) nasıl tepki vermesi gerektiğini belirleyebilirsiniz. Tüm betikler Lua programlama dilinde yazılır. Defold ile çalışabilmek için sizin veya ekibinizden birinin Lua ile programlamayı öğrenmesi gerekir.
+
+*Assets bölmesinde* "main" klasörünü seçin, sağ tıklayıp <kbd>New ▸ Script File</kbd> seçeneğini seçin. Yeni dosyaya *car.script* adını verin; ardından *Outline* görünümünde "car" nesnesini seçip sağ tıklayın ve <kbd>Add Component File</kbd> seçeneğini seçerek dosyayı "car" oyun nesnesine ekleyin. *car.script* dosyasını seçin ve *OK* düğmesine tıklayın. Koleksiyon dosyasını kaydedin.
+
+*car.script* dosyasını açmak için çift tıklayın.
+
+::: sidenote
+Defold, oyun mantığını kodlamak için çeşitli yaşam döngüsü işlevleri sağlar. Bunlar hakkında daha fazla bilgiyi [Betik kılavuzunda](/manuals/script) bulabilirsiniz.
+:::
+
+Bu öğreticide ihtiyaç duymayacağımız için önce `final`, `on_message` ve `on_reload` işlevlerini
+kaldırın.
+
+Ardından `init` işlevinin başlangıcından önce aşağıdaki kod satırlarını ekleyin.
+
+```lua
+-- Constants
+local turn_speed = 0.1                           									  -- Slerp factor
+local max_steer_angle_left = vmath.quat_rotation_z(math.pi / 6)     -- 30 degrees
+local max_steer_angle_right = vmath.quat_rotation_z(-math.pi / 6)   -- -30 degrees
+local steer_angle_zero = vmath.quat_rotation_z(0)									  -- Zero degrees
+local wheels_vector = vmath.vector3(0, 72, 0)         		        	-- Vector from center of back and front wheel pairs
+
+local acceleration = 100 																						-- The acceleration of the car
+
+-- prehash the inputs
+local left = hash("left")
+local right = hash("right")
+local accelerate = hash("accelerate")
+local brake = hash("brake")
+```
+
+Burada yapılan değişiklikler oldukça basit; betiğimize, daha sonra arabamızın kodunu yazarken kullanacağımız bir dizi sabit (`constants`) ekledik.
+
+::: sidenote
+Karma değerlerini (hash) önceden değişkenlerde nasıl sakladığımıza dikkat edin. Bunu yapmak iyi bir uygulamadır; çünkü kodunuzu daha okunabilir ve performanslı hâle getirir.
+:::
+
+Ardından `init` işlevini aşağıdakileri içerecek şekilde düzenleyin:
+
+```lua
+function init(self)
+	-- Send a message to the render script (see builtins/render/default.render_script) to set the clear color.
+	-- This changes the background color of the game. The vector4 contains color information
+	-- by channel from 0-1: Red = 0.2. Green = 0.2, Blue = 0.2 and Alpha = 1.0
+	msg.post("@render:", "clear_color", { color = vmath.vector4(0.2, 0.2, 0.2, 1.0) } )		--<1>
+
+	-- Acquire input focus so we can react to input
+	msg.post(".", "acquire_input_focus")		-- <2>
+
+	-- Some variables
+	self.steer_angle = vmath.quat()				 -- <3>
+	self.direction = vmath.quat()
+
+	-- Velocity and acceleration are car relative (not rotated)
+	self.velocity = vmath.vector3()
+	self.acceleration = vmath.vector3()
+
+	-- Input vector. This is modified later in the on_input function
+	-- to store the input.
+	self.input = vmath.vector3()
+end
+```
+
+Az önce neleri değiştirdiğimizi merak ediyorsanız aşağıdaki açıklamaya bakın.
+
+1. İşleme betiğimize, arka plan rengini gri olarak ayarlamasını isteyen bir ileti gönderiyoruz. İşleme betikleri, nesnelerin ekranda nasıl gösterileceğini kontrol eden özel Defold betikleridir.
+2. Bir betik bileşeninde veya GUI betiğinde girdi eylemlerini dinlemek için bileşeni barındıran oyun nesnesine `acquire_input_focus` iletisinin gönderilmesi gerekir. Bu örnekte iletiyi araba betiğini barındıran oyun nesnesine gönderiyoruz.
+3. Ardından arabamızın geçerli durumunu takip etmek için kullanacağımız bazı değişkenler tanımlıyoruz.
+
+Kolaydı, değil mi? Şimdi `update` işlevini aşağıdakileri içerecek şekilde düzenleyerek devam edeceğiz:
+
+```lua
+function update(self, dt)
+	-- Set acceleration to the y input
+	self.acceleration.y = self.input.y * acceleration				-- <1>
+
+	-- Calculate the new positions of front and back wheels
+	local front_vel = vmath.rotate(self.steer_angle, self.velocity)
+	local new_front_pos = vmath.rotate(self.direction, wheels_vector + front_vel)
+	local new_back_pos = vmath.rotate(self.direction, self.velocity)								-- <2>
+
+	-- Calculate the car's new direction
+	local new_dir = vmath.normalize(new_front_pos - new_back_pos)
+	self.direction = vmath.quat_rotation_z(math.atan2(new_dir.y, new_dir.x) - math.pi / 2)			-- <3>
+
+	-- Calculate new velocity based on current acceleration
+	self.velocity = self.velocity + self.acceleration * dt			-- <4>
+
+	-- Update position based on current velocity and direction
+	local pos = go.get_position()
+	pos = pos + vmath.rotate(self.direction, self.velocity)
+	go.set_position(pos)																			-- <5>
+
+	-- Interpolate the wheels using vmath.slerp
+	if self.input.x > 0 then																		-- <6>
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, max_steer_angle_right)
+	elseif self.input.x < 0 then
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, max_steer_angle_left)
+	else
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, steer_angle_zero)
+	end
+
+	-- Update the wheel rotation
+	go.set_rotation(self.steer_angle, "left_wheel")					-- <7>
+	go.set_rotation(self.steer_angle, "right_wheel")
+
+	-- Set the game object's rotation to the direction
+	go.set_rotation(self.direction)
+
+	-- reset acceleration and input
+	self.acceleration = vmath.vector3()								-- <8>
+	self.input = vmath.vector3()
+end
+```
+
+Bu oldukça büyük bir işlevdi! Ama endişelenmeyin; işte tüm bunların nasıl çalıştığı:
+
+1. Önce ivme vektörümüzü girdi vektörümüze göre ayarlarız. Bu, arabanın ivmesinin girdi yönünde olmasını sağlar.
+2. Ardından her iki tekerleğin yer değiştirmesi hesaplanır. Bunun dayandığı basit mantık şudur: arabanın arka tekerlekleri her zaman ileri doğru hareket ederken ön tekerlekler döndürüldükleri yönde hareket eder.
+3. Her iki tekerleğin yer değiştirmesine göre arabamızın yeni hareket yönü hesaplanır.
+4. Burada hesaplanan ivmeyi hıza ekleriz.
+5. Son olarak arabanın konumunu geçerli hızımıza göre güncelleriz.
+6. Sol/sağ girdimize göre direksiyon açısına küresel doğrusal ara değerleme (slerp) uygularız. Böylece girdi değiştiğinde tekerlekler aniden yeni açıya geçmez.
+7. Ardından tekerleklerin dönmesi, arabanın geçerli direksiyon açısına göre ayarlanır. Benzer şekilde arabanın dönmesi de o anda hareket ettiği yöne göre ayarlanır.
+8. Son olarak ivme ve girdi vektörlerini sıfırlarız.
+
+Sonunda arabamızın girdiye tepki vermesini sağlamanın zamanı geldi. `on_input` işlevini şu şekilde güncelleyin:
+
+```lua
+function on_input(self, action_id, action)
+	-- set the input vector to correspond to the key press
+	if action_id == left then
+		self.input.x = -1
+	elseif action_id == right then
+		self.input.x = 1
+	elseif action_id == accelerate then
+		self.input.y = 1
+	elseif action_id == brake then
+		self.input.y = -1
+	end
+end
+```
+
+Bu işlev aslında oldukça basit; yalnızca girdiyi alıp girdi vektörümüzü ayarlarız.
+
+Düzenlemelerinizi kaydetmeyi unutmayın.
+
+## Girdi
+
+Henüz hiçbir girdi eylemi ayarlanmadı; şimdi bunu yapalım. */input/game.input_bindings* dosyasını açın ve "accelerate", "brake", "left" ve "right" için *key_trigger* girdi eşlemeleri (input binding) ekleyin. Bunları ok tuşlarına (KEY_LEFT, KEY_RIGHT, KEY_UP ve KEY_DOWN) eşliyoruz:
+
+![Girdi eşlemeleri](images/car/start_input_bindings.png)
+
+## Arabayı oyuna ekleme
+
+Araba artık sürüşe hazır. Onu "car.collection" içinde oluşturduk, ancak henüz oyunda mevcut değil. Bunun nedeni, motorun şu anda başlatılırken "main.collection" dosyasını yüklemesidir. Bunu düzeltmek için *car.collection* dosyasını *main.collection* dosyasına eklememiz yeterlidir. *main.collection* dosyasını açın, *Outline* görünümünde kök "Collection" düğümünü seçin, sağ tıklayıp <kbd>Add Collection From File</kbd> seçeneğini seçin; ardından *car.collection* dosyasını seçip *OK* düğmesine tıklayın. Artık *car.collection* dosyasının içeriği, yeni örnekler olarak *main.collection* içine yerleştirilir. *car.collection* dosyasının içeriğini değiştirirseniz koleksiyonun her örneği oyun derlendiğinde otomatik olarak güncellenir.
+
+![Araba koleksiyonunu ekleme](images/car/start_adding_car_collection.png)
+
+Şimdi <kbd>Project ▸ Build</kbd> seçeneğini seçin ve yeni arabanızla bir tur atın!
+Artık arabayı istediğiniz gibi hareket ettirebildiğinizi göreceksiniz. Ancak hâlâ yolunda gitmeyen bir şey var. Kontrolleri bıraktığınızda araba, durması gerektiği hâlde durmuyor. Şimdi bunu ekleme zamanı!
+
+## Sürükleme kuvveti imdada yetişiyor
+
+Gerçek dünyada bir nesne hareket ettiğinde sürükleme kuvveti (drag), nesnenin hareketine karşı koyarak yavaşlamasına neden olur. Bu kuvvet, hareketli nesnenin hızının karesiyle yaklaşık olarak orantılıdır ve dolayısıyla `D = k * |V| * V` olarak ifade edilebilir. Burada `k` bir sabit, `V` hız ve `|V|` hızın büyüklüğüdür (sürat). Bunu ekleyelim.
+
+Betiğin başındaki sabitler bölümüne aşağıdaki sabiti ekleyin
+
+```lua
+local drag = 1.1	        --the drag constant <1>
+```
+
+Ardından `update` işlevinde bu satırın hemen üstüne aşağıdaki satırları ekleyin ve dosyayı kaydedin.
+
+```lua
+function update(self, dt)
+	...
+  -- Calculate new velocity based on current acceleration
+	self.velocity = self.velocity + self.acceleration * dt
+	...
+end
+```
+
+```lua
+function update(self, dt)
+	...
+	-- Speed is the magnitude of the velocity
+	local speed = vmath.length_sqr(self.velocity)
+
+	-- Apply drag
+	self.acceleration = self.acceleration - speed * self.velocity * drag
+
+	-- Stop if we are already slow enough
+	if speed < 0.5 then self.velocity = vmath.vector3(0) end
+	...
+end
+```
+
+1. Sürükleme değerini sabit olarak tanımlayın.
+2. Hareket ettiğimiz sürati hesaplayın.
+3. Formüle göre geçerli ivmeye sürükleme kuvvetini uygulayın
+4. Araba zaten yeterince yavaşsa durdurun.
+
+## Araba betiğinin tamamı
+
+Yukarıdaki adımları tamamladıktan sonra *car.script* dosyanız şöyle görünmelidir:
+
+```lua
+local turn_speed = 0.1                           				          	-- Slerp factor
+local max_steer_angle_left = vmath.quat_rotation_z(math.pi / 6)	    -- 30 degrees
+local max_steer_angle_right = vmath.quat_rotation_z(-math.pi / 6)   -- -30 degrees
+local steer_angle_zero = vmath.quat_rotation_z(0)				          	-- Zero degrees
+local wheels_vector = vmath.vector3(0, 72, 0)         				      -- Vector from center of back and front wheel pairs
+
+local acceleration = 100 		                      									-- The acceleration of the car
+local drag = 1.1                                                  	-- the drag constant
+
+function init(self)
+	-- Send a message to the render script (see builtins/render/default.render_script) to set the clear color.
+	-- This changes the background color of the game. The vector4 contains color information
+	-- by channel from 0-1: Red = 0.2. Green = 0.2, Blue = 0.2 and Alpha = 1.0
+	msg.post("@render:", "clear_color", { color = vmath.vector4(0.2, 0.2, 0.2, 1.0) } )
+
+	-- Acquire input focus so we can react to input
+	msg.post(".", "acquire_input_focus")
+
+	-- Some variables
+	self.steer_angle = vmath.quat()
+	self.direction = vmath.quat()
+
+	-- Velocity and acceleration are car relative (not rotated)
+	self.velocity = vmath.vector3()
+	self.acceleration = vmath.vector3()
+
+	-- Input vector. This is modified later in the on_input function
+	-- to store the input.
+	self.input = vmath.vector3()
+end
+
+function update(self, dt)
+	-- Set acceleration to the y input
+	self.acceleration.y = self.input.y * acceleration
+
+	-- Calculate the new positions of front and back wheels
+	local front_vel = vmath.rotate(self.steer_angle, self.velocity)
+	local new_front_pos = vmath.rotate(self.direction, wheels_vector + front_vel)
+	local new_back_pos = vmath.rotate(self.direction, self.velocity)
+
+	-- Calculate the car's new direction
+	local new_dir = vmath.normalize(new_front_pos - new_back_pos)
+	self.direction = vmath.quat_rotation_z(math.atan2(new_dir.y, new_dir.x) - math.pi / 2)
+
+	-- Speed is the magnitude of the velocity
+	local speed = vmath.length(self.velocity)
+
+	-- Apply drag
+	self.acceleration = self.acceleration - speed * self.velocity * drag
+
+	-- Stop if we are already slow enough
+	if speed < 0.5 then self.velocity = vmath.vector3() end
+
+	-- Calculate new velocity based on current acceleration
+	self.velocity = self.velocity + self.acceleration * dt
+
+	-- Update position based on current velocity and direction
+	local pos = go.get_position()
+	pos = pos + vmath.rotate(self.direction, self.velocity)
+	go.set_position(pos)
+
+	-- Interpolate the wheels using vmath.slerp
+	if self.input.x > 0 then
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, max_steer_angle_right)
+	elseif self.input.x < 0 then
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, max_steer_angle_left)
+	else
+		self.steer_angle = vmath.slerp(turn_speed, self.steer_angle, steer_angle_zero)
+	end
+
+	-- Update the wheel rotation
+	go.set_rotation(self.steer_angle, "left_wheel")
+	go.set_rotation(self.steer_angle, "right_wheel")
+
+	-- Set the game object's rotation to the direction
+	go.set_rotation(self.direction)
+
+	-- reset acceleration and input
+	self.acceleration = vmath.vector3()
+	self.input = vmath.vector3()
+end
+
+function on_input(self, action_id, action)
+	-- set the input vector to correspond to the key press
+	if action_id == hash("left") then
+		self.input.x = -1
+	elseif action_id == hash("right") then
+		self.input.x = 1
+	elseif action_id == hash("accelerate") then
+		self.input.y = 1
+	elseif action_id == hash("brake") then
+		self.input.y = -1
+	end
+end
+```
+
+## Son hâliyle oyunu deneme
+
+Şimdi ana menüden <kbd>Project ▸ Build</kbd> seçeneğini seçin ve yeni arabanızla bir tur atın!
+
+Bu giriş öğreticisini tamamladık. İşte kendi başınıza çözmeyi deneyebileceğiniz bazı görevler:
+
+1. Araba şu anda hem ileri hem de geri yönde aynı ivmeyle hareket ediyor. Bunu, araba geri giderken daha yavaş hareket edecek şekilde değiştirmek isteyebilirsiniz.
+2. Bazı sabitleri (örneğin ivmeyi) özelliklere (`properties`) dönüştürerek arabanın farklı örnekleri için değiştirilebilmelerini sağlayın.
+3. Arabanıza sesler ekleyin ve vınlasın! ([İpucu](/manuals/sound/))
+
+Şimdi Defold'u keşfetmeye devam edin. Size yol göstermek için hazırladığımız pek çok [kılavuz ve öğretici](/learn) var; takıldığınızda sizi [forumda](//forum.defold.com) görmekten memnuniyet duyarız.
+
+Defold ile keyifli çalışmalar!

--- a/docs/tr/tutorials/colorslide.md
+++ b/docs/tr/tutorials/colorslide.md
@@ -1,0 +1,28 @@
+---
+title: Colorslide öğreticisi
+brief: Orta zorluktaki bu öğreticide, çok bölümlü basit bir mobil oyun için oyun içi bir grafik kullanıcı arayüzü (GUI), bölüm seçimi için bir GUI ekranı ve bir başlangıç ekranı oluşturacaksınız.
+github: https://github.com/defold/tutorial-colorslide
+---
+
+# Colorslide öğreticisi
+
+Orta zorluktaki bu öğreticide, çok bölümlü basit bir mobil oyun için oyun içi bir grafik kullanıcı arayüzü (GUI), bölüm seçimi için bir GUI ekranı ve bir başlangıç ekranı oluşturacaksınız.
+
+Öğretici, Defold düzenleyicisine entegredir ve kolayca erişilebilir:
+
+1. Defold'u başlatın.
+2. Soldaki *New Project* seçeneğini seçin.
+3. *From Tutorial* sekmesini seçin.
+4. "Colorslide tutorial" seçeneğini seçin
+5. Yerel diskinizde proje için bir konum seçin ve *Create New Project* düğmesine tıklayın.
+
+![yeni proje](images/new-colorslide.png)
+
+Düzenleyici, öğreticinin tam metnini içeren "README" dosyasını projenin kök dizininden otomatik olarak açar.
+
+![simge](images/icon-tutorial.svg){.icon} [Öğreticinin tam metnini GitHub'da da okuyabilirsiniz](https://github.com/defold/tutorial-colorslide)
+
+Bir yerde takılırsanız, Defold ekibinden ve birçok yardımsever kullanıcıdan destek alabileceğiniz [Defold Forumu'na](//forum.defold.com) uğrayın.
+
+Defold ile keyifli geliştirmeler!
+

--- a/docs/tr/tutorials/getting-started.md
+++ b/docs/tr/tutorials/getting-started.md
@@ -1,0 +1,35 @@
+---
+title: Defold ile çalışmaya başlama
+brief: Bu öğretici, Defold'daki öğreticileri uygulamaya nasıl başlayacağınızı açıklar.
+---
+
+# Başlarken
+
+Defold motoru ve düzenleyicisi, öğrenebileceğiniz pek çok özellik ve işlev sunan güçlü araçlardır. Size yol göstermek için çeşitli öğreticiler hazırladık. Öğreticilerin birçoğuna doğrudan düzenleyiciden erişebilirsiniz; bu da öğreticilere başlamayı çok kolaylaştırır.
+
+## Düzenleyiciden bir öğretici başlatma
+
+Defold düzenleyicisini çalıştırdığınızda proje seçme ve oluşturma ekranıyla karşılaşırsınız. Buradan denemek istediğiniz öğreticiyi kolayca seçebilirsiniz:
+
+1. Defold'u başlatın.
+2. Soldaki *New Project* seçeneğini seçin.
+3. *From Tutorial* sekmesini seçin.
+4. İlginizi çeken bir öğretici seçin.
+5. Yerel diskinizde proje için bir konum seçin.
+6. *Create New Project* düğmesine tıklayın.
+
+![proje oluşturma](images/getting-started/new-project.png)
+
+Düzenleyici şimdi öğretici projesini otomatik olarak indirir, projeyi düzenleyicide açar ve öğretici metnini (projenin kök dizinindeki "README" dosyasını) açar.
+
+![öğretici metni](images/getting-started/tutorial-text.png)
+
+Şimdi öğretici metnindeki adımları izleyin! Metne geri dönmek isterseniz *Assets* görünümündeki "README" dosyasına <kbd>çift tıklayın</kbd>. Ayrıca açık dosyaların sekmesine <kbd>sağ tıklayıp</kbd> <kbd>Move to Other Tab Pane</kbd> seçeneğini seçerek öğretici metnini üzerinde çalıştığınız dosyayla yan yana görüntüleyebilirsiniz.
+
+![yan yana](images/getting-started/side-by-side.png)
+
+Defold'u kullanmaya yeni başlıyorsanız [düzenleyiciye giriş](/manuals/editor) sayfasına da göz atmak isteyebilirsiniz.
+
+Bir noktada takılırsanız Defold geliştiricilerinden ve birçok yardımsever kullanıcıdan yardım alabileceğiniz [Defold Forumu'nu](//forum.defold.com) ziyaret edin.
+
+Defold ile iyi eğlenceler!

--- a/docs/tr/tutorials/grading.md
+++ b/docs/tr/tutorials/grading.md
@@ -1,0 +1,456 @@
+---
+title: Renk düzenleme gölgelendiricisi öğreticisi
+brief: Bu öğreticide Defold'da tam ekran bir son işlem efekti oluşturacaksınız.
+---
+
+# Renk düzenleme öğreticisi
+
+Bu öğreticide renk düzenleme (color grading) yapan bir tam ekran son işlem efekti (post effect) oluşturacağız. Görüntü oluşturmak için kullanılan temel işleme (rendering) yöntemi bulanıklaştırma, izler, parlama, renk ayarları gibi çeşitli son işlem efektlerine de uygulanabilir.
+
+Defold düzenleyicisini kullanmayı bildiğiniz ve GL gölgelendiricileri (shader) ile Defold işleme hattı (rendering pipeline) hakkında temel bilginiz olduğu varsayılır. Bu konuları öğrenmeniz gerekiyorsa [Gölgelendirici kılavuzumuza](/manuals/shader/) ve [İşleme kılavuzuna](/manuals/render/) göz atın.
+
+## İşleme hedefleri
+
+Varsayılan işleme betiğiyle (render script), her görsel bileşen (component; sprite bileşeni, karo haritası, parçacık efekti, GUI vb.) doğrudan grafik kartının *kare arabelleğine (frame buffer)* işlenir. Ardından donanım, grafiklerin ekranda görünmesini sağlar. Bir bileşenin piksellerinin asıl çizimini bir GL *gölgelendirici programı (shader program)* yapar. Defold, her bileşen türü için piksel verilerini değiştirmeden ekrana çizen varsayılan bir gölgelendirici programıyla gelir. Normalde istediğiniz davranış budur: görüntüleriniz ekranda ilk tasarlandıkları hâliyle görünmelidir.
+
+Bir bileşenin gölgelendirici programını, piksel verilerini değiştiren veya program yoluyla tamamen yeni piksel renkleri oluşturan bir programla değiştirebilirsiniz. [Shadertoy öğreticisi](/tutorials/shadertoy) bunu nasıl yapacağınızı öğretir.
+
+Şimdi oyununuzun tamamını siyah beyaz işlemek istediğinizi varsayalım. Olası çözümlerden biri, her bileşen türünün kendi gölgelendirici programını, piksel renklerinin doygunluğunu kaldıracak şekilde değiştirmektir. Defold şu anda 6 yerleşik materyal ve 6 köşe ve parça gölgelendiricisi program çiftiyle geldiğinden bu epey çalışma gerektirir. Ayrıca daha sonraki her değişikliğin veya efekt eklemesinin de her gölgelendirici programına uygulanması gerekir.
+
+Çok daha esnek bir yaklaşım, işlemeyi iki ayrı adımda yapmaktır:
+
+![İşleme hedefi](images/grading/render_target.png)
+
+1. Tüm bileşenleri her zamanki gibi çizin, ancak olağan kare arabelleği yerine ekran dışı bir arabelleğe çizin. Bunu *işleme hedefi (render target)* adı verilen bir hedefe çizim yaparak gerçekleştirirsiniz.
+2. Kare arabelleğine kare biçiminde bir çokgen çizin ve işleme hedefinde saklanan piksel verilerini çokgenin doku kaynağı olarak kullanın. Ayrıca kare çokgenin tüm ekranı kaplayacak şekilde gerildiğinden emin olun.
+
+Bu yöntemle, oluşan görsel verileri ekrana ulaşmadan önce okuyabilir ve değiştirebiliriz. Yukarıdaki 2. adıma gölgelendirici programları ekleyerek kolayca tam ekran efektler elde edebiliriz. Bunun Defold'da nasıl kurulacağını görelim.
+
+## Özel bir işleyici kurma
+
+Yerleşik işleme betiğini değiştirip yeni işleme işlevini eklememiz gerekiyor. Varsayılan işleme betiği iyi bir başlangıç noktasıdır; bu nedenle onu kopyalayarak başlayın:
+
+1. */builtins/render/default.render_script* dosyasını kopyalayın: *Asset* görünümünde *default.render_script* dosyasına sağ tıklayıp <kbd>Copy</kbd> seçeneğini seçin, ardından *main* klasörüne sağ tıklayıp <kbd>Paste</kbd> seçeneğini seçin. Kopyaya sağ tıklayıp <kbd>Rename...</kbd> seçeneğini seçin ve "grade.render_script" gibi uygun bir ad verin.
+2. *Asset* görünümünde *main* klasörüne sağ tıklayıp <kbd>New ▸ Render</kbd> seçeneğini seçerek */main/grade.render* adlı yeni bir işleme dosyası oluşturun.
+3. *grade.render* dosyasını açın ve *Script* özelliğini "/main/grade.render_script" olarak ayarlayın.
+
+   ![grade.render](images/grading/grade_render.png)
+
+4. *game.project* dosyasını açın ve *Render* ayarını "/main/grade.render" olarak ayarlayın.
+
+   ![game.project](images/grading/game_project.png)
+
+Oyun artık değiştirebileceğimiz yeni bir işleme hattıyla çalışacak şekilde ayarlandı. Motorun işleme betiği kopyamızı kullandığını sınamak için oyununuzu çalıştırın, ardından işleme betiğinde görsel bir sonuç verecek bir değişiklik yapıp betiği yeniden yükleyin. Örneğin, karoların ve sprite bileşenlerinin çizimini devre dışı bırakabilir, ardından <kbd>⌘ + R</kbd> tuşlarına basarak "bozuk" işleme betiğini çalışan oyunda yeniden yükleyebilirsiniz (hot reload):
+
+```lua
+...
+
+render.set_projection(vmath.matrix4_orthographic(0, render.get_width(), 0, render.get_height(), -1, 1))
+
+-- render.draw(self.tile_pred) -- <1>
+render.draw(self.particle_pred)
+render.draw_debug3d()
+
+...
+```
+1. Tüm sprite bileşenlerini ve karoları içeren "tile" yükleminin çizim satırını yorum satırı hâline getirin. Bu kod satırı, işleme betiği dosyasında yaklaşık 33. satırda bulunur.
+
+Bu basit sınamada sprite bileşenleri ve karolar kaybolursa oyunun sizin işleme betiğinizi çalıştırdığını anlarsınız. Her şey beklendiği gibi çalışıyorsa işleme betiğinde yaptığınız değişikliği geri alabilirsiniz.
+
+## Ekran dışı bir hedefe çizim yapma
+
+Şimdi işleme betiğini, kare arabelleği yerine ekran dışı işleme hedefine çizecek şekilde değiştirelim. Önce işleme hedefini oluşturmamız gerekiyor:
+
+```lua
+function init(self)
+    self.tile_pred = render.predicate({"tile"})
+    self.gui_pred = render.predicate({"gui"})
+    self.text_pred = render.predicate({"text"})
+    self.particle_pred = render.predicate({"particle"})
+
+    self.clear_color = vmath.vector4(0, 0, 0, 1)
+    self.clear_color.x = sys.get_config_number("render.clear_color_red", 0)
+    self.clear_color.y = sys.get_config_number("render.clear_color_green", 0)
+    self.clear_color.z = sys.get_config_number("render.clear_color_blue", 0)
+    self.clear_color.w = sys.get_config_number("render.clear_color_alpha", 1)
+
+    self.view = vmath.matrix4()
+
+    local color_params = { format = graphics.TEXTURE_FORMAT_RGBA,
+                       width = render.get_width(),
+                       height = render.get_height() } -- <1>
+    local target_params = {[graphics.BUFFER_TYPE_COLOR0_BIT] = color_params }
+
+    self.target = render.render_target("original", target_params) -- <2>
+end
+```
+1. İşleme hedefinin renk arabelleği parametrelerini ayarlayın. Oyunun hedef çözünürlüğünü kullanıyoruz.
+2. İşleme hedefini renk arabelleği parametreleriyle oluşturun.
+
+Şimdi yalnızca özgün işleme kodunun başına ve sonuna şu şekilde `render.set_render_target()` çağrıları eklememiz gerekiyor:
+
+```lua
+function update(self)
+  render.set_render_target(self.target) -- <1>
+
+  render.set_depth_mask(true)
+  render.set_stencil_mask(0xff)
+  render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = self.clear_color, [graphics.BUFFER_TYPE_DEPTH_BIT] = 1, [graphics.BUFFER_TYPE_STENCIL_BIT] = 0})
+
+  render.set_viewport(0, 0, render.get_width(), render.get_height()) -- <2>
+  render.set_view(self.view)
+  ...
+
+  render.set_render_target(render.RENDER_TARGET_DEFAULT) -- <3>
+end
+```
+1. İşleme hedefini etkinleştirin. Bundan sonra her `render.draw()` çağrısı ekran dışı işleme hedefimizin arabelleklerine çizecektir.
+2. İşleme hedefinin çözünürlüğüne ayarlanan görüntü alanı dışında, `update()` içindeki tüm özgün çizim kodu olduğu gibi bırakılır.
+3. Bu noktada oyunun tüm grafikleri işleme hedefine çizilmiştir. Dolayısıyla varsayılan işleme hedefine geçerek onu devre dışı bırakmanın zamanı gelmiştir.
+
+Yapmamız gerekenlerin hepsi bu. Oyunu şimdi çalıştırırsanız her şeyi işleme hedefine çizecektir. Ancak artık kare arabelleğine hiçbir şey çizmediğimiz için yalnızca siyah bir ekran göreceğiz.
+
+## Ekranı dolduracak bir nesne
+
+İşleme hedefinin renk arabelleğindeki pikselleri ekrana çizmek için piksel verilerini doku olarak uygulayabileceğimiz bir şey hazırlamamız gerekiyor. Bu amaçla düz, kare biçiminde bir 3B model kullanacağız.
+
+1. *`main.collection`* dosyasını açın ve "`grade`" adlı yeni bir oyun nesnesi (game object) oluşturun.
+2. "`grade`" oyun nesnesine bir Model bileşeni ekleyin.
+3. Model bileşeninin *Mesh* özelliğini, `builtins/assets/meshes` içinde bulunan *`quad.gltf`* dosyasına ayarlayın.
+
+Oyun nesnesini ölçeklemeden başlangıç noktasında bırakın. Daha sonra, kareyi işlerken tüm ekranı dolduracak şekilde izdüşümünü alacağız. Ancak önce kare için bir materyal ve gölgelendirici programları gerekiyor:
+
+1. *Asset* görünümünde *main* klasörüne sağ tıklayıp <kbd>New ▸ Material</kbd> seçeneğini seçerek yeni bir materyal oluşturun ve *`grade.material`* adını verin.
+2. *Asset* görünümünde *main* klasörüne sağ tıklayıp <kbd>New ▸ Vertex program</kbd> ve <kbd>New ▸ Fragment program</kbd> seçeneklerini seçerek *`grade.vp`* adlı bir köşe gölgelendiricisi programı ve *`grade.fp`* adlı bir parça gölgelendiricisi programı oluşturun.
+3. *grade.material* dosyasını açın ve *Vertex program* ile *Fragment program* özelliklerini yeni gölgelendirici programı dosyalarına ayarlayın.
+4. `CONSTANT_TYPE_VIEWPROJ` türünde "`view_proj`" adlı bir *Vertex constant* ekleyin. Bu, kare köşeleri için köşe programında kullanılan görünüm ve izdüşüm matrisidir.
+5. "`original`" adlı bir *Sampler* ekleyin. Bu, ekran dışı işleme hedefinin renk arabelleğinden pikselleri örneklemek için kullanılacaktır.
+6. "`grade`" adlı bir *Tag* ekleyin. Kareyi çizmek için işleme betiğinde bu etiketle eşleşen yeni bir *işleme yüklemi (render predicate)* oluşturacağız.
+
+   ![grade.material](images/grading/grade_material.png)
+
+7. *`main.collection`* dosyasını açın, "`grade`" oyun nesnesindeki model bileşenini seçin ve *Material* özelliğini "`/main/grade.material`" olarak ayarlayın.
+
+   ![Model özellikleri](images/grading/model_properties.png)
+
+8. Köşe gölgelendiricisi programı, temel şablondan oluşturulduğu hâliyle bırakılabilir:
+
+    ```glsl
+    // grade.vp
+    uniform mediump mat4 view_proj;
+
+    // positions are in world space
+    attribute mediump vec4 position;
+    attribute mediump vec2 texcoord0;
+
+    varying mediump vec2 var_texcoord0;
+
+    void main()
+    {
+      gl_Position = view_proj * vec4(position.xyz, 1.0);
+      var_texcoord0 = texcoord0;
+    }
+    ```
+
+9. Parça gölgelendiricisi programında, `gl_FragColor` değerini doğrudan örneklenen renk değerine ayarlamak yerine basit bir renk değişikliği yapalım. Bunu esas olarak buraya kadar her şeyin beklendiği gibi çalıştığından emin olmak için yapıyoruz:
+
+    ```glsl
+    // grade.fp
+    varying mediump vec4 position;
+    varying mediump vec2 var_texcoord0;
+
+    uniform lowp sampler2D original;
+
+    void main()
+    {
+      vec4 color = texture2D(original, var_texcoord0.xy);
+      // Desaturate the color sampled from the original texture
+      float grey = color.r * 0.3 + color.g * 0.59 + color.b * 0.11;
+      gl_FragColor = vec4(grey, grey, grey, 1.0);
+    }
+    ```
+
+Artık kare modelimiz, materyali ve gölgelendiricileriyle birlikte hazır. Yalnızca onu ekranın kare arabelleğine çizmemiz gerekiyor.
+
+## Ekran dışı arabelleği doku olarak kullanma
+
+Kare modeli çizebilmek için işleme betiğine bir işleme yüklemi eklememiz gerekiyor. *`grade.render_script`* dosyasını açın ve `init()` işlevini düzenleyin:
+
+```lua
+function init(self)
+    self.tile_pred = render.predicate({"tile"})
+    self.gui_pred = render.predicate({"gui"})
+    self.text_pred = render.predicate({"text"})
+    self.particle_pred = render.predicate({"particle"})
+    self.grade_pred = render.predicate({"grade"}) -- <1>
+
+    ...
+end
+```
+1. *`grade.material`* dosyasında belirlediğimiz "grade" etiketiyle eşleşen yeni bir yüklem ekleyin.
+
+`update()` içinde işleme hedefinin renk arabelleği doldurulduktan sonra, kare modelin tüm ekranı doldurmasını sağlayan bir görünüm ve izdüşüm ayarlarız. Ardından işleme hedefinin renk arabelleğini karenin dokusu olarak kullanırız:
+
+```lua
+function update(self)
+  render.set_render_target(self.target)
+
+  ...
+
+  render.set_render_target(render.RENDER_TARGET_DEFAULT)
+
+  render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = self.clear_color}) -- <1>
+
+  render.set_viewport(0, 0, render.get_window_width(), render.get_window_height()) -- <2>
+  render.set_view(vmath.matrix4()) -- <3>
+  render.set_projection(vmath.matrix4())
+
+  render.enable_texture(0, self.target, graphics.BUFFER_TYPE_COLOR0_BIT) -- <4>
+  render.draw(self.grade_pred) -- <5>
+  render.disable_texture(0, self.target) -- <6>
+end
+```
+1. Kare arabelleğini temizleyin. Önceki `render.clear()` çağrısının ekranın kare arabelleğini değil, işleme hedefini etkilediğini unutmayın.
+2. Görüntü alanını pencere boyutuyla eşleşecek şekilde ayarlayın.
+3. Görünümü birim matrise ayarlayın. Bu, kameranın başlangıç noktasında olduğu ve doğrudan Z ekseni boyunca baktığı anlamına gelir. Ayrıca izdüşümü de birim matrise ayarlayarak karenin tüm ekranı kaplayacak şekilde düz olarak yansıtılmasını sağlayın.
+4. 0 numaralı doku yuvasını işleme hedefinin renk arabelleğine ayarlayın. *`grade.material`* dosyamızın 0 numaralı yuvasında "original" örnekleyicisi bulunduğundan, parça gölgelendiricisi işleme hedefinden örnekleme yapacaktır.
+5. "grade" etiketine sahip herhangi bir materyalle eşleşen, oluşturduğumuz yüklemi çizin. Kare model, bu etiketi belirleyen *`grade.material`* materyalini kullanır; böylece kare çizilecektir.
+6. Çizimden sonra, işimiz bittiği için 0 numaralı doku yuvasını devre dışı bırakın.
+
+Şimdi oyunu çalıştırıp sonucu görelim:
+
+![Renk doygunluğu kaldırılmış oyun](images/grading/desaturated_game.png)
+
+## Renk düzenleme
+
+Renkler, her biri rengin ne kadar kırmızı, yeşil veya maviden oluştuğunu belirleyen üç bileşen değeriyle ifade edilir. Siyahtan kırmızı, yeşil, mavi, sarı ve pembeye, oradan beyaza uzanan tüm renk tayfı bir küp biçimine sığdırılabilir:
+
+![Renk küpü](images/grading/color_cube.png)
+
+Ekranda gösterilebilen her renk bu renk küpünde bulunabilir. Renk düzenlemenin temel fikri, böyle bir renk küpünü renklerini değiştirerek 3B bir *arama tablosu (lookup table)* olarak kullanmaktır.
+
+Her piksel için:
+
+1. Renginin renk küpündeki konumunu (kırmızı, yeşil ve mavi değerlerine göre) bulun.
+2. Renkleri düzenlenmiş küpte o konumda hangi rengin saklandığını *okuyun*.
+3. Pikseli özgün rengi yerine okunan renkte çizin.
+
+Bunu parça gölgelendiricimizde yapabiliriz:
+
+1. Ekran dışı arabellekteki her pikselin renk değerini örnekleyin.
+2. Örneklenen pikselin renk konumunu, renkleri düzenlenmiş bir renk küpünde bulun.
+3. Çıktı parçasının rengini aramayla bulunan değere ayarlayın.
+
+![İşleme hedefinde renk düzenleme](images/grading/render_target_grading.png)
+
+## Arama tablosunu temsil etme
+
+Open GL ES 2.0, 3B dokuları desteklemediğinden 3B renk küpünü temsil etmenin başka bir yolunu bulmamız gerekiyor. Bunun yaygın bir yolu, küpü Z ekseni (mavi) boyunca dilimlemek ve her dilimi iki boyutlu bir ızgarada yan yana yerleştirmektir. 16 dilimin her biri 16⨉16 piksellik bir ızgara içerir. Bunu, parça gölgelendiricisinde bir örnekleyiciyle okuyabileceğimiz bir dokuda saklarız:
+
+![Arama dokusu](images/grading/lut.png)
+
+Elde edilen doku 16 hücre (her mavi renk yoğunluğu için bir hücre) ve her hücre içinde X ekseni boyunca 16 kırmızı renk, Y ekseni boyunca da 16 yeşil renk içerir. Doku, 16 milyon renkli RGB renk uzayının tamamını yalnızca 4096 renkle, yani sadece 4 bit renk derinliğiyle temsil eder. Çoğu ölçüte göre bu berbat olsa da GL grafik donanımının bir özelliği sayesinde çok yüksek renk doğruluğunu geri kazanabiliriz. Nasıl olduğunu görelim.
+
+## Renkleri arama
+
+Bir rengi bulmak için mavi bileşeni kontrol edip kırmızı ve yeşil değerlerin hangi hücreden alınacağını belirlemek gerekir. Doğru kırmızı-yeşil renk kümesine sahip hücreyi bulmanın formülü basittir:
+
+```math
+cell = \left \lfloor{B \times (N - 1)} \right \rfloor
+```
+
+Burada `B`, 0 ile 1 arasındaki mavi bileşen değeri; `N` ise toplam hücre sayısıdır. Bizim durumumuzda hücre numarası `0`--`15` aralığında olacaktır. `0` numaralı hücre mavi bileşeni `0` olan tüm renkleri, `15` numaralı hücre ise mavi bileşeni `1` olan tüm renkleri içerir.
+
+Örneğin, `(0.63, 0.83, 0.4)` RGB değeri, mavi değeri `0.4` olan tüm renklerin bulunduğu hücrede, yani 6 numaralı hücrede bulunur. Bunu bildikten sonra yeşil ve kırmızı değerlere göre son doku koordinatlarını bulmak basittir:
+
+![Arama tablosu](images/grading/lut_lookup.png)
+
+Kırmızı ve yeşil değerler olan `(0, 0)` değerlerini sol alt pikselin *merkezinde*, `(1.0, 1.0)` değerlerini ise sağ üst pikselin *merkezinde* kabul etmemiz gerektiğine dikkat edin.
+
+::: sidenote
+Sol alt pikselin merkezinden başlayıp sağ üst pikselin merkezine kadar okumamızın nedeni, geçerli hücrenin dışındaki hiçbir pikselin örneklenen değeri etkilemesini istemememizdir. Aşağıdaki filtreleme açıklamasına bakın.
+:::
+
+Dokunun bu belirli koordinatlarında örnekleme yaptığımızda, tam 4 pikselin ortasına denk geldiğimizi görürüz. Peki GL bu noktanın renk değeri olarak bize ne söyleyecek?
+
+![Arama tablosunda filtreleme](images/grading/lut_filtering.png)
+
+Yanıt, materyalde örnekleyicinin *filtrelemesini* nasıl belirlediğimize bağlıdır.
+
+- Örnekleyicinin filtrelemesi `NEAREST` ise GL, en yakın pikselin renk değerini döndürür (konum değeri aşağı yuvarlanır). Yukarıdaki durumda GL, `(0.60, 0.80)` konumundaki renk değerini döndürür. 4 bitlik arama dokumuz için bu, renk değerlerini toplamda yalnızca 4096 renge nicemleyeceğimiz anlamına gelir.
+
+- Örnekleyicinin filtrelemesi `LINEAR` ise GL, *ara değerlemeyle (interpolation) hesaplanmış* renk değerini döndürür. GL, örnekleme konumunun çevresindeki piksellere olan uzaklığa göre bir renk karışımı oluşturur. Yukarıdaki durumda GL, örnekleme noktasının çevresindeki 4 pikselin her birinden %25 içeren bir renk döndürür.
+
+Böylece doğrusal filtreleme kullanarak renk nicemlemesini ortadan kaldırır ve oldukça küçük bir arama tablosundan çok iyi renk hassasiyeti elde ederiz.
+
+## Aramayı uygulama
+
+Parça gölgelendiricisinde doku aramasını uygulayalım:
+
+1. *`grade.material`* dosyasını açın.
+2. Arama tablosu (lookup table) için "`lut`" adlı ikinci bir örnekleyici ekleyin.
+3. *`Filter min`* özelliğini `FILTER_MODE_MIN_LINEAR`, *`Filter mag`* özelliğini ise `FILTER_MODE_MAG_LINEAR` olarak ayarlayın.
+
+    ![Arama tablosu örnekleyicisi](images/grading/material_lut_sampler.png)
+
+4. Aşağıdaki arama tablosu dokusunu (*`lut16.png`*) indirip projenize ekleyin.
+
+    ![16 renkli arama tablosu](images/grading/lut16.png)
+
+5. *`main.collection`* dosyasını açın ve *`lut`* doku özelliğini indirdiğiniz arama dokusuna ayarlayın.
+
+    ![Kare modelin arama tablosu](images/grading/quad_lut.png)
+
+6. Son olarak, renk arama desteğini ekleyebilmemiz için *`grade.fp`* dosyasını açın:
+
+    ```glsl
+    varying mediump vec4 position;
+    varying mediump vec2 var_texcoord0;
+
+    uniform lowp sampler2D original;
+    uniform lowp sampler2D lut; // <1>
+
+    #define MAXCOLOR 15.0 // <2>
+    #define COLORS 16.0
+    #define WIDTH 256.0
+    #define HEIGHT 16.0
+
+    void main()
+    {
+        vec4 px = texture2D(original, var_texcoord0.xy); // <3>
+
+        float cell = floor(px.b * MAXCOLOR); // <4>
+
+        float half_px_x = 0.5 / WIDTH; // <5>
+        float half_px_y = 0.5 / HEIGHT;
+
+        float x_offset = half_px_x + px.r / COLORS * (MAXCOLOR / COLORS);
+        float y_offset = half_px_y + px.g * (MAXCOLOR / COLORS); // <6>
+
+        vec2 lut_pos = vec2(cell / COLORS + x_offset, y_offset); // <7>
+
+        vec4 graded_color = texture2D(lut, lut_pos); // <8>
+
+        gl_FragColor = graded_color; // <9>
+    }
+    ```
+    1. `lut` örnekleyicisini bildirin.
+    2. En büyük renk değeri (0'dan başladığımız için 15), kanal başına renk sayısı ve arama dokusunun genişliği ile yüksekliği için sabitler.
+    3. Özgün dokudan (ekran dışı işleme hedefinin renk arabelleğinden) bir piksel rengini (`px` adıyla) örnekleyin.
+    4. `px` değerinin mavi kanal değerine göre rengin hangi hücreden okunacağını hesaplayın.
+    5. Piksel merkezlerinden okumak için yarım piksellik kaydırmaları hesaplayın.
+    6. `px` değerinin kırmızı ve yeşil değerlerine göre doku üzerindeki X ve Y kaydırmalarını hesaplayın.
+    7. Arama dokusundaki son örnekleme konumunu hesaplayın.
+    8. Arama dokusundan sonuç rengini örnekleyin.
+    9. Karenin dokusundaki rengi sonuç rengine ayarlayın.
+
+Şu anda arama tablosu dokusu, aradığımız renk değerlerini olduğu gibi döndürüyor. Bu, oyunun özgün renkleriyle işlenmesi gerektiği anlamına gelir:
+
+![Dünyanın özgün görünümü](images/grading/world_original.png)
+
+Buraya kadar her şeyi doğru yapmışız gibi görünüyor, ancak yüzeyin altında gizlenen bir sorun var. Degrade test dokusuna sahip bir sprite bileşeni eklediğimizde neler olduğuna bakın:
+
+![Mavide bantlaşma](images/grading/blue_banding.png)
+
+Mavi degradede gerçekten çirkin bantlaşmalar görülüyor. Bunun nedeni ne?
+
+## Mavi kanalda ara değerleme
+
+Mavi kanaldaki bantlaşma sorunu, GL'nin rengi dokudan okurken mavi kanalda herhangi bir ara değerleme yapamamasından kaynaklanır. Mavi renk değerine göre okunacak belirli bir hücreyi önceden seçeriz ve işlem burada biter. Örneğin, mavi kanal `0.400`--`0.466` aralığında herhangi bir değer içeriyorsa değerin tam olarak ne olduğu önemli değildir: son rengi her zaman mavi kanalın `0.400` olarak ayarlandığı 6 numaralı hücreden örnekleriz.
+
+Mavi kanalda daha iyi çözünürlük elde etmek için ara değerlemeyi kendimiz uygulayabiliriz. Mavi değer iki komşu hücrenin değeri arasındaysa bu hücrelerin her ikisinden de örnekleme yapıp renkleri karıştırabiliriz. Örneğin, mavi değer `0.420` ise 6 numaralı hücreden *ve* 7 numaralı hücreden örnekleme yapıp ardından renkleri karıştırmalıyız.
+
+Dolayısıyla iki hücreden okumalıyız:
+
+```math
+cell_{low} = \left \lfloor{B \times (N - 1)} \right \rfloor
+```
+
+ve:
+
+```math
+cell_{high} = \left \lceil{B \times (N - 1)} \right \rceil
+```
+
+Ardından bu hücrelerin her birinden renk değerlerini örnekleyip şu formüle göre renkler arasında doğrusal ara değerleme yaparız:
+
+```math
+color = color_{low} \times (1 - C_{frac}) + color_{high} \times C_{frac}
+```
+
+Burada `color`~low~, daha düşük numaralı (en soldaki) hücreden örneklenen renk; `color`~high~ ise daha yüksek numaralı (en sağdaki) hücreden örneklenen renktir. GLSL'nin `mix()` işlevi bu doğrusal ara değerlemeyi bizim için yapar.
+
+Yukarıdaki `C~frac~` değeri, mavi kanal değerinin `0`--`15` renk aralığına ölçeklenmiş hâlinin kesirli kısmıdır:
+
+```math
+C_{frac} = B \times (N - 1) - \left \lfloor{B \times (N - 1)} \right \rfloor
+```
+
+Bir değerin kesirli kısmını veren bir GLSL işlevi de vardır. Bu işlev `frac()` olarak adlandırılır. Parça gölgelendiricisindeki (*`grade.fp`*) son uygulama oldukça basittir:
+
+```glsl
+varying mediump vec4 position;
+varying mediump vec2 var_texcoord0;
+
+uniform lowp sampler2D original;
+uniform lowp sampler2D lut;
+
+#define MAXCOLOR 15.0
+#define COLORS 16.0
+#define WIDTH 256.0
+#define HEIGHT 16.0
+
+void main()
+{
+  vec4 px = texture2D(original, var_texcoord0.xy);
+
+    float cell = px.b * MAXCOLOR;
+
+    float cell_l = floor(cell); // <1>
+    float cell_h = ceil(cell);
+
+    float half_px_x = 0.5 / WIDTH;
+    float half_px_y = 0.5 / HEIGHT;
+    float r_offset = half_px_x + px.r / COLORS * (MAXCOLOR / COLORS);
+    float g_offset = half_px_y + px.g * (MAXCOLOR / COLORS);
+
+    vec2 lut_pos_l = vec2(cell_l / COLORS + r_offset, g_offset); // <2>
+    vec2 lut_pos_h = vec2(cell_h / COLORS + r_offset, g_offset);
+
+    vec4 graded_color_l = texture2D(lut, lut_pos_l); // <3>
+    vec4 graded_color_h = texture2D(lut, lut_pos_h);
+
+    // <4>
+    vec4 graded_color = mix(graded_color_l, graded_color_h, fract(cell));
+
+    gl_FragColor = graded_color;
+}
+```
+
+1. Okunacak iki komşu hücreyi hesaplayın.
+2. Her hücre için bir tane olmak üzere iki ayrı arama konumu hesaplayın.
+3. Hücre konumlarından iki rengi örnekleyin.
+3. Ölçeklenmiş mavi renk değeri olan `cell` değerinin kesirli kısmına göre renkleri doğrusal olarak karıştırın.
+
+Oyunu test dokusuyla yeniden çalıştırmak artık çok daha iyi sonuçlar verir. Mavi kanaldaki bantlaşma kaybolmuştur:
+
+![Mavide bantlaşma yok](images/grading/blue_no_banding.png)
+
+## Arama dokusunun renklerini düzenleme
+
+Pekâlâ, özgün oyun dünyasıyla tamamen aynı görünen bir şey çizmek için epey uğraştık. Ancak bu düzenek gerçekten harika bir şey yapmamızı sağlıyor. Sıkı durun!
+
+1. Oyunun üzerinde değişiklik yapılmamış hâlinin ekran görüntüsünü alın.
+2. Ekran görüntüsünü tercih ettiğiniz görüntü düzenleme programında açın.
+3. İstediğiniz sayıda renk ayarı (parlaklık, karşıtlık, renk eğrileri, beyaz dengesi, pozlama vb.) uygulayın.
+
+![Affinity'de dünya](images/grading/world_graded_affinity.png)
+
+4. Aynı renk ayarlarını arama tablosu dokusu dosyasına (*`lut16.png`*) uygulayın.
+5. Renkleri ayarlanmış arama tablosu dokusu dosyasını kaydedin.
+6. Defold projenizde kullanılan *`lut16.png`* dokusunu renkleri ayarlanmış olanla değiştirin.
+7. Oyunu çalıştırın!
+
+![Renkleri düzenlenmiş dünya](images/grading/world_graded.png)
+
+İşte bu!

--- a/docs/tr/tutorials/hud.md
+++ b/docs/tr/tutorials/hud.md
@@ -1,0 +1,164 @@
+---
+title: HUD kod örneği
+brief: Bu örnek projede puan sayımı için efektleri öğrenirsiniz.
+---
+# HUD - örnek proje
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NoPHHG2kbOk" frameborder="0" allowfullscreen></iframe>
+
+[Düzenleyiciden açabileceğiniz](/manuals/project-setup/) veya [GitHub üzerinden indirebileceğiniz](https://github.com/defold/sample-hud) bu örnek projede, oyun içi bilgi göstergesinde (HUD) puan sayımı için kullanılan efektleri gösteriyoruz. Puanlar ekranda rastgele belirerek oyuncunun farklı konumlarda puan kazandığı bir oyunu simüle eder.
+
+Puanlar belirdikten sonra bir süre süzülür. Bunu sağlamak için puanları saydam hale getirir, ardından renklerini kademeli olarak görünür kılarız. Ayrıca yukarı doğru hareket etmeleri için animasyon uygularız. Bu işlemler aşağıdaki `on_message()` işlevinde yapılır.
+
+Ardından ekranın üst kısmındaki toplam puana doğru hareket eder ve orada toplanırlar.
+Yukarı doğru hareket ederken hafifçe soluklaşırlar. Bu işlem `float_done()` işlevinde yapılır.
+
+Üstteki puana ulaştıklarında değerleri, toplam puanın kademeli olarak ulaşacağı bir hedef puana eklenir. Bu işlem `swoosh_done()` işlevinde yapılır.
+
+Betik (script) güncellendiğinde hedef puanın artırılıp artırılmadığını ve toplam puanın artırılması gerekip gerekmediğini denetler. Bu koşul sağlandığında toplam puan daha küçük bir adımla artırılır.
+Ardından, zıplama efekti vermek için toplam puanın ölçeğine animasyon uygulanır. Bu işlem `update()` işlevinde yapılır.
+
+Toplam puan her artırıldığında belirli sayıda daha küçük yıldız oluşturur ve toplam puandan dışarı doğru hareket etmeleri için onlara animasyon uygularız. Yıldızların oluşturulması, canlandırılması ve silinmesi `spawn_stars()`, `fade_out_star()` ve `delete_star()` işlevlerinde yapılır.
+
+```lua
+-- file: hud.gui_script
+-- how fast the score counts up per second
+local score_inc_speed = 1000
+
+function init(self)
+    -- the target score is the current score in the game
+    self.target_score = 0
+    -- the current score being counted up towards the target score
+    self.current_score = 0
+    -- the score as displayed in the hud
+    self.displayed_score = 0
+    -- keep a reference to the node displaying the score for later use below
+    self.score_node = gui.get_node("score")
+end
+
+local function delete_star(self, star)
+    -- star has finished animation, delete it
+    gui.delete_node(star)
+end
+
+local function fade_out_star(self, star)
+    -- fade out the star before deletion
+    gui.animate(star, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 0), gui.EASING_INOUT, 0.2, 0.0, delete_star)
+end
+
+local function spawn_stars(self, amount)
+    -- position of the score node, to be used for placing the stars
+    local p = gui.get_position(self.score_node)
+    -- distance from the position where the star is spawned
+    local start_distance = 0
+    -- distance where the star stops
+    local end_distance = 240
+    -- angle distance between each star in the star circle
+    local angle_step = 2 * math.pi / amount
+    -- randomize start angle
+    local angle = angle_step * math.random()
+    for i=1,amount do
+        -- increment the angle by the step to get an even distribution of stars
+        angle = angle + angle_step
+        -- direction of the star movement
+        local dir = vmath.vector3(math.cos(angle), math.sin(angle), 0)
+        -- start/end positions of the star
+        local start_p = p + dir * start_distance
+        local end_p = p + dir * end_distance
+        -- create the star node
+        local star = gui.new_box_node(vmath.vector3(start_p.x, start_p.y, 0), vmath.vector3(30, 30, 0))
+        -- set its texture
+        gui.set_texture(star, "star")
+        -- set to transparent
+        gui.set_color(star, vmath.vector4(1, 1, 1, 0))
+        -- fade in
+        gui.animate(star, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_OUT, 0.2, 0.0, fade_out_star)
+        -- animate position
+        gui.animate(star, gui.PROP_POSITION, end_p, gui.EASING_NONE, 0.55)
+    end
+end
+
+function update(self, dt)
+    -- check if the score needs to be updated
+    if self.current_score < self.target_score then
+        -- increment the score for this timestep to grow towards the target score
+        self.current_score = self.current_score + score_inc_speed * dt
+        -- clamp the score so it doesn't grow past the target score
+        self.current_score = math.min(self.current_score, self.target_score)
+        -- floor the score so it can be displayed without decimals
+        local floored_score = math.floor(self.current_score)
+        -- check if the displayed score should be updated
+        if self.displayed_score ~= floored_score then
+            -- update displayed score
+            self.displayed_score = floored_score
+            -- update the text of the score node
+            gui.set_text(self.score_node, string.format("%d p", self.displayed_score))
+            -- set the scale of the score node to be slightly bigger than normal
+            local s = 1.3
+            gui.set_scale(self.score_node, vmath.vector3(s, s, s))
+            -- then animate the scale back to the original value
+            s = 1.0
+            gui.animate(self.score_node, gui.PROP_SCALE, vmath.vector3(s, s, s), gui.EASING_OUT, 0.2)
+            -- spawn stars
+            spawn_stars(self, 4)
+        end
+    end
+end
+
+-- this function stores the added score so that the displayed score can be counted up in the update function
+local function swoosh_done(self, node)
+    -- retrieve score from node
+    local amount = tonumber(gui.get_text(node))
+    -- increase the target score, see the update function for how the score is updated to match the target score
+    self.target_score = self.target_score + amount
+    -- remove the temp score
+    gui.delete_node(node)
+end
+
+-- this function animates the node from having floated first to swoosh away towards the displayed total score
+local function float_done(self, node)
+    local duration = 0.2
+    -- swoosh away towards the displayed score
+    gui.animate(node, gui.PROP_POSITION, gui.get_position(self.score_node), gui.EASING_IN, duration, 0.0, swoosh_done)
+    -- also fade out partially during the swoosh
+    gui.animate(node, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 0.6), gui.EASING_IN, duration)
+end
+
+function on_message(self, message_id, message, sender)
+    -- register added score, this message could be sent by anyone wanting to increment the score
+    if message_id == hash("add_score") then
+        -- create a new temporary score node
+        local node = gui.new_text_node(message.position, tostring(message.amount))
+        -- use the small font for it
+        gui.set_font(node, "small_score")
+        -- initially transparent
+        gui.set_color(node, vmath.vector4(1, 1, 1, 0))
+        gui.set_outline(node, vmath.vector4(0, 0, 0, 0))
+        -- fade in
+        gui.animate(node, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_OUT, 0.3)
+        gui.animate(node, gui.PROP_OUTLINE, vmath.vector4(0, 0, 0, 1), gui.EASING_OUT, 0.3)
+        -- float
+        local offset = vmath.vector3(0, 20, 0)
+        gui.animate(node, gui.PROP_POSITION, gui.get_position(node) + offset, gui.EASING_NONE, 0.5, 0.0, float_done)
+    end
+end
+```
+
+main.script dosyasında dokunma/fare girdisini alır, ardından dokunma konumunu kullanarak yeni puanlar oluşturmak için GUI betiğine bir ileti (message) göndeririz.
+
+```lua
+-- On click/touch get touch position and send it via message to hud gui script as well as the scored point amount.
+
+function init(self)
+    msg.post(".", "acquire_input_focus")
+end
+
+function on_input(self, action_id, action)
+    local pos = vmath.vector3(action.x, action.y, 0) -- use input action.x & action.y as x & y positions of touch
+    if action_id == hash("touch") then
+        if action.pressed then
+            msg.post("main:/hud#hud", "add_score" , { position = pos, amount = 1500})
+        end
+    end
+end
+```

--- a/docs/tr/tutorials/level-complete.md
+++ b/docs/tr/tutorials/level-complete.md
@@ -1,0 +1,226 @@
+---
+title: Bölüm tamamlama kod örneği
+brief: Bu örnek projede, bir bölüm tamamlandığında puan sayımını göstermek için kullanılabilecek efektleri öğrenirsiniz.
+---
+# Bölüm tamamlandı - örnek proje
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/tSdTSvku1o8" frameborder="0" allowfullscreen></iframe>
+
+[Düzenleyiciden açabileceğiniz](/manuals/project-setup/) veya [GitHub'dan indirebileceğiniz](https://github.com/defold/sample-levelcomplete) bu örnek projede, bir bölüm tamamlandığında puan sayımını göstermek için kullanılabilecek efektleri gösteriyoruz. Toplam puana ulaşılana kadar sayım yapılır ve farklı puan eşiklerine ulaşıldığında üç yıldız belirir. Örnek ayrıca değerlerde ince ayar yaparken sonuçları hızlıca görmek için yeniden yükleme (reload) işlevini kullanır.
+
+Sahne, oyundan gelen bir iletiyle (message) tetiklenir.
+İleti, elde edilen toplam puanı ve üç yıldızın hangi puan eşiklerinde görünmesi gerektiğini içerir.
+Bu olduğunda, başlık metni ("Level completed!") yavaşça belirirken normal boyutuna (%100) küçültülür. Bu işlem, aşağıdaki `on_message()` işlevinde yapılır.
+
+Başlık metninin animasyonu tamamlandıktan sonra toplam puanın sayımı başlar. Sayımın her adımında geçerli puan küçük bir miktar artırılır. Ardından yıldızların puan eşiklerinden birinin aşılıp aşılmadığını kontrol ederiz; aşılmışsa ilgili yıldızın animasyonu başlar (aşağıya bakın). Hedef puana ulaşılmadığı sürece toplam puana sıçrama efektli bir animasyon uygulanır.
+Toplam puana yaklaştıkça, gösterilen puanın ölçeği de en büyük değerine doğru artar. Aynı şekilde, rengi de beyazdan yeşile doğru yavaş yavaş değişir. Bu işlem `inc_score()` işlevinde yapılır.
+
+Her yıldız, yavaşça belirirken normal boyutuna küçülür. Bu işlem `animate_star()` işlevinde yapılır.
+
+Yıldızın animasyonu tamamlandığında, büyük yıldızın çevresinde bir çember oluşturacak şekilde daha küçük yıldızlar oluşturulur. Bu işlem `spawn_small_stars()` işlevinde yapılır.
+
+Ardından küçük yıldızlara, büyük yıldızdan rastgele dışarı fırlamaları için animasyon uygulanır. Dışarı doğru yayılırken hem hızları hem de ölçekleri rastgele belirlenir. Daha sonra yavaşça kaybolur ve sonunda silinirler. Bu işlem `animate_small_star()` ve `delete_small_star()` işlevlerinde yapılır.
+
+Puan toplam puana ulaştığında, en yüksek puan damgası yavaşça belirir ve küçülerek yerine oturur. Bu işlem `inc_score()` işlevinin sonunda başlatılır ve `animate_imprint()` işlevinde gerçekleştirilir.
+
+`setup()` işlevi, düğümlerin (node) doğru başlangıç değerlerine sahip olmasını sağlar. `setup()` işlevini `on_reload()` içinden çağırarak, betik Defold düzenleyicisinden her yeniden yüklendiğinde her şeyin doğru ayarlanmasını sağlarız.
+
+```lua
+-- file: level_complete.gui_script
+
+-- how fast the score is incremented per second
+local score_inc_speed = 51100
+-- how long time between each update of the score
+local dt = 0.03
+-- scale of the score at the start of counting
+local score_start_scale = 0.7
+-- scale of the score when the target score has been reached
+local score_end_scale = 1.0
+-- how much the score "bounces" at each increment
+local score_bounce_factor = 1.1
+-- how many small stars to spawn for each big star
+local small_star_count = 16
+
+local function setup(self)
+    -- make heading color transparent
+    local c = gui.get_color(self.heading)
+    c.w = 0
+    gui.set_color(self.heading, c)
+    -- make heading shadow transparent
+    c = gui.get_shadow(self.heading)
+    c.w = 0
+    gui.set_shadow(self.heading, c)
+    -- set heading to twice the scale initially
+    local s = 2
+    gui.set_scale(self.heading, vmath.vector3(s, s, s))
+    -- set initial score (0)
+    gui.set_text(self.score, "0")
+    -- set score color to opaque white
+    gui.set_color(self.score, vmath.vector4(1, 1, 1, 1))
+    -- set scale so the score can grow while counting
+    gui.set_scale(self.score, vmath.vector4(score_start_scale, score_start_scale, 1, 0))
+
+    -- make all big stars transparent
+    for i=1,#self.stars do
+        gui.set_color(self.stars[i], vmath.vector4(1, 1, 1, 0))
+    end
+    -- make the imprint transparent
+    gui.set_color(self.imprint, vmath.vector4(1, 1, 1, 0))
+    -- the score currently being displayed
+    self.current_score = 0
+    -- the target score when counting
+    self.target_score = 0
+end
+
+function init(self)
+    -- retrieve nodes for easier access
+    self.heading = gui.get_node("heading")
+    self.stars = {gui.get_node("star_left"), gui.get_node("star_mid"), gui.get_node("star_right")}
+    self.score = gui.get_node("score")
+    self.imprint = gui.get_node("imprint")
+    -- start color of the score
+    self.score_start_color = vmath.vector4(1, 1, 1, 1)
+    -- save score color and animate towards it during counting later
+    self.score_end_color = gui.get_color(self.score)
+    setup(self)
+end
+
+-- delete a small star, called when the star has finished animating
+local function delete_small_star(self, small_star)
+    gui.delete_node(small_star)
+end
+
+-- animate a small star according to the given initial position and angle
+local function animate_small_star(self, pos, angle)
+    -- direction of travel for the small star
+    local dir = vmath.vector3(math.cos(angle), math.sin(angle), 0, 0)
+    -- create a small star
+    local small_star = gui.new_box_node(pos + dir * 20, vmath.vector3(64, 64, 0))
+    -- set its texture
+    gui.set_texture(small_star, "small_star")
+    -- set its color to full white
+    gui.set_color(small_star, vmath.vector4(1, 1, 1, 1))
+    -- set start scale low
+    local start_s = 0.3
+    gui.set_scale(small_star, vmath.vector3(start_s, start_s, 1))
+    -- variation in scale of each small star
+    local end_s_var = 1
+    -- actual end scale of this star
+    local end_s = 0.5 + math.random() * end_s_var
+    gui.animate(small_star, gui.PROP_SCALE, vmath.vector4(end_s, end_s, 1, 0), gui.EASING_NONE, 0.5)
+    -- variation in distance traveled (essentially speed of the star)
+    local dist_var = 300
+    -- actual distance the star will travel
+    local dist = 400 + math.random() * dist_var
+    gui.animate(small_star, gui.PROP_POSITION, pos + dir * dist, gui.EASING_NONE, 0.5)
+    gui.animate(small_star, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 0), gui.EASING_OUT, 0.3, 0.2, delete_small_star)
+end
+
+-- spawn a number of small stars
+local function spawn_small_stars(self, star)
+    -- position of the big star the small star will spawn around
+    local p = gui.get_position(star)
+    for i = 1,small_star_count do
+        -- calculate the angle of the particular small star
+        local angle = 2 * math.pi * i/small_star_count
+        -- as well as position
+        local pos = vmath.vector3(p.x, p.y, 0)
+        -- spawn and animate the small star
+        animate_small_star(self, pos, angle)
+    end
+end
+
+-- start the animation of a big star fading in
+local function animate_star(self, star)
+    -- fade in duration
+    local fade_in = 0.2
+    -- make it transparent
+    gui.set_color(star, vmath.vector4(1, 1, 1, 0))
+    -- fade in
+    gui.animate(star, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_IN, fade_in)
+    -- initial scale
+    local scale = 5
+    gui.set_scale(star, vmath.vector3(scale, scale, 1))
+    -- shrink back into place
+    gui.animate(star, gui.PROP_SCALE, vmath.vector4(1, 1, 1, 0), gui.EASING_IN, fade_in, 0, spawn_small_stars)
+end
+
+-- start the animation of the imprint fading in
+local function animate_imprint(self)
+    -- wait a bit before the imprint appears
+    local delay = 0.8
+    -- fade in duration
+    local fade_in = 0.2
+    -- initial scale
+    local scale = 4
+    gui.set_scale(self.imprint, vmath.vector4(scale, scale, 1, 0))
+    -- shrink back into place
+    gui.animate(self.imprint, gui.PROP_SCALE, vmath.vector4(1, 1, 1, 0), gui.EASING_IN, fade_in, delay)
+    -- also fade in
+    gui.animate(self.imprint, gui.PROP_COLOR, vmath.vector4(1, 1, 1, 1), gui.EASING_IN, fade_in, delay)
+end
+
+-- increment the score one step towards the target
+local function inc_score(self, node)
+    -- how much the score is incremented this step
+    local score_inc = score_inc_speed * dt
+    -- new score after increment
+    local new_score = self.current_score + score_inc
+    for i = 1,#self.stars do
+        -- start animating a big star if we cross the level in score for it to appear
+        if self.current_score < self.star_levels[i] and new_score >= self.star_levels[i] then
+            animate_star(self, self.stars[i])
+        end
+    end
+    -- update score, but clamp at target
+    self.current_score = math.min(new_score, self.target_score)
+    -- update the score on screen
+    gui.set_text(self.score, tostring(self.current_score))
+    -- if we are not yet done, keep animating and incrementing
+    if self.current_score < self.target_score then
+        -- how close we are to the target
+        local f = self.current_score / self.target_score
+        -- blend the color to get a slow fade
+        local c = vmath.lerp(f, self.score_start_color, self.score_end_color)
+        gui.animate(self.score, gui.PROP_COLOR, c, gui.EASING_NONE, dt, 0, inc_score)
+        -- new scale for this step
+        local s = vmath.lerp(f, score_start_scale, score_end_scale)
+        -- increase the scale by the bounce factor
+        local sp = s * score_bounce_factor
+        -- animate from bounced scale back to the appropriate scale
+        gui.set_scale(self.score, vmath.vector4(sp, sp, 1, 0))
+        gui.animate(self.score, gui.PROP_SCALE, vmath.vector4(s, s, 1, 0), gui.EASING_NONE, dt)
+    else
+        -- we are done, fade in the imprint
+        -- NOTE! this should in a real case be checked against the actual stored high score
+        animate_imprint(self)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    -- someone tells us that we should display the level completed scene
+    if message_id == hash("level_completed") then
+        -- retrieve the obtained score and at which score levels the stars should be displayed
+        self.target_score = message.score
+        self.star_levels = message.star_levels
+        -- fade in heading ("level completed")
+        local c = gui.get_color(self.heading)
+        c.w = 1
+        gui.animate(self.heading, gui.PROP_COLOR, c, gui.EASING_IN, dt, 0.0, inc_score)
+        c = gui.get_shadow(self.heading)
+        c.w = 1
+        gui.animate(self.heading, gui.PROP_SHADOW, c, gui.EASING_IN, dt, 0.0)
+        -- shrink it into place
+        gui.animate(self.heading, gui.PROP_SCALE, vmath.vector4(1, 1, 1, 0), gui.EASING_IN, 0.2, 0.0)
+    end
+end
+
+-- this function is called when the script is reloaded
+-- by setting up the scene and simulating level complete, we get a really fast workflow for tweaking
+function on_reload(self)
+    -- make sure any setup changes are taken into account
+    setup(self)
+    -- simulate that the level has been completed
+    msg.post("#gui", "level_completed", {score = 102000, star_levels = {40000, 70000, 100000}})
+end
+```

--- a/docs/tr/tutorials/magic-link.md
+++ b/docs/tr/tutorials/magic-link.md
@@ -1,0 +1,1338 @@
+---
+title: Magic Link öğreticisi
+brief: Bu öğreticide başlangıç ekranı, oyun mekanikleri ve giderek zorlaşan bölümlerle basit bir ilerleme sistemi içeren, eksiksiz küçük bir bulmaca oyunu oluşturacaksınız.
+---
+
+# Magic Link öğreticisi
+
+Bu oyun, _Bejeweled_ ve _Candy Crush_ tarzındaki klasik eşleştirme oyununun bir çeşididir. Oyuncu aynı renkteki blokları kaldırmak için sürükleyerek birbirine bağlar. Ancak oyunun amacı aynı renkteki uzun blok dizilerini kaldırmak, tahtayı temizlemek veya puan toplamak değil, tahtanın çeşitli yerlerine dağılmış özel "sihirli blokların" birbirine bağlanmasını sağlamaktır.
+
+Bu öğretici, tamamlanmış bir tasarımdan yola çıkarak oyunu oluşturduğumuz, adım adım ilerleyen bir kılavuz olarak yazılmıştır. Gerçekte işe yarayan bir tasarım bulmak çok zaman ve emek ister. Temel bir fikirle başlayıp ardından bu fikrin neler sunabileceğini daha iyi anlamak için bir prototipini oluşturmanın yolunu bulabilirsiniz. "Magic Link" gibi basit bir oyun bile oldukça fazla tasarım çalışması gerektirir. Bu oyun, son biçimine (hâlâ kusursuz olmaktan çok uzak olsa da) ve oyun kurallarına ulaşana kadar birkaç yinelemeden ve bazı denemelerden geçti. Ancak bu öğreticide o süreci atlayıp son tasarım üzerinden oyunu oluşturmaya başlayacağız.
+
+## Başlarken
+
+Yeni bir proje oluşturup varlık (asset) paketini içe aktararak başlamanız gerekir:
+
+* "Empty Project" şablonundan [yeni bir proje](/manuals/project-setup/#creating-a-new-project) oluşturun
+* Başvuru olarak kullanmak için "Magic Link" projesinin tamamını [magic-link.zip](https://github.com/defold/defold-examples/releases/latest) dosyası olarak indirin. Projeyi sıfırdan oluşturmak isterseniz gereken tüm varlıklar bu eksiksiz projede bulunur.
+
+## Oyun kuralları
+
+![Oyun kuralları şeması](images/magic-link/linker_rules.png)
+
+Tahta her turda rastgele renkli bloklarla ve bir dizi sihirli blokla doldurulur. Renkli bloklar şu kurallara uyar:
+
+* Oyuncu onları aynı renkteki bloklarla (sürükleyerek) bağlarsa kaybolurlar.
+* Bloklar kaybolduğunda alt tarafta boşluklar bırakır. Renkli bloklar, altlarında açılan boşluklara dikey olarak düşer.
+* Ekranın alt kenarı tüm blokların daha fazla düşmesini engeller.
+
+Sihirli bloklar ise şu kurallara göre farklı davranır:
+
+* Sihirli bloklar, iki yanlarından birinde bir boşluk açılırsa _yana doğru_ hareket eder.
+* Altlarında bir boşluk açılırsa bunun yerine normal renkli bloklar gibi düşerler.
+
+Oyuncu oyunla şu kurallar çerçevesinde etkileşime girer:
+
+* Oyuncu yatay, dikey ve çapraz olarak komşu olan renkli blokları sürükleyerek birbirine bağlayabilir.
+* Bağlanan bloklar, oyuncu dokunma girdisini bıraktığı (parmağını kaldırdığı) anda kaybolur.
+* Sihirli bloklar sürüklemeye tepki vermez ve elle bağlanamaz.
+* Ancak sihirli bloklar yatay veya dikey olarak birbirine temas ettiğinde tepki verir. Yani bu koşullarda otomatik olarak bağlanırlar.
+* Oyuncu tahtadaki tüm sihirli blokların otomatik olarak bağlanmasını sağlamayı başarırsa bölüm tamamlanır.
+
+Zorluk düzeyi, tahtaya yerleştirilen sihirli blokların sayısını belirler.
+
+## Genel bakış
+
+Her projede olduğu gibi, uygulamaya genel hatlarıyla nasıl yaklaşacağımızı planlamamız gerekir. Oyunu yapılandırmanın ve oluşturmanın birçok yolu vardır. İsteseydik teknik olarak oyunun tamamını grafik kullanıcı arayüzü (GUI) sistemi içinde geliştirebilirdik. Ancak oyunu oyun nesneleri (game object) ve sprite bileşenleriyle (sprite component) oluşturup ekrandaki GUI ve oyun içi bilgi göstergesi (HUD) öğeleri için GUI API'lerini kullanmak çoğu zaman oyun oluşturmanın doğal yoludur; biz de bu yolu izleyeceğiz.
+
+Dosya sayısının oldukça az kalmasını beklediğimiz için proje klasör yapısını çok basit tutacağız:
+
+![Klasör yapısı](images/magic-link/linker_folders.png)
+
+*main*
+: Oyunun tüm mantığı bu klasörde yer alacak. Tüm betikler (script), oyun nesnesi dosyaları, koleksiyon (collection) dosyaları, GUI dosyaları ve benzerleri bu klasörde bulunacak. Bu klasörü birkaç klasöre bölmek veya alt klasörler kullanmak isterseniz bunda hiçbir sakınca yoktur.
+
+*images*
+: Tüm görüntü varlıkları bu klasörde bulunacak.
+
+*fonts*
+: Metin işleme (rendering) için kullanılan yazı tipleri burada tutulur.
+
+*input*
+: Girdi eşlemeleri (input binding) bu klasörde tutulur.
+
+## Projeyi hazırlama
+
+*game.project* dosyasında çoğunlukla varsayılan ayarlar korunur, ancak karar vermemiz gereken bazı ayarlar vardır. Öncelikle oyun için bir çözünürlük seçmemiz gerekir. Çözünürlüğü daha sonra değiştirmek oldukça kolaydır. Oyunun son hâlinde ise hedef cihazın çözünürlüğünden veya en boy oranından bağımsız olarak iyi görünmesini sağlamak için biraz çalışma yapmamız gerekecek.
+
+Çözünürlüğü iPhone 4'ün doğal çözünürlüğü olan 640x960 piksel olarak ayarlamayı seçtik. Bu çözünürlük birçok monitöre de sığdığından bilgisayarda oynanış testi yapmak rahat olur. Farklı bir çözünürlükte çalışmak isterseniz yalnızca birkaç değeri farklı şekilde ayarlamanız gerekir.
+
+![Proje ayarları](images/magic-link/linker_project_settings.png)
+
+Ayrıca işlenebilecek en fazla sprite sayısını artırmamız gerekecek. İsterseniz sonraki bölüme geçebilir ve konsolda sprite sınırına ulaştığınız bildirildiğinde buraya dönebilirsiniz.
+
+![Oyun boyutlarının yerleşimi](images/magic-link/linker_layout.png)
+
+Gereken en fazla sprite sayısını hesaplayabiliriz:
+
+* Oyun tahtasında 7x9 blok bulunacak. Tahtanın kenarlarında biraz boşluk, üst kısmında da bazı GUI öğeleri için yer gerekecek. Bu da blokların boyutunun yaklaşık 90x90 piksel olacağı anlamına gelir. Daha küçük olurlarsa küçük bir telefon ekranında etkileşime girmek için fazla küçük kalırlar.
+* Her blok bir sprite bileşenidir. Bloğun rengini ayarlamak için tek karelik animasyonlar kullanacağız.
+* Blokların bazıları sihirli blok olacak ve bunların her birinde özel efektler için 4 sprite bileşeni kullanacağız.
+* Bağlantı grafikleri için öğe başına bir sprite bileşeni gerekecek. En kötü durumda oyuncu bir şekilde tüm tahtayı (sürükleyerek bağlanamayan 2 sihirli blok dışında) bağlarsa bu, 61 ek sprite bileşeni demektir.
+
+En fazla 30 sihirli bloğumuz olduğunu varsayalım. Tahta 63 bloktan (sprite bileşeninden) oluşur. Bunların içindeki 30 sihirli bloğun her biri özel efektler için 4 sprite bileşeni ekler. Bu, 120 ek sprite bileşeni demektir. Dolayısıyla bağlantı grafikleriyle birlikte (bu durumda en fazla 33) her karede en az 120 + 33 = 153 sprite çizmemiz gerekecek. İkinin en yakın kuvveti 256'dır.
+
+Ancak üst sınırı 256 olarak ayarlamak yeterli değildir. Tahtayı her temizleyip sıfırladığımızda mevcut tüm oyun nesnelerini silip yenilerini oluşturacağız. Sprite sayısının, kare boyunca yaşamını sürdüren tüm nesnelere yetecek kadar olması gerekir. Silinen nesneler de buna dahildir; çünkü bunlar karenin sonunda kaldırılır. Bu nedenle en fazla sprite sayısını 512 olarak ayarlamak yeterli olacaktır.
+
+![En fazla sprite sayısı](images/magic-link/linker_sprite_max_count.png)
+
+## Grafik varlıklarını ekleme
+
+Oyun için gereken tüm varlıklar önceden hazırlandı. Bunları 512x512 piksellik görüntüler olarak ekliyor ve motorun hedef boyuta küçültmesini sağlıyoruz.
+
+::: sidenote
+Proje ayarlarında *hidpi* seçeneğini etkinleştirmek arka arabelleğin yüksek çözünürlüklü olmasını sağlar. Büyük görüntüleri küçülterek çizdiğinizde Retina ekranlarda çok net görünürler.
+:::
+
+![Görüntü ekleme](images/magic-link/linker_add_images.png)
+
+Bloklara ek olarak bir "connector" (bağlayıcı) görüntüsü ve efekt sprite bileşenleri de bulunur. Ayrıca iki arka plan görüntümüz vardır. Biri oyun tahtasının arka planı, diğeri ana menü için kullanılacak. Tüm görüntüleri *images* klasörüne ekleyin, ardından *sprites.atlas* adlı bir atlas dosyası oluşturun. Atlas dosyasını açıp tüm görüntüleri ekleyin.
+
+![Atlasa görüntü ekleme](images/magic-link/linker_add_to_atlas.png)
+
+Düğmeler ve açılır pencereler gibi GUI öğelerini oluşturmak için kullanılan bir dizi GUI görüntüsü vardır. Bunlar *gui.atlas* adlı ayrı bir atlasa eklenir.
+
+## Tahtayı oluşturma
+
+İlk adım tahta mantığını oluşturmaktır. Tahta, oynanış sırasında ekranda görünen her şeyi içeren kendi koleksiyonunda yer alacak. Şimdilik yalnızca "blockfactory" fabrika (factory) bileşeni ve betik gerekiyor. Daha sonra bağlantılar için bir fabrika, ana menü GUI bileşenleri ve son olarak ana menüden oyunu başlatmak için yükleme mekanikleri ile menüye dönmenin bir yolunu ekleyeceğiz.
+
+1. *`board.collection`* dosyasını *`main`* klasöründe oluşturun. Daha sonra adresleyebilmek için adını "board" olarak ayarladığınızdan emin olun. Arka plan sprite bileşenini eklerseniz Z konumunu -1 olarak ayarladığınızdan emin olun; aksi takdirde daha sonra oluşturacağımız tüm blokların arkasında çizilmez.
+2. Kolayca test edebilmek için *game.project* dosyasında (*Bootstrap* altındaki) *Main Collection* ayarını geçici olarak `/main/board.collection` yapın.
+
+![Tahta koleksiyonu](images/magic-link/linker_board_collection.png)
+
+![Başlangıçta tahta koleksiyonunun yüklenmesi](images/magic-link/linker_bootstrap_board.png)
+
+*board.script* betik dosyası, tahtanın kendisi ve tahtadaki bloklar için tüm mantığı içerecek. Tahtayı oluşturan işlevi yazarak başlayın ve onu `init()` içinden (geçici olarak) çağırın. Şu an kullanmayacağımız, ancak daha sonra işimize yarayacak iki işlev daha ekliyoruz:
+
+`filter()`
+: Bu işlev, öğe (blok) listelerini filtrelememizi sağlayacak.
+
+`build_blocklist()`
+: Tahtadaki tüm blokları tek düzeyli bir liste hâlinde toplar; böylece listeyi filtreleyebiliriz.
+
+Tahta oluşturulduktan sonra tüm blokları içeren iki farklı veri kümesi kullanacağız: `self.blocks` ve `self.board`:
+
+```lua
+-- board.script
+go.property("timer", 0)     -- Use to time events
+local blocksize = 80        -- Distance between block centers
+local edge = 40             -- Left and right edge.
+local bottom_edge = 50      -- Bottom edge.
+local boardwidth = 7        -- Number of columns
+local boardheight = 9       -- Number of rows
+local centeroff = vmath.vector3(8, -8, 0) -- Center offset for connector gfx since there's shadow below in the block img
+local dropamount = 3        -- The number of blocks dropped on a "drop"
+local colors = { hash("orange"), hash("pink"), hash("blue"), hash("yellow"), hash("green") }
+
+--
+-- filter(function, table)
+-- e.g: filter(is_even, {1,2,3,4}) -> {2,4}
+--
+local function filter(func, tbl)
+    local new = {}
+    for i, v in pairs(tbl) do
+        if func(v) then
+            new[i] = v
+        end
+    end
+    return new
+end
+
+--
+-- Build a list of blocks in 1 dimension for easy filtering
+--
+local function build_blocklist(self)
+    self.blocks = {}
+    for x, l in pairs(self.board) do
+        for y, b in pairs(self.board[x]) do
+            table.insert(self.blocks, { id = b.id, color = b.color, x = b.x, y = b.y })
+        end
+    end
+end
+
+--
+-- INIT
+--
+function init(self)
+    self.board = {}             -- Contains the board structure
+    self.blocks = {}            -- List of all blocks. Used for easy filtering on selection.
+    self.chain = {}             -- Current selection chain
+    self.connectors = {}        -- Connector elements to mark the selection chain
+    self.num_magic = 3          -- Number of magic blocks on the board
+    self.drops = 1              -- Number of drops you have available
+    self.magic_blocks = {}      -- Magic blocks that are lined up
+    self.dragging = false       -- Drag touch input
+    msg.post(".", "acquire_input_focus")
+    msg.post("#", "start_level")
+end
+
+local function build_board(self)
+    math.randomseed(os.time())
+    local pos = vmath.vector3()
+    local c
+    local x = 0
+    local y = 0
+    for x = 0,boardwidth-1 do
+        pos.x = edge + blocksize / 2 + blocksize * x
+        self.board[x] = {}
+        for y = 0,boardheight-1 do
+            pos.y = bottom_edge + blocksize / 2 + blocksize * y
+            -- Calc z
+            pos.z = x * -0.1 + y * 0.01 -- <1>
+            c = colors[math.random(#colors)]    -- Pick a random color
+            local id = factory.create("#blockfactory", pos, null, { color = c })
+            self.board[x][y] = { id = id, color = c,  x = x, y = y }
+        end
+    end
+
+    -- Build 1d list that we can easily filter.
+    build_blocklist(self)
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("start_level") then
+        build_board(self)
+    end
+end
+```
+1. Blok grafikleri üst üste geldiği için bunları doğru sırada çizmemiz gerektiğine dikkat edin. Bu, her bloğun z koordinatını ayarlayarak yapılır. Değer, arka plan sprite bileşeninin bulunduğu -1'in oldukça üzerinde kalacaktır.
+
+Tahta mantığı, "`blockfactory`" fabrika bileşeni aracılığıyla "`block`" oyun nesneleri oluşturur. Bunun çalışması için blok oyun nesnesini oluşturmamız gerekir. Blokta bir betik ve bir sprite bileşeni bulunur. Sprite bileşeninin varsayılan animasyonunu *`sprites.atlas`* içindeki renkli bloklardan herhangi birine ayarlıyor, ardından blok oluşturulduğunda doğru rengi alması için *`block.script`* dosyasına kod ekliyoruz:
+
+![Blok oyun nesnesi](images/magic-link/linker_block.png)
+
+```lua
+-- block.script
+go.property("color", hash("none"))
+
+function init(self)
+    go.set_scale_xy(0.18)     -- render scaled down without changing Z
+
+    if self.color ~= nil then
+        sprite.play_flipbook("#sprite", self.color)
+    else
+        msg.post("#sprite", "disable")
+    end
+end
+```
+
+"blockfactory" fabrika bileşeninin *Prototype* özelliğini yeni *block.go* oyun nesnesi dosyasına ayarlayın.
+
+![Blok fabrikası](images/magic-link/linker_blockfactory.png)
+
+Artık oyunu çalıştırıp tahtanın rastgele renkli bloklarla dolduğunu görebilmelisiniz:
+
+![İlk ekran görüntüsü](images/magic-link/linker_first_screenshot.png)
+
+## Etkileşimler
+
+Artık bir tahtamız olduğuna göre kullanıcı etkileşimi eklemeliyiz. Önce *input* klasöründeki *game.input_binding* dosyasında girdi eşlemelerini tanımlıyoruz. *game.project* ayarlarının girdi eşlemeleri dosyanızı kullandığından emin olun.
+
+![Girdi eşlemeleri](images/magic-link/linker_input_bindings.png)
+
+Yalnızca bir eşlemeye ihtiyacımız var ve `MOUSE_BUTTON_LEFT` girdisini "touch" eylem adına atıyoruz. Bu oyun çoklu dokunma kullanmaz ve kolaylık sağlamak için Defold tek parmakla dokunma girdisini sol fare tıklamalarına dönüştürür.
+
+Girdiyi işleme görevi tahtaya düştüğünden bunun için *board.script* dosyasına kod eklememiz gerekir:
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.value == 1 then
+        -- What block was touched or dragged over?
+        local x = math.floor((action.x - edge) / blocksize)
+        local y = math.floor((action.y - bottom_edge) / blocksize)
+
+        if x < 0 or x >= boardwidth or y < 0 or y >= boardheight or self.board[x][y] == nil then
+            -- outside board.
+            return
+        end
+
+        if action.pressed then
+            -- Player started touch
+            msg.post(self.board[x][y].id, "make_orange")
+
+            self.dragging = true
+        elseif self.dragging then
+            -- then drag
+            msg.post(self.board[x][y].id, "make_green")
+        end
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+    end
+end
+```
+
+`make_orange` ve `make_green` iletileri (message), kodun çalıştığını görsel olarak doğrulamak için yalnızca geçici olarak kullanılır. Bu iletileri işlemek için *block.script* dosyasına kod eklememiz gerekir:
+
+```lua
+-- block.script
+function on_message(self, message_id, message, sender)
+    if message_id == hash("make_orange") then
+        sprite.play_flipbook("#sprite", hash("orange"))
+    elseif message_id == hash("make_green") then
+        sprite.play_flipbook("#sprite", hash("green"))
+    end
+end
+```
+
+Artık dokunduğunuz (veya fare düğmesini basılı tuttuğunuz) sürece bloklara önce bir `make_orange` iletisi, ardından `make_green` iletileri gönderilecektir. Bu nedenle bloklar yeşile dönmeden önce muhtemelen yalnızca bir anlığına turuncu yanıp söneceklerdir (hatta bu bile olmayabilir). Ancak oyuncunun hangi bloğa dokunduğunu biliyoruz! Girdinin nasıl işlendiğini daha ayrıntılı izlemek isterseniz koda `print()` veya `pprint()` çağrıları ekleyin.
+
+## Bağlantıları işaretleme
+
+Şimdi blokların oyuncu tarafından bağlandığını göstermek için kullanılacak işaretleyicinin varlıklarına ihtiyacımız var. Amaç, her bloğun bağlı olduğunu göstermek için üzerine bir grafik yerleştirmektir.
+
+Bağlayıcının sprite görüntüsünü tutan bir "connector" oyun nesnesi ve "board" oyun nesnesinde bir "connector factory" fabrika bileşeni oluşturmamız gerekir:
+
+![Bağlayıcı oyun nesnesi](images/magic-link/linker_connector.png)
+
+![Bağlayıcı fabrikası](images/magic-link/linker_connector_factory.png)
+
+Bu oyun nesnesinin betiği çok kısadır; yalnızca grafikleri oyunun geri kalanıyla uyumlu olacak şekilde ölçeklemesi ve Z sırasını doğru ayarlaması gerekir.
+
+```lua
+-- connector.script
+function init(self)
+    go.set_scale_xy(0.18)           -- Scale in 2D without changing Z.
+    go.set(".", "position.z", 1)    -- Put on top.
+end
+```
+
+`same_color_neighbors()` işlevi, belirli bir bloğa (x, y konumundaki) komşu olan ve onunla aynı renkteki blokların listesini döndürür. Bu işlev, `self.blocks` içindeki blokların tamamını içeren tek düzeyli listeye uygulanan `filter()` işlevini kullanır.
+
+```lua
+-- board.script
+--
+-- Returns a list of neighbor blocks of the same color as the
+-- block on x, y
+--
+local function same_color_neighbors(self, x, y)
+    local f = function (v)
+        return (v.id ~= self.board[x][y].id) and
+               (v.x == x or v.x == x - 1 or v.x == x + 1) and
+               (v.y == y or v.y == y - 1 or v.y == y + 1) and
+               (v.color == self.board[x][y].color)
+    end
+    return filter(f, self.blocks)
+end
+```
+
+`in_blocklist()` yardımcı işlevi, bir bloğun blok listesinde bulunup bulunmadığını denetler:
+
+```lua
+-- board.script
+--
+-- Does the block exist in the list of blocks?
+--
+local function in_blocklist(blocks, block)
+    for i, b in pairs(blocks) do
+        if b.id == block then
+            return true
+        end
+    end
+    return false
+end
+```
+
+Bu işlevleri, dokunarak seçilen blok zincirini oluşturmak için `on_input()` içindeki dokunma ve sürükleme girdileri sırasında kullanıyoruz. Henüz sihirli bloklar bulunmasa da burada onları denetleyip yok sayacağız:
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    -- If trying to manipulate magic blocks, ignore.
+    if self.board[x][y].color == hash("magic") then
+        return
+    end
+
+    if action.pressed then
+        -- List of neighbors of the same color as touched block
+        self.neighbors = same_color_neighbors(self, x, y)
+        self.chain = {}
+        table.insert(self.chain, self.board[x][y])
+
+        -- Mark block.
+        p = go.get_position(self.board[x][y].id)
+        local id = factory.create("#connectorfactory", p + centeroff)
+        table.insert(self.connectors, id)
+
+        self.dragging = true
+    elseif self.dragging then
+        -- then drag
+        if in_blocklist(self.neighbors, self.board[x][y].id) and not in_blocklist(self.chain, self.board[x][y].id) then
+            -- dragging over a same-colored neighbor
+            table.insert(self.chain, self.board[x][y])
+            self.neighbors = same_color_neighbors(self, x, y)
+
+            -- Mark block.
+            p = go.get_position(self.board[x][y].id)
+            local id = factory.create("#connectorfactory", p + centeroff)
+            table.insert(self.connectors, id)
+        end
+    end
+```
+
+Son olarak, dokunma bırakıldığında tüm bağlantı işaretlerini görünümden kaldırın.
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+
+        -- Empty chain of connector graphics.
+        for i, c in ipairs(self.connectors) do
+            go.delete(c)
+        end
+        self.connectors = {}
+    end
+end
+```
+
+![Oyun içindeki bağlayıcılar](images/magic-link/linker_connector_screen.png)
+
+## Bağlanan blokları kaldırma
+
+Artık aynı renkteki blokların bağlanmasını sağlayan mantık hazır ve bağlanan blokları kaldırmak kolay. Tahtadaki konumu doğrudan `nil` yapmak yerine `hash("removing")` olarak ayarlamamızın nedeni, daha sonra sihirli blok mantığını yazarken sihirli blokların yalnızca yeni kaldırılmış blokların yerine kaymasını sağlamamızın gerekmesidir. Tahtadaki konumu burada `nil` olarak ayarlarsak yeni kaldırılmış bloklarla daha önce kaldırılan blokları ayırt edemeyiz.
+
+```lua
+-- board.script
+-- Remove the currently selected block-chain
+--
+local function remove_chain(self)
+    -- Delete all chained blocks
+    for i, c in ipairs(self.chain) do
+        self.board[c.x][c.y] = hash("removing")
+        go.delete(c.id)
+    end
+    self.chain = {}
+end
+```
+
+Tahtada `hash("removing")` olarak ayarlanmış konumları gerçekten kaldırmak (`nil` yapmak) için de bir işleve ihtiyacımız olacak:
+
+```lua
+-- board.script
+--
+-- Set removed blocks to nil
+--
+local function nilremoved(self)
+    for y = 0,boardheight - 1 do
+        for x = 0,boardwidth - 1 do
+            if self.board[x][y] == hash("removing") then
+                self.board[x][y] = nil
+            end
+        end
+    end
+end
+```
+
+Ayrıca altlarındaki bloklar kaldırıldığında (`nil` yapıldığında) kalan blokları aşağı kaydıran bir işlev oluşturuyoruz. Tahtayı sütun sütun soldan sağa dolaşıyor ve her sütunu aşağıdan yukarıya inceliyoruz. Boş (`nil`) bir konumla karşılaşırsak bu konumun üzerindeki tüm blokları aşağı kaydırıyoruz.
+
+```lua
+-- board.script
+--
+-- Apply shift-down logic to all blocks.
+--
+local function slide_board(self)
+    -- Slide all remaining blocks down into blank spots.
+    -- Going column by column makes this easy.
+    local dy = 0
+    local pos = vmath.vector3()
+    for x = 0,boardwidth - 1 do
+        dy = 0
+        for y = 0,boardheight - 1 do
+            if self.board[x][y] ~= nil then
+                if dy > 0 then
+                    -- Move down dy steps
+                    self.board[x][y - dy] = self.board[x][y]
+                    self.board[x][y] = nil
+                    -- Calc new position
+                    self.board[x][y - dy].y = self.board[x][y - dy].y - dy
+                    go.animate(self.board[x][y-dy].id, "position.y", go.PLAYBACK_ONCE_FORWARD, bottom_edge + blocksize / 2 + blocksize * (y - dy), go.EASING_OUTBOUNCE, 0.3)
+                    -- Calc new z
+                    go.set(self.board[x][y-dy].id, "position.z", x * -0.1 + (y-dy) * 0.01)
+                end
+            else
+                dy = dy + 1
+            end
+        end
+    end
+    -- blocklist needs updating
+    build_blocklist(self)
+end
+```
+
+![Blokları aşağı kaydırma](images/magic-link/linker_blocks_slide.png)
+
+Artık dokunma bırakıldığında ve `self.chain` içinde bloklar olduğunda bu işlevleri çağıracak kodu `on_input()` içine ekleyebiliriz.
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+
+        if #self.chain > 1 then
+            -- There is a chain of blocks. Remove it from board and slide the remaining blocks down.
+            remove_chain(self)
+            nilremoved(self)
+            slide_board(self)
+        end
+
+        -- Empty chain of connector graphics.
+        for i, c in ipairs(self.connectors) do
+            go.delete(c)
+        end
+        self.connectors = {}
+    end
+```
+
+## Sihirli blok mantığı
+
+Şimdi sihirli blokları ekleme zamanı. Öncelikle blokların sihirli bloklara dönüşebilmesini sağlayalım. Böylece doldurulmuş tahtayı ayrı bir geçişte dolaşıp istediğimiz blokları sihirli bloklara dönüştürebiliriz. Sihirli blokları biraz daha ilgi çekici hâle getirmek için önce sihirli bloktan oluşturabileceğimiz *`magic_fx.go`* oyun nesnesi biçiminde animasyonlu bir sihir efekti oluşturalım.
+
+![Magic_fx.go](images/magic-link/linker_magic_fx.png)
+
+Bu oyun nesnesi iki sprite bileşeni içerir. Biri "magic" rengidir (*`magic-sphere_layer2.png`* görüntüsünü kullanan bir sprite bileşeni), diğeri ise "light" adlı bir ışık efektidir (*`magic-sphere_layer3.png`* görüntüsünü kullanan bir sprite bileşeni). Nesne, oluşturulduğunda `direction` özelliğinin değerine bağlı olarak dönecek şekilde ayarlanır. Ayrıca nesnenin, ışık efekti sprite bileşenini denetleyen iki iletiyi dinlemesini sağlarız: `lights_on` ve `lights_off`.
+
+Yeni bir betik oluşturun ve bunu *`magic_fx.go`* nesnesine betik bileşeni olarak ekleyin:
+
+```lua
+-- magic_fx.script
+go.property("direction", hash("left"))
+
+function init(self)
+    msg.post("#", "lights_off")
+    if self.direction == hash("left") then
+        go.set(".", "euler.z", 0)
+        go.animate(".", "euler.z", go.PLAYBACK_LOOP_FORWARD, 360,  go.EASING_LINEAR, 3 + math.random())
+    else
+        go.set(".", "euler.z", 0)
+        go.animate(".", "euler.z", go.PLAYBACK_LOOP_FORWARD, -360,  go.EASING_LINEAR, 2 + math.random())
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("lights_on") then
+        msg.post("#light", "enable")
+    elseif message_id == hash("lights_off") then
+        msg.post("#light", "disable")
+    end
+end
+```
+
+Artık sihirli blok, `make_magic` iletisini aldığında iki `magic_fx` oyun nesnesi oluşturacak. Bunların her biri zıt yönde dönerek blokların içinde hoş bir renk dansı yaratacak. Ayrıca *`block.go`* nesnesine *`magic-sphere_layer4.png`* görüntüsünü kullanan ek bir sprite bileşeni ekliyoruz. Bu görüntü, oluşturulan efektinkinden daha yüksek bir Z konumuna yerleştirilir ve sihirli kürenin kabuğunu ya da "cover" adı verilen kapağını çizer.
+
+![Kapak sprite bileşeni](images/magic-link/linker_cover.png)
+
+Blok oyun nesnesine bir *Factory* bileşeni eklememiz ve *Prototype* olarak *`magic_fx.go`* oyun nesnemizi kullanmasını sağlamamız gerektiğine dikkat edin. Blok betiğinin de `lights_on` ve `lights_off` iletilerini dinlemesi ve bunları oluşturulan nesnelere iletmesi gerekir. Blok silindiğinde oluşturulan nesnelerin de silinmesi gerektiğini unutmayın. Bu işlem, bloğun `final()` işlevinde yapılır. Bunların tümü *`block.script`* içinde gerçekleşir.
+
+```lua
+-- block.script
+function init(self)
+    go.set_scale_xy(0.18) -- render scaled down without changing Z
+
+    self.fx1 = nil
+    self.fx2 = nil
+
+    msg.post("#cover", "disable")
+
+    if self.color ~= nil then
+        sprite.play_flipbook("#sprite", self.color)
+    else
+        msg.post("#sprite", "disable")
+    end
+end
+
+function final(self)
+    if self.fx1 ~= nil then
+        go.delete(self.fx1)
+    end
+
+    if self.fx2 ~= nil then
+        go.delete(self.fx2)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("make_magic") then
+        self.color = hash("magic")
+        msg.post("#cover", "enable")
+        msg.post("#sprite", "enable")
+        sprite.play_flipbook("#sprite", hash("magic-sphere_layer1"))
+
+        self.fx1 = factory.create("#fxfactory", p, nil, { direction = hash("left") })
+        self.fx2 = factory.create("#fxfactory", p, nil, { direction = hash("right") })
+
+        go.set_parent(self.fx1, go.get_id())
+        go.set_parent(self.fx2, go.get_id())
+
+        go.set(self.fx1, "position.z", 0.01)
+        go.set(self.fx1, "scale.xy", 1)
+        go.set(self.fx2, "position.z", 0.02)
+        go.set(self.fx2, "scale.xy", 1)
+    elseif message_id == hash("lights_on") or message_id == hash("lights_off") then
+        msg.post(self.fx1, message_id)
+        msg.post(self.fx2, message_id)
+    end
+end
+```
+
+Artık sihirli bloklar oluşturabilir ve ışıklarını yakabiliriz. Bu efekti, bir sihirli bloğun başka bir sihirli bloğun yanında bulunduğunu göstermek için kullanacağız.
+
+![Işığı kapalı ve açık sihirli blok](images/magic-link/linker_magic_blocks.png)
+
+Tahtayı bloklarla dolduran kodu, tahtaya bazı sihirli bloklar da ekleyecek şekilde değiştirmemiz gerekiyor:
+
+```lua
+-- board.script
+local function build_board(self)
+
+    ...
+
+    -- Distribute magic blocks.
+    local rand_x = 0
+    local rand_y
+    for y = 0, boardheight - 1, boardheight / self.num_magic do
+        local set = false
+        while not set do
+            rand_y = math.random(math.floor(y), math.min(boardheight - 1, math.floor(y + boardheight / self.num_magic)))
+            rand_x = math.random(0, boardwidth - 1)
+            if self.board[rand_x][rand_y].color ~= hash("magic") then
+                msg.post(self.board[rand_x][rand_y].id, "make_magic")
+                self.board[rand_x][rand_y].color = hash("magic")
+                set = true
+            end
+        end
+    end
+
+    -- Build 1d list that we can easily filter.
+    build_blocklist(self)
+end
+```
+
+Sihirli blokların temel mekaniği, yanlarındaki başka bir blok kaybolduğunda yana kayabilmeleridir. Bu mekaniğin tüm ayrıntılarını *board.script* içindeki `slide_magic_blocks()` işlevine yansıtıyoruz. Algoritma basittir:
+
+1. Tahtadaki her satır için sihirli blokları içeren bir `M` listesi oluşturun.
+2. `M` listesi küçülmeyi bırakana kadar listedeki her sihirli bloğu dolaşın. Her yinelemede:
+    1. Sihirli bloğun altında `hash("removing")` değerine sahip bir blok konumu varsa bloğu yalnızca `M` listesinden kaldırın.
+    2. Sihirli bloğun yanında `hash("removing")` olarak işaretlenmiş bir boşluk varsa bloğu oraya kaydırın, eski konumunu `hash("removing")` olarak ayarlayın ve ardından `M` listesinden kaldırın.
+
+```lua
+-- board.script
+-- Apply the shifting logic to magic blocks. Only slide to positions
+-- marked for removal with hash("removing")
+--
+local function slide_magic_blocks(self)
+    -- Slide all magic blocks to the side that should slide first.
+    -- This works best going row by row!
+    local row_m
+    for y = 0,boardheight - 1 do
+        row_m = {}
+        -- Build list of magic blocks on this row.
+        for x = 0,boardwidth - 1 do
+            if self.board[x][y] ~= nil and self.board[x][y] ~= hash("removing") and self.board[x][y].color == hash("magic") then
+                table.insert(row_m, self.board[x][y])
+            end
+        end
+
+        local mc = #row_m + 1
+        -- Go through list, slide and remove if possible. Reiterate until the list does not shrink.
+        while #row_m < mc do
+            mc = #row_m
+            for i, m in pairs(row_m) do
+                local x = m.x
+                if y > 0 and self.board[x][y-1] == hash("removing") then
+                    -- Hole below, do nothing.
+                    row_m[i] = nil
+                elseif x > 0 and self.board[x-1][y] == hash("removing") then
+                    -- Hole to the left! Slide magic block there
+                    self.board[x-1][y] = self.board[x][y]
+                    self.board[x-1][y].x = x - 1
+                    go.animate(self.board[x][y].id, "position.x", go.PLAYBACK_ONCE_FORWARD, edge + blocksize / 2 + blocksize * (x - 1), go.EASING_OUTBOUNCE, 0.3)
+                    -- Calc new z
+                    go.set(self.board[x][y].id, "position.z", (x - 1) * -0.1 + y * 0.01)
+                    self.board[x][y] = hash("removing") -- Will be nilled later
+                    row_m[i] = nil
+                elseif x < boardwidth - 1 and self.board[x + 1][y] == hash("removing") then
+                    -- Hole to the right. Slide magic block there
+                    self.board[x+1][y] = self.board[x][y]
+                    self.board[x+1][y].x = x + 1
+                    go.animate(self.board[x+1][y].id, "position.x", go.PLAYBACK_ONCE_FORWARD, edge + blocksize / 2 + blocksize * (x + 1), go.EASING_OUTBOUNCE, 0.3)
+                    -- Calc new z
+                    go.set(self.board[x+1][y].id, "position.z", (x + 1) * -0.1 + y * 0.01)
+                    self.board[x][y] = hash("removing") -- Will be nilled later
+                    row_m[i] = nil
+                end
+            end
+        end
+    end
+end
+```
+
+`on_input()` içinde bu işlevi çağırarak mekaniği deneyebiliriz:
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+
+        if #self.chain > 1 then
+            -- There is a chain of blocks. Remove it from board
+            remove_chain(self)
+            slide_magic_blocks(self)
+            nilremoved(self)
+            -- Slide remaining blocks down.
+            slide_board(self)
+        end
+        self.chain = {}
+        -- Empty chain clears connector graphics.
+        for i, c in ipairs(self.connectors) do
+            go.delete(c)
+        end
+        self.connectors = {}
+    end
+```
+
+Artık konumları kaldırırken neden ara bir `hash("removing")` "etiketi" kullandığımızı açıkça görüyoruz. Bu etiket olmasaydı sihirli bloklar yanlarındaki herhangi bir boş konuma ileri geri kayardı. Belki ilginç bir mekanik olurdu, ancak bu küçük oyun için amaçladığımız mekanik bu değil.
+
+Şimdi sihirli blokların birbirine bağlı olup olmadığını (birbirlerinin solunda, sağında, üstünde veya altında bulunup bulunmadığını) algılayan bir mantığa ihtiyacımız var. Ayrıca tahtadaki tüm sihirli blokların birbirine bağlı olup olmadığını bilmemiz gerekiyor. Kullanılan algoritma oldukça basittir:
+
+1. Tahtadaki tüm sihirli blokları içeren bir `M` listesi oluşturun.
+2. `M` listesindeki her blok için:
+    1. Bloğun `region` değeri ayarlanmamışsa ona `R` bölge numarasını atayın (başlangıçta `1`).
+    2. Bloğun işaretlenmemiş tüm komşularını aynı `R` bölge numarasıyla işaretleyin ve onların komşularına, o komşuların komşularına ve bu şekilde devam edin.
+    3. `R` bölge numarasını `1` artırın.
+
+![Bölgeleri işaretleme](images/magic-link/linker_regions.png)
+
+Algoritmanın uygulaması şöyledir:
+
+```lua
+-- board.script
+--
+-- Build list of all current magic blocks.
+--
+local function magic_blocks(self)
+    local magic = {}
+    for x = 0,boardwidth - 1 do
+        for y = 0,boardheight - 1 do
+            if self.board[x][y] ~= nil and self.board[x][y].color == hash("magic") then
+                table.insert(magic, self.board[x][y])
+            end
+        end
+    end
+    return magic
+end
+
+--
+-- Filter out adjacent magic blocks
+--
+local function adjacent_magic_blocks(blocks, block)
+    return filter(function (e)
+        return (block.x == e.x and math.abs(block.y - e.y) == 1) or
+            (block.y == e.y and math.abs(block.x - e.x) == 1)
+    end, blocks)
+end
+
+--
+-- Spread region to neighbors
+--
+local function mark_neighbors(blocks, block, region)
+    local neighbors = adjacent_magic_blocks(blocks, block)
+    for i, m in pairs(neighbors) do
+        if m.region == nil then
+            m.region = region
+            mark_neighbors(blocks, m, region)
+        end
+    end
+end
+
+--
+-- Mark all magic block regions
+--
+local function mark_magic_regions(self)
+    local m_blocks = magic_blocks(self)
+    -- 1. Clear all region marks and count neighbors
+    for i, m in pairs(m_blocks) do
+        m.region = nil
+        local n = 0
+        for _ in pairs(adjacent_magic_blocks(m_blocks, m)) do n = n + 1 end
+        m.neighbors = n
+    end
+
+    -- 2. Assign regions and spread them
+    local region = 1
+    for i, m in pairs(m_blocks) do
+        if m.region == nil then
+            m.region = region
+            mark_neighbors(m_blocks, m, region)
+            region = region + 1
+        end
+    end
+    return m_blocks
+end
+```
+
+Sihirli bloklar arasındaki bölgelerin sayısını hesaplamamızı sağlayan işlevler de oluşturuyoruz. Bölge sayısı 1 ise tüm sihirli blokların birbirine bağlı olduğunu biliriz. Ayrıca tüm sihirli blokların ışıklarını kapatan bir işlev ve komşusunda sihirli blok bulunan sihirli blokların ışık efektlerini açan bir işlev ekliyoruz:
+
+```lua
+-- board.script
+--
+-- Count the number of connected regions among the magic blocks.
+--
+local function count_magic_regions(blocks)
+    local maxr = 0
+    for i, m in pairs(blocks) do
+        if m.region > maxr then
+            maxr = m.region
+        end
+    end
+    return maxr
+end
+
+--
+-- Shut off lights on all listed magic blocks
+--
+local function shutdown_lined_up_magic(self)
+    for i, m in ipairs(self.lined_up_magic) do
+        msg.post(m.id, "lights_off")
+    end
+end
+
+--
+-- Set highlight for all magic blocks
+--
+local function highlight_magic(blocks)
+    for i, m in pairs(blocks) do
+        if m.neighbors > 0 then
+            msg.post(m.id, "lights_on")
+        else
+            msg.post(m.id, "lights_off")
+        end
+    end
+end
+```
+
+Artık bu mantık parçalarını genel akışa ekleyebiliriz. Öncelikle tahta rastgele oluşturulduğu için küçük de olsa kazanılmış durumda başlama olasılığı vardır. Bu olursa tahtayı silip yeniden oluştururuz:
+
+```lua
+-- board.script
+--
+-- Clear the board
+--
+local function clear_board(self)
+    for y = 0,boardheight - 1 do
+        for x = 0,boardwidth - 1 do
+            if self.board[x][y] ~= nil then
+                go.delete(self.board[x][y].id)
+                self.board[x][y] = nil
+            end
+        end
+    end
+end
+
+local function build_board(self)
+
+    ...
+
+    -- Build 1d list that we can easily filter.
+    build_blocklist(self)
+
+    local magic_blocks = mark_magic_regions(self)
+    if count_magic_regions(magic_blocks) == 1 then
+        -- "Win" from start. Make new board.
+        clear_board(self)
+        build_board(self)
+    end
+    highlight_magic(magic_blocks)
+end
+```
+
+Mantığın geri kalanı `on_input()` içine sığar. `level_completed` iletisini işleyen kod hâlâ yok, ancak şimdilik bu sorun değil:
+
+```lua
+-- board.script
+function on_input(self, action_id, action)
+
+    ...
+
+    elseif action_id == hash("touch") and action.released then
+        -- Player released touch.
+        self.dragging = false
+
+        if #self.chain > 1 then
+            -- There is a chain of blocks. Remove it from board and refill board.
+            remove_chain(self)
+            slide_magic_blocks(self)
+            nilremoved(self)
+            -- Slide remaining blocks down.
+            slide_board(self)
+
+            local magic_blocks = mark_magic_regions(self)
+            -- Highlight adjacent magic blocks.
+            if count_magic_regions(magic_blocks) == 1 then
+                -- Win!
+                msg.post("#", "level_completed")
+            end
+            highlight_magic(magic_blocks)
+        end
+        self.chain = {}
+        -- Empty chain clears connector graphics.
+        for i, c in ipairs(self.connectors) do
+            go.delete(c)
+        end
+        self.connectors = {}
+    end
+```
+
+Tüm sihirli blokları bağladığınızda henüz hiçbir şey olmasa da artık oyunu oynamak ve kazanma durumuna ulaşmak mümkün.
+
+![İlk kazanma](images/magic-link/linker_first_win.png)
+
+## Blok bırakma
+
+"Blok bırakma" (drop) fikrinin amacı basit bir ilerleme mekaniği eklemektir. Oyuncu *DROP* düğmesine basarak sınırlı sayıda "blok bırakma" işlemi yapabilir; bu işlem tahtaya yukarıdan birkaç yeni rastgele parça bırakır. Oyuncu bir blok bırakma hakkıyla başlar ve her bölüm tamamlandığında ek bir hak kazanır. Blok bırakma mekaniğinin kodu iki işleve sığar. Biri blokların yerleşebileceği olası konumların listesini döndürür; diğeri ise animasyonu ve diğer ayrıntılarıyla blok bırakma işlemini gerçekleştirir.
+
+```lua
+-- board.script
+--
+-- Find spots for a drop.
+--
+local function dropspots(self)
+    local spots = {}
+    for x = 0, boardwidth - 1 do
+        for y = 0, boardheight - 1 do
+            if self.board[x][y] == nil then
+                table.insert(spots, { x = x, y = y })
+                break
+            end
+        end
+    end
+    -- If more than dropamount, randomly remove a slot until dropamount
+    for c = 1, #spots - dropamount do
+        table.remove(spots, math.random(#spots))
+    end
+    return spots
+end
+
+--
+-- Perform the drop
+--
+local function drop(self, spots)
+    for i, s in pairs(spots) do
+        local pos = vmath.vector3()
+        pos.x = edge + blocksize / 2 + blocksize * s.x
+        pos.y = 1000
+        c = colors[math.random(#colors)]    -- Pick a random color
+        local id = factory.create("#blockfactory", pos, null, { color = c })
+        go.animate(id, "position.y", go.PLAYBACK_ONCE_FORWARD, bottom_edge + blocksize / 2 + blocksize * s.y, go.EASING_OUTBOUNCE, 0.5)
+        -- Calc new z
+        go.set(id, "position.z", s.x * -0.1 + s.y * 0.01)
+
+        self.board[s.x][s.y] = { id = id, color = c,  x = s.x, y = s.y }
+    end
+
+    -- Rebuild blocklist
+    build_blocklist(self)
+end
+```
+
+Aşağıdaki kodu örneğin `on_reload()` içinde çalıştırarak veya geçici bir girdi eylemine bağlayarak blok bırakmayı test edebiliriz:
+
+```lua
+s = dropspots(self)
+if #s > 0 then
+    -- Do the drop
+    drop(self, s)
+end
+```
+
+![Blok bırakma](images/magic-link/linker_drop.png)
+
+## Ana menü
+
+Şimdi her şeyi bir araya getirme zamanı. Öncelikle bir başlangıç ekranı oluşturup bunu tahtadan ayıralım. İlk adım, bir *main_menu.gui* dosyası oluşturup içine bir *Start* düğmesi (bir metin düğümü ve dokulu bir kutu düğümü), bir başlık metni düğümü ve birkaç dekoratif blok (dokulu kutu düğümleri) yerleştirmektir. GUI'ye bağladığımız *main_menu.gui_script* betiği, `init()` içinde dekoratif bloklara animasyon uygular. Ayrıca ana betiğe `start_game` iletisi gönderen bir `on_input()` işlevi içerir. O betiği birazdan oluşturacağız.
+
+![Ana menü GUI'si](images/magic-link/linker_main_menu.png)
+
+```lua
+-- main_menu.gui_script
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    local bs = { "brick1", "brick2", "brick3", "brick4", "brick5", "brick6" }
+    for i, b in ipairs(bs) do
+        local n = gui.get_node(b)
+        local rt = (math.random() * 3) + 1
+        local a = math.random(-45, 45)
+        gui.set_color(n, vmath.vector4(1, 1, 1, 0))
+
+        gui.animate(n, "position.y", -100 - math.random(0, 50), gui.EASING_INSINE, 1 + rt, 0, nil, gui.PLAYBACK_LOOP_FORWARD)
+        gui.animate(n, "color.w", 1, gui.EASING_INSINE, 1 + rt, 0, nil, gui.PLAYBACK_LOOP_FORWARD)
+        gui.animate(n, "rotation.z", a, gui.EASING_INSINE, 1 + rt, 0, nil, gui.PLAYBACK_LOOP_FORWARD)
+    end
+
+    gui.animate(gui.get_node("start"), "color.x", 1, gui.EASING_INOUTSINE, 1, 0, nil, gui.PLAYBACK_LOOP_PINGPONG)
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local start = gui.get_node("start")
+
+        if gui.pick_node(start, action.x, action.y) then
+            msg.post("/main#script", "start_game")
+        end
+    end
+end
+```
+
+Oyunu başlatma görevini yakında ana menü betiği üstleneceği için *board.script* içindeki `init()` işlevinden geçici tahta hazırlama çağrısını kaldırın:
+
+```lua
+-- board.script
+--
+-- INIT
+--
+function init(self)
+    self.board = {}                -- Contains the board structure
+    self.blocks = {}            -- List of all blocks. Used for easy filtering on selection.
+
+    self.chain = {}                -- Current selection chain
+    self.connectors = {}        -- Connector elements to mark the selection chain
+    self.num_magic = 3            -- Number of magic blocks on the board
+
+    self.drops = 1                -- Number of drops you have available
+
+    self.magic_blocks = {}        -- Magic blocks that are lined up
+
+    self.dragging = false        -- Drag touch input
+end
+```
+
+Ana betik oyunun genel durumunu tutacak ve istendiğinde oyunu başlatacak. Burada *main.collection* dosyasının, başlangıçta göstermemiz gereken en az miktarda varlığı içermesini istiyoruz. Bunu, *main.collection* içine ana menü GUI'sini, bir betik bileşenini ve en önemlisi bir *Collection Proxy* bileşenini barındıran "main" oyun nesnesini koyarak yapıyoruz.
+
+Koleksiyon vekili (collection proxy), çalışan oyuna koleksiyonları dinamik olarak yüklememizi ve bunları bellekten kaldırmamızı sağlar. Belirtilen bir koleksiyon dosyası adına hareket eder; vekile ileti göndererek dinamik koleksiyonu yükler, başlangıç işlemlerini yapar, etkinleştirir, devre dışı bırakır ve bellekten kaldırırız. Koleksiyon vekillerinin kullanımına ilişkin eksiksiz açıklama için [koleksiyon vekili belgelerine](/manuals/collection-proxy) bakın.
+
+Bu örnekte koleksiyon vekili bileşeninin *Collection* özelliğini, "bölümü" içeren *board.collection* dosyasına ayarlıyoruz.
+
+![Ana koleksiyon](images/magic-link/linker_main_collection.png)
+
+Şimdi *game.project* dosyasını açıp başlangıç koleksiyonunu (bootstrap collection) belirleyen *main_collection* ayarını `/main/main.collectionc` olarak değiştirmeliyiz.
+
+![Başlangıçtaki ana koleksiyon](images/magic-link/linker_bootstrap_main.png)
+
+Artık oyunu başlatmak, tahtayı yüklemesi, başlangıç işlemlerini yapması ve etkinleştirmesi için koleksiyon vekilimize ileti göndermek, ardından ana menüyü (görünmemesi için) devre dışı bırakmak anlamına gelir. Ana menüye dönmek ise bu işlemleri tersine çevirir (vekilin koleksiyonu yüklemiş olması koşuluyla).
+
+```lua
+-- main.script
+function init(self)
+    msg.post("#", "to_main_menu")
+    self.state = "MAIN_MENU"
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("to_main_menu") then
+        if self.state ~= "MAIN_MENU" then
+            msg.post("#boardproxy", "unload")
+        end
+        msg.post("main:/main#menu", "enable") -- <1>
+        self.state = "MAIN_MENU"
+    elseif message_id == hash("start_game") then
+        msg.post("#boardproxy", "load")
+        msg.post("#menu", "disable")
+    elseif message_id == hash("proxy_loaded") then
+        -- Board collection has loaded...
+        msg.post(sender, "init")
+        msg.post("board:/board#script", "start_level", { difficulty = 1 }) -- <2>
+        msg.post(sender, "enable")
+        self.state = "GAME_RUNNING"
+    end
+end
+```
+1. Sokete (socket) "main" adını verdiğimize dikkat edin; *main.collection* içinde bu adı ayarladığımızdan emin olmamız gerekir. Kök düğümü seçin ve *Name* özelliğinin "main" olduğunu denetleyin.
+2. Benzer şekilde, yüklenen koleksiyona iletileri koleksiyonun *Name* özelliği aracılığıyla adlandırılan soketi üzerinden göndeririz.
+
+## Oyun içi GUI
+
+Tahta betiğine mantığın son parçasını eklemeden önce tahtaya bir dizi GUI öğesi eklemeliyiz. Önce tahtanın üst kısmına bir *RESTART* düğmesi ve bir *DROP* düğmesi ekliyoruz.
+
+![Tahta GUI'si](images/magic-link/linker_board_gui.png)
+
+Tahta GUI'sinin betiği, yeniden başlatma düğmesine tıklandığında yeniden başlatma GUI iletişim kutusuna, *DROP* düğmesine tıklandığında ise tahta betiğinin kendisine ileti gönderir:
+
+```lua
+-- board.gui_script
+function init(self)
+    msg.post("#", "show")
+    msg.post("/restart#gui", "hide")
+    msg.post("/level_complete#gui", "hide")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+    elseif message_id == hash("show") then
+        msg.post("#", "enable")
+    elseif message_id == hash("set_drop_counter") then
+        local n = gui.get_node("drop_counter")
+        gui.set_text(n, message.drops .. " x")
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local restart = gui.get_node("restart")
+        local drop = gui.get_node("drop")
+
+        if gui.pick_node(restart, action.x, action.y) then
+            -- Show the restart dialog box.
+            msg.post("/restart#gui", "show")
+            msg.post("#", "hide")
+        elseif gui.pick_node(drop, action.x, action.y) then
+            msg.post("/board#script", "drop")
+        end
+    end
+end
+```
+
+*RESTART* iletişim kutusu basittir. Bunu *restart.gui* olarak oluşturup oyuncu *NO* seçeneğine tıkladığında hiçbir şey yapmayan, *YES* seçeneğine tıkladığında tahta betiğine `restart_level` iletisi ve *Quit to main menu* seçeneğine tıkladığında ana betiğe `to_main_menu` iletisi gönderen basit bir betik ekliyoruz:
+
+![Yeniden başlatma GUI'si](images/magic-link/linker_restart_gui.png)
+
+```lua
+-- restart.gui_script
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+        msg.post(".", "release_input_focus")
+    elseif message_id == hash("show") then
+        msg.post("#", "enable")
+        msg.post(".", "acquire_input_focus")
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local yes = gui.get_node("yes")
+        local no = gui.get_node("no")
+        local quit = gui.get_node("quit")
+
+        if gui.pick_node(no, action.x, action.y) then
+            msg.post("#", "hide")
+            msg.post("/board#gui", "show")
+        elseif gui.pick_node(yes, action.x, action.y) then
+            msg.post("board:/board#script", "restart_level")
+            msg.post("/board#gui", "show")
+            msg.post("#", "hide")
+        elseif gui.pick_node(quit, action.x, action.y) then
+            msg.post("main:/main#script", "to_main_menu")
+            msg.post("#", "hide")
+        end
+    end
+    -- Consume all input until we're gone.
+    return true
+end
+```
+
+Ayrıca *level_complete.gui* içinde bölümün tamamlanması için basit bir GUI iletişim kutusu oluşturuyor ve oyuncu *CONTINUE* seçeneğine tıkladığında tahta betiğine `next_level` iletisi gönderen basit bir betik ekliyoruz:
+
+![Bölüm tamamlandı iletişim kutusu](images/magic-link/linker_level_complete_gui.png)
+
+```lua
+-- level_complete.gui_script
+function init(self)
+    msg.post("#", "hide")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+        msg.post(".", "release_input_focus")
+    elseif message_id == hash("show") then
+        msg.post("#", "enable")
+        msg.post(".", "acquire_input_focus")
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("touch") and action.pressed then
+        local continue = gui.get_node("continue")
+
+        if gui.pick_node(continue, action.x, action.y) then
+            msg.post("board#script", "next_level")
+            msg.post("#", "hide")
+        end
+    end
+    -- Consume all input until we're gone.
+    return true
+end
+```
+
+Geçerli bölümü tanıtmak için kullanılan bir iletişim kutusu ve yalnızca kutuyu gizleme ile gösterme işlemlerini içeren bir betik oluşturuyoruz. Gösterildiğinde iletişim kutusunun metni, geçerli zorluk düzeyini içerecek şekilde ayarlanır:
+
+![Bölümü tanıtan GUI](images/magic-link/linker_present_level_gui.png)
+
+```lua
+-- present_level.gui_script
+function init(self)
+    msg.post("#", "hide")
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+    elseif message_id == hash("show") then
+        local n = gui.get_node("message")
+        gui.set_text(n, "Level " .. message.level)
+        msg.post("#", "enable")
+    end
+end
+```
+
+Oyuncu blok bırakmaya çalıştığında buna yer yoksa gösterilen bir iletişim kutusu da ekliyoruz.
+
+![Blok bırakacak yer olmadığını gösteren GUI](images/magic-link/linker_no_drop_room_gui.png)
+
+```lua
+-- no_drop_room.gui_script
+function init(self)
+    msg.post("#", "hide")
+    self.t = 0
+end
+
+function update(self, dt)
+    if self.t < 0 then
+        msg.post("#", "hide")
+    else
+        self.t = self.t - dt
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("hide") then
+        msg.post("#", "disable")
+    elseif message_id == hash("show") then
+        self.t = 1
+        msg.post("#", "enable")
+    end
+end
+```
+
+Son olarak bu GUI bileşenlerini *board.collection* içine ve gerekli kodu *board.script* içine ekliyoruz:
+
+![Son tahta koleksiyonu](images/magic-link/linker_board_collection_final.png)
+
+Tahtaya gönderilen ve tahtadan gelen tüm iletiler için `on_message()` içinde kod yazmamız gerekiyor.
+
+`start_level`
+: Sihirli blokların sayısını zorluk parametresine göre ayarlayın, tahtayı oluşturun ve ardından oyunu başlatmadan (iletişim kutusunu kaldırıp girdi odağını almadan) önce "present_level" GUI iletişim kutusunu 2 saniye boyunca gösterin. Başka hiçbir amaçla kullanılmayan "timer" değerine animasyon uygulayarak `go.animate()` işlevini zamanlayıcı olarak kullandığımıza dikkat edin.
+
+`restart_level`
+: Oyuncu *RESTART* GUI düğmesine basıp onayladığında bu gerçekleşir. Tahtayı temizleyip yeniden oluşturun ve blok bırakma sayacını başlangıç değerine döndürün.
+
+`level_completed`
+: Tahta kazanma durumuna ulaşır ulaşmaz gönderilir. Girdiyi kapatın, sihirli bloklara animasyon uygulayın ve "level_complete" GUI iletişim kutusunu gösterin. Oyuncu iletişim kutusundaki *CONTINUE* düğmesine tıkladığında kutu yanıt olarak bir `next_level` iletisi gönderecektir.
+
+`next_level`
+: Bu ileti alındığında tahtayı temizleyin, blok bırakma sayacını artırın ve bir sonraki zorluk düzeyi ayarlanmış olarak `start_level` iletisini gönderin.
+
+`drop`
+: Blok bırakılabilecek yerleri denetleyin. Uygun konum yoksa "no_drop_room" GUI iletişim kutusunu gösterin. Aksi takdirde blok bırakma işlemini gerçekleştirin (oyuncunun hakkı kaldıysa), blok bırakma sayacını azaltın ve sayacın görsel gösterimini güncelleyin.
+
+```lua
+-- board.script
+function on_message(self, message_id, message, sender)
+    if message_id == hash("start_level") then
+        self.num_magic = message.difficulty + 1
+        build_board(self)
+
+        msg.post("#gui", "set_drop_counter", { drops = self.drops } )
+
+        msg.post("present_level#gui", "show", { level = message.difficulty } )
+        -- Wait some...
+        go.animate("#", "timer", go.PLAYBACK_ONCE_FORWARD, 1, go.EASING_LINEAR, 2, 0, function ()
+            msg.post("present_level#gui", "hide")
+            msg.post(".", "acquire_input_focus")
+        end)
+    elseif message_id == hash("restart_level") then
+        clear_board(self)
+        build_board(self)
+        self.drops = 1
+        msg.post("#gui", "set_drop_counter", { drops = self.drops } )
+        msg.post(".", "acquire_input_focus")
+    elseif message_id == hash("level_completed") then
+        -- turn off input
+        msg.post(".", "release_input_focus")
+
+        -- Animate the magic!
+        for i, m in ipairs(magic_blocks(self)) do
+            go.set_scale_xy(0.17, m.id)
+            go.animate(m.id, "scale.xy", go.PLAYBACK_LOOP_PINGPONG, 0.19, go.EASING_INSINE, 0.5, 0)
+        end
+
+        -- Show completion screen
+        msg.post("level_complete#gui", "show")
+    elseif message_id == hash("next_level") then
+        clear_board(self)
+        self.drops = self.drops + 1
+        -- Difficulty level is number of magic blocks - 1
+        msg.post("#", "start_level", { difficulty = self.num_magic })
+    elseif message_id == hash("drop") then
+        s = dropspots(self)
+        if #s == 0 then
+            -- Can't perform drop
+            msg.post("no_drop_room#gui", "show")
+        elseif self.drops > 0 then
+            -- Do the drop
+            drop(self, s)
+            self.drops = self.drops - 1
+            msg.post("#gui", "set_drop_counter", { drops = self.drops } )
+        end
+    end
+end
+```
+
+İşte bu kadar! Oyun ve bu öğretici artık tamamlandı! Oyunun tadını çıkarın!
+
+![Tamamlanan oyun](images/magic-link/linker_game_finished.png)
+
+## Devam etmek için
+
+Bu küçük oyunun bazı ilginç özellikleri var ve üzerinde denemeler yapmanızı öneririz. Defold'a daha fazla alışmak için yapabileceğiniz alıştırmaların listesi şöyledir:
+
+* Etkileşimi daha anlaşılır hâle getirin. Yeni bir oyuncu oyunun nasıl çalıştığını ve nelerle etkileşime girebileceğini anlamakta zorlanabilir. Öğretici öğeler eklemeden oyunu daha anlaşılır kılmaya biraz zaman ayırın.
+* Ses ekleyin. Oyun şu anda tamamen sessiz; hoş bir müzik ve etkileşim sesleri oyunu iyileştirebilir.
+* Oyunun bittiğini otomatik olarak algılayın.
+* En yüksek puan. Kalıcı bir en yüksek puan özelliği ekleyin.
+* Oyunu yalnızca GUI API'lerini kullanarak yeniden geliştirin.
+* Şu anda oyun, her yeni bölümde bir sihirli blok ekleyerek devam ediyor. Bu sonsuza kadar sürdürülemez. Bu soruna tatmin edici bir çözüm bulun.
+* Oyunu optimize edin ve sprite bileşenlerini silip yeniden oluşturmak yerine yeniden kullanarak en fazla sprite sayısını azaltın.
+* Oyunun farklı çözünürlüklere ve en boy oranlarına sahip ekranlarda aynı derecede iyi görünmesi için çözünürlükten bağımsız işleme uygulayın.

--- a/docs/tr/tutorials/main-menu.md
+++ b/docs/tr/tutorials/main-menu.md
@@ -1,0 +1,92 @@
+---
+title: Ana menü animasyonu örneği
+brief: Bu örnek projede bir ana menüyü göstermek için kullanabileceğiniz efektleri öğrenirsiniz.
+---
+# Ana menü animasyonu - örnek proje
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/dPQpSlt3ahw" frameborder="0" allowfullscreen></iframe>
+
+[Düzenleyiciden açabileceğiniz](/manuals/project-setup/) veya [GitHub'dan indirebileceğiniz](https://github.com/defold/sample-main-menu-animation) bu örnek projede, bir ana menüyü göstermek için kullanılan efektleri gösteriyoruz. Menü, bir arka plan ve iki menü öğesi içerir.
+Bu proje, aşağıda gösterilen kodun uygulandığı menu.gui ve menu.gui_script dosyalarıyla hazır olarak sunulur. Görsel varlıklar (assets), images.atlas adlı bir atlasa eklenmiş ve menu.gui dosyasındaki düğümlere (nodes) uygulanmıştır.
+
+Arka plana ve iki menü öğesinin her birine aynı animasyonlar farklı gecikmelerle uygulanır. Bu işlem, aşağıdaki `init()` işlevinde ayarlanır.
+
+İlk animasyonlarda her düğüm, ölçeği %70'ten %110'a çıkarılırken yavaşça görünür hâle gelir.
+Bu işlem `anim1()` içinde yapılır.
+
+Sonraki animasyonlarda ölçek, animasyonla önce %110'dan %98'e, ardından %106'ya ve son olarak %100'e değiştirilir. Bu, zıplama efektini oluşturur ve `anim2()`, `anim3()` ve `anim4()` içinde yapılır.
+
+Arka plana son aşamada özel bir hafif saydamlaşma efekti uygulanır; bu işlem `anim5()` içinde yapılır.
+
+```lua
+-- file: menu.gui_script
+
+-- the functions animX represents the animation time-line
+-- first is anim1 executed, when finished anim2 is executed, etc
+-- anim1 to anim4 creates a bouncing rubber effect.
+-- anim5 fades down alpha and is only used for the background
+
+local function anim5(self, node)
+	if gui.get_node("background") == node then
+		-- special case for background. animate alpha to 60%
+		local to_color = gui.get_color(node)
+		to_color.w = 0.6
+		gui.animate(node, gui.PROP_COLOR, to_color, gui.EASING_OUTCUBIC, 2.4, 0.1)
+	end
+end
+
+local function anim4(self, node)
+	-- animate scale to 100%
+	local s = 1
+	gui.animate(node, gui.PROP_SCALE, vmath.vector4(s, s, s, 0), gui.EASING_INOUTCUBIC, 0.24, 0, anim5)
+end
+
+local function anim3(self, node)
+	-- animate scale to 106%
+	local s = 1.06
+	gui.animate(node, gui.PROP_SCALE, vmath.vector4(s, s, s, 0), gui.EASING_INOUTCUBIC, 0.24, 0, anim4)
+end
+
+local function anim2(self, node)
+	-- animate scale to 98%
+	local s = 0.98
+	gui.animate(node, gui.PROP_SCALE, vmath.vector4(s, s, s, 0), gui.EASING_INOUTCUBIC, 0.24, 0, anim3)
+end
+
+local function anim1(node, d)
+	-- set scale to 70%
+	local start_scale = 0.7
+	gui.set_scale(node, vmath.vector4(start_scale, start_scale, start_scale, 0))
+
+	-- get current color and set alpha to 0 to fade up
+	local from_color = gui.get_color(node)
+	local to_color = gui.get_color(node)
+	from_color.w = 0
+	gui.set_color(node, from_color)
+
+	-- animate alpha value from 0 to 1
+	gui.animate(node, gui.PROP_COLOR, to_color, gui.EASING_INOUTCUBIC, 0.4, d)
+
+	-- animate scale from %70 to 110%
+	local s = 1.1
+	gui.animate(node, gui.PROP_SCALE, vmath.vector4(s, s, s, 0), gui.EASING_INOUTCUBIC, 0.4, d, anim2)
+end
+
+function init(self)
+	-- start animations for all nodes
+	-- background, button-boxes and text are animated equally
+	-- d is the animation start delay
+	local d = 0.4
+	anim1(gui.get_node("new_game"), d)
+	anim1(gui.get_node("new_game_shadow"), d)
+	anim1(gui.get_node("new_game_button"), d)
+
+	d = 0.3
+	anim1(gui.get_node("quit"), d)
+	anim1(gui.get_node("quit_shadow"), d)
+	anim1(gui.get_node("quit_button"), d)
+
+	d = 0.1
+	anim1(gui.get_node("background"), d)
+end
+```

--- a/docs/tr/tutorials/movement.md
+++ b/docs/tr/tutorials/movement.md
@@ -1,0 +1,27 @@
+---
+title: Hareket öğreticisi
+brief: Yeni başlayanlara yönelik bu öğreticide vektörleri ve basit vektör cebiri işlemlerini kullanarak gerçekçi hareket oluşturmayı öğreneceksiniz.
+---
+
+# Hareket öğreticisi
+
+Yeni başlayanlara yönelik bu öğreticide vektörleri (vector) ve basit vektör cebiri işlemlerini kullanarak gerçekçi hareket oluşturmayı öğreneceksiniz.
+
+Öğretici Defold düzenleyicisine dahil edilmiştir ve kolayca erişilebilir:
+
+1. Defold'u başlatın.
+2. Soldaki *New Project* seçeneğini seçin.
+3. *From Tutorial* sekmesini seçin.
+4. "Movement tutorial" seçeneğini seçin
+5. Yerel diskinizde proje için bir konum seçin ve *Create New Project* seçeneğine tıklayın.
+
+![yeni proje](images/new-movement.png)
+
+Düzenleyici, proje kök dizinindeki öğretici metninin tamamını içeren "README" dosyasını otomatik olarak açar.
+
+![simge](images/icon-tutorial.svg){.icon} [Öğretici metninin tamamını GitHub'da da okuyabilirsiniz](https://github.com/defold/tutorial-movement)
+
+Bir yerde takılırsanız, Defold ekibinden ve yardımsever birçok kullanıcıdan yardım alacağınız [Defold forumuna](//forum.defold.com) uğrayın.
+
+Defold ile keyifli çalışmalar!
+

--- a/docs/tr/tutorials/parallax.md
+++ b/docs/tr/tutorials/parallax.md
@@ -1,0 +1,82 @@
+---
+title: Paralaks kod örneği
+brief: Bu örnekte, oyun dünyasında derinlik hissi yaratmak için paralaks efektini nasıl kullanacağınızı öğreneceksiniz.
+---
+# Paralaks - örnek proje
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/UdNA7kanRQE" frameborder="0" allowfullscreen></iframe>
+
+
+[Düzenleyiciden açabileceğiniz](/manuals/project-setup/) veya [GitHub'dan indirebileceğiniz](https://github.com/defold/sample-parallax) bu örnek projede, oyun dünyasında derinlik hissi yaratmak için paralaks (parallax) efektinin nasıl kullanılacağını gösteriyoruz.
+Bulutlardan oluşan iki katman vardır; katmanlardan biri diğerinden daha gerideymiş gibi görünür. Sahneye renk katmak için animasyonlu bir uçan daire de bulunur.
+
+Bulut katmanları, her biri bir *Tile Map* (karo haritası) ve bir *Script* (betik) bileşeni (component) içeren iki ayrı oyun nesnesi (game object) olarak oluşturulmuştur.
+Paralaks efekti oluşturmak için katmanlar farklı hızlarda hareket ettirilir. Aşağıdaki kodda bu işlem `update()` işlevi içinde, *background1.script* ve *background2.script* dosyalarında yapılır.
+
+```lua
+-- file: background1.script
+
+function init(self)
+    msg.post("@render:", "clear_color", { color = vmath.vector4(0.52, 0.80, 1, 0) } )
+end
+
+-- the background is a tilemap in a gameobject
+-- we move the gameobject for the parallax effect
+
+function update(self, dt)
+    -- decrease x-position by 1 units per frame for parallax effect
+    local p = go.get_position()
+    p.x = p.x + 1
+    go.set_position(p)
+end
+```
+
+```lua
+-- file: background2.script
+
+-- the background is a tilemap in a gameobject
+-- we move the gameobject for the parallax effect
+
+function update(self, dt)
+    -- decrease x-position by 0.5 units per frame for parallax effect
+    local p = go.get_position()
+    p.x = p.x + 0.5
+    go.set_position(p)
+end
+```
+
+Uçan daire, bir *Sprite* bileşeni ve bir *Script* bileşeni içeren ayrı bir oyun nesnesidir.
+Sabit hızla sola hareket ettirilir. Yukarı aşağı hareketi, Lua sinüs işlevi (`math.sin()`) kullanılarak y bileşeninin sabit bir değer etrafında animasyonla değiştirilmesiyle elde edilir. Bu işlem `update()` işlevi içinde, *spaceship.script* dosyasında yapılır.
+
+
+```lua
+-- file: spaceship.script
+
+function init(self)
+    -- remeber initial y position such that we
+    -- can move the spaceship without changing the script
+    self.start_y = go.get_position().y
+    -- set counter to zero. use for sin-movement below
+    self.counter = 0
+end
+
+function update(self, dt)
+    -- decrease x-position by 2 units per frame
+    local p = go.get_position()
+    p.x = p.x - 2
+
+    -- move the y position around initial y
+    p.y = self.start_y + 8 * math.sin(self.counter * 0.08)
+
+    -- update position
+    go.set_position(p)
+
+    -- remove shaceship when outside of screen
+    if p.x < - 32 then
+        go.delete()
+    end
+
+    -- increase the counter
+    self.counter = self.counter + 1
+end
+```

--- a/docs/tr/tutorials/platformer.md
+++ b/docs/tr/tutorials/platformer.md
@@ -1,0 +1,416 @@
+---
+title: Defold platform oyunu öğreticisi
+brief: Bu yazıda, Defold'da karolara dayalı temel bir 2B platform oyununun nasıl geliştirildiğini inceleyeceksiniz. Öğreneceğiniz mekanikler sola/sağa hareket etme, zıplama ve düşmedir.
+---
+
+# Platform oyunu
+
+Bu yazıda, Defold'da karolara dayalı temel bir 2B platform oyununun (platformer) nasıl geliştirildiğini inceleyeceğiz. Öğreneceğimiz mekanikler sola/sağa hareket etme, zıplama ve düşmedir.
+
+Bir platform oyunu oluşturmanın pek çok farklı yolu vardır. Rodrigo Monteiro, bu konu ve daha fazlası hakkında [burada](http://higherorderfun.com/blog/2012/05/20/the-guide-to-implementing-2d-platformers/) kapsamlı bir analiz yazmış.
+
+Platform oyunu yapmaya yeni başlıyorsanız okumanızı özellikle öneririz; çünkü pek çok değerli bilgi içeriyor. Anlatılan yöntemlerin birkaçını ve bunları Defold'da nasıl uygulayacağınızı biraz daha ayrıntılı ele alacağız. Bununla birlikte, anlatılanları diğer platformlara ve dillere taşımak da kolay olmalı (Defold'da Lua kullanıyoruz).
+
+Vektör matematiği (doğrusal cebir) hakkında biraz bilgi sahibi olduğunuzu varsayıyoruz. Değilseniz, oyun geliştirmede son derece yararlı olduğu için bu konuda okuma yapmanız iyi olur. Wolfire'dan David Rosen, bu konuda [burada](http://blog.wolfire.com/2009/07/linear-algebra-for-game-developers-part-1/) çok iyi bir yazı dizisi hazırlamış.
+
+Defold'u zaten kullanıyorsanız _Platformer_ şablon projesini temel alan yeni bir proje oluşturabilir ve bu yazıyı okurken onunla denemeler yapabilirsiniz.
+
+::: sidenote
+Bazı okuyucular, önerdiğimiz yöntemin Box2D'nin varsayılan uygulamasıyla mümkün olmadığını belirtti. Bunun çalışması için Box2D'de birkaç değişiklik yaptık:
+
+Kinematik (kinematic) ve statik (static) nesneler arasındaki çarpışmalar yok sayılır. `b2Body::ShouldCollide` ve `b2ContactManager::Collide` içindeki kontrolleri değiştirin.
+
+Ayrıca temas mesafesi (Box2D'de separation olarak adlandırılır) geri çağırım işlevine (callback function) iletilmez.
+`b2ManifoldPoint` yapısına bir mesafe üyesi ekleyin ve `b2Collide*` işlevlerinde güncellendiğinden emin olun.
+:::
+
+## Çarpışma algılama
+
+Oyuncunun bölüm geometrisinin (level geometry) içinden geçmesini önlemek için çarpışma algılama (collision detection) gerekir.
+Oyununuza ve özel gereksinimlerine bağlı olarak bunu ele almanın çeşitli yolları vardır.
+Mümkünse bunu bir fizik motoruna (physics engine) bırakmak en kolay yollardan biridir.
+Defold'da 2B oyunlar için [Box2D](http://box2d.org/) fizik motorunu kullanıyoruz.
+Box2D'nin varsayılan uygulaması gereken tüm özellikleri içermez; yaptığımız değişiklikler için bu yazının sonuna bakın.
+
+Bir fizik motoru, fiziksel davranışı benzetmek için fizik nesnelerinin durumlarını şekilleriyle birlikte saklar. Benzetim sırasında çarpışmaları da bildirir; böylece oyun, çarpışmalar gerçekleştiğinde tepki verebilir. Çoğu fizik motorunda üç nesne türü vardır: _statik_, _dinamik_ (dynamic) ve _kinematik_ nesneler (bu adlar diğer fizik motorlarında farklı olabilir). Başka nesne türleri de vardır, ancak şimdilik onları bir kenara bırakalım.
+
+- *Statik* bir nesne hiçbir zaman hareket etmez (örneğin bölüm geometrisi).
+- *Dinamik* bir nesne, benzetim sırasında hıza (velocity) dönüştürülen kuvvetlerden ve torklardan etkilenir.
+- *Kinematik* bir nesne uygulama mantığı tarafından kontrol edilir, ancak yine de diğer dinamik nesneleri etkiler.
+
+Böyle bir oyunda, gerçek dünyadaki fiziksel davranışa benzeyen bir şey arıyoruz; ancak hızlı tepki veren kontroller ve dengeli mekanikler çok daha önemlidir. İyi hissettiren bir zıplamanın fiziksel olarak doğru olması veya gerçek dünyadaki yerçekimine göre davranması gerekmez. Yine de [bu](http://hypertextbook.com/facts/2007/mariogravity.shtml) analiz, Mario oyunlarındaki yerçekiminin her sürümde 9,8 m/s<sup>2</sup> değerine yaklaştığını gösteriyor. :-)
+
+Amaçlanan deneyimi elde etmek üzere mekanikleri tasarlayıp ince ayar yapabilmek için olup bitenleri tamamen kontrol edebilmemiz önemlidir. Bu nedenle oyuncu karakterini kinematik bir nesneyle modellemeyi seçiyoruz. Böylece fiziksel kuvvetlerle uğraşmadan oyuncu karakterini istediğimiz gibi hareket ettirebiliriz. Bu, karakteri bölüm geometrisinden ayırmayı kendimizin çözmesi gerektiği anlamına gelir (bunu ileride ayrıntılı olarak ele alacağız), ancak bu dezavantajı kabul ediyoruz. Oyuncu karakterini fizik dünyasında bir kutu şekliyle temsil edeceğiz.
+
+## Hareket
+
+Oyuncu karakterinin kinematik bir nesneyle temsil edilmesine karar verdiğimize göre, konumunu ayarlayarak onu serbestçe hareket ettirebiliriz. Sola/sağa hareketle başlayalım.
+
+Karaktere ağırlık hissi vermek için hareketi ivmeye dayandıracağız. Sıradan bir araçta olduğu gibi ivme, oyuncu karakterinin en yüksek sürate ne kadar çabuk ulaşabileceğini ve yön değiştirebileceğini belirler. İvme, karenin (frame) zaman adımı boyunca---genellikle `dt` (delta-`t`) parametresiyle verilir---etki eder ve ardından hıza eklenir. Benzer biçimde hız da kare boyunca etki eder ve ortaya çıkan öteleme (translation) konuma eklenir. Matematikte buna [zamana göre integral alma](http://en.wikipedia.org/wiki/Integral) denir.
+
+![Hızın yaklaşık integralinin alınması](images/platformer/integration.png)
+
+İki dikey çizgi karenin başlangıcını ve sonunu gösterir. Çizgilerin yüksekliği, oyuncu karakterinin bu iki andaki hızıdır. Bu hızlara `v0` ve `v1` diyelim. `v1`, ivmenin (eğrinin eğiminin) `dt` zaman adımı boyunca uygulanmasıyla elde edilir:
+
+![Hız denklemi](images/platformer/equationofvelocity.png)
+
+Turuncu alan, geçerli kare sırasında oyuncu karakterine uygulamamız gereken ötelemedir. Geometrik olarak alanı yaklaşık şu şekilde hesaplayabiliriz:
+
+![Öteleme denklemi](images/platformer/equationoftranslation.png)
+
+Güncelleme döngüsünde karakteri hareket ettirmek için ivmenin ve hızın integralini şöyle alırız:
+
+1. Girdiye (input) göre hedef sürati belirleyin
+2. Geçerli süratimizle hedef sürat arasındaki farkı hesaplayın
+3. İvmeyi farkın yönünde etki edecek şekilde ayarlayın
+4. Yukarıdaki gibi bu karedeki hız değişimini hesaplayın (`dv`, hız değişimi anlamındaki delta-velocity ifadesinin kısaltmasıdır):
+
+    ```lua
+    local dv = acceleration * dt
+    ```
+
+5. `dv` değerinin amaçlanan sürat farkını aşıp aşmadığını kontrol edin; aşıyorsa onu bu farkla sınırlandırın
+6. Geçerli hızı daha sonra kullanmak üzere kaydedin (şu anda önceki karede kullanılan hız olan `self.velocity`):
+
+    ```lua
+    local v0 = self.velocity
+    ```
+
+7. Hız değişimini ekleyerek yeni hızı hesaplayın:
+
+    ```lua
+    self.velocity = self.velocity + dv
+    ```
+
+8. Yukarıdaki gibi hızın integralini alarak bu karedeki x yönündeki ötelemeyi hesaplayın:
+
+    ```lua
+    local dx = (v0 + self.velocity) * dt * 0.5
+    ```
+
+9. Bunu oyuncu karakterine uygulayın
+
+Defold'da girdiyi nasıl işleyeceğinizden emin değilseniz, bu konuda [burada](/manuals/input) bir kılavuz var.
+
+Bu aşamada karakteri sola ve sağa hareket ettirebiliyor, kontrollerde ağırlık hissi ve akıcılık elde edebiliyoruz. Şimdi yerçekimini ekleyelim!
+
+Yerçekimi de bir ivmedir, ancak oyuncuyu y ekseni boyunca etkiler. Bu, yukarıda açıklanan hareket ivmesiyle aynı şekilde uygulanacağı anlamına gelir. Yukarıdaki hesaplamaları vektörlerle çalışacak biçimde değiştirip 3. adımda yerçekimini ivmenin y bileşenine dahil etmemiz yeterlidir. Vektör matematiğini sevmemek mümkün mü! :-)
+
+## Çarpışmaya tepki
+
+Oyuncu karakterimiz artık hareket edip düşebildiğine göre, çarpışmaya tepkileri (collision response) inceleme zamanı geldi.
+Bölüm geometrisinin üzerine inmemiz ve onun boyunca hareket etmemiz gerektiği açık. Hiçbir şeyle iç içe geçmediğimizden emin olmak için fizik motorunun sağladığı temas noktalarını (contact point) kullanacağız.
+
+Bir temas noktası, temasın _normal vektörünü_ (çarpıştığımız nesnenin dışına doğru yönelir, ancak diğer motorlarda farklı olabilir) ve diğer nesnenin ne kadar içine girdiğimizi ölçen bir _mesafeyi_ içerir. Oyuncuyu bölüm geometrisinden ayırmak için ihtiyacımız olan tek şey budur.
+Kutu kullandığımız için bir kare sırasında birden fazla temas noktası alabiliriz. Örneğin kutunun iki köşesi yatay zeminle kesiştiğinde veya oyuncu bir köşeye doğru hareket ettiğinde bu durum oluşur.
+
+![Oyuncu karakterine etki eden temas normalleri](images/platformer/collision.png)
+
+Aynı düzeltmeyi birden fazla kez yapmamak için düzeltmeleri bir vektörde biriktiririz; böylece gereğinden fazla düzeltme yapmadığımızdan emin oluruz. Aksi halde çarpıştığımız nesneden fazla uzaklaşırdık. Yukarıdaki görüntüde, iki okla (normal vektörleriyle) gösterilen iki temas noktamız olduğunu görebilirsiniz. İç içe geçme mesafesi her iki temas için de aynıdır; bu mesafeyi her seferinde doğrudan kullansaydık oyuncuyu amaçlanan miktarın iki katı kadar hareket ettirirdik.
+
+::: sidenote
+Biriktirilen düzeltmeleri her karede sıfır vektörüne sıfırlamak önemlidir.
+`update()` işlevinin sonuna şöyle bir satır ekleyin:
+`self.corrections = vmath.vector3()`
+:::
+
+Her temas noktası için çağrılacak bir geri çağırım işlevi olduğunu varsayarsak, o işlevde ayırma işlemini şöyle yapabilirsiniz:
+
+```lua
+local proj = vmath.dot(self.correction, normal) -- <1>
+local comp = (distance - proj) * normal -- <2>
+self.correction = self.correction + comp -- <3>
+go.set_position(go.get_position() + comp) -- <4>
+```
+
+1. Düzeltme vektörünün temas normali üzerine izdüşümünü alın (ilk temas noktası için düzeltme vektörü sıfır vektörüdür)
+2. Bu temas noktası için yapmamız gereken düzeltme miktarını hesaplayın
+3. Bunu düzeltme vektörüne ekleyin
+4. Düzeltmeyi oyuncu karakterine uygulayın
+
+Oyuncunun hızının temas noktasına doğru yönelen kısmını da sıfırlamamız gerekir:
+
+```lua
+proj = vmath.dot(self.velocity, message.normal) -- <1>
+if proj < 0 then
+    self.velocity = self.velocity - proj * message.normal -- <2>
+end
+```
+1. Hızın normal üzerine izdüşümünü alın
+2. İzdüşüm negatifse, hızın bir kısmı temas noktasına doğru yöneliyor demektir; bu durumda o bileşeni kaldırın
+
+## Zıplama
+
+Artık bölüm geometrisi üzerinde koşup aşağı düşebildiğimize göre, zıplama zamanı geldi! Platform oyunlarında zıplama pek çok farklı şekilde uygulanabilir. Bu oyunda Super Mario Bros ve Super Meat Boy'dakine benzer bir şey hedefliyoruz. Zıplarken oyuncu karakteri, temelde sabit bir sürat olan bir itmeyle yukarı doğru itilir.
+
+Yerçekimi karakteri sürekli yeniden aşağı çeker ve bunun sonucunda hoş bir zıplama yayı oluşur. Oyuncu havadayken de karakteri kontrol edebilir. Oyuncu, zıplama yayının tepe noktasından önce zıplama düğmesini bırakırsa zıplamayı erken sonlandırmak için yukarı yönlü sürat azaltılır.
+
+1. Girdi düğmesine basıldığında şunu yapın:
+
+    ```lua
+    -- jump_takeoff_speed is a constant defined elsewhere
+    self.velocity.y = jump_takeoff_speed
+    ```
+
+    Bu işlem yalnızca girdi düğmesine _basıldığı anda_ yapılmalıdır; düğmenin sürekli _basılı tutulduğu_ her karede değil.
+
+2. Girdi düğmesi bırakıldığında şunu yapın:
+
+    ```lua
+    -- cut the jump short if we are still going up
+    if self.velocity.y > 0 then
+        -- scale down the upwards speed
+        self.velocity.y = self.velocity.y * 0.5
+    end
+    ```
+
+ExciteMike, [Super Mario Bros 3](http://meyermike.com/wp/?p=175) ve [Super Meat Boy](http://meyermike.com/wp/?p=160) oyunlarındaki zıplama yaylarını gösteren, incelemeye değer güzel grafikler hazırlamış.
+
+## Bölüm geometrisi
+
+Bölüm geometrisi, oyuncu karakterinin (ve muhtemelen başka şeylerin) çarpıştığı çevrenin çarpışma şekilleridir. Defold'da bu geometriyi oluşturmanın iki yolu vardır.
+
+Bir seçenek, oluşturduğunuz bölümlerin üzerine ayrı çarpışma şekilleri yerleştirmektir. Bu yöntem çok esnektir ve grafiklerin hassas biçimde konumlandırılmasına olanak tanır. Özellikle yumuşak eğimler istiyorsanız kullanışlıdır.
+[Braid](http://braid-game.com/) oyunu, bölümleri oluşturmak için bu yöntemi kullanmıştır; bu öğreticideki örnek bölüm de aynı yöntemle oluşturulmuştur. Defold düzenleyicisindeki görünümü şöyledir:
+
+![Bölüm geometrisinin ve oyuncunun dünyaya yerleştirildiği Defold düzenleyicisi](images/platformer/editor.png)
+
+Başka bir seçenek de bölümleri karolardan oluşturmak ve düzenleyicinin karo grafiklerine göre fizik şekillerini otomatik olarak üretmesini sağlamaktır. Bu, bölümleri değiştirdiğinizde bölüm geometrisinin de otomatik olarak güncelleneceği anlamına gelir ve son derece yararlı olabilir.
+
+Yerleştirilen karolar hizalanıyorsa fizik şekilleri otomatik olarak tek bir şekilde birleştirilir.
+Böylece birkaç yatay karo üzerinde kayarken oyuncu karakterinizin durmasına veya takılmasına neden olabilecek boşluklar ortadan kalkar. Bu işlem, yükleme sırasında Box2D'de karo çokgenlerinin kenar şekilleriyle değiştirilmesiyle yapılır.
+
+![Birleştirilerek tek şekil haline getirilmiş birden fazla karo çokgeni](images/platformer/stitching.png)
+
+Yukarıdaki örnekte, platform oyunu grafiklerinin bir parçasından yan yana beş karo oluşturduk. Görüntüde, yerleştirilen karoların (üstte) birleştirilmiş tek bir şekle (alttaki gri dış hat) nasıl karşılık geldiğini görebilirsiniz.
+
+Daha fazla bilgi için [fizik](/manuals/physics) ve [karolar](/manuals/2dgraphics) hakkındaki kılavuzlarımıza bakın.
+
+## Son sözler
+
+Platform oyunu mekanikleri hakkında daha fazla bilgi istiyorsanız [Sonic](http://info.sonicretro.org/Sonic_Physics_Guide) oyunundaki fizikle ilgili burada etkileyici miktarda bilgi bulabilirsiniz.
+
+Şablon projemizi bir iOS aygıtında veya fareyle denerseniz zıplama oldukça tuhaf hissettirebilir.
+Bu, tek dokunma girdisiyle platform oyunu oynatmaya yönelik pek başarılı olmayan denememizden kaynaklanıyor. :-)
+
+Bu oyundaki animasyonları nasıl ele aldığımızdan söz etmedik. Aşağıdaki *player.script* dosyasındaki `update_animations()` işlevini inceleyerek fikir edinebilirsiniz.
+
+Umarız bu bilgileri yararlı bulmuşsunuzdur!
+Lütfen hepimizin oynayabileceği harika bir platform oyunu yapın! <3
+
+## Kod
+
+*player.script* dosyasının içeriği şöyle:
+
+```lua
+-- player.script
+
+-- these are the tweaks for the mechanics, feel free to change them for a different feeling
+-- the acceleration to move right/left
+local move_acceleration = 3500
+-- acceleration factor to use when air-borne
+local air_acceleration_factor = 0.8
+-- max speed right/left
+local max_speed = 450
+-- gravity pulling the player down in pixel units
+local gravity = -1000
+-- take-off speed when jumping in pixel units
+local jump_takeoff_speed = 550
+-- time within a double tap must occur to be considered a jump (only used for mouse/touch controls)
+local touch_jump_timeout = 0.2
+
+-- prehashing ids improves performance
+local msg_contact_point_response = hash("contact_point_response")
+local msg_animation_done = hash("animation_done")
+local group_obstacle = hash("obstacle")
+local input_left = hash("left")
+local input_right = hash("right")
+local input_jump = hash("jump")
+local input_touch = hash("touch")
+local anim_run = hash("run")
+local anim_idle = hash("idle")
+local anim_jump = hash("jump")
+local anim_fall = hash("fall")
+
+function init(self)
+    -- this lets us handle input in this script
+    msg.post(".", "acquire_input_focus")
+
+    -- initial player velocity
+    self.velocity = vmath.vector3(0, 0, 0)
+    -- support variable to keep track of collisions and separation
+    self.correction = vmath.vector3()
+    -- if the player stands on ground or not
+    self.ground_contact = false
+    -- movement input in the range [-1,1]
+    self.move_input = 0
+    -- the currently playing animation
+    self.anim = nil
+    -- timer that controls the jump-window when using mouse/touch
+    self.touch_jump_timer = 0
+end
+
+local function play_animation(self, anim)
+    -- only play animations which are not already playing
+    if self.anim ~= anim then
+        -- tell the sprite to play the animation
+        sprite.play_flipbook("#sprite", anim)
+        -- remember which animation is playing
+        self.anim = anim
+    end
+end
+
+local function update_animations(self)
+    -- make sure the player character faces the right way
+    sprite.set_hflip("#sprite", self.move_input < 0)
+    -- make sure the right animation is playing
+    if self.ground_contact then
+        if self.velocity.x == 0 then
+            play_animation(self, anim_idle)
+        else
+            play_animation(self, anim_run)
+        end
+    else
+        if self.velocity.y > 0 then
+            play_animation(self, anim_jump)
+        else
+            play_animation(self, anim_fall)
+        end
+    end
+end
+
+function update(self, dt)
+    -- determine the target speed based on input
+    local target_speed = self.move_input * max_speed
+    -- calculate the difference between our current speed and the target speed
+    local speed_diff = target_speed - self.velocity.x
+    -- the complete acceleration to integrate over this frame
+    local acceleration = vmath.vector3(0, gravity, 0)
+    if speed_diff ~= 0 then
+        -- set the acceleration to work in the direction of the difference
+        if speed_diff < 0 then
+            acceleration.x = -move_acceleration
+        else
+            acceleration.x = move_acceleration
+        end
+        -- decrease the acceleration when air-borne to give a slower feel
+        if not self.ground_contact then
+            acceleration.x = air_acceleration_factor * acceleration.x
+        end
+    end
+    -- calculate the velocity change this frame (dv is short for delta-velocity)
+    local dv = acceleration * dt
+    -- check if dv exceeds the intended speed difference, clamp it in that case
+    if math.abs(dv.x) > math.abs(speed_diff) then
+        dv.x = speed_diff
+    end
+    -- save the current velocity for later use
+    -- (self.velocity, which right now is the velocity used the previous frame)
+    local v0 = self.velocity
+    -- calculate the new velocity by adding the velocity change
+    self.velocity = self.velocity + dv
+    -- calculate the translation this frame by integrating the velocity
+    local dp = (v0 + self.velocity) * dt * 0.5
+    -- apply it to the player character
+    go.set_position(go.get_position() + dp)
+
+    -- update the jump timer
+    if self.touch_jump_timer > 0 then
+        self.touch_jump_timer = self.touch_jump_timer - dt
+    end
+
+    update_animations(self)
+
+    -- reset volatile state
+    self.correction = vmath.vector3()
+    self.move_input = 0
+    self.ground_contact = false
+
+end
+
+local function handle_obstacle_contact(self, normal, distance)
+    -- project the correction vector onto the contact normal
+    -- (the correction vector is the 0-vector for the first contact point)
+    local proj = vmath.dot(self.correction, normal)
+    -- calculate the compensation we need to make for this contact point
+    local comp = (distance - proj) * normal
+    -- add it to the correction vector
+    self.correction = self.correction + comp
+    -- apply the compensation to the player character
+    go.set_position(go.get_position() + comp)
+    -- check if the normal points enough up to consider the player standing on the ground
+    -- (0.7 is roughly equal to 45 degrees deviation from pure vertical direction)
+    if normal.y > 0.7 then
+        self.ground_contact = true
+    end
+    -- project the velocity onto the normal
+    proj = vmath.dot(self.velocity, normal)
+    -- if the projection is negative, it means that some of the velocity points towards the contact point
+    if proj < 0 then
+        -- remove that component in that case
+        self.velocity = self.velocity - proj * normal
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    -- check if we received a contact point message
+    if message_id == msg_contact_point_response then
+        -- check that the object is something we consider an obstacle
+        if message.group == group_obstacle then
+            handle_obstacle_contact(self, message.normal, message.distance)
+        end
+    end
+end
+
+local function jump(self)
+    -- only allow jump from ground
+    -- (extend this with a counter to do things like double-jumps)
+    if self.ground_contact then
+        -- set take-off speed
+        self.velocity.y = jump_takeoff_speed
+        -- play animation
+        play_animation(self, anim_jump)
+    end
+end
+
+local function abort_jump(self)
+    -- cut the jump short if we are still going up
+    if self.velocity.y > 0 then
+        -- scale down the upwards speed
+        self.velocity.y = self.velocity.y * 0.5
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == input_left then
+        self.move_input = -action.value
+    elseif action_id == input_right then
+        self.move_input = action.value
+    elseif action_id == input_jump then
+        if action.pressed then
+            jump(self)
+        elseif action.released then
+            abort_jump(self)
+        end
+    elseif action_id == input_touch then
+        -- move towards the touch-point
+        local diff = action.x - go.get_position().x
+        -- only give input when far away (more than 10 pixels)
+        if math.abs(diff) > 10 then
+            -- slow down when less than 100 pixels away
+            self.move_input = diff / 100
+            -- clamp input to [-1,1]
+            self.move_input = math.min(1, math.max(-1, self.move_input))
+        end
+        if action.released then
+            -- start timing the last release to see if we are about to jump
+            self.touch_jump_timer = touch_jump_timeout
+        elseif action.pressed then
+            -- jump on double tap
+            if self.touch_jump_timer > 0 then
+                jump(self)
+            end
+        end
+    end
+end
+```

--- a/docs/tr/tutorials/rpgmap.md
+++ b/docs/tr/tutorials/rpgmap.md
@@ -1,0 +1,80 @@
+---
+title: RPG haritası örneği
+brief: Bu örnek projede, çok büyük RPG haritaları oluşturmanın bir yöntemini öğreneceksiniz.
+---
+# RPG haritası - örnek proje
+
+[Düzenleyiciden açabileceğiniz](/manuals/project-setup/) veya [GitHub'dan indirebileceğiniz](https://github.com/defold/sample-rpgmap) bu örnek projede, Defold'da çok büyük RPG haritaları oluşturmanın bir yöntemini gösteriyoruz. Tasarım şu varsayımlara dayanır:
+
+1. Dünya, her seferinde tek bir ekran gösterilerek sunulur. Bu, oyunun düşmanları ve NPC karakterlerini doğal olarak tek bir ekranın sınırları içinde tutmasını sağlar. Bölüm tasarımcısı, dünyanın oyuncunun ekranında nasıl sunulacağı üzerinde tam kontrole sahiptir.
+2. Oyuncu karakteri, oyunda kayan noktalı sayıların hassasiyetiyle ilgili sorunlar oluşmadan istediği kadar uzağa gidebilmelidir. Bu sorunlar genellikle nesnelerin başlangıç noktasından uzaklaştıklarında tuhaf bir şekilde titreşmelerine neden olur.
+3. Oyuncunun hareketi haritadaki engellerle sınırlandırılır; böylece bölüm tasarımcısı ağaçları, kayaları, suyu ve diğer engelleri kullanarak oyuncuyu ekranlar arasında yönlendirebilir.
+4. Karo haritalarını (tilemap), sprite bileşenlerini (sprite component) ve diğer görsel içerikleri farklı birleşimler halinde bir arada kullanmak mümkün olmalıdır.
+
+Önce örneği çalıştırın ve nasıl yapılandırıldığını anlamak için 3x3 ekran büyüklüğündeki dünyada dolaşın. Karakteri ok tuşlarıyla kontrol edersiniz.
+
+## Ana koleksiyon
+
+Bu örneğin başlangıç koleksiyonunu (bootstrap collection) görmek için "/main/main.collection" dosyasını açın.
+
+![](images/rpgmap/main_collection.png)
+
+Ana koleksiyon, ok tuşlarıyla 8 yönde kontrol edilen oyuncu karakterinin oyun nesnesini (game object) ve oyunun akışını kontrol eden "game" adlı ikinci bir oyun nesnesini içerir. "game" nesnesi, bir betikten ve oyundaki her ekran için bir koleksiyon fabrikasından (collection factory) oluşur. Fabrikalar, ekran ızgarasının adlandırma şemasına göre adlandırılır.
+
+"/main/game.script" betiği, oyuncunun o anda hangi ekranda olduğunu takip eder. Betik ayrıca "load_screen" adlı özel bir iletiye tepki verir. Bu ileti yeni bir ekran yükler ve kahramanın hareket ettiği yönde bu ekranı geçerli ekranla değiştirir. Başlangıçta bir ekran, görüntünün merkezine yüklenir ve yer değiştirecek başka bir ekran yoktur.
+
+## Ekran değiştirme
+
+Kahraman, "/main/hero.script" betiğiyle kontrol edilir. Betik, kahramanın oyun nesnesinin ekranın üst, alt, sol veya sağ kenarına yakın bir çizgiyi geçip geçmediğini kontrol eder:
+
+![](images/rpgmap/change_screen.png)
+
+1. Kahraman bir ekran kenarına yeterince yaklaşırsa, sonraki ekranı yüklemek için "game" nesnesinin betiğine bir ileti gönderilir.
+2. Sonraki ekranın koleksiyonu, doğru collectionfactory bileşeninde `factory.create()` çağrılarak oluşturulur. Koleksiyonun içeriği ekranın dışına yerleştirilir.
+3. Sonraki ekran, görüntünün merkezine kaydırılır ve geçerli ekran ters yönde dışarı kaydırılır. Oyuncu karakteri de aynı mesafe boyunca ve aynı hızla kaydırılır.
+4. Artık ekran dışında kalan eski geçerli ekran silinir ve sonraki ekran, yeni geçerli ekran olur.
+5. Kahraman, bir animasyonla yeni ekranda görünür hâle gelir ve oyuncu kontrolü geri kazanır.
+
+Bütün bunlar bir saniye içinde gerçekleştiğinden geçiş akıcıdır ve oynanışı kesintiye uğratmaz.
+
+## Ekranlar
+
+Oyun dünyasındaki her ekran, o ekrana özgü karo haritasını, çarpışma nesnesini (collision object) ve diğer oyun nesnelerini içeren ayrı bir koleksiyonun içinde oluşturulur. Ekranların yönetimini ve yüklenmesini kolaylaştırmak için ekran koleksiyonları basit bir şemaya göre adlandırılır:
+
+![](images/rpgmap/screens.png)
+
+Her ekran koleksiyonu, dünya ızgarasındaki konumuna göre adlandırılır. İlk sayı ızgaradaki X konumunu, ikinci sayı ise Y konumunu belirtir.
+
+*Assets* görünümünde, haritanın sol alt köşesindeki ekranı tanımlayan "/main/screens/0-0.collection" koleksiyonunu bulun ve açın:
+
+![](images/rpgmap/screen_collection.png)
+
+Ekranın tüm içeriğinin üst nesnesi olan "root" adlı bir oyun nesnesi bulunduğuna dikkat edin. Bu, örnekte kullanılan başka bir düzenleme kuralıdır ve çok önemli bir amaca hizmet eder: bir ekran görüntüye getirildiğinde yalnızca "root" oyun nesnesinin taşınması gerekir. Tüm alt nesneler otomatik olarak kök üst nesneyle birlikte taşınır. Bir ekranda özel oyun nesneleri varsa bunların hareketi kök üst nesneye göre tanımlandığından bu nesnelere serbestçe animasyon da uygulanabilir. Ekran içeri veya dışarı kaydırıldığında bu alt nesneler ekranla birlikte hareket eder. Yalnızca bir nesnenin ekranlar arasında hareket etmesi gerekiyorsa özel kod gerekir.
+
+0-1 ekranındaki arılar bu fikri gösteren basit örneklerdir:
+
+![](images/rpgmap/bees.png)
+
+## Ekranları dünya bağlamında düzenleme
+
+Her ekranın, yerleşik karo haritası düzenleyicisinde düzenlenebilen kendi karo haritası vardır. Ancak her ekranı ayrı olarak düzenlemenin başlıca dezavantajı, komşu ekranlarla nasıl birleştiğinin kolayca görülememesidir. Bu bağlantılar, oyun dünyası boyunca süreklilik sağlamanın önemli bir parçasıdır.
+
+Bu nedenle özel bir koleksiyon oluşturulmuştur. Dünyanın test düzenini içeren bu koleksiyonu görmek için "/main/map/test_layout.collection" dosyasını açın:
+
+![](images/rpgmap/test_layout.png)
+
+Bu koleksiyonun tek amacı, geliştirme sırasında bir düzenleme aracı olarak kullanılmaktır. Belirli bir ekranı test düzeni koleksiyonuyla yan yana düzenlemek, üzerinde çalıştığınız ekranın bağlamını görmenizi sağlar ve düzenleme sürecini çok daha rahat hâle getirir:
+
+![](images/rpgmap/side_by_side.png)
+
+Ekranın karo haritasında (burada sağ bölmede) yapılan tüm düzenlemeler, test koleksiyonuna (sol bölmede) anında yansıtılır. Ayrıca test düzeni koleksiyonunun statik hiyerarşiye eklenmediğine, dolayısıyla tüm derlemelerden otomatik olarak çıkarıldığına dikkat edin.
+
+## Özet
+
+Gördüğünüz gibi bu örnek, oyun dünyası ve kahramanın bu dünyada nasıl ilerlediğiyle ilgili belirli kısıtlamalara göre oluşturulmuştur. Oyununuzun gereksinimleri farklıysa muhtemelen farklı bir çözüm bulmanız gerekir. Örneğin oyununuz kameranın dünya haritası üzerinde kesintisiz biçimde hareket etmesini gerektiriyorsa, içeriğinizi parçalara ayırmak için farklı bir yönteme, farklı bir yükleme mekanizmasına ve oyun dünyanızı oluşturmanıza yardımcı olacak farklı araçlara ihtiyacınız vardır.
+
+RPG haritası örneğinin tanıtımı burada sona eriyor. Her zaman olduğu gibi örneğin içeriğini uygun gördüğünüz şekilde kullanmakta özgürsünüz. Defold hakkında daha fazla bilgi edinmek için daha çok örnek, öğretici, kılavuz ve API belgesi bulabileceğiniz [belge sayfalarımıza](https://defold.com/learn) göz atın.
+
+Bir sorunla karşılaşırsanız veya sorularınız varsa [forumumuzu ziyaret edin](https://forum.defold.com/).
+
+Defold ile keyifli çalışmalar!

--- a/docs/tr/tutorials/runner.md
+++ b/docs/tr/tutorials/runner.md
@@ -1,0 +1,942 @@
+---
+title: Sonsuz koşu oyunu öğreticisi
+brief: Bu öğreticide boş bir projeyle başlayıp animasyonlu bir karakter, fiziksel çarpışmalar, toplanabilir nesneler ve puanlama içeren eksiksiz bir koşu oyunu oluşturacaksınız.
+---
+
+# Koşu oyunu öğreticisi
+
+Bu öğreticide boş bir projeyle başlayıp animasyonlu bir karakter, fiziksel çarpışmalar, toplanabilir nesneler ve puanlama içeren eksiksiz bir koşu oyunu oluşturacağız.
+
+Yeni bir oyun motorunu öğrenirken kavranması gereken çok şey vardır; bu öğreticiyi başlamanıza yardımcı olmak için hazırladık. Motorun ve düzenleyicinin nasıl çalıştığını adım adım anlatan, oldukça kapsamlı bir öğreticidir. Programlamaya biraz aşina olduğunuzu varsayıyoruz.
+
+Lua programlamaya giriş yapmak istiyorsanız [Defold'da Lua kılavuzumuza](/manuals/lua) göz atın.
+
+Bu öğreticinin başlangıç için biraz fazla kapsamlı olduğunu düşünüyorsanız farklı zorluk düzeylerinde öğreticiler sunduğumuz [öğreticiler sayfamıza](//www.defold.com/tutorials) göz atın.
+
+Video öğreticileri izlemeyi tercih ediyorsanız [YouTube'daki video sürümüne](https://www.youtube.com/playlist?list=PLXsXu5srjNlxtYPQ_YJQSxJG2AN9OVS5b) göz atın.
+
+Diğer iki öğreticideki oyun varlıklarını (asset) küçük değişikliklerle kullanıyoruz. Öğretici, her biri bizi tamamlanmış oyuna önemli ölçüde yaklaştıran birkaç adıma ayrılmıştır.
+
+Sonuçta, bir ortamda koşarak paraları toplayan ve engellerden kaçınan bir kahraman karakteri kontrol ettiğiniz bir oyun elde edeceksiniz. Kahraman sabit süratle koşar; oyuncu tek bir düğmeye basarak (veya mobil cihazda ekrana dokunarak) yalnızca kahramanın zıplamasını kontrol eder. Bölüm, üzerine zıplanacak platformların ve toplanacak paraların sonsuz akışından oluşur.
+
+Bu öğreticinin herhangi bir yerinde veya oyununuzu oluştururken takılırsanız [Defold Forum](//forum.defold.com) üzerinden bizden yardım istemekten çekinmeyin. Forumda Defold hakkında konuşabilir, Defold ekibinden yardım isteyebilir, diğer oyun geliştiricilerinin sorunlarını nasıl çözdüğünü görebilir ve yeni fikirler bulabilirsiniz. Hemen başlayın.
+
+::: sidenote
+Öğretici boyunca kavramların ayrıntılı açıklamaları ve belirli işlemlerin nasıl yapılacağı bu paragraftaki gibi işaretlenmiştir. Bu bölümlerin fazla ayrıntıya girdiğini düşünüyorsanız onları atlayabilirsiniz.
+:::
+
+Öyleyse başlayalım. Bu öğreticiyi uygularken çok eğlenmenizi ve Defold'a başlamanıza yardımcı olmasını umuyoruz.
+
+> Bu öğreticinin varlıklarını [buradan](https://github.com/defold/sample-runner/tree/main/def-runner) indirin.
+
+## Adım 1 - Kurulum ve hazırlık
+
+İlk adım, [şu dosyaları indirmektir](https://github.com/defold/sample-runner/tree/main/def-runner).
+
+Defold düzenleyicisini henüz indirip kurmadıysanız şimdi bunu yapma zamanı:
+
+:[install](../shared/install.md)
+
+Düzenleyici kurulup başlatıldıktan sonra yeni bir proje oluşturup hazırlama zamanı gelmiştir. "Empty Project" şablonundan [yeni bir proje](/manuals/project-setup/#creating-a-new-project) oluşturun.
+
+::: sidenote
+Bu öğretici [Spine Extension](https://github.com/defold/extension-spine) içindeki Spine özelliklerini kullanır. Eklentiyi *game.project* dosyasının bağımlılıklar bölümüne ekleyin.
+:::
+
+## Düzenleyici
+
+Düzenleyiciyi ilk kez başlattığınızda hiçbir proje açık olmadan boş olarak açılır; bu yüzden menüden <kbd>Open Project</kbd> seçeneğini seçip yeni oluşturduğunuz projeyi açın. Ayrıca proje için bir "dal" (branch) oluşturmanız istenecektir.
+
+Artık *Assets* bölmesinde projenin parçası olan bütün dosyaları göreceksiniz. "main/main.collection" dosyasına çift tıklarsanız dosya ortadaki düzenleyici görünümünde açılır:
+
+![Düzenleyiciye genel bakış](images/runner/1/editor2_overview.png)
+
+Düzenleyici şu ana alanlardan oluşur:
+
+Assets bölmesi
+: Projenizdeki bütün dosyaları gösterir. Farklı dosya türlerinin farklı simgeleri vardır. Bir dosyayı, türüne uygun düzenleyicide açmak için dosyaya çift tıklayın. Salt okunur özel *builtins* klasörü bütün projeler için ortaktır; varsayılan bir işleme betiği, bir yazı tipi, çeşitli bileşenlerin görüntüsünü oluşturmak için kullanılan işleme (rendering) materyalleri ve başka yararlı öğeler içerir.
+
+Ana düzenleyici görünümü
+: Düzenlediğiniz dosya türüne göre bu görünümde o türe uygun bir düzenleyici gösterilir. En sık kullanılanı, burada gördüğünüz Scene düzenleyicisidir. Açık olan her dosya ayrı bir sekmede gösterilir.
+
+Changed Files
+: Geçerli Git commit'ine göre yerelde eklenen, değiştirilen, yeniden adlandırılan veya silinen dosyaları içerir. Değiştirilmiş veya yeniden adlandırılmış metin dosyalarının farklarını tek seferde bir dosya için görüntüleyebilirsiniz; seçtiğiniz yerel değişiklikleri burada geri alabilirsiniz. Uzak depoyla eşitlemek için haricî bir Git istemcisi veya komut satırını kullanın.
+
+Outline
+: Düzenlenmekte olan dosyanın içeriğini hiyerarşik olarak gösterir. Bu görünüm üzerinden oyun nesnelerini (game object) ve bileşenleri (component) ekleyebilir, silebilir, değiştirebilir ve seçebilirsiniz.
+
+Properties
+: Seçili nesne veya bileşen üzerinde ayarlanmış özelliklerdir.
+
+Console
+: Oyun çalışırken bu görünüm, oyun motorunun çıktısını (günlükler, hatalar, hata ayıklama bilgileri vb.) ve betiklerinizdeki özel `print()` ve `pprint()` hata ayıklama iletilerini yakalar. Uygulamanız veya oyununuz başlamıyorsa ilk kontrol etmeniz gereken yer konsoldur. Konsolun arkasında hata bilgilerini gösteren sekmeler ve parçacık efektleri oluştururken kullanılan bir eğri düzenleyicisi bulunur.
+
+## Oyunu çalıştırma
+
+"Empty" proje şablonu gerçekten tamamen boştur. Yine de projeyi derleyip oyunu başlatmak için <kbd>Project ▸ Build</kbd> seçeneğini seçin.
+
+![Derleme](images/runner/1/build_and_launch.png)
+
+Siyah bir ekran pek heyecan verici olmayabilir, ancak bu çalışan bir Defold oyun uygulamasıdır ve onu kolayca daha ilgi çekici bir şeye dönüştürebiliriz. Öyleyse bunu yapalım.
+
+::: sidenote
+Defold düzenleyicisi dosyalar üzerinde çalışır. *Assets* bölmesindeki bir dosyaya çift tıklayarak onu uygun bir düzenleyicide açarsınız. Ardından dosyanın içeriği üzerinde çalışabilirsiniz.
+
+Bir dosyayı düzenlemeyi bitirdiğinizde onu kaydetmeniz gerekir. Ana menüden <kbd>File ▸ Save</kbd> seçeneğini seçin. Düzenleyici, kaydedilmemiş değişiklikler içeren her dosyanın sekmesindeki dosya adına bir yıldız '\*' ekleyerek bunu belirtir.
+
+![Kaydedilmemiş değişiklikler içeren dosya](images/runner/1/file_changed.png)
+:::
+
+## Projeyi hazırlama
+
+Başlamadan önce projemizin birkaç ayarını yapalım. `Assets Pane` içinden *game.project* varlığını açın ve Display bölümüne kadar aşağı kaydırın. Projenin `width` ve `height` değerlerini sırasıyla `1280` ve `720` olarak ayarlayın.
+
+Kahraman karakteri canlandırabilmemiz için projeye Spine eklentisini de eklemeniz gerekir. Spine eklentisinin, kurduğunuz Defold düzenleyicisi sürümüyle uyumlu bir sürümünü ekleyin. Kullanılabilir Spine sürümlerini burada görebilirsiniz:
+
+[https://github.com/defold/extension-spine/releases](https://github.com/defold/extension-spine/releases)
+
+Kullanmak istediğiniz sürümün zip dosyası bağlantısına sağ tıklayın:
+
+![Sağ tıklayıp sürüm bağlantısını kopyalama](images/runner/extension-spine-releases.png)
+
+Sürüm bağlantısını [game.project bağımlılıkları](/manuals/libraries/#setting-up-library-dependencies) listenize ekleyin. Spine eklentisi eklendikten sonra, eklentiyle birlikte gelen düzenleyici entegrasyonunu etkinleştirmek için düzenleyiciyi yeniden başlatmanız da gerekir.
+
+
+## Adım 2 - Zemini oluşturma
+
+İlk küçük adımları atıp karakterimiz için bir alan, daha doğrusu kayan bir zemin parçası oluşturalım. Bunu birkaç adımda yapacağız.
+
+1. "ground01.png" ve "ground02.png" görüntü dosyalarını (varlık paketindeki "level-images" alt klasöründen) projede uygun bir konuma, örneğin "main" klasörünün içindeki "images" klasörüne sürükleyerek görüntü varlıklarını projeye aktarın.
+2. Zemin dokularını tutmak için yeni bir *Atlas* dosyası oluşturun (*Assets* bölmesinde uygun bir klasöre, örneğin *main* klasörüne sağ tıklayıp <kbd>New ▸ Atlas File</kbd> seçeneğini seçin). Atlas dosyasına *level.atlas* adını verin.
+
+  ::: sidenote
+  Bir *atlas* (Atlas), ayrı görüntüleri tek ve daha büyük bir görüntü dosyasında birleştiren bir dosyadır. Bunun amacı yerden tasarruf etmek ve performansı artırmaktır. Atlaslar ve diğer 2B grafik özellikleri hakkında daha fazla bilgiyi [2B grafik belgelerinde](/manuals/2dgraphics) bulabilirsiniz.
+  :::
+
+3. *Outline* görünümünde atlasın köküne sağ tıklayıp <kbd>Add Images</kbd> seçeneğini seçerek zemin görüntülerini yeni atlasa ekleyin. İçe aktardığınız görüntüleri seçip *OK* düğmesine tıklayın. Artık atlastaki her görüntüye sprite bileşenlerinde, parçacık efektlerinde ve diğer görsel öğelerde kullanılacak tek karelik bir animasyon (durağan görüntü) olarak erişilebilir. Dosyayı kaydedin.
+
+  ![Yeni atlas oluşturma](images/runner/1/new_atlas.png)
+
+  ![Atlasa görüntü ekleme](images/runner/1/add_images_to_atlas.png)
+
+  ::: sidenote
+  *Neden çalışmıyor!?* Defold'a yeni başlayanların sık yaşadığı bir sorun kaydetmeyi unutmaktır! Bir atlasa görüntü ekledikten sonra bu görüntüye erişebilmek için dosyayı kaydetmeniz gerekir.
+  :::
+
+4. Zemin için *ground.collection* adlı bir koleksiyon (collection) dosyası oluşturup içine 7 oyun nesnesi ekleyin (*Outline* görünümünde koleksiyonun köküne sağ tıklayıp <kbd>Add Game Object</kbd> seçeneğini seçin). *Properties* görünümündeki *Id* özelliğini değiştirerek nesnelere "ground0", "ground1", "ground2" vb. adlar verin. Defold'un yeni oyun nesnelerine otomatik olarak benzersiz bir tanımlayıcı atadığını unutmayın.
+
+5. Her nesneye bir sprite bileşeni ekleyin (*Outline* görünümünde oyun nesnesine sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin, ardından *Sprite* seçeneğini seçip *OK* düğmesine tıklayın), sprite bileşeninin *Image* özelliğini az önce oluşturduğunuz atlasa ayarlayın ve sprite bileşeninin varsayılan animasyonunu iki zemin görüntüsünden birine ayarlayın. _Sprite bileşeninin_ (oyun nesnesinin değil) X konumunu 190, Y konumunu 40 yapın. Görüntünün genişliği 380 piksel olduğundan ve onu bunun yarısı kadar piksel yana kaydırdığımızdan, oyun nesnesinin dayanak noktası sprite görüntüsünün en sol kenarında olacaktır.
+
+  ![Zemin koleksiyonu oluşturma](images/runner/1/ground_collection.png)
+
+6. Kullandığımız grafikler biraz fazla büyük olduğundan her oyun nesnesini %60'a ölçekleyin (X ve Y için 0.6 ölçeği, 228 piksel genişliğinde zemin parçaları verir).
+
+  ![Zemini ölçekleme](images/runner/1/scale_ground.png)
+
+7. Bütün _oyun nesnelerini_ yan yana dizin. _Oyun nesnelerinin_ (sprite bileşenlerinin değil) X konumlarını 0, 228, 456, 684, 912, 1140 ve 1368 (228 piksel genişliğin katları) olarak ayarlayın.
+
+  ::: sidenote
+  Muhtemelen en kolayı, sprite bileşeni eklenmiş ve ölçeği ayarlanmış tek bir oyun nesnesi oluşturup onu kopyalamaktır. Nesneyi *Outline* görünümünde seçin, ardından <kbd>Edit ▸ Copy</kbd> ve sonra <kbd>Edit ▸ Paste</kbd> seçeneğini seçin.
+
+  Daha büyük veya daha küçük karolar istiyorsanız yalnızca ölçeği değiştirebilirsiniz. Ancak bunu yaptığınızda bütün zemin oyun nesnelerinin X konumlarını da yeni genişliğin katlarına ayarlamanız gerekir.
+  :::
+
+8. Dosyayı kaydedin, ardından *ground.collection* dosyasını *main.collection* dosyasına ekleyin: önce *main.collection* dosyasına çift tıklayın, ardından *Outline* görünümünde kök nesneye sağ tıklayıp <kbd>Add Collection From File</kbd> seçeneğini seçin. İletişim kutusunda *ground.collection* dosyasını seçip *OK* düğmesine tıklayın. *ground.collection* koleksiyonunu 0, 0, 0 konumuna yerleştirdiğinizden emin olun; aksi halde görüntüde kaymış olacaktır. Kaydedin.
+
+9. Her şeyin yerinde olduğunu görmek için oyunu başlatın (<kbd>Project ▸ Build</kbd>).
+
+  ![Durağan zemin](images/runner/1/still_ground.png)
+
+Şimdiye kadar oluşturduğumuz bütün bu şeylerin aslında ne olduğu konusunda kafanız karışmış olabilir. Bu yüzden biraz durup herhangi bir Defold projesindeki en temel yapı taşlarına bakalım:
+
+Oyun nesneleri
+: Çalışan oyunda var olan öğelerdir. Her oyun nesnesinin 3B uzayda bir konumu, dönmesi ve ölçeği vardır. Görünür olması gerekmez. Bir oyun nesnesi; grafikler (sprite bileşenleri, karo haritaları, modeller, Spine modelleri ve parçacık efektleri), sesler, fizik, fabrikalar (factory; çalışma sırasında nesne oluşturmak için) ve daha fazlası gibi yetenekler ekleyen, istenen sayıda _bileşen_ barındırır. Oyun nesnesine davranış kazandırmak için Lua _betik bileşenleri_ de eklenebilir. Oyunlarınızda var olan her oyun nesnesinin, ileti aktarımı yoluyla onunla iletişim kurmak için ihtiyaç duyduğunuz bir *id* değeri vardır.
+
+Koleksiyonlar
+: Koleksiyonlar, çalışan bir oyunda kendi başlarına var olmaz; oyun nesnelerinin statik olarak adlandırılmasını ve aynı zamanda aynı oyun nesnesinin birden çok örneğinin oluşturulmasını sağlamak için kullanılır. Uygulamada koleksiyonlar, oyun nesneleri ve diğer koleksiyonlar için kapsayıcı olarak kullanılır. Koleksiyonları, oyun nesneleri ve koleksiyonlardan oluşan karmaşık hiyerarşilerin prototipleri (diğer motorlarda "prefab" veya "blueprint" olarak da bilinir) gibi kullanabilirsiniz. Motor başlangıçta bir ana koleksiyon yükler ve içine koyduğunuz her şeyi hayata geçirir. Varsayılan olarak bu, projenizin *main* klasöründeki *main.collection* dosyasıdır; ancak bunu proje ayarlarından değiştirebilirsiniz.
+
+Şimdilik bu açıklamalar muhtemelen yeterlidir. Yine de bu konuların çok daha kapsamlı bir incelemesini [Yapı taşları kılavuzunda](/manuals/building-blocks) bulabilirsiniz. Defold'un nasıl çalıştığını daha derinden anlamak için daha sonra bu kılavuzu okumanız iyi olacaktır.
+
+## Adım 3 - Zemini hareket ettirme
+
+Bütün zemin parçaları yerinde olduğuna göre onları hareket ettirmek oldukça basittir. Fikir şu: parçaları sağdan sola taşıyın; bir parça ekranın dışındaki en sol kenara ulaştığında onu en sağdaki konuma taşıyın. Bütün bu oyun nesnelerini hareket ettirmek için bir Lua betiği gerekir; öyleyse bir tane oluşturalım:
+
+1. *Assets* bölmesinde *main* klasörüne sağ tıklayıp <kbd>New ▸ Script File</kbd> seçeneğini seçin. Yeni dosyaya *ground.script* adını verin.
+2. Lua betik düzenleyicisini açmak için yeni dosyaya çift tıklayın.
+3. Dosyanın varsayılan içeriğini silip aşağıdaki Lua kodunu içine kopyalayın, ardından dosyayı kaydedin.
+
+```lua
+-- ground.script
+local pieces = { "ground0", "ground1", "ground2", "ground3",
+                    "ground4", "ground5", "ground6" } -- <1>
+
+function init(self) -- <2>
+    self.speed = 360  -- Speed in pixels/s
+end
+
+function update(self, dt) -- <3>
+    for i, p in ipairs(pieces) do -- <4>
+        local pos = go.get_position(p)
+        if pos.x <= -228 then -- <5>
+            pos.x = 1368 + (pos.x + 228)
+        end
+        pos.x = pos.x - self.speed * dt -- <6>
+        go.set_position(pos, p) -- <7>
+    end
+end
+```
+1. Zemin oyun nesnelerinin tanımlayıcılarını, üzerlerinde dolaşabilmek için bir Lua tablosunda saklayın.
+2. `init()` işlevi, oyun nesnesi oyunda hayata geçtiğinde çağrılır. Zeminin süratini tutan, bu nesneye özgü bir üye değişkenine başlangıç değeri atıyoruz.
+3. `update()` her karede bir kez, genellikle saniyede 60 kez çağrılır. `dt`, son çağrıdan bu yana geçen saniye sayısını içerir.
+4. Bütün zemin oyun nesneleri üzerinde dolaşın.
+5. Geçerli konumu yerel bir değişkende saklayın; ardından geçerli nesne en sol kenardaysa onu en sağ kenara taşıyın.
+6. Geçerli X konumunu ayarlanan süratle azaltın. Piksel/s cinsinden, kare hızından bağımsız bir sürat elde etmek için `dt` ile çarpın.
+7. Nesnenin konumunu yeni süratle güncelleyin.
+
+::: sidenote
+Defold, verilerinizi ve oyun nesnelerinizi yöneten hızlı bir motor çekirdeğidir. Oyununuz için gereken her türlü mantık veya davranış Lua dilinde oluşturulur. Lua, oyun mantığı yazmaya çok uygun, hızlı ve hafif bir programlama dilidir. Dili öğrenmek için [Programming in Lua](http://www.lua.org/pil/) kitabı ve resmî [Lua başvuru kılavuzu](http://www.lua.org/manual/5.3/) gibi harika kaynaklar bulunur.
+
+Defold, Lua'nın üzerine bir dizi API ve oyun nesneleri arasındaki iletişimi programlamanızı sağlayan bir _ileti aktarımı_ (message passing) sistemi ekler. Bunun nasıl çalıştığına ilişkin ayrıntılar için [İleti aktarımı kılavuzuna](/manuals/message-passing) bakın.
+:::
+
+::: sidenote
+Düzenleyicinin Assets Pane, Console ve Outline bölümlerini sırasıyla <kbd>F6</kbd>, <kbd>F7</kbd> ve <kbd>F8</kbd> tuşlarıyla açıp kapatabilirsiniz
+:::
+
+Artık bir betik dosyamız olduğuna göre bir oyun nesnesindeki bileşene bu dosyanın başvurusunu eklememiz gerekir. Böylece betik, oyun nesnesinin yaşam döngüsünün bir parçası olarak yürütülür. Bunun için *ground.collection* içinde yeni bir oyun nesnesi oluşturup bu nesneye, az önce oluşturduğumuz Lua betik dosyasına başvuran bir *Script* bileşeni ekleyeceğiz:
+
+1. Koleksiyonun köküne sağ tıklayıp <kbd>Add Game Object</kbd> seçeneğini seçin. Nesnenin *id* değerini "controller" olarak ayarlayın.
+2. "controller" nesnesine sağ tıklayıp <kbd>Add Component from file</kbd> seçeneğini seçin, ardından *ground.script* dosyasını seçin.
+
+![Zemin denetleyicisi](images/runner/1/ground_controller.png)
+
+Artık oyunu çalıştırdığınızda "controller" oyun nesnesi, *Script* bileşenindeki betiği çalıştırarak zeminin ekran boyunca akıcı biçimde kaymasını sağlayacaktır.
+
+## Adım 4 - Bir kahraman karakter oluşturma
+
+Kahraman karakter, şu bileşenlerden oluşan bir oyun nesnesi olacak:
+
+Bir *Spine Model*
+: Bize, vücut parçaları akıcı biçimde (ve düşük işlem maliyetiyle) canlandırılabilen, kâğıt bebeğe benzeyen küçük bir kahraman karakter sağlar.
+
+Bir *Collision Object*
+: Bu çarpışma nesnesi (collision object), kahraman karakter ile bölümde üzerine koşabileceği, tehlikeli olan veya toplanabilen şeyler arasındaki çarpışmaları algılar.
+
+Bir *Script*
+: Kullanıcı girdisini alıp ona tepki verir, kahraman karakteri zıplatır, canlandırır ve çarpışmaları ele alır.
+
+Vücut parçalarının görüntülerini içe aktararak başlayın; ardından bunları *hero.atlas* adını vereceğimiz yeni bir atlasa ekleyin:
+
+1. *Assets* bölmesine sağ tıklayıp <kbd>New ▸ Folder</kbd> seçeneğini seçerek yeni bir klasör oluşturun. Tıklamadan önce bir klasör seçmediğinizden emin olun; aksi halde yeni klasör, seçili klasörün içinde oluşturulur. Klasöre "hero" adını verin.
+2. *hero* klasörüne sağ tıklayıp <kbd>New ▸ Atlas File</kbd> seçeneğini seçerek yeni bir atlas dosyası oluşturun. Dosyaya *hero.atlas* adını verin.
+3. *hero* klasöründe *images* adlı yeni bir alt klasör oluşturun. *hero* klasörüne sağ tıklayıp <kbd>New ▸ Folder</kbd> seçeneğini seçin.
+4. Varlık paketindeki *hero-images* klasöründe bulunan vücut parçası görüntülerini, *Assets* bölmesinde az önce oluşturduğunuz *images* klasörüne sürükleyin.
+5. *hero.atlas* dosyasını açın, *Outline* görünümündeki kök düğüme sağ tıklayıp <kbd>Add Images</kbd> seçeneğini seçin. Bütün vücut parçası görüntülerini seçip *OK* düğmesine tıklayın.
+6. Atlas dosyasını kaydedin.
+
+![Kahraman atlası](images/runner/2/hero_atlas.png)
+
+Spine animasyon verilerini de içe aktarıp bunlar için bir *Spine Scene* hazırlamamız gerekir:
+
+1. *hero.spinejson* dosyasını (varlık paketine dahildir) *Assets* bölmesindeki *hero* klasörüne sürükleyin.
+2. Bir *Spine Scene* dosyası oluşturun. *hero* klasörüne sağ tıklayıp <kbd>New ▸ Spine Scene File</kbd> seçeneğini seçin. Dosyaya *hero.spinescene* adını verin.
+3. *Spine Scene* dosyasını açıp düzenlemek için yeni dosyaya çift tıklayın.
+4. *spine_json* özelliğini, içe aktarılan *hero.spinejson* JSON dosyasına ayarlayın. Özelliğe tıklayın, ardından kaynak tarayıcısını açmak için *...* dosya seçici düğmesine tıklayın.
+5. *atlas* özelliğini, *hero.atlas* dosyasına başvuracak şekilde ayarlayın.
+6. Dosyayı kaydedin.
+
+![Kahramanın Spine sahnesi](images/runner/2/hero_spinescene.png)
+
+::: sidenote
+*hero.spinejson* dosyası Spine JSON biçiminde dışa aktarılmıştır. Bu tür dosyalar oluşturabilmek için Spine animasyon yazılımına ihtiyacınız vardır. Başka bir animasyon yazılımı kullanmak istiyorsanız animasyonlarınızı sprite sayfaları olarak dışa aktarabilir ve bunları *Tile Source* veya *Atlas* kaynaklarından kare dizisi animasyonları (flip-book animation) olarak kullanabilirsiniz. Daha fazla bilgi için [Animasyon](/manuals/animation) kılavuzuna bakın.
+:::
+
+### Oyun nesnesini oluşturma
+
+Artık kahramanın oyun nesnesini oluşturmaya başlayabiliriz:
+
+1. *hero.go* adlı yeni bir dosya oluşturun (*hero* klasörüne sağ tıklayıp <kbd>New ▸ Game Object File</kbd> seçeneğini seçin).
+2. Oyun nesnesi dosyasını açın.
+3. İçine bir *Spine Model* bileşeni ekleyin. (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin, ardından "Spine Model" seçeneğini seçin.)
+4. Bileşenin *Spine Scene* özelliğini, az önce oluşturduğunuz *hero.spinescene* dosyasına ayarlayın ve varsayılan animasyon olarak "run_right" seçeneğini seçin (animasyonu daha sonra gerektiği gibi düzenleyeceğiz)
+5. Dosyayı kaydedin.
+
+![Spine modeli özellikleri](images/runner/2/spinemodel_properties.png)
+
+Şimdi çarpışmanın çalışması için fizik ekleme zamanı:
+
+1. Kahraman oyun nesnesine bir *Collision Object* bileşeni ekleyin. (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin, ardından "Collision Object" seçeneğini seçin)
+2. Yeni bileşene sağ tıklayıp <kbd>Add Shape</kbd> seçeneğini seçin. Karakterin vücudunu kaplayacak iki şekil ekleyin. Bir küre ve bir kutu yeterli olacaktır.
+3. Şekillere tıklayın ve onları uygun konumlara taşımak için *Move Tool* aracını (<kbd>Scene ▸ Move Tool</kbd>) kullanın.
+4. *Collision Object* bileşenini seçip *Type* özelliğini "Kinematic" olarak ayarlayın.
+
+::: sidenote
+Kinematik çarpışma ("Kinematic"), çarpışmaların algılanmasını istediğimiz, ancak fizik motorunun çarpışmaları otomatik olarak çözmeyeceği ve nesnelerin simülasyonunu yapmayacağı anlamına gelir. Fizik motoru birkaç farklı çarpışma nesnesi türünü destekler. Bunlar hakkında daha fazla bilgiyi [Fizik belgelerinde](/manuals/physics) bulabilirsiniz.
+:::
+
+Çarpışma nesnesinin nelerle etkileşime girmesi gerektiğini belirtmemiz önemlidir:
+
+1. *Group* özelliğini "hero" adlı yeni bir çarpışma grubuna ayarlayın.
+2. *Mask* özelliğini, bu çarpışma nesnesinin çarpışmalarını algılayacağı diğer grup olan "geometry" olarak ayarlayın. "geometry" grubunun henüz var olmadığını, ancak yakında bu gruba ait çarpışma nesneleri ekleyeceğimizi unutmayın.
+
+Son olarak yeni bir *hero.script* dosyası oluşturup oyun nesnesine ekleyin.
+
+1. *Assets* bölmesindeki *hero* klasörüne sağ tıklayıp <kbd>New ▸ Script File</kbd> seçeneğini seçin. Yeni dosyaya *hero.script* adını verin.
+2. Yeni dosyayı açın, ardından aşağıdaki kodu betik dosyasına kopyalayıp yapıştırın ve kaydedin. (Kahramanın çarpışma şeklini çarpıştığı nesneden ayıran çözücü dışında kod oldukça basittir. Bu işlemi `handle_geometry_contact()` işlevi yapar.)
+
+![Kahraman oyun nesnesi](images/runner/2/hero_game_object.png)
+
+::: sidenote
+Çarpışmayı kendimiz ele almamızın nedeni şudur: karakterin çarpışma nesnesinin türünü dinamik olarak ayarlasaydık motor, ilgili cisimler için Newton mekaniğine dayalı bir simülasyon yapardı. Bunun gibi bir oyunda böyle bir simülasyon en uygun çözüm olmaktan uzaktır; bu nedenle çeşitli kuvvetlerle fizik motoruyla uğraşmak yerine kontrolü tamamen ele alıyoruz.
+
+Bunu yapmak ve çarpışmaları doğru biçimde ele almak için biraz vektör matematiği gerekir. Kinematik çarpışmaların nasıl çözüleceğine ilişkin ayrıntılı bir açıklama [Fizik belgelerinde](/manuals/physics-resolving-collisions/) bulunur.
+:::
+
+```lua
+-- gravity pulling the player down in pixel units/sˆ2
+local gravity = -20
+
+-- take-off speed when jumping in pixel units/s
+local jump_takeoff_speed = 900
+
+function init(self)
+    -- this tells the engine to send input to on_input() in this script
+    msg.post(".", "acquire_input_focus")
+
+    -- save the starting position
+    self.position = go.get_position()
+
+    -- keep track of movement vector and if there is ground contact
+    self.velocity = vmath.vector3(0, 0, 0)
+    self.ground_contact = false
+end
+
+function final(self)
+    -- Return input focus when the object is deleted
+    msg.post(".", "release_input_focus")
+end
+
+function update(self, dt)
+    local gravity = vmath.vector3(0, gravity, 0)
+
+    if not self.ground_contact then
+        -- Apply gravity if there's no ground contact
+        self.velocity = self.velocity + gravity
+    end
+
+    -- apply velocity to the player character
+    go.set_position(go.get_position() + self.velocity * dt)
+
+    -- reset volatile state
+    self.correction = vmath.vector3()
+    self.ground_contact = false
+end
+
+local function handle_geometry_contact(self, normal, distance)
+    -- project the correction vector onto the contact normal
+    -- (the correction vector is the 0-vector for the first contact point)
+    local proj = vmath.dot(self.correction, normal)
+    -- calculate the compensation we need to make for this contact point
+    local comp = (distance - proj) * normal
+    -- add it to the correction vector
+    self.correction = self.correction + comp
+    -- apply the compensation to the player character
+    go.set_position(go.get_position() + comp)
+    -- check if the normal points enough up to consider the player standing on the ground
+    -- (0.7 is roughly equal to 45 degrees deviation from pure vertical direction)
+    if normal.y > 0.7 then
+        self.ground_contact = true
+    end
+    -- project the velocity onto the normal
+    proj = vmath.dot(self.velocity, normal)
+    -- if the projection is negative, it means that some of the velocity points towards the contact point
+    if proj < 0 then
+        -- remove that component in that case
+        self.velocity = self.velocity - proj * normal
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("contact_point_response") then
+        -- check if we received a contact point message. One message for each contact point
+        if message.group == hash("geometry") then
+            handle_geometry_contact(self, message.normal, message.distance)
+        end
+    end
+end
+
+local function jump(self)
+    -- only allow jump from ground
+    if self.ground_contact then
+        -- set take-off speed
+        self.velocity.y = jump_takeoff_speed
+    end
+end
+
+local function abort_jump(self)
+    -- cut the jump short if we are still going up
+    if self.velocity.y > 0 then
+        -- scale down the upwards speed
+        self.velocity.y = self.velocity.y * 0.5
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("jump") or action_id == hash("touch") then
+        if action.pressed then
+            jump(self)
+        elseif action.released then
+            abort_jump(self)
+        end
+    end
+end
+```
+
+1. Betiği kahraman nesnesine bir *Script* bileşeni olarak ekleyin (*Outline* görünümünde *hero.go* dosyasının köküne sağ tıklayıp <kbd>Add Component from File</kbd> seçeneğini seçin, ardından *hero.script* dosyasını seçin).
+
+İsterseniz şimdi kahraman karakteri geçici olarak ana koleksiyona ekleyip oyunu çalıştırmayı deneyerek karakterin dünyanın içinden geçip düştüğünü görebilirsiniz.
+
+Kahramanın işlevsel olması için gereken son şey girdidir. Yukarıdaki betik, "jump" ve "touch" (dokunmatik ekranlar için) eylemlerine yanıt veren bir `on_input()` işlevi zaten içerir. Bu eylemler için girdi eşlemeleri (input binding) ekleyelim.
+
+1. "input/game.input_bindings" dosyasını açın
+2. "KEY_SPACE" için bir tuş tetikleyicisi ekleyip eyleme "jump" adını verin
+3. "TOUCH_MULTI" için bir dokunma tetikleyicisi ekleyip eyleme "touch" adını verin. (Eylem adlarını istediğiniz gibi seçebilirsiniz, ancak betiğinizdeki adlarla eşleşmeleri gerekir. Birden çok tetikleyicide aynı eylem adını kullanamayacağınızı unutmayın)
+4. Dosyayı kaydedin.
+
+![Girdi eşlemeleri](images/runner/2/input_bindings.png)
+
+## Adım 5 - Bölümü yeniden yapılandırma
+
+Kahraman karakteri çarpışma dahil her şeyiyle hazırladığımıza göre, çarpışabileceği (veya üzerinde koşabileceği) bir şey olması için zemine de çarpışma eklememiz gerekir. Birazdan bunu yapacağız; ancak önce küçük bir yeniden yapılandırma yapıp bölümle ilgili her şeyi ayrı bir koleksiyona yerleştirelim ve dosya yapısını biraz düzenleyelim:
+
+1. Yeni bir *level.collection* dosyası oluşturun (*Assets* bölmesinde *main* klasörüne sağ tıklayıp <kbd>New ▸ Collection File</kbd> seçeneğini seçin).
+2. Yeni dosyayı açın, *Outline* görünümündeki köke sağ tıklayıp <kbd>Add Collection from File</kbd> seçeneğini seçin ve *ground.collection* dosyasını seçin.
+3. *level.collection* içinde *Outline* görünümündeki köke sağ tıklayıp <kbd>Add Game Object File</kbd> seçeneğini seçin ve *hero.go* dosyasını seçin.
+4. Şimdi proje kökünde *level* adlı yeni bir klasör oluşturun (*game.project* dosyasının altındaki beyaz alana sağ tıklayıp <kbd>New ▸ Folder</kbd> seçeneğini seçin), ardından şimdiye kadar oluşturduğunuz bölüm varlıklarını buraya taşıyın: *level.collection* ve *level.atlas* dosyalarını, bölüm atlasının görüntülerini tutan "images" klasörünü, *ground.collection* ve *ground.script* dosyalarını.
+5. *main.collection* dosyasını açın, *ground.collection* koleksiyonunu silin ve yerine artık *ground.collection* koleksiyonunu içeren *level.collection* koleksiyonunu ekleyin (sağ tıklayıp <kbd>Add Collection from File</kbd> seçeneğini seçin). Koleksiyonu 0, 0, 0 konumuna yerleştirdiğinizden emin olun.
+
+::: sidenote
+Şimdiye kadar fark etmiş olabileceğiniz gibi, *Assets* bölmesinde görünen dosya hiyerarşisi, koleksiyonlarınızda oluşturduğunuz içerik yapısından bağımsızdır. Koleksiyon ve oyun nesnesi dosyalarından tek tek dosyalara başvurulur, ancak bu dosyaların konumları tamamen size bağlıdır.
+
+Bir dosyayı yeni bir konuma taşımak istediğinizde Defold, dosyaya yapılan başvuruları otomatik olarak güncelleyerek (yeniden yapılandırma) yardımcı olur. Oyun gibi karmaşık bir yazılım geliştirirken, proje büyüyüp değiştikçe yapısını değiştirebilmek son derece yararlıdır. Defold bunu destekler ve süreci kolaylaştırır; bu yüzden dosyalarınızı taşımaktan çekinmeyin!
+:::
+
+Bölüm koleksiyonuna, betik bileşeni olan bir denetleyici oyun nesnesi de eklememiz gerekir:
+
+1. Yeni bir betik dosyası oluşturun. *Assets* bölmesindeki *level* klasörüne sağ tıklayıp <kbd>New ▸ Script File</kbd> seçeneğini seçin. Dosyaya *controller.script* adını verin.
+2. Betik dosyasını açın, aşağıdaki kodu içine kopyalayın ve dosyayı kaydedin:
+
+    ```lua
+    -- controller.script
+    go.property("speed", 360) -- <1>
+
+    function init(self)
+        msg.post("ground/controller#ground", "set_speed", { speed = self.speed })
+    end
+    ```
+    1. Bu bir betik özelliğidir. Ona varsayılan bir değer atıyoruz; ancak yerleştirilmiş herhangi bir betik örneği, doğrudan düzenleyicinin özellikler görünümünde bu değeri geçersiz kılabilir.
+
+3. *level.collection* dosyasını açın.
+4. *Outline* görünümündeki köke sağ tıklayıp <kbd>Add Game Object</kbd> seçeneğini seçin.
+5. *Id* değerini "controller" olarak ayarlayın.
+6. *Outline* görünümündeki "controller" oyun nesnesine sağ tıklayıp <kbd>Add Component from File</kbd> seçeneğini seçin ve *level* klasöründeki *controller.script* dosyasını seçin.
+7. Dosyayı kaydedin.
+
+![Betik özelliği](images/runner/2/script_property.png)
+
+::: sidenote
+"controller" oyun nesnesi ayrı bir dosyada bulunmaz; bölüm koleksiyonunda yerinde (in-place) oluşturulur. Bu, oyun nesnesi örneğinin yerinde tanımlanmış verilerden oluşturulduğu anlamına gelir. Bu nesne gibi tek bir amaca hizmet eden oyun nesneleri için bu uygundur. Bir oyun nesnesinin birden çok örneğine ihtiyacınız varsa ve her örneği oluşturmak için kullanılan prototipi/şablonu değiştirebilmek istiyorsanız, bir oyun nesnesi dosyası oluşturup oyun nesnesini dosyadan koleksiyona eklemeniz yeterlidir. Bu işlem, dosyaya prototip/şablon olarak başvuran bir oyun nesnesi oluşturur.
+
+Bu "controller" oyun nesnesinin amacı, çalışan bölümle ilgili her şeyi kontrol etmektir. Yakında bu betik, kahramanın etkileşime gireceği platformları ve paraları oluşturmakla sorumlu olacak; ancak şimdilik yalnızca bölümün süratini ayarlayacaktır.
+:::
+
+Bölüm denetleyicisi betiğinin `init()` işlevi, zemin denetleyicisi nesnesinin betik bileşenine, tanımlayıcısıyla adresleyerek bir ileti gönderir:
+
+```lua
+msg.post("ground/controller#controller", "set_speed", { speed = self.speed })
+```
+
+Denetleyici oyun nesnesi "ground" koleksiyonunda bulunduğundan tanımlayıcısı `"ground/controller"` olarak ayarlanır. Ardından nesne tanımlayıcısını bileşen tanımlayıcısından ayıran `"#"` karakterinden sonra `"controller"` bileşen tanımlayıcısını ekleriz. Zemin betiğinde henüz `set_speed` iletisine tepki verecek kod bulunmadığını unutmayın; bu yüzden *ground.script* dosyasına bir `on_message()` işlevi ve bunun için gereken mantığı eklememiz gerekir.
+
+1. *ground.script* dosyasını açın.
+2. Aşağıdaki kodu ekleyip dosyayı kaydedin:
+
+```lua
+-- ground.script
+function on_message(self, message_id, message, sender)
+    if message_id == hash("set_speed") then -- <1>
+        self.speed = message.speed -- <2>
+    end
+end
+```
+1. Bütün iletilerin gönderildiklerinde dahili olarak karma değerleri alınır ve karşılaştırma karma değeriyle yapılmalıdır.
+2. İleti verisi, iletiyle birlikte gönderilen verileri içeren bir Lua tablosudur.
+
+![Zemin kodunu ekleme](images/runner/insert_ground_code.png)
+
+## Adım 6 - Zemin fiziği ve platformlar
+
+Bu noktada zemine fiziksel çarpışma eklememiz gerekir:
+
+1. *ground.collection* dosyasını açın.
+2. Uygun bir oyun nesnesine yeni bir *Collision Object* bileşeni ekleyin. Zemin betiği çarpışmalara tepki vermediğinden (bu mantığın tamamı kahraman betiğindedir) bileşeni herhangi bir _hareketsiz_ oyun nesnesine koyabiliriz (zemin karolarının nesneleri hareketsiz değildir; bu yüzden onları kullanmayın). "controller" oyun nesnesi uygun bir adaydır, ancak isterseniz bunun için ayrı bir nesne oluşturabilirsiniz. Oyun nesnesine sağ tıklayıp <kbd>Add Component</kbd> seçeneğini, ardından *Collision Object* seçeneğini seçin.
+3. *Collision Object* bileşenine sağ tıklayıp <kbd>Add Shape</kbd> seçeneğini, ardından *Box* seçeneğini seçerek bir kutu şekli ekleyin.
+4. Kutunun bütün zemin karolarını kaplamasını sağlamak için *Move Tool* ve *Scale Tool* araçlarını (<kbd>Scene ▸ Move Tool</kbd> ve <kbd>Scene ▸ Scale Tool</kbd>) kullanın.
+5. Zeminin fizik nesnesi hareket etmeyeceğinden çarpışma nesnesinin *Type* özelliğini "Static" olarak ayarlayın.
+6. Çarpışma nesnesinin *Group* özelliğini "geometry", *Mask* özelliğini ise "hero" olarak ayarlayın. Artık kahramanın çarpışma nesnesi ile bu nesne, aralarındaki çarpışmaları algılayacaktır.
+7. Dosyayı kaydedin.
+
+![Zemin çarpışması](images/runner/2/ground_collision.png)
+
+Artık oyunu çalıştırmayı deneyebilirsiniz (<kbd>Project ▸ Build</kbd>). Kahraman karakterin zeminde koşması ve <kbd>Space</kbd> tuşuyla zıplayabilmesi gerekir. Oyunu mobil cihazda çalıştırırsanız ekrana dokunarak zıplayabilirsiniz.
+
+Oyun dünyamızdaki hayatı biraz daha az sıkıcı hale getirmek için üzerine zıplanacak platformlar eklemeliyiz.
+
+1. Varlık paketindeki *rock_planks.png* görüntü dosyasını *level/images* alt klasörüne sürükleyin.
+2. *level.atlas* dosyasını açıp yeni görüntüyü atlasa ekleyin (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Images</kbd> seçeneğini seçin).
+3. Dosyayı kaydedin.
+4. *level* klasöründe *platform.go* adlı yeni bir *Game Object* dosyası oluşturun. (*Assets* bölmesindeki *level* klasörüne sağ tıklayıp <kbd>New ▸ Game Object File</kbd> seçeneğini seçin.)
+5. Oyun nesnesine bir *Sprite* bileşeni ekleyin (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Component</kbd> seçeneğini, ardından *Sprite* seçeneğini seçin).
+6. *Image* özelliğini *level.atlas* dosyasına başvuracak şekilde ayarlayıp *Default Animation* değerini "rock_planks" yapın. Kolaylık olması için bölüm nesnelerini "level/objects" adlı bir alt klasörde tutun.
+7. Platform oyun nesnesine bir *Collision Object* bileşeni ekleyin (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin).
+8. Bileşenin *Type* değerini "Kinematic", *Group* ve *Mask* değerlerini ise sırasıyla "geometry" ve "hero" olarak ayarladığınızdan emin olun.
+9. *Collision Object* bileşenine bir *Box Shape* ekleyin. (*Outline* görünümündeki bileşene sağ tıklayıp <kbd>Add Shape</kbd> seçeneğini seçin, ardından *Box* seçeneğini seçin).
+10. *Collision Object* bileşenindeki şeklin platformu kaplamasını sağlamak için *Move Tool* ve *Scale Tool* araçlarını (<kbd>Scene ▸ Move Tool</kbd> ve <kbd>Scene ▸ Scale Tool</kbd>) kullanın.
+11. *platform.script* adlı bir *Script* dosyası oluşturun (*Assets* bölmesine sağ tıklayıp <kbd>New ▸ Script File</kbd> seçeneğini seçin) ve aşağıdaki kodu dosyaya yerleştirip kaydedin:
+
+    ```lua
+    -- platform.script
+    function init(self)
+        self.speed = 540      -- Default speed in pixels/s
+    end
+
+    function update(self, dt)
+        local pos = go.get_position()
+        if pos.x < -500 then
+            go.delete() -- <1>
+        end
+        pos.x = pos.x - self.speed * dt
+        go.set_position(pos)
+    end
+
+    function on_message(self, message_id, message, sender)
+        if message_id == hash("set_speed") then
+            self.speed = message.speed
+        end
+    end
+    ```
+    1. Platform ekranın sağ kenarının dışına taşındığında onu silmeniz yeterlidir
+
+12. *platform.go* dosyasını açıp yeni betiği bir bileşen olarak ekleyin (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Component From File</kbd> seçeneğini seçin ve *platform.script* dosyasını seçin).
+13. *platform.go* dosyasını yeni bir dosyaya kopyalayın (*Assets* bölmesindeki dosyaya sağ tıklayıp <kbd>Copy</kbd> seçeneğini seçin, ardından tekrar sağ tıklayıp <kbd>Paste</kbd> seçeneğini seçin) ve yeni dosyaya *platform_long.go* adını verin.
+14. *platform_long.go* dosyasını açıp ikinci bir *Sprite* bileşeni ekleyin (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin). Alternatif olarak mevcut *Sprite* bileşenini kopyalayabilirsiniz.
+15. *Sprite* bileşenlerini yan yana yerleştirmek için *Move Tool* aracını (<kbd>Scene ▸ Move Tool</kbd>) kullanın.
+16. *Collision Object* bileşenindeki şeklin her iki platformu da kaplamasını sağlamak için *Move Tool* ve *Scale Tool* araçlarını kullanın.
+
+![Platform](images/runner/2/platform_long.png)
+
+::: sidenote
+Hem *platform.go* hem de *platform_long.go* dosyasının aynı betik dosyasına başvuran *Script* bileşenleri bulunduğunu unutmayın. Bu iyi bir durumdur; çünkü betik dosyasında yaptığımız her değişiklik hem normal hem de uzun platformların davranışını etkileyecektir.
+:::
+
+## Çalışma sırasında platform oluşturma
+
+Oyunun fikri, basit bir sonsuz koşu oyunu olmasıdır. Bu, platform oyun nesnelerinin düzenleyicide bir koleksiyona yerleştirilemeyeceği anlamına gelir. Onları çalışma sırasında dinamik olarak oluşturmamız gerekir:
+
+1. *level.collection* dosyasını açın.
+2. "controller" oyun nesnesine iki *Factory* bileşeni ekleyin (nesneye sağ tıklayıp <kbd>Add Component</kbd> seçeneğini, ardından *Factory* seçeneğini seçin)
+3. Bileşenlerin *Id* özelliklerini "platform_factory" ve "platform_long_factory" olarak ayarlayın.
+4. "platform_factory" bileşeninin *Prototype* özelliğini */level/objects/platform.go* dosyasına ayarlayın.
+5. "platform_long_factory" bileşeninin *Prototype* özelliğini */level/objects/platform_long.go* dosyasına ayarlayın.
+6. Dosyayı kaydedin.
+7. Bölümü yöneten *controller.script* dosyasını açın.
+8. Betiği aşağıdaki içeriğe sahip olacak şekilde değiştirin ve dosyayı kaydedin:
+
+```lua
+-- controller.script
+go.property("speed", 360)
+
+local grid = 460
+local platform_heights = { 100, 200, 350 } -- <1>
+
+function init(self)
+    msg.post("ground/controller#controller", "set_speed", { speed = self.speed })
+    self.gridw = 0
+end
+
+function update(self, dt) -- <2>
+    self.gridw = self.gridw + self.speed * dt
+
+    if self.gridw >= grid then
+        self.gridw = 0
+
+        -- Maybe spawn a platform at random height
+        if math.random() > 0.2 then
+            local h = platform_heights[math.random(#platform_heights)]
+            local f = "#platform_factory"
+            if math.random() > 0.5 then
+                f = "#platform_long_factory"
+            end
+
+            local p = factory.create(f, vmath.vector3(1600, h, 0), nil, {}, vmath.vector3(0.6, 0.6, 1))
+            msg.post(p, "set_speed", { speed = self.speed })
+        end
+    end
+end
+```
+1. Platformların oluşturulacağı Y konumu için önceden tanımlanmış değerler.
+2. `update()` işlevi her karede bir kez çağrılır; bunu, belirli aralıklarla (üst üste binmeyi önlemek için) ve yüksekliklerde normal veya uzun bir platform oluşturup oluşturmayacağımıza karar vermek için kullanırız. Farklı oynanışlar oluşturmak için çeşitli oluşturma algoritmalarını denemek kolaydır.
+
+Şimdi oyunu çalıştırın (<kbd>Project ▸ Build</kbd>).
+
+Vay canına, bu (neredeyse) oynanabilir bir şeye dönüşmeye başlıyor...
+
+![Oyunu çalıştırma](images/runner/2/run_game.png)
+
+## Adım 7 - Animasyon ve ölüm
+
+İlk yapacağımız şey, kahraman karaktere hayat vermek. Şu anda zavallı karakter bir koşu döngüsüne takılıp kalmış durumda; zıplamalara veya başka şeylere iyi tepki vermiyor. Varlık paketinden eklediğimiz Spine dosyası aslında tam da bunun için bir dizi animasyon içeriyor.
+
+1. *hero.script* dosyasını açın ve aşağıdaki işlevleri mevcut `update()` işlevinden _önce_ ekleyin:
+
+```lua
+    -- hero.script
+    local function play_animation(self, anim)
+        -- only play animations which are not already playing
+        if self.anim ~= anim then
+            -- tell the spine model to play the animation
+            local anim_props = { blend_duration = 0.15 }
+            spine.play_anim("#spinemodel", anim, go.PLAYBACK_LOOP_FORWARD, anim_props)
+            -- remember which animation is playing
+            self.anim = anim
+        end
+    end
+
+    local function update_animation(self)
+        -- make sure the right animation is playing
+        if self.ground_contact then
+            play_animation(self, hash("run"))
+        else
+            play_animation(self, hash("jump"))
+
+        end
+    end
+```
+
+2. `update()` işlevini bulup bir `update_animation` çağrısı ekleyin:
+
+```lua
+    ...
+    -- apply it to the player character
+    go.set_position(go.get_position() + self.velocity * dt)
+
+    update_animation(self)
+    ...
+  ```
+
+![Kahraman kodunu ekleme](images/runner/insert_hero_code.png)
+
+::: sidenote
+Lua'da yerel değişkenler için "sözcüksel kapsam" (lexical scope) vardır ve `local` işlevleri yerleştirdiğiniz sıra önemlidir. `update()` işlevi, yerel `update_animation()` ve `play_animation()` işlevlerini çağırır; yani çalışma zamanı ortamının bu yerel işlevleri çağırabilmesi için onları önceden görmüş olması gerekir. Bu yüzden işlevleri `update()` işlevinden önce koymalıyız. İşlevlerin sırasını değiştirirseniz hata alırsınız. Bunun yalnızca `local` değişkenler için geçerli olduğunu unutmayın. Lua'nın kapsam kuralları ve yerel işlevler hakkında daha fazla bilgiyi http://www.lua.org/pil/6.2.html adresinde bulabilirsiniz
+:::
+
+Kahramana zıplama ve düşme animasyonları eklemek için gerekenlerin hepsi bu kadar. Oyunu çalıştırırsanız oynamanın çok daha iyi hissettirdiğini fark edeceksiniz. Ne yazık ki platformların kahramanı ekranın dışına itebildiğini de fark edebilirsiniz. Bu, çarpışmaların ele alınışının bir yan etkisidir; ancak çözümü kolaydır: biraz şiddet ekleyip platformların kenarlarını tehlikeli hale getirin!
+
+1. Varlık paketindeki *spikes.png* dosyasını *Assets* bölmesindeki "level/images" klasörüne sürükleyin.
+2. *level.atlas* dosyasını açıp görüntüyü ekleyin (sağ tıklayıp <kbd>Add Images</kbd> seçeneğini seçin).
+3. *platform.go* dosyasını açıp birkaç *Sprite* bileşeni ekleyin. *Image* değerini *level.atlas*, *Default Animation* değerini ise "spikes" olarak ayarlayın.
+4. Dikenleri platformun kenarlarına yerleştirmek için *Move Tool* ve *Rotate Tool* araçlarını kullanın.
+5. Dikenlerin platformun arkasında işlenmesini sağlamak için diken sprite bileşenlerinin *Z* konumunu -0.1 olarak ayarlayın.
+6. Platformlara yeni bir *Collision Object* bileşeni ekleyin (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin). *Group* özelliğini "danger" olarak ayarlayın. *Mask* değerini de "hero" yapın.
+7. *Collision Object* bileşenine bir kutu şekli ekleyin (sağ tıklayıp <kbd>Add Shape</kbd> seçeneğini seçin). *Move Tool* (<kbd>Scene ▸ Move Tool</kbd>) ve *Scale Tool* araçlarını kullanarak şekli, kahraman karakter platforma yandan veya alttan çarptığında "danger" nesnesiyle çarpışacak biçimde yerleştirin.
+8. Dosyayı kaydedin.
+
+    ![Platform dikenleri](images/runner/3/danger_edges.png)
+
+9. *hero.go* dosyasını açın, *Collision Object* bileşenini seçip *Mask* özelliğine "danger" adını ekleyin. Ardından dosyayı kaydedin.
+
+    ![Kahraman çarpışması](images/runner/3/hero_collision.png)
+
+10. *hero.script* dosyasını açın ve kahraman karakter bir "danger" kenarına çarptığında tepki alabilmek için `on_message()` işlevini değiştirin:
+
+    ```lua
+    -- hero.script
+    function on_message(self, message_id, message, sender)
+        if message_id == hash("reset") then
+            self.velocity = vmath.vector3(0, 0, 0)
+            self.correction = vmath.vector3()
+            self.ground_contact = false
+            self.anim = nil
+            go.set(".", "euler.z", 0)
+            go.set_position(self.position)
+            msg.post("#collisionobject", "enable")
+
+        elseif message_id == hash("contact_point_response") then
+            -- check if we received a contact point message
+            if message.group == hash("danger") then
+                -- Die and restart
+                play_animation(self, hash("death"))
+                msg.post("#collisionobject", "disable")
+                -- <1>
+                go.animate(".", "euler.z", go.PLAYBACK_ONCE_FORWARD, 160, go.EASING_LINEAR, 0.7)
+                go.animate(".", "position.y", go.PLAYBACK_ONCE_FORWARD, go.get_position().y - 200, go.EASING_INSINE, 0.5, 0.2,
+                    function()
+                        msg.post("#", "reset")
+                    end)
+            elseif message.group == hash("geometry") then
+                handle_geometry_contact(self, message.normal, message.distance)
+            end
+        end
+    end
+    ```
+    1. Kahraman ölürken dönme ve düşme hareketi ekleyin. Bu çok daha iyi hale getirilebilir!
+
+11. Nesnenin başlangıç işlemlerini yapmak için `init()` işlevini bir "reset" iletisi gönderecek şekilde değiştirin, ardından dosyayı kaydedin:
+
+    ```lua
+    -- hero.script
+    function init(self)
+        -- this lets us handle input in this script
+        msg.post(".", "acquire_input_focus")
+        -- save position
+        self.position = go.get_position()
+        msg.post("#", "reset")
+    end
+    ```
+
+## Adım 8 - Bölümü sıfırlama
+
+Oyunu şimdi denerseniz sıfırlama mekanizmasının çalışmadığı hemen anlaşılır. Kahraman doğru biçimde sıfırlanır; ancak sıfırlama sizi anında bir platform kenarına düşüp yeniden öldüğünüz bir duruma kolayca sokabilir. İstediğimiz, ölüm gerçekleştiğinde bütün bölümü düzgün biçimde sıfırlamaktır. Bölüm yalnızca çalışma sırasında oluşturulan bir dizi platformdan oluştuğu için, oluşturulan bütün platformları takip edip sıfırlama sırasında silmemiz yeterlidir:
+
+1. *controller.script* dosyasını açıp oluşturulan bütün platformların tanımlayıcılarını saklayacak şekilde kodu düzenleyin:
+
+    ```lua
+    -- controller.script
+    go.property("speed", 360)
+
+    local grid = 460
+    local platform_heights = { 100, 200, 350 }
+
+    function init(self)
+        msg.post("ground/controller#controller", "set_speed", { speed = self.speed })
+        self.gridw = 0
+        self.spawns = {} -- <1>
+    end
+
+    function update(self, dt)
+        self.gridw = self.gridw + self.speed * dt
+
+        if self.gridw >= grid then
+            self.gridw = 0
+
+            -- Maybe spawn a platform at random height
+            if math.random() > 0.2 then
+                local h = platform_heights[math.random(#platform_heights)]
+                local f = "#platform_factory"
+                if math.random() > 0.5 then
+                    f = "#platform_long_factory"
+                end
+
+                local p = factory.create(f, vmath.vector3(1600, h, 0), nil, {}, vmath.vector3(0.6, 0.6, 1))
+                msg.post(p, "set_speed", { speed = self.speed })
+                table.insert(self.spawns, p) -- <1>
+            end
+        end
+    end
+
+    function on_message(self, message_id, message, sender)
+        if message_id == hash("reset") then -- <2>
+            -- Tell the hero to reset.
+            msg.post("hero#hero", "reset")
+            -- Delete all platforms
+            for i,p in ipairs(self.spawns) do
+                go.delete(p)
+            end
+            self.spawns = {}
+        elseif message_id == hash("delete_spawn") then -- <3>
+            for i,p in ipairs(self.spawns) do
+                if p == message.id then
+                    table.remove(self.spawns, i)
+                    go.delete(p)
+                end
+            end
+        end
+    end
+    ```
+    1. Oluşturulan bütün platformları saklamak için bir tablo kullanıyoruz
+    2. "reset" iletisi, tabloda saklanan bütün platformları siler
+    3. "delete_spawn" iletisi, belirli bir platformu silip tablodan kaldırır
+
+2. Dosyayı kaydedin.
+3. *platform.script* dosyasını açıp en sol kenara ulaşan bir platformu yalnızca silmek yerine, bölüm denetleyicisine platformun kaldırılmasını isteyen bir ileti gönderecek şekilde değiştirin:
+
+    ```lua
+    -- platform.script
+    ...
+    if pos.x < -500 then
+        msg.post("/level/controller#controller", "delete_spawn", { id = go.get_id() })
+    end
+    ...
+    ```
+
+    ![Platform kodunu ekleme](images/runner/insert_platform_code.png)
+
+4. Dosyayı kaydedin.
+5. *hero.script* dosyasını açın. Şimdi yapmamız gereken son şey, bölüme sıfırlama yapmasını söylemektir. Kahramanın sıfırlanmasını isteyen iletiyi bölüm denetleyicisinin betiğine taşıdık. Sıfırlama kontrolünü bu şekilde merkezîleştirmek mantıklıdır; çünkü örneğin daha uzun süreli bir ölüm dizisi eklememizi kolaylaştırır:
+
+```lua
+-- hero.script
+...
+go.animate(".", "position.y", go.PLAYBACK_ONCE_FORWARD, go.get_position().y - 200, go.EASING_INSINE, 0.5, 0.2,
+    function()
+        msg.post("controller#controller", "reset")
+    end)
+...
+```
+
+![Kahraman kodunu ekleme](images/runner/insert_hero_code_2.png)
+
+Artık temel yeniden başlama ve ölme döngüsü hazır!
+
+Sırada uğruna yaşayacak bir şey var: paralar!
+
+## Adım 9 - Toplanacak paralar
+
+Fikir, oyuncunun toplaması için bölüme paralar yerleştirmektir. İlk sorulması gereken, bunları bölüme nasıl yerleştireceğimizdir. Örneğin platform oluşturma algoritmasıyla bir şekilde uyumlu bir oluşturma düzeni geliştirebiliriz. Ancak sonunda çok daha kolay bir yaklaşım seçtik ve paraları platformların kendisinin oluşturmasını sağladık:
+
+1. Varlık paketindeki *coin.png* görüntüsünü *Assets* bölmesindeki "level/images" klasörüne sürükleyin.
+2. *level.atlas* dosyasını açıp görüntüyü ekleyin (sağ tıklayıp <kbd>Add Images</kbd> seçeneğini seçin).
+3. *level* klasöründe *coin.go* adlı bir *Game Object* dosyası oluşturun (*Assets* bölmesindeki *level* klasörüne sağ tıklayıp <kbd>New ▸ Game Object File</kbd> seçeneğini seçin).
+4. *coin.go* dosyasını açıp bir *Sprite* bileşeni ekleyin (*Outline* görünümünde sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin). *Image* değerini *level.atlas*, *Default Animation* değerini ise "coin" olarak ayarlayın.
+5. Bir *Collision Object* ekleyin (*Outline* görünümünde sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin)
+ve görüntüyü kaplayan bir *Sphere* şekli ekleyin (bileşene sağ tıklayıp <kbd>Add Shape</kbd> seçeneğini seçin).
+6. Kürenin para görüntüsünü kaplamasını sağlamak için *Move Tool* (<kbd>Scene ▸ Move Tool</kbd>) ve *Scale Tool* araçlarını kullanın.
+7. Çarpışma nesnesinin *Type* değerini "Kinematic", *Group* değerini "pickup" ve *Mask* değerini "hero" olarak ayarlayın.
+8. *hero.go* dosyasını açın ve *Collision Object* bileşeninin *Mask* özelliğine "pickup" ekleyin, ardından dosyayı kaydedin.
+9. *coin.script* adlı yeni bir betik dosyası oluşturun (*Assets* bölmesindeki *level* klasörüne sağ tıklayıp <kbd>New ▸ Script File</kbd> seçeneğini seçin). Şablon kodunu aşağıdakiyle değiştirin:
+
+    ```lua
+    -- coin.script
+    function init(self)
+        self.collected = false
+    end
+
+    function on_message(self, message_id, message, sender)
+        if self.collected == false and message_id == hash("collision_response") then
+            self.collected = true
+            msg.post("#sprite", "disable")
+        elseif message_id == hash("start_animation") then
+            pos = go.get_position()
+            go.animate(go.get_id(), "position.y", go.PLAYBACK_LOOP_PINGPONG, pos.y + 24, go.EASING_INOUTSINE, 0.75, message.delay)
+        end
+    end
+    ```
+
+10. Betik dosyasını para nesnesine bir *Script* bileşeni olarak ekleyin (*Outline* görünümündeki köke sağ tıklayıp <kbd>Add Component from File</kbd> seçeneğini seçin).
+
+    ![Para oyun nesnesi](images/runner/3/coin.png)
+
+Plan, paraları platform nesnelerinden oluşturmaktır; bu yüzden *platform.go* ve *platform_long.go* dosyalarına paralar için fabrikalar yerleştirin.
+
+1. *platform.go* dosyasını açıp bir *Factory* bileşeni ekleyin (*Outline* görünümünde sağ tıklayıp <kbd>Add Component</kbd> seçeneğini seçin).
+2. *Factory* bileşeninin *Id* değerini "coin_factory", *Prototype* değerini ise *coin.go* dosyası olarak ayarlayın.
+3. Şimdi *platform_long.go* dosyasını açıp aynı özelliklere sahip bir *Factory* bileşeni oluşturun.
+4. Her iki dosyayı kaydedin.
+
+![Para fabrikası](images/runner/3/coin_factory.png)
+
+Şimdi *platform.script* dosyasını, paraları oluşturup silecek şekilde değiştirmemiz gerekir:
+
+```lua
+-- platform.script
+function init(self)
+    self.speed = 540     -- Default speed in pixels/s
+    self.coins = {}
+end
+
+function final(self)
+    for i,p in ipairs(self.coins) do
+        go.delete(p)
+    end
+end
+
+function update(self, dt)
+    local pos = go.get_position()
+    if pos.x < -500 then
+        msg.post("/level/controller#controller", "delete_spawn", { id = go.get_id() })
+    end
+    pos.x = pos.x - self.speed * dt
+    go.set_position(pos)
+end
+
+function create_coins(self, params)
+    local spacing = 56
+    local pos = go.get_position()
+    local x = pos.x - params.coins * (spacing*0.5) - 24
+    for i = 1, params.coins do
+        local coin = factory.create("#coin_factory", vmath.vector3(x + i * spacing , pos.y + 64, 1))
+        msg.post(coin, "set_parent", { parent_id = go.get_id() }) -- <1>
+        msg.post(coin, "start_animation", { delay = i/10 }) -- <2>
+        table.insert(self.coins, coin)
+    end
+end
+
+function on_message(self, message_id, message, sender)
+    if message_id == hash("set_speed") then
+        self.speed = message.speed
+    elseif message_id == hash("create_coins") then
+        create_coins(self, message)
+    end
+end
+```
+1. Oluşturulan paranın üst nesnesini (parent) platform olarak ayarlarsanız para platformla birlikte hareket eder.
+2. Animasyon, paraların artık üst nesneleri olan platforma göre yukarı aşağı dans etmesini sağlar.
+
+::: sidenote
+Üst-alt nesne ilişkileri yalnızca _sahne grafını_ (scene graph) değiştirir. Alt nesne (child), üst nesnesiyle birlikte dönüşüme uğrar (taşınır, ölçeklenir veya döndürülür). Oyun nesneleri arasında ek "sahiplik" ilişkilerine ihtiyacınız varsa bunları kodda ayrıca takip etmeniz gerekir.
+:::
+
+Bu öğreticinin son adımı, *controller.script* dosyasına birkaç satır eklemektir:
+
+```lua
+-- controller.script
+...
+local platform_heights = { 100, 200, 350 }
+local coins = 3 -- <1>
+...
+```
+1. Normal bir platformda oluşturulacak para sayısı.
+
+```lua
+-- controller.script
+...
+local coins = coins
+if math.random() > 0.5 then
+    f = "#platform_long_factory"
+    coins = coins * 2 -- Twice the number of coins on long platforms
+end
+...
+```
+
+```lua
+-- controller.script
+...
+msg.post(p, "set_speed", { speed = self.speed })
+msg.post(p, "create_coins", { coins = coins })
+table.insert(self.spawns, p)
+...
+```
+
+![Denetleyici kodunu ekleme](images/runner/insert_controller_code.png)
+
+Artık basit ama işlevsel bir oyunumuz var! Buraya kadar geldiyseniz kendi başınıza devam edip şunları eklemek isteyebilirsiniz:
+
+1. Puan ve can sayaçları
+2. Nesne toplama ve ölüm için parçacık efektleri
+3. Güzel arka plan görüntüleri
+
+> Projenin tamamlanmış sürümünü [buradan](images/runner/sample-runner.zip) indirin
+
+Bu giriş öğreticisi burada sona eriyor. Şimdi Defold'u keşfetmeye devam edin. Size yol göstermek için hazırladığımız pek çok [kılavuz ve öğretici](//www.defold.com/learn) var; takılırsanız [foruma](//forum.defold.com) bekleriz.
+
+Defold ile iyi çalışmalar!

--- a/docs/tr/tutorials/shadertoy.md
+++ b/docs/tr/tutorials/shadertoy.md
@@ -1,0 +1,340 @@
+---
+brief: Bu öğreticide shadertoy.com sitesindeki bir gölgelendiriciyi Defold için dönüştüreceksiniz.
+layout: tutorial
+locale: tr
+title: Shadertoy'dan Defold'a dönüştürme öğreticisi
+---
+
+# Shadertoy öğreticisi
+
+[Shadertoy.com](https://www.shadertoy.com/), kullanıcıların katkıda bulunduğu GL gölgelendiricilerini (shader) bir araya getiren bir sitedir. Gölgelendirici kodu bulmak ve ilham almak için harika bir kaynaktır. Bu öğreticide Shadertoy'dan bir gölgelendirici alıp Defold'da çalışır hâle getireceğiz. Gölgelendiriciler hakkında temel bilgiye sahip olduğunuz varsayılır. Konuyu öğrenmeniz gerekiyorsa [Gölgelendirici kılavuzu](/manuals/shader/) iyi bir başlangıç noktasıdır.
+
+Kullanacağımız gölgelendirici, Pablo Andrioli tarafından (Shadertoy'daki kullanıcı adı "Kali") oluşturulan [Star Nest](https://www.shadertoy.com/view/XlfGRj). Tamamen prosedürel çalışan, matematiği kara büyüyü andıran bir parça gölgelendiricisidir (fragment shader); işleme (rendering) yoluyla gerçekten etkileyici bir yıldız alanı efekti oluşturur.
+
+![Star Nest](../images/shadertoy/starnest.png)
+
+Gölgelendirici, oldukça karmaşık yalnızca 65 satırlık GLSL kodundan oluşuyor; ancak endişelenmeyin. Onu, birkaç basit girdiye göre işini yapan bir kara kutu olarak ele alacağız. Buradaki işimiz, gölgelendiriciyi Shadertoy yerine Defold ile iletişim kuracak şekilde değiştirmek.
+
+## Doku uygulanacak bir nesne
+
+Star Nest gölgelendiricisi yalnızca bir parça gölgelendiricisidir; bu nedenle gölgelendiricinin doku (texture) uygulayacağı bir nesneye ihtiyacımız var. Bunun için birkaç seçenek bulunur: bir sprite bileşeni, karo haritası (tilemap), GUI veya model. Bu öğreticide basit bir 3B model kullanacağız. Bunun nedeni, modelin işlenmesini kolayca tam ekran efektine dönüştürebilmemizdir---örneğin görsel son işleme yapmak istiyorsak buna ihtiyacımız olur.
+
+Boş bir projeyle başlayabiliriz.
+
+1. Defold'u açın ve Create From bölümünde *Templates* seçeneğini seçin.
+2. *Empty Project* seçeneğini seçin.
+3. *Title* değerini ayarlayın ve diskinizdeki *Location* konumunu seçin.
+4. <kbd>Create New Project</kbd> düğmesine tıklayın.
+
+![başlangıç](../images/shadertoy/empty_project.png)
+
+`builtins/assets/meshes` içindeki yerleşik `quad.gltf` örgüsünü (mesh) kullanabilirsiniz.
+
+İsteğe bağlı olarak Blender'da veya başka bir 3B modelleme programında kare bir düzlem örgüsü de oluşturabilirsiniz --- kolaylık olması için 4 köşenin koordinatları X ekseninde -1 ve 1, Y ekseninde ise -1 ve 1 olacak şekilde ayarlanır. Blender'da Z ekseni varsayılan olarak yukarı yönlüdür; bu nedenle örgüyü X ekseni etrafında 90° döndürmeniz gerekir. Ayrıca örgü için doğru UV koordinatları oluşturduğunuzdan emin olmalısınız. Blender'da örgü seçiliyken *Edit Mode* moduna geçin, ardından <kbd>Mesh ▸ UV unwrap... ▸ Unwrap</kbd> seçeneğini seçin.
+
+<div class='sidenote' markdown='1'>
+Blender, [blender.org](https://www.blender.org) adresinden indirilebilen ücretsiz ve açık kaynaklı bir 3B yazılımıdır.
+</div>
+
+![Blender'da dörtgen](../images/shadertoy/quad_blender.png)
+
+1. Defold'da "main.collection" dosyanızı açın ve "star-nest" adlı yeni bir oyun nesnesi (game object) oluşturun.
+2. "star-nest" oyun nesnesine bir *Model* bileşeni (component) ekleyin.
+3. *Mesh* özelliğini `quad.gltf` olarak ayarlayın.
+4. Modelin materyalini (material) ayarlamamız gerekiyor; şimdilik yerleşik `model.material` dosyasını seçin.
+
+Model sahne düzenleyicisinde görünmelidir, ancak tamamen siyah işlenir. Bunun nedeni, henüz bir dokusunun ayarlanmamış olmasıdır:
+
+![Defold'da dörtgen](../images/shadertoy/quad_default_material.png)
+
+## Materyali oluşturma
+
+1. `Assets` bölmesindeki `main` klasörüne <kbd>Right Mouse Button</kbd> ile tıklayıp <kbd>New</kbd>-><kbd>Material</kbd> seçeneğini seçin ve `star-nest` adını vererek yeni bir *`star-nest.material`* materyal dosyası oluşturun.
+
+ ![materyal](../images/shadertoy/new_material.png)
+
+2. Aynı şekilde `star-nest.vp` adlı bir köşe gölgelendiricisi (vertex shader) programı ve `star-nest.fp` adlı bir parça gölgelendiricisi programı oluşturun:
+3. *star-nest.material* dosyasını açın.
+4. *Vertex Program* değerini `star-nest.vp` olarak ayarlayın.
+5. *Fragment Program* değerini `star-nest.fp` olarak ayarlayın.
+6. Bir *Vertex Constant* ekleyin ve adını "`view_proj`", türünü de `Viewproj` ("görünüm izdüşümü" için) olarak ayarlayın.
+8. *Tags* bölümüne "tile" etiketini ekleyin. Böylece dörtgen, sprite bileşenleri ve karolar çizilirken yapılan işleme geçişine dahil edilir.
+
+ ![materyal](../images/shadertoy/material.png)
+
+### Köşe programı
+
+1. `star-nest.vp` köşe gölgelendiricisi program dosyasını açın. Aşağıdaki kodu içermelidir:
+
+    ```glsl
+    #version 140
+
+    // positions are in world space
+    in vec4 position;
+    in vec2 texcoord0;
+
+    out vec2 var_texcoord0;
+
+    uniform vertex_inputs
+    {
+        mat4 view_proj;
+    };
+
+    void main()
+    {
+        gl_Position = view_proj * vec4(position.xyz, 1.0);
+        var_texcoord0 = texcoord0;
+    }
+    ```
+
+### Parça programı
+
+1. `star-nest.fp` parça gölgelendiricisi program dosyasını açın ve kodu, parça rengi UV koordinatlarının (`var_texcoord0`) X ve Y koordinatlarına göre ayarlanacak şekilde değiştirin. Bunu, modeli doğru kurduğumuzdan emin olmak için yapıyoruz:
+
+    ```glsl
+    #version 140
+
+    in vec2 var_texcoord0;
+
+    out vec4 out_fragColor;
+
+    void main()
+    {
+        out_fragColor = vec4(var_texcoord0.xy, 0.0, 1.0);
+    }
+    ```
+
+2. `main.collection` içindeki `star-nest` oyun nesnesinin model bileşeninde, `Material` özelliğini yeni oluşturduğumuz `star-nest` materyaline ayarlayın.
+
+Artık düzenleyici modeli yeni gölgelendiriciyle işlemelidir ve UV koordinatlarının doğru olup olmadığını açıkça görebiliriz; sol alt köşe siyah (0, 0, 0), sol üst köşe yeşil (0, 1, 0), sağ üst köşe sarı (1, 1, 0) ve sağ alt köşe kırmızı (1, 0, 0) olmalıdır:
+
+![Defold'da dörtgen](../images/shadertoy/quad_material.png)
+
+## Kamera
+
+Artık projeyi çalıştırabiliriz (<kbd>Project</kbd>-><kbd>Build</kbd> veya <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>B</kbd> kısayolu), ancak siyah bir ekran göreceğiz (aslında neredeyse tamamen siyah; sol alt köşede belki tek bir küçük piksel olabilir). Bunun nedeni, bir kameranın bulunmaması ve varsayılan işleme betiğinin (render script), çok geniş bir 2B uzayı gösteren basit bir yedek yöntem kullanmasıdır; oysa modelimiz (0,0,0) konumunda ve yalnızca 1 birim genişliğindedir.
+
+Oyunda ne göreceğimizi belirlemek için kamera bileşeni olan bir oyun nesnesi ekleyelim.
+
+1. (0,0,1) konumunda `camera` adlı bir oyun nesnesi ekleyin. (Z koordinatını 1 olarak ayarlamak önemlidir; böylece bu oyun nesnesi modelimizin önünde olur, çünkü varsayılan 2B kurulumda Z ekseni bize doğru bakar).
+2. Bir `Camera` bileşeni ekleyin; içinde dörtgenimizin bulunduğu bir kamera önizlemesi göreceksiniz. Bu kurulumda varsayılan özellikler sayesinde hiçbir şeyi değiştirmeden doğru sonucu görebiliriz; tek bir şey hariç: bu kadar büyük bir kamera görüş hacmine (view frustum) ihtiyacımız yok, bu nedenle `Far Z` değerini `2` olarak azaltabiliriz.
+
+![kamera](../images/shadertoy/camera.png)
+
+İsteğe bağlı olarak `Orthographic Projection` değerini `true` yaparak kamera türünü değiştirebilir, ardından `Orthographic Zoom` değerini 600 gibi bir değere ayarlayabiliriz. Ancak bu durumda en boy oranı otomatik olarak ayarlanmaz ve modelimiz ekranı doldurmaz.
+
+## Star Nest gölgelendiricisi
+
+Artık her şey hazır olduğuna göre asıl gölgelendirici kodu üzerinde çalışmaya başlayalım. Önce özgün koda bakalım. Kod birkaç bölümden oluşuyor:
+
+![Star Nest gölgelendiricisinin kodu](../images/shadertoy/starnest_code.png)
+
+GLSL sürüm 140 ile modern bir işleme hattı kullanacağız. Bunun için dosyanın en başında `#version 140` ile sürümü bildireceğiz.
+
+1. 5--18. satırlar bir dizi sabit tanımlar. Bunları olduğu gibi bırakabiliriz. Bunlar, özellikle Shadertoy veya Defold'a bağımlı olmayan sıradan GLSL sabitleridir.
+
+2. 21. ve 63. satırlar, girdi parçasının ekran uzayındaki X ve Y doku koordinatlarını (`in vec2 fragCoord`) ve çıktı parçasının rengini (`out vec4 fragColor`) içerir.
+
+    Defold, doku koordinatlarını köşe gölgelendiricisinden parça gölgelendiricisine ara değerleri hesaplanan bir değişken aracılığıyla UV koordinatları (0--1 aralığında) olarak aktarır. Köşe gölgelendiricimizde bu değişken `out` niteleyicisiyle bildirilir:
+
+    ```glsl
+    // in star-nest.vp
+    out vec2 var_texcoord0;
+    ```
+
+     Parça gölgelendiricisinde aynı değer `in` niteleyicisiyle alınır:
+
+    ```glsl
+    // in star-nest.fp
+    in vec2 var_texcoord0;
+    ```
+
+    Ardından GLSL 140'ta `out` niteleyicisiyle açık bir parça çıktısı bildiririz:
+
+    ```glsl
+    // in star-nest.fp
+    out vec4 out_fragColor;
+    ```
+
+    Böylece, özgün Shadertoy kodunun `fragColor` değişkenine yazdığı yerde Defold gölgelendiricimiz `out_fragColor` değişkenine yazar.
+
+3. 23--27. satırlar dokunun boyutlarını, hareket yönünü ve ölçeklenmiş zamanı ayarlar. Shadertoy'da gölgelendirici, piksel konumunu `fragCoord` aracılığıyla alır ve görüntü alanının/dokunun çözünürlüğü gölgelendiriciye `uniform vec3 iResolution` olarak aktarılır. Gölgelendirici, parça koordinatlarından ve çözünürlükten doğru en boy oranına sahip UV tarzı koordinatlar hesaplar. Daha güzel bir kadraj elde etmek için çözünürlüğe bağlı bazı kaydırmalar da yapılır.
+
+    Defold'da piksel koordinatlarından başlamayız. Bunun yerine, köşe gölgelendiricisinden `var_texcoord0` aracılığıyla zaten normalleştirilmiş UV koordinatları alırız. Bu koordinatlar, işlenen dörtgen boyunca `0.0` ile `1.0` aralığındadır.
+
+    Defold sürümünde, bu hesaplamaların `var_texcoord0` içindeki UV koordinatlarını kullanacak şekilde değiştirilmesi gerekir.
+    Tipik bir dönüşüm şöyle görünür:
+
+    ```glsl
+    vec2 uv = var_texcoord0.xy;
+    uv = uv * 2.0 - 1.0;
+    uv.x *= aspect;
+    ```
+    `aspect` değerinin tam olarak ne olacağı, örneğin nasıl kurulduğuna bağlıdır. Efekt, ekran boyutu bilinen tam ekran bir dörtgen üzerinde işleniyorsa öğretici için en boy oranı kodda sabit bir değer olarak yazılabilir. Efektin herhangi bir pencere boyutunu desteklemesi gerekiyorsa çözünürlüğü bir parça sabiti olarak aktarın ve GLSL 140 uniform bloğunun içine yerleştirin.
+
+    Zaman da burada ayarlanır. Gölgelendiriciye `uniform float iGlobalTime` olarak aktarılır. Defold (1.12.3 sürümünden itibaren), gölgelendiricilere zamanı kullanacağımız özel bir `Time` sabiti aracılığıyla sağlar.
+
+    Modern Defold sürümlerinde, opak olmayan uniform değişkenleri uniform bloklarının içinde bildirilir.
+    Parça gölgelendiricisinde bunu şöyle bildiririz:
+
+    ```glsl
+    uniform fragment_inputs
+    {
+        vec4 time;
+    };
+    ```
+
+    Ardından `star-nest.material` dosyasında `time` adlı bir Fragment Constant ekleyip türünü `Time` olarak ayarlayacağız.
+
+    Değer daha sonra şöyle kullanılabilir:
+
+    ```glsl
+    float iGlobalTime = time.x;
+    float dt = time.y;
+    ```
+    Burada `time.x`, motor başlatıldığından beri geçen süredir; `time.y` ise önceki kareden bu yana geçen süredir.
+
+4. 29--39. satırlar hacimsel işlemenin dönmesini ayarlar; fare konumu bu dönmeyi etkiler. Fare koordinatları gölgelendiriciye `uniform vec4 iMouse` olarak aktarılır.
+
+    Bu öğreticide fare girdisini atlayacağız.
+
+5. 41--62. satırlar gölgelendiricinin temel bölümüdür. Bu kodu olduğu gibi bırakabiliriz.
+
+## Değiştirilmiş Star Nest gölgelendiricisi
+
+Yukarıdaki bölümleri inceleyip gerekli değişiklikleri yaptığımızda aşağıdaki gölgelendirici kodunu elde ederiz. Daha kolay okunması için kod biraz düzenlenmiştir. Defold ve Shadertoy sürümleri arasındaki farklar işaretlenmiştir:
+
+```glsl
+#version 140 // <1>
+
+// Star Nest by Pablo Román Andrioli
+// This content is under the MIT License.
+
+#define iterations 17
+#define formuparam 0.53
+
+#define volsteps 20
+#define stepsize 0.1
+
+#define zoom   0.800
+#define tile   0.850
+#define speed  0.010
+
+#define brightness 0.0015
+#define darkmatter 0.300
+#define distfading 0.730
+#define saturation 0.850
+
+in vec2 var_texcoord0; // <2>
+
+out vec4 out_fragColor; // <3>
+
+uniform fragment_inputs // <4>
+{
+	vec4 time;
+};
+
+void main() // <5>
+{
+	// get coords and direction
+	vec2 res = vec2(1.0, 1.0); // <6>
+	vec2 uv = var_texcoord0.xy * res.xy - 0.5;
+	vec3 dir = vec3(uv * zoom, 1.0);
+
+	float iGlobalTime = time.x; // <7>
+	float shader_time = iGlobalTime * speed;
+
+	float a1 = 0.5; // <8>
+	float a2 = 0.8;
+	mat2 rot1 = mat2(cos(a1), sin(a1), -sin(a1), cos(a1));
+	mat2 rot2 = mat2(cos(a2), sin(a2), -sin(a2), cos(a2));
+
+	dir.xz *= rot1;
+	dir.xy *= rot2;
+
+	vec3 from = vec3(1.0, 0.5, 0.5);
+	from += vec3(shader_time * 2.0, shader_time, -2.0);
+	from.xz *= rot1;
+	from.xy *= rot2;
+
+	// volumetric rendering
+	float s = 0.1;
+	float fade = 1.0;
+	vec3 v = vec3(0.0);
+
+	for (int r = 0; r < volsteps; r++) {
+		vec3 p = from + s * dir * 0.5;
+
+		// tiling fold
+		p = abs(vec3(tile) - mod(p, vec3(tile * 2.0)));
+
+		float pa = 0.0;
+		float a = 0.0;
+
+		for (int i = 0; i < iterations; i++) {
+			// the magic formula
+			p = abs(p) / dot(p, p) - formuparam;
+
+			// absolute sum of average change
+			a += abs(length(p) - pa);
+			pa = length(p);
+		}
+
+		// dark matter
+		float dm = max(0.0, darkmatter - a * a * 0.001);
+
+		a *= a * a;
+
+		// dark matter, don't render near
+		if (r > 6) {
+			fade *= 1.0 - dm;
+		}
+
+		v += fade;
+
+		// coloring based on distance
+		v += vec3(s, s * s, s * s * s * s) * a * brightness * fade;
+
+		fade *= distfading;
+		s += stepsize;
+	}
+
+	// color adjust
+	v = mix(vec3(length(v)), v, saturation);
+
+	out_fragColor = vec4(v * 0.01, 1.0); // <9>
+}
+```
+
+1. Defold'un modern GLSL işleme hattını kullanmak için dosyanın en başında #version 140 bildiririz. Ardından define tanımlarını olduğu gibi bırakırız.
+2. Köşe gölgelendiricisi, UV koordinatlarını var_texcoord0 aracılığıyla parça gölgelendiricisine aktarır. GLSL 140'ta parça gölgelendiricisi, ara değerleri hesaplanan bu değeri in niteleyicisiyle alır.
+3. GLSL 140'ta parça gölgelendiricisinin, gl_FragColor değişkenine yazmak yerine açık bir çıktı değişkeni bildirmesi önerilir. Burada out vec4 out_fragColor kullanıyoruz.
+4. Defold'un Time materyal sabiti, bir uniform bloğu aracılığıyla gölgelendiriciye sunulur. star-nest.material dosyasında time adlı bir Fragment Constant ekleyin ve türünü Time olarak ayarlayın.
+5. Shadertoy, mainImage(out vec4 fragColor, in vec2 fragCoord) kullanır. Defold'da normal void main() giriş noktasını kullanır, ara değerleri hesaplanan UV koordinatlarını var_texcoord0 değişkeninden okur ve son rengi out_fragColor değişkenine yazarız.
+6. Bu öğreticide işleme için sabit bir çözünürlük/en boy oranı değeri tanımlarız. Model şu anda kare olduğundan vec2 res = vec2(1.0, 1.0); kullanabiliriz. 1280×720 boyutunda dikdörtgen bir modelde ise vec2 res = vec2(1.78, 1.0); kullanabilir ve doğru en boy oranını korumak için UV koordinatlarını bununla çarpabiliriz.
+7. Özgün Shadertoy gölgelendiricisi iGlobalTime kullanır. Bu Defold sürümünde time.x, motor başlatıldığından beri geçen süreyi içerir; dolayısıyla bu değeri yerel bir iGlobalTime değişkenine atar ve yıldız alanı boyunca kamera hareketini canlandırmak için kullanırız.
+8. Bu öğreticiyi basit tutmak için iMouse değerlerini tamamen kaldırırız. Dönmenin kendisi ise korunur, çünkü hacimsel işlemedeki görsel simetriyi azaltır.
+9. Son olarak gölgelendirici, ortaya çıkan parça rengini out_fragColor değişkenine yazar.
+
+Parça gölgelendiricisi programını kaydedin. Model artık Scene düzenleyicisinde ve çalışma sırasında bir yıldız alanı dokusuyla güzel bir şekilde kaplanmış olmalıdır:
+
+![Star Nest ile kaplanmış dörtgen](../images/shadertoy/quad_starnest.png)
+
+
+## Animasyon {#animation}
+
+Bulmacanın son parçası, yıldızları hareket ettirmek için zamanı devreye sokmaktır. Defold (1.12.3 sürümünden itibaren) bunu `Time` türündeki bir parça sabiti aracılığıyla otomatik olarak sağlar.
+
+1. *star-nest.material* dosyasını açın.
+2. Bir *Fragment Constant* ekleyin ve adını "time" olarak ayarlayın.
+3. *Type* değerini `Time` olarak ayarlayın.
+
+![zaman sabiti](../images/shadertoy/time_constant.png)
+
+İşte bu kadar! Parça gölgelendiricisinde bu `time` değerini zaten kullanıyoruz. İşimiz tamam!
+
+## Alıştırmalar
+
+Eğlenceli bir devam alıştırması olarak gölgelendiriciye özgün fare hareketi girdisini ekleyebilirsiniz. Bu kez `User` türünde yeni bir Fragment Constant oluşturmanız gerekir. Fare hareketini algılayan bir betiğin `on_input` işlevinde, `go.set()` işlevini kullanarak girdi koordinatlarını bu yeni sabite atayın ve sabiti güncelleyin.
+
+Defold ile keyifli çalışmalar!

--- a/docs/tr/tutorials/side-scroller.md
+++ b/docs/tr/tutorials/side-scroller.md
@@ -1,0 +1,27 @@
+---
+title: Yana kaydırmalı oyun öğreticisi
+brief: Bu öğretici, Defold'da oyun yapmanın nasıl bir deneyim olduğuna dair fikir vermeyi amaçlar. Basit bir yana kaydırmalı oyun (side-scroller) temelinde yeni bir proje oluşturmayı anlatır. Ardından oyunu daha eğlenceli hale getirmek için küçük değişiklikler yapmayı öğreneceksiniz. Son olarak yeni bir oyun nesnesi (game object) ekleyeceksiniz. Öğreticiyi tamamlamanın yalnızca yaklaşık 10 dakika sürmesi beklenir.
+github: https://github.com/defold/tutorial-side-scroller
+---
+
+# Yana kaydırmalı oyun öğreticisi
+
+
+Öğretici, Defold düzenleyicisine entegre edilmiştir ve kolayca erişilebilir:
+
+Defold'u başlatın ve:
+1. Soldaki `Create From` ▸ `TUTORIALS` seçeneğini seçin.
+2. "Side Scroller Tutorial" seçeneğini seçin.
+3. İsterseniz adını değiştirin.
+4. Yerel diskinizde proje için bir konum seçin.
+5. `Create New Project` seçeneğine tıklayın.
+
+![yeni proje](images/new-side-scroller.webp)
+
+Düzenleyici, öğreticinin tam metnini içeren "README" dosyasını projenin kök dizininden otomatik olarak açar.
+
+![simge](images/icon-tutorial.svg){.icon} [Öğreticinin tam metnini GitHub'da da okuyabilirsiniz](https://github.com/defold/tutorial-side-scroller)
+
+Bir noktada takılırsanız, Defold ekibinden ve birçok yardımsever kullanıcıdan yardım alabileceğiniz [Defold Forumuna](//forum.defold.com) uğrayın.
+
+Defold ile iyi eğlenceler!

--- a/docs/tr/tutorials/snake.md
+++ b/docs/tr/tutorials/snake.md
@@ -1,0 +1,659 @@
+---
+brief: Defold'a yeni başladıysanız bu kılavuz, betik mantığına ve Defold'un bazı yapı taşlarına giriş yaparak sıfırdan bir Snake benzeri oyun oluşturmanıza yardımcı olacaktır.
+layout: tutorial
+title: Defold'da bir yılan oyunu oluşturma
+difficulty: Beginner
+---
+
+# Yılan
+
+Bu öğretici, yeniden yapmayı deneyebileceğiniz en yaygın klasik oyunlardan birini oluşturma sürecinde size yol gösterir. Bu oyunun birçok çeşidi vardır; burada "yiyecek" yiyen ve yalnızca yediğinde büyüyen bir yılan bulunur. Bu yılan ayrıca engellerin bulunduğu bir oyun alanında sürünür.
+
+![Küçük resim](images/snake/thumbnail.png)
+
+### Neler öğreneceksiniz
+
+Bu öğreticide şunları öğreneceksiniz:
+- Defold'da sıfırdan oyun oluşturma
+- Girdileri ayarlama ve işleme
+- Karo haritaları oluşturma ve bunları çalışma sırasında değiştirme
+- Lua dilinde betik yazma
+
+### Yeni başlayanlar için bir not
+
+Bu öğretici yeni başlayanlar için tasarlanmıştır; ancak Defold ve oyun geliştirme konusunda tamamen yeniyseniz önce giriş niteliğindeki bazı kılavuzları, özellikle [Defold'un yapı taşları](/manuals/building-blocks/) ve [Terim sözlüğü](/manuals/glossary/) kılavuzlarını okumanızı öneririz. Henüz Defold'u indirmediyseniz [Kurulum kılavuzuna](/manuals/install/) bakın. Düzenleyiciyi hızla tanımak için [Düzenleyiciye genel bakış](/manuals/editor/) kılavuzuna da göz atmanız önerilir; ayrıca burada her adım için ekran görüntüleri sunuyoruz.
+
+## Projeyi oluşturma
+
+Defold'u başlatın ve:
+
+1. Sol tarafta *Create From* ▸ *Templates* seçeneğini seçin.
+2. *Empty Project* seçeneğini seçin.
+3. *Title* alanına bir proje adı yazın.
+4. Proje için *Location* alanında bir konum seçin.
+5. *Create New Project* düğmesine tıklayın.
+
+![Başlangıç](images/snake/1.png)
+
+<input type="checkbox"/> Tamam!
+
+## Proje ayarları
+
+Oyunun çözünürlüğünü belirleyerek başlayacağız.
+
+1. Düzenleyici açıldığında sol taraftaki *Assets* bölmesinde `game.project` dosyasını bulun. Açmak için dosyaya çift tıklayın.
+2. `game.project` dosyasının *Display* bölümüne gidin.
+3. Oyunun boyutlarını (`Width` ve `Height`) 768⨉768 veya 16'nın başka bir katı olacak şekilde ayarlayın.
+
+![Ekran ayarları](images/snake/2.png)
+
+Bunu yapmanızın nedeni, oyunun her parçası 16x16 piksel olan bir ızgara üzerine çizilecek olmasıdır; böylece oyun ekranı hiçbir parçayı kısmen kesmez. `game.project` dosyası projenin tüm önemli ayarlarını içerir; bunların tamamını [Proje ayarları kılavuzunda](/manuals/project-settings/) okuyabilirsiniz.
+
+<input type="checkbox"/> Tamam!
+
+## Assets bölmesinde yeni klasörler oluşturma
+
+Sade bir Snake benzeri oyun için çok az grafik gerekir. Yılan için 16⨉16 boyutunda bir yeşil parça, engeller için bir beyaz blok ve yiyeceği temsil eden daha küçük bir kırmızı blok.
+
+Önce Defold düzenleyicisinde varlıklar (assets) için bir dizin oluşturun:
+
+1. `main` klasörüne <kbd>sağ tıklayın</kbd>
+2. `New Folder` seçeneğini seçin.
+3. Ad soran bir açılır pencere görünecektir; `assets` yazın ve `Create Folder` düğmesine tıklayın.
+
+![Yeni klasör](images/snake/3.png)
+
+<input type="checkbox"/> Tamam!
+
+## Oyuna grafik ekleme
+
+Aşağıdaki görüntü, ihtiyacınız olan tek varlıktır:
+
+![Yılan sprite görüntüleri](images/snake/snake.png)
+
+1. Yukarıdaki görüntüye <kbd>sağ tıklayın</kbd> ve yerel diskinize kaydedin. Ardından indirdiğiniz görüntüyü proje klasöründe az önce oluşturduğunuz yeni konuma sürükleyip bırakın (veya kopyalayıp yapıştırın).
+
+![Yeni klasör](images/snake/4.png)
+
+[Varlıkları içe aktarma hakkında daha fazla ayrıntıyı burada](/manuals/importing-graphics/) da okuyabilirsiniz.
+
+<input type="checkbox"/> Tamam!
+
+## Karo kaynağı ekleme
+
+Defold, ızgara üzerinde hizalanmış *karolardan* (tiles) oluşan oyun alanını oluşturmak için kullanacağınız yerleşik bir [karo haritası (Tile Map)](/manuals/tilemap/) bileşeni (component) sunar. Karo haritası, karoları tek tek ayarlamanıza ve okumanıza olanak tanır; bu da bu oyun için çok uygundur. Karo haritaları grafiklerini bir [karo kaynağından (Tile Source)](/manuals/tilesource/) aldığı için bir karo kaynağı oluşturmanız gerekir:
+
+1. `assets` klasörüne <kbd>sağ tıklayın</kbd>.
+2. "Resources" bölümünde `New` ▸ `Tile Source` seçeneğini seçin.
+3. Yeni dosyaya "snake" adını verin (düzenleyici dosyayı `snake.tilesource` olarak kaydedecektir).
+
+![Yeni karo kaynağı](images/snake/5.png)
+
+Karo kaynağı, bu dosya türüne özel Tile Source Editor içinde açılır ve çalışabilmesi için bir görüntü belirtmeniz istenir. Sağ tarafta `Properties` bölmesini bulabilirsiniz:
+
+4. `Image` özelliğini az önce içe aktardığınız grafik dosyasına ayarlayın.
+![Karo kaynağı](images/snake/6.png)
+
+5. `Width` ve `Height` özellikleri 16 (varsayılan değer) olarak bırakılmalıdır. Bu, 32⨉32 piksellik görüntüyü 1–4 olarak numaralandırılmış 4 karoya böler.
+
+![Karo kaynağı özellikleri](images/snake/7.png)
+
+*Extrude Borders* özelliğinin 2 piksel olarak ayarlandığına dikkat edin. Bu, grafikleri kenara kadar uzanan karoların çevresinde görüntü kusurları oluşmasını önler.
+
+Bir dosyada değişiklik yaparsanız sekmesinde adının yanında bir yıldız işareti `*` görünür. Tüm dosyaları kaydetmek için `File` ▸ `Save All` seçeneğini seçin veya <kbd>Ctrl</kbd>+<kbd>S</kbd> (Mac'te <kbd>⌘Cmd</kbd> + <kbd>S</kbd>) kısayolunu kullanın.
+
+<input type="checkbox"/> Tamam!
+
+## Oyun alanının karo haritasını oluşturma
+
+Artık kullanıma hazır bir karo kaynağınız var; şimdi oyun alanının karo haritası bileşenini oluşturma zamanı:
+
+1. `main` klasörüne <kbd>sağ tıklayın</kbd> ve "Components" bölümünde <kbd>New</kbd> ▸ <kbd>Tile Map</kbd> seçeneğini seçin. Yeni dosyaya "grid" adını verin (düzenleyici dosyayı "grid.tilemap" olarak kaydedecektir).
+![Karo haritası ekleme](images/snake/8.png)
+
+2. Dosya Tile Map Editor içinde açılır ve bir **Tile Source** gerektiğini belirtir; bu nedenle *Tile Source* özelliğini daha önce oluşturduğunuz "snake.tilesource" dosyasına ayarlayın.
+![Karo kaynağını ayarlama](images/snake/9.png)
+
+<input type="checkbox"/> Tamam!
+
+## Karo haritasına karo çizme
+
+Defold, karo haritasının yalnızca kullanılan alanını saklar; bu nedenle ekran sınırlarını dolduracak kadar karo eklemeniz gerekir.
+
+1. Sağ taraftaki `Outline` bölmesinde `layer1` katmanını seçin.
+2. Karo paletini göstermek için `Edit` ▸ `Select Tile...` menü seçeneğini veya <kbd>Space</kbd> kısayolunu kullanın, ardından boyarken kullanmak istediğiniz karoya tıklayın.
+![Karo haritası](images/snake/10.png)
+
+3. Ekranın kenarlarını çevreleyen bir sınır ve birkaç engel boyayın.
+![Tamamlanmış karo haritası](images/snake/11.png)
+
+Oyun ekranını doldurmak için 48x48 karo boyutunda bir karo haritasına ihtiyacınız olacak (çünkü ekran boyutumuz 768 ve karolarımız 16 piksel, dolayısıyla 768/16 = 48).
+
+Bitirdiğinizde karo haritasını kaydedin.
+
+<input type="checkbox"/> Tamam!
+
+## Karo haritasını oyuna ekleme
+
+Şimdi karo haritamızı oyuna eklememiz gerekiyor. Defold'un yapı taşlarını biliyorsanız bileşenlerin oyun nesnelerinin (game objects) bir parçası olduğunu ve oyun nesnelerinin koleksiyonlarda (collections) tanımlanabildiğini de biliyorsunuzdur.
+
+1. `Assets` bölmesinde `main.collection` dosyasına çift tıklayarak açın. Bu dosya, Empty Project şablonunda varsayılan olarak motor başlatıldığında yüklenen başlangıç koleksiyonudur (bootstrap collection).
+
+2. `Outline` görünümünde köke <kbd>sağ tıklayın</kbd> ve `Add Game Object` seçeneğini seçin. Bu işlem, oyun başladığında yüklenen koleksiyonda yeni bir oyun nesnesi oluşturur.
+![Oyun nesnesi ekleme](images/snake/12.png)
+
+3. Yeni oyun nesnesine <kbd>sağ tıklayın</kbd> ve `Add Component File` seçeneğini seçin. Az önce oluşturduğunuz "grid.tilemap" dosyasını seçin.
+![Bileşen ekleme](images/snake/13.png)
+
+Artık oyun koleksiyonumuzda bir karo haritası var. Oyunu düzenleyiciden çalıştırdığınızda görünür olmalıdır.
+
+1. `Project` ▸ `Build` seçeneğini seçin veya <kbd>Ctrl</kbd> + <kbd>B</kbd> (Mac'te <kbd>⌘Cmd</kbd> + <kbd>B</kbd>) kısayolunu kullanın.
+
+![Oyunu çalıştırma](images/snake/14.png)
+
+<input type="checkbox"/> Tamam!
+
+## Oyuna betik ekleme
+
+1. `Assets` tarayıcısında `main` klasörüne <kbd>sağ tıklayın</kbd> ve Scripts bölümünde `New` ▸ `Script` seçeneğini seçin. Yeni betik (script) dosyasına "snake" adını verin ("snake.script" olarak kaydedilecektir). Bu dosya oyunun tüm mantığını içerecektir.
+![Betik ekleme](images/snake/15.png)
+
+2. *main.collection* dosyasına dönün ve karo haritasını barındıran oyun nesnesine <kbd>sağ tıklayın</kbd>. <kbd>Add&nbsp;Component&nbsp;File</kbd> seçeneğini seçin ve "snake.script" dosyasını seçin.
+
+![Ana koleksiyon](images/snake/16.png)
+
+Artık karo haritası bileşeni ve betik hazır.
+
+<input type="checkbox"/> Tamam!
+
+## Oyun betiği
+
+Yazacağınız betik oyunun tamamını yönetecek. Özellikleri tek tek ekleyeceğiz.
+
+### Basit hareket algoritması
+
+Nasıl çalışacağına ilişkin fikir şu:
+
+1. Betik, yılanın o anda kapladığı karo konumlarının bir listesini tutar.
+2. Oyuncu bir yön tuşuna basarsa yılanın hareket etmesi gereken yönü saklayın.
+3. Düzenli aralıklarla yılanı geçerli hareket yönünde bir adım ilerletin.
+
+### Başlangıç işlemleri
+
+*snake.script* dosyasını açın ve `init()` işlevini bulun. Oyun başladığında betiğin başlangıç işlemleri yapılırken motor bu işlevi çağırır. Kodu aşağıdaki gibi değiştirin:
+
+```lua
+function init(self)
+    self.segments = { -- <1>
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0} -- <2>
+    self.speed = 7.0 -- <3>
+    self.time = 0 -- <4>
+end
+```
+
+Bu kodda şunları yapıyoruz:
+
+1. Yılanın parçalarını `self.segments` adlı bir Lua tablosunda saklıyoruz. Bu tablo, her biri bir parçanın X ve Y konumunu tutan tabloların listesini içerir.
+2. Geçerli yönü, X ve Y yönünü tutan `self.dir` adlı bir tabloda saklıyoruz.
+3. Geçerli hareket hızını, saniyede geçilen karo sayısı olarak `self.speed` içinde saklıyoruz.
+4. Hareket hızını takip etmek için kullanılacak bir zamanlayıcı değerini `self.time` içinde saklıyoruz.
+
+Yukarıdaki betik kodu Lua dilinde yazılmıştır. Kod hakkında dikkat etmeniz gereken birkaç nokta var; ancak aşağıdakileri henüz anlamıyorsanız endişelenmeyin. Adımları izleyin, denemeler yapın ve kendinize zaman tanıyın; sonunda anlayacaksınız. Şimdilik `init()` içinde kullanacağımız değişkenlere yalnızca başlangıç değerlerini verdiğimizi aklınızda tutmanız yeterli.
+
+- Defold, betik bileşeninin yaşam süresi boyunca çağrılan bir dizi yerleşik geri çağırım (callback) *işlevi* ayırır. Bunlar yöntem *değildir*, sıradan işlevlerdir.
+- Çalışma zamanı ortamı, `self` parametresi aracılığıyla geçerli betik bileşeni örneğine (instance) bir başvuru geçirir. `self` başvurusu örneğe ait verileri saklamak için kullanılır.
+- `self` başvurusu, içinde veri saklayabileceğiniz bir Lua tablosu olarak kullanılabilir. Diğer tablolarda olduğu gibi noktalı gösterimi kullanmanız yeterlidir: `self.data = "value"`. Başvuru, betiğin yaşam süresi boyunca geçerlidir; bu örnekte oyunun başlangıcından siz oyundan çıkana kadar.
+- Lua tablo değişmezleri süslü ayraçlar `{}` içine yazılır.
+- Tablo girdileri anahtar-değer çiftleri (`{x = 10, y = 20}`), iç içe Lua tabloları (`{ {a = 1}, {b = 2} }`) veya başka veri türleri olabilir.
+
+<input type="checkbox"/> Tamam!
+
+### Güncelleme
+
+`init()` işlevi, betik bileşeninin çalışan oyunda bir örneği oluşturulduğunda tam olarak bir kez çağrılır. Buna karşılık `update()` işlevi **her karede** bir kez çağrılır. Bu da işlevi gerçek zamanlı oyun mantığı için ideal kılar.
+
+Güncellemenin temel fikri şu: belirli aralıklarla aşağıdakileri yapın:
+
+1. Yılanın başının nerede olduğunu bulun, ardından geçerli hareket yönünde bir adım ötesindeki konumda yeni bir baş oluşturun. Yani yılan X=1 ve Y=0 yönünde hareket ediyorsa ve geçerli baş X=0 ve Y=0 konumundaysa yeni baş X=1 ve Y=0 konumunda olmalıdır.
+2. Yeni başın konumunu yılanı oluşturan parçaların listesine kaydedin.
+3. Kuyruğun konumunu parçalar tablosundan alın.
+4. Bu konumdaki kuyruk karosunu temizleyin.
+5. Yılanın tüm parçalarını (karoları) tablodaki konumlara çizin.
+
+![Algoritma](images/snake/17.png)
+
+:::sidenote
+Yılanın başının tablonun sonunda, kuyruğunun ise başında olduğunu unutmayın.
+:::
+
+1. *snake.script* dosyasında `update()` işlevini bulun ve kodu aşağıdaki gibi değiştirin:
+
+```lua
+function update(self, dt)
+    self.time = self.time + dt -- <1>
+    if self.time >= 1.0 / self.speed then -- <2>
+        local head = self.segments[#self.segments] -- <3>
+
+        local newhead = {
+            x = head.x + self.dir.x,
+            y = head.y + self.dir.y
+        } -- <4>
+
+        table.insert(self.segments, newhead) -- <5>
+
+        local tail = table.remove(self.segments, 1) -- <6>
+
+        tilemap.set_tile("#grid", "layer1", tail.x, tail.y, 0) -- <7>
+
+        for i, s in ipairs(self.segments) do -- <8>
+            tilemap.set_tile("#grid", "layer1", s.x, s.y, 2) -- <9>
+        end
+
+        self.time = 0 -- <10>
+    end
+end
+```
+
+Bu kodda şunları yapıyoruz:
+
+1. Zamanlayıcıyı, `update()` işlevinin son çağrılışından bu yana geçen süre (saniye cinsinden), yani "delta time" veya `dt` kadar ilerletiyoruz.
+2. Zamanlayıcı yeterince ilerlediyse:
+3. Geçerli başın konumunu alıyoruz. `#`, dizi olarak kullanılan bir tablonun uzunluğunu almak için kullanılan işleçtir. Bizim tablomuz da dizi olarak kullanılır; tüm parçalar, anahtar belirtilmeden tanımlanmış tablo değerleridir.
+4. Geçerli başın konumuna ve hareket yönüne (`self.dir`) göre yeni bir baş parçası oluşturuyoruz.
+5. Yeni başı parçalar tablosunun (sonuna) ekliyoruz.
+6. Kuyruğu parçalar tablosunun başından kaldırıyoruz.
+7. Kaldırılan kuyruğun konumundaki karoyu temizliyoruz. `#grid` karo haritamızda `layer1` adlı yalnızca 1 katman bulunur.
+8. Parçalar tablosundaki öğeler üzerinde döngü kuruyoruz. Her yinelemede `i`, tablodaki konuma (1'den başlayarak), `s` ise geçerli parçaya ayarlanır.
+9. Parçanın konumundaki karoyu 2 değerine ayarlıyoruz (bu, yılanın yeşil rengini içeren karodur).
+10. İşimiz bittiğinde zamanlayıcıyı sıfırlıyoruz.
+
+Oyunu şimdi çalıştırırsanız 4 parça uzunluğundaki yılanın oyun alanında soldan sağa süründüğünü görmelisiniz.
+
+![Oyunu çalıştırma](images/snake/snake_run_1.png)
+
+<input type="checkbox"/> Tamam!
+
+## Oyuncu girdisi
+
+Oyuncu girdisine tepki verecek kodu eklemeden önce girdi bağlantılarını ayarlamanız gerekir.
+
+### Girdi eşlemeleri
+
+1. `input` klasöründeki `game.input_binding` dosyasını bulun ve açmak için dosyaya <kbd>çift tıklayın</kbd>.
+2. Yukarı, aşağı, sola ve sağa hareket için bir dizi *Key Trigger* eşlemesi ekleyin. *Input* sütununda klavye tuşlarını seçin ve *Action* sütunlarına eylem adlarını yazın.
+
+![Girdi](images/snake/18.png)
+
+Girdi eşlemesi (input binding) dosyası, gerçek kullanıcı girdilerini (tuşlar, fare hareketleri vb.) girdi almayı talep etmiş betiklere iletilen eylem *adlarıyla* eşler.
+
+<input type="checkbox"/> Tamam!
+
+### Girdi odağını alma
+
+Eşlemeler hazır olduğunda girdi odağını (input focus) almak için *snake.script* dosyasını açın ve `init()` işlevinin başına aşağıdaki satırı ekleyin:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus") -- <1>
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.speed = 7.0
+    self.time = 0
+end
+```
+
+Eklenen satır:
+1. Geçerli oyun nesnesine ("." geçerli oyun nesnesinin kısa yazımıdır) motordan girdi almaya başlamasını söyleyen bir ileti (message) gönderir.
+
+Ardından `on_input` işlevini bulun ve aşağıdaki kodu yazın:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("up") and action.pressed then -- <1>
+        self.dir.x = 0 -- <2>
+        self.dir.y = 1
+    elseif action_id == hash("down") and action.pressed then
+        self.dir.x = 0
+        self.dir.y = -1
+    elseif action_id == hash("left") and action.pressed then
+        self.dir.x = -1
+        self.dir.y = 0
+    elseif action_id == hash("right") and action.pressed then
+        self.dir.x = 1
+        self.dir.y = 0
+    end
+end
+```
+
+Bu `if...elseif...` dalları şunları yapar:
+1. Girdi eşlemelerinde ayarlandığı gibi "up" girdi eylemi alınırsa ve `action` tablosunun `pressed` alanı `true` değerindeyse (oyuncu tuşa basmışsa):
+2. Hareket yönünü ayarlar.
+
+Oyunu yeniden çalıştırın ve yılanı yönlendirebildiğinizi kontrol edin.
+
+<input type="checkbox"/> Tamam!
+
+### Girdi işlemeyi iyileştirme
+
+İki tuşa aynı anda basarsanız her basış için bir tane olmak üzere `on_input()` işlevinin iki kez çağrılacağına dikkat edin. Yukarıdaki kodda, sonraki `on_input()` çağrıları `self.dir` içindeki değerlerin üzerine yazacağından yalnızca en son çağrı yılanın yönünü etkiler.
+
+Ayrıca yılan sola giderken <kbd>right</kbd> tuşuna basarsanız yılanın kendi üzerine döneceğine dikkat edin. Bu sorunun *görünüşte* bariz çözümü, `on_input()` içindeki `if` koşullarına ek bir koşul koymaktır:
+
+```lua
+if action_id == hash("up") and self.dir.y ~= -1 and action.pressed then
+    ...
+elseif action_id == hash("down") and self.dir.y ~= 1 and action.pressed then
+    ...
+```
+
+Ancak yılan sola giderken oyuncu bir sonraki hareket adımı gerçekleşmeden önce *hızla* sırasıyla <kbd>up</kbd> ve <kbd>right</kbd> tuşlarına basarsa yalnızca <kbd>right</kbd> tuşuna basılması etkili olur ve yılan kendi üzerine hareket eder. Yukarıda gösterilen `if` ifadelerine koşullar eklendiğinde girdi yok sayılır. *Bu iyi değil!*
+
+Bu sorunu doğru biçimde çözmek için girdiyi bir kuyrukta saklayıp yılan hareket ettikçe bu kuyruktan girdileri almak gerekir:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.speed = 7.0
+    self.time = 0
+
+    self.dirqueue = {} -- <1>
+end
+```
+
+Bu kez:
+1. Boş bir tablo olarak başlatılan `self.dirqueue` değişkenini ekledik.
+
+`update()` işlevine şunları ekleyin:
+
+```lua
+function update(self, dt)
+    self.time = self.time + dt
+    if self.time >= 1.0 / self.speed then
+        local newdir = table.remove(self.dirqueue, 1) -- <1>
+        if newdir then
+            local opposite = newdir.x == -self.dir.x or newdir.y == -self.dir.y -- <2>
+            if not opposite then
+                self.dir = newdir -- <3>
+            end
+        end
+
+        local head = self.segments[#self.segments]
+        local newhead = {x = head.x + self.dir.x, y = head.y + self.dir.y}
+
+        table.insert(self.segments, newhead)
+
+        local tail = table.remove(self.segments, 1)
+        tilemap.set_tile("#grid", "layer1", tail.x, tail.y, 0)
+
+        for i, s in ipairs(self.segments) do
+            tilemap.set_tile("#grid", "layer1", s.x, s.y, 2)
+        end
+
+        self.time = 0
+    end
+end
+```
+
+1. Yön kuyruğundan ilk öğeyi alın.
+2. Bir öğe varsa (`newdir` null değilse) `newdir` yönünün `self.dir` yönünün tersi olup olmadığını kontrol edin.
+3. Yeni yönü yalnızca ters yönü göstermiyorsa ayarlayın.
+
+Ayrıca `on_input` işlevini, bunun yerine geçerli girdiyi kuyrukta saklayacak şekilde değiştirin:
+
+```lua
+function on_input(self, action_id, action)
+    if action_id == hash("up") and action.pressed then
+        table.insert(self.dirqueue, {x = 0, y = 1}) -- <1>
+    elseif action_id == hash("down") and action.pressed then
+        table.insert(self.dirqueue, {x = 0, y = -1})
+    elseif action_id == hash("left") and action.pressed then
+        table.insert(self.dirqueue, {x = -1, y = 0})
+    elseif action_id == hash("right") and action.pressed then
+        table.insert(self.dirqueue, {x = 1, y = 0})
+    end
+end
+```
+
+1. `self.dir` değerini doğrudan ayarlamak yerine girdi yönünü yön kuyruğuna ekleyin.
+
+Oyunu başlatın ve beklendiği gibi oynandığını kontrol edin.
+
+<input type="checkbox"/> Tamam!
+
+## Yiyecek ve engellerle çarpışma
+
+Yılanın uzaması ve hızlanması için haritada yiyeceğe ihtiyacı var. Bunu ekleyelim!
+
+### Yiyecek oluşturma
+
+`init()` işlevinin üstüne yeni bir işlev ekleyin:
+
+```lua
+local function put_food(self) -- <1>
+    self.food = {x = math.random(2, 47), y = math.random(2, 47)} -- <2>
+    tilemap.set_tile("#grid", "layer1", self.food.x, self.food.y, 3) -- <3>
+end
+```
+
+Bu işlevde şunları yapıyoruz:
+1. Haritaya bir yiyecek yerleştiren `put_food()` adlı yeni bir işlev tanımlıyoruz.
+2. Rastgele bir X ve Y konumunu `self.food` adlı değişkende saklıyoruz.
+3. X ve Y konumundaki karoyu, yiyeceğin karo grafiği olan 3 değerine ayarlıyoruz.
+
+Ardından bu işlevi `init()` işlevinin sonunda çağırın:
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.dirqueue = {}
+    self.speed = 7.0
+    self.time = 0
+
+    math.randomseed(socket.gettime()) -- <1>
+    put_food(self) -- <2>
+end
+```
+
+1. `math.random()` ile rastgele değerler almaya başlamadan önce rastgelelik tohumunu ayarlayın; aksi takdirde aynı rastgele değer dizisi üretilir. Bu tohum yalnızca bir kez ayarlanmalıdır.
+2. Oyuncunun haritada bir yiyecekle başlaması için oyun başlangıcında `put_food()` işlevini çağırın.
+
+<input type="checkbox"/> Tamam!
+
+### Yiyeceği yeme
+
+Artık yılanın bir şeye çarpıp çarpmadığını algılamak için karo haritasında yılanın gideceği yerde ne olduğuna bakıp buna tepki vermek yeterli.
+
+Yılanın hayatta olup olmadığını takip eden bir değişken ekleyin:
+
+```lua
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.dirqueue = {}
+    self.speed = 7.0
+    self.time = 0
+
+    self.alive = true -- <1>
+
+    math.randomseed(socket.gettime())
+    put_food(self)
+end
+```
+
+1. Yılanın hayatta olup olmadığını belirten bir bayrak.
+
+Ardından duvar/engel ve yiyecekle çarpışmayı denetleyen mantığı ekleyin:
+
+```lua
+function update(self, dt)
+    self.time = self.time + dt
+    if self.time >= 1.0 / self.speed and self.alive then -- <1>
+        local newdir = table.remove(self.dirqueue, 1)
+
+        if newdir then
+            local opposite = newdir.x == -self.dir.x or newdir.y == -self.dir.y
+            if not opposite then
+                self.dir = newdir
+            end
+        end
+
+        local head = self.segments[#self.segments]
+        local newhead = {x = head.x + self.dir.x, y = head.y + self.dir.y}
+
+        table.insert(self.segments, newhead)
+
+        local tile = tilemap.get_tile("#grid", "layer1", newhead.x, newhead.y) -- <2>
+
+        if tile == 2 or tile == 4 then
+            self.alive = false -- <3>
+        elseif tile == 3 then
+            self.speed = self.speed + 1 -- <4>
+            put_food(self)
+        else
+            local tail = table.remove(self.segments, 1) -- <5>
+            tilemap.set_tile("#grid", "layer1", tail.x, tail.y, 1)
+        end
+
+        for i, s in ipairs(self.segments) do
+            tilemap.set_tile("#grid", "layer1", s.x, s.y, 2)            
+        end
+
+        self.time = 0
+    end
+end
+```
+
+1. Yılanı yalnızca hayattaysa ilerletin.
+2. Karo haritasına çizim yapmadan önce yılanın yeni başının bulunacağı konumda ne olduğunu okuyun.
+3. Karo bir engel veya yılanın başka bir parçasıysa oyun biter!
+4. Karo yiyecekse hızı artırın, ardından yeni bir yiyecek yerleştirin.
+5. Kuyruğun yalnızca çarpışma olmadığında kaldırıldığına dikkat edin. Bu, oyuncu yiyecek yediğinde o hareket sırasında kuyruk kaldırılmadığı için yılanın bir parça uzayacağı anlamına gelir.
+
+Şimdi oyunu deneyin ve oynanışın düzgün olduğundan emin olun!
+
+Öğretici burada sona eriyor; ancak oyun üzerinde denemeler yapmaya devam edin ve aşağıdaki alıştırmalardan bazılarını tamamlayın!
+
+<input type="checkbox"/> Tamam!
+
+## Betiğin tamamı
+
+Başvurmanız için betiğin tüm kodu aşağıdadır:
+
+```lua
+local function put_food(self)
+    self.food = {x = math.random(2, 47), y = math.random(2, 47)}
+    tilemap.set_tile("#grid", "layer1", self.food.x, self.food.y, 3)        
+end
+
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    self.segments = {
+        {x = 7, y = 24},
+        {x = 8, y = 24},
+        {x = 9, y = 24},
+        {x = 10, y = 24}
+    }
+    self.dir = {x = 1, y = 0}
+    self.dirqueue = {}
+    self.speed = 7.0
+    self.time = 0
+
+    self.alive = true
+
+    math.randomseed(socket.gettime())
+    put_food(self)
+end
+
+function update(self, dt)
+    self.time = self.time + dt
+    if self.time >= 1.0 / self.speed and self.alive then
+        local newdir = table.remove(self.dirqueue, 1)
+
+        if newdir then
+            local opposite = newdir.x == -self.dir.x or newdir.y == -self.dir.y
+            if not opposite then
+                self.dir = newdir
+            end
+        end
+
+        local head = self.segments[#self.segments]
+        local newhead = {x = head.x + self.dir.x, y = head.y + self.dir.y}
+
+        table.insert(self.segments, newhead)
+
+        local tile = tilemap.get_tile("#grid", "layer1", newhead.x, newhead.y)
+
+        if tile == 2 or tile == 4 then
+            self.alive = false
+        elseif tile == 3 then
+            self.speed = self.speed + 1
+            put_food(self)
+        else
+            local tail = table.remove(self.segments, 1)
+            tilemap.set_tile("#grid", "layer1", tail.x, tail.y, 1)
+        end
+
+        for i, s in ipairs(self.segments) do
+            tilemap.set_tile("#grid", "layer1", s.x, s.y, 2)            
+        end
+
+        self.time = 0
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("up") and action.pressed then
+        table.insert(self.dirqueue, {x = 0, y = 1})
+    elseif action_id == hash("down") and action.pressed then
+        table.insert(self.dirqueue, {x = 0, y = -1})
+    elseif action_id == hash("left") and action.pressed then
+        table.insert(self.dirqueue, {x = -1, y = 0})
+    elseif action_id == hash("right") and action.pressed then
+        table.insert(self.dirqueue, {x = 1, y = 0})
+    end
+end
+```
+
+## Alıştırmalar
+
+Şu iyileştirmeleri uygulamayı denemek iyi bir alıştırmadır:
+
+1. Oyun bittiğinde yeniden başlatmak için bir tuş girdisini işleyen kod ekleyin.
+2. İster yalnızca bir etiket bileşeni (label component) kullanarak (daha kolay), ister bir GUI oluşturarak puanlama ve puan sayacı ekleyin.
+3. put_food() işlevi, yılanın konumunu veya engelleri hesaba katmaz. Yiyeceği yalnızca boş yerlere yerleştirecek şekilde düzeltin.
+4. Oyun bittiğinde bir "Game Over" iletisi gösterin ve oyuncunun yeniden denemesine izin verin.
+5. Ek alıştırma: oyuncunun kontrol ettiği ikinci bir yılan ekleyin.

--- a/docs/tr/tutorials/war-battles.md
+++ b/docs/tr/tutorials/war-battles.md
@@ -1,0 +1,28 @@
+---
+title: War battles öğreticisi
+brief: Bu öğreticide küçük bir nişancı oyununun temellerini oluşturacaksınız. Defold'a yeni başlıyorsanız bu öğretici iyi bir başlangıç noktasıdır.
+github: https://github.com/defold/tutorial-war-battles
+---
+
+# War battles öğreticisi
+
+Bu öğreticide hareket ve ateş etme mekaniklerine sahip, oynanabilir küçük bir oyunun nasıl oluşturulacağını öğreneceksiniz.
+
+Öğretici, Defold düzenleyicisiyle bütünleşiktir ve kolayca erişilebilir:
+
+1. Defold'u başlatın.
+2. Sol taraftaki *New Project* seçeneğini seçin.
+3. *From Tutorial* sekmesini seçin.
+4. "War battles tutorial" seçeneğini seçin
+5. Proje için yerel diskinizde bir konum seçin ve *Create New Project* düğmesine tıklayın.
+
+![yeni proje](images/new-war-battles.png)
+
+Düzenleyici, proje kök dizinindeki "README" dosyasını otomatik olarak açar. Bu dosya öğreticinin tam metnini içerir.
+
+![simge](images/icon-tutorial.svg){.icon}
+[Öğreticinin tam metnini GitHub'da da okuyabilirsiniz](https://github.com/defold/tutorial-war-battles)
+
+Takıldığınız bir nokta olursa Defold ekibinden ve yardımsever birçok kullanıcıdan yardım alabileceğiniz [Defold Forumu'na](//forum.defold.com) uğrayın.
+
+Defold ile iyi çalışmalar!


### PR DESCRIPTION
Adds German and Turkish versions of the manuals, tutorials, and FAQ, and enables both languages on the documentation site.

### Technical changes

- Add 204 translated Markdown files per language: 160 manuals, 19 tutorials, 24 shared snippets, and 1 FAQ.
- Add terminology glossaries and translation guidelines for both languages.
- Register `de` and `tr` as active languages in `docs/languages.json`.
- Preserve code examples, API identifiers, include directives, and link destinations, with English anchors retained for existing fragment links.
- Validation: coverage, Markdown structure, frontmatter, and local-link checks passed for all 408 translated files. All 790 source code blocks remain unchanged in each language.